### PR TITLE
Add hierarchical pages with drag-and-drop to sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@dnd-kit/core": "^6.1.0",
+				"@dnd-kit/sortable": "^8.0.0",
 				"@wordpress/block-editor": "^15.17.0",
 				"@wordpress/block-library": "^9.44.0",
 				"@wordpress/components": "^32.6.0",
@@ -2298,6 +2300,59 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+			"integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.1.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/@dual-bundle/import-meta-resolve": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"@wordpress/scripts": "^30.0.0"
 	},
 	"dependencies": {
+		"@dnd-kit/core": "^6.1.0",
+		"@dnd-kit/sortable": "^8.0.0",
 		"@wordpress/block-editor": "^15.17.0",
 		"@wordpress/block-library": "^9.44.0",
 		"@wordpress/components": "^32.6.0",

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -1,0 +1,304 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { useState, useEffect, useRef } from '@wordpress/element';
+import {
+	Button,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	TextControl,
+} from '@wordpress/components';
+import { useDraggable, useDroppable } from '@dnd-kit/core';
+
+const GRID_UNIT = 20; // matches $grid-unit-20 in index.scss
+
+// A single page in the sidebar tree plus its rendered subtree.
+//
+// Three overlay strips per row (top 25% / middle 50% / bottom 25%) act as
+// separate droppables. dnd-kit hit-tests their bounding boxes during a drag,
+// so we can leave pointer-events off them and not interfere with normal
+// clicks when nothing is being dragged.
+export default function PageRow( {
+	node,
+	depth,
+	selectedId,
+	expandedIds,
+	draggedId,
+	activeDrop, // { zone, targetId } | null
+	onSelect,
+	onToggleExpand,
+	onCreateChild,
+	onRename,
+	onDuplicate,
+	onDelete,
+	autoRenameId, // page id that should immediately enter rename mode
+	onAutoRenameConsumed,
+} ) {
+	const { page, children } = node;
+	const hasChildren = children.length > 0;
+	const isExpanded = expandedIds.has( page.id );
+	const isSelected = page.id === selectedId;
+	const isBeingDragged = draggedId === page.id;
+
+	const [ isRenaming, setIsRenaming ] = useState( false );
+	const [ draftTitle, setDraftTitle ] = useState( '' );
+	const renameInputRef = useRef( null );
+
+	// Start rename automatically if the parent asked for it (new page flow).
+	useEffect( () => {
+		if ( autoRenameId === page.id ) {
+			setDraftTitle( page.title?.raw ?? page.title?.rendered ?? '' );
+			setIsRenaming( true );
+			onAutoRenameConsumed?.();
+		}
+	}, [
+		autoRenameId,
+		page.id,
+		page.title?.raw,
+		page.title?.rendered,
+		onAutoRenameConsumed,
+	] );
+
+	// Focus the rename input whenever rename mode is entered. The ref sits on
+	// the wrapper div (TextControl doesn't forward refs to its input), so we
+	// have to reach in for the actual input element.
+	useEffect( () => {
+		if ( isRenaming && renameInputRef.current ) {
+			const input = renameInputRef.current.querySelector( 'input' );
+			input?.focus();
+			input?.select();
+		}
+	}, [ isRenaming ] );
+
+	// --- Drag source ---
+	const {
+		attributes,
+		listeners,
+		setNodeRef: setDragRef,
+	} = useDraggable( {
+		id: `page:${ page.id }`,
+		data: { pageId: page.id },
+	} );
+
+	// --- Drop zones (three strips overlaying the row) ---
+	const dropBefore = useDroppable( {
+		id: `before:${ page.id }`,
+		data: { zone: 'before', pageId: page.id },
+	} );
+	const dropInside = useDroppable( {
+		id: `inside:${ page.id }`,
+		data: { zone: 'inside', pageId: page.id },
+	} );
+	const dropAfter = useDroppable( {
+		id: `after:${ page.id }`,
+		data: { zone: 'after', pageId: page.id },
+	} );
+
+	const isDropTarget = activeDrop && activeDrop.targetId === page.id;
+
+	const rowClasses = [ 'cortext-sidebar__row' ];
+	if ( isSelected ) {
+		rowClasses.push( 'is-selected' );
+	}
+	if ( isBeingDragged ) {
+		rowClasses.push( 'is-dragging' );
+	}
+	if ( isDropTarget ) {
+		rowClasses.push( `is-drop-${ activeDrop.zone }` );
+	}
+
+	const title = page.title?.rendered?.trim() || __( '(untitled)', 'cortext' );
+
+	function commitRename() {
+		const next = draftTitle.trim();
+		if ( next && next !== ( page.title?.raw ?? page.title?.rendered ) ) {
+			onRename( page.id, next );
+		}
+		setIsRenaming( false );
+	}
+
+	function cancelRename() {
+		setIsRenaming( false );
+	}
+
+	function startRename() {
+		setDraftTitle( page.title?.raw ?? page.title?.rendered ?? '' );
+		setIsRenaming( true );
+	}
+
+	return (
+		<li className="cortext-sidebar__node">
+			<div
+				className="cortext-sidebar__row-wrapper"
+				style={ { '--cortext-depth': depth } }
+			>
+				<div
+					ref={ setDragRef }
+					className={ rowClasses.join( ' ' ) }
+					style={ {
+						paddingInlineStart: `${ depth * GRID_UNIT }px`,
+					} }
+					{ ...attributes }
+					{ ...listeners }
+				>
+					{ hasChildren ? (
+						<Button
+							className="cortext-sidebar__chevron"
+							icon={
+								isExpanded
+									? 'arrow-down-alt2'
+									: 'arrow-right-alt2'
+							}
+							label={
+								isExpanded
+									? __( 'Collapse', 'cortext' )
+									: __( 'Expand', 'cortext' )
+							}
+							onClick={ ( e ) => {
+								e.stopPropagation();
+								onToggleExpand( page.id );
+							} }
+							onPointerDown={ ( e ) => e.stopPropagation() }
+						/>
+					) : (
+						<span
+							className="cortext-sidebar__chevron cortext-sidebar__chevron--placeholder"
+							aria-hidden="true"
+						/>
+					) }
+
+					{ isRenaming ? (
+						<div
+							ref={ renameInputRef }
+							className="cortext-sidebar__rename"
+						>
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								value={ draftTitle }
+								onChange={ setDraftTitle }
+								onBlur={ commitRename }
+								onKeyDown={ ( e ) => {
+									e.stopPropagation();
+									if ( e.key === 'Enter' ) {
+										e.preventDefault();
+										commitRename();
+									} else if ( e.key === 'Escape' ) {
+										e.preventDefault();
+										cancelRename();
+									}
+								} }
+								onPointerDown={ ( e ) => e.stopPropagation() }
+							/>
+						</div>
+					) : (
+						<Button
+							className="cortext-sidebar__title"
+							onClick={ () => onSelect( page.id ) }
+							isPressed={ isSelected }
+						>
+							{ title }
+						</Button>
+					) }
+
+					<DropdownMenu
+						className="cortext-sidebar__menu"
+						icon="ellipsis"
+						label={ sprintf(
+							/* translators: %s: page title */
+							__( 'Actions for %s', 'cortext' ),
+							title
+						) }
+						popoverProps={ { placement: 'bottom-end' } }
+						toggleProps={ {
+							onPointerDown: ( e ) => e.stopPropagation(),
+						} }
+					>
+						{ ( { onClose } ) => (
+							<MenuGroup>
+								<MenuItem
+									icon="plus"
+									onClick={ () => {
+										onCreateChild( page.id );
+										onClose();
+									} }
+								>
+									{ __( 'Add child page', 'cortext' ) }
+								</MenuItem>
+								<MenuItem
+									icon="edit"
+									onClick={ () => {
+										startRename();
+										onClose();
+									} }
+								>
+									{ __( 'Rename', 'cortext' ) }
+								</MenuItem>
+								<MenuItem
+									icon="admin-page"
+									onClick={ () => {
+										onDuplicate( page.id );
+										onClose();
+									} }
+								>
+									{ __( 'Duplicate', 'cortext' ) }
+								</MenuItem>
+								<MenuItem
+									icon="trash"
+									isDestructive
+									onClick={ () => {
+										onDelete( page.id );
+										onClose();
+									} }
+								>
+									{ __( 'Delete', 'cortext' ) }
+								</MenuItem>
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+
+					{ /* Drop zones overlay the row. pointer-events are off
+					     so they don't block clicks when idle. */ }
+					<div
+						ref={ dropBefore.setNodeRef }
+						className="cortext-sidebar__drop-zone cortext-sidebar__drop-zone--before"
+						aria-hidden="true"
+					/>
+					<div
+						ref={ dropInside.setNodeRef }
+						className="cortext-sidebar__drop-zone cortext-sidebar__drop-zone--inside"
+						aria-hidden="true"
+					/>
+					<div
+						ref={ dropAfter.setNodeRef }
+						className="cortext-sidebar__drop-zone cortext-sidebar__drop-zone--after"
+						aria-hidden="true"
+					/>
+				</div>
+			</div>
+
+			{ hasChildren && isExpanded && (
+				<ul className="cortext-sidebar__children">
+					{ children.map( ( child ) => (
+						<PageRow
+							key={ child.page.id }
+							node={ child }
+							depth={ depth + 1 }
+							selectedId={ selectedId }
+							expandedIds={ expandedIds }
+							draggedId={ draggedId }
+							activeDrop={ activeDrop }
+							onSelect={ onSelect }
+							onToggleExpand={ onToggleExpand }
+							onCreateChild={ onCreateChild }
+							onRename={ onRename }
+							onDuplicate={ onDuplicate }
+							onDelete={ onDelete }
+							autoRenameId={ autoRenameId }
+							onAutoRenameConsumed={ onAutoRenameConsumed }
+						/>
+					) ) }
+				</ul>
+			) }
+		</li>
+	);
+}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,28 +1,292 @@
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { Button, Spinner } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useState, useMemo, useRef, useCallback } from '@wordpress/element';
+import {
+	Button,
+	Spinner,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import {
+	DndContext,
+	DragOverlay,
+	PointerSensor,
+	KeyboardSensor,
+	useSensor,
+	useSensors,
+	pointerWithin,
+} from '@dnd-kit/core';
+
+import PageRow from './PageRow';
+import {
+	buildTree,
+	collectDescendants,
+	computeDropTarget,
+	isDescendantOf,
+	nextChildOrder,
+} from './pages-tree';
 
 // Stand-in until the `cortext_page` CPT lands — change this constant to swap.
 const POST_TYPE = 'page';
+
+const AUTO_EXPAND_DELAY = 700;
+
+function parseDropId( id ) {
+	if ( typeof id !== 'string' ) {
+		return null;
+	}
+	const [ zone, rest ] = id.split( ':' );
+	const pageId = Number( rest );
+	if ( ! pageId || ! [ 'before', 'inside', 'after' ].includes( zone ) ) {
+		return null;
+	}
+	return { zone, targetId: pageId };
+}
 
 export default function Sidebar( { selectedId, onSelect } ) {
 	const { records, isResolving } = useEntityRecords( 'postType', POST_TYPE, {
 		per_page: 100,
 		status: [ 'private', 'publish' ],
+		context: 'edit',
 	} );
-	const { saveEntityRecord } = useDispatch( 'core' );
-	const pages = records ?? [];
+	const { saveEntityRecord, deleteEntityRecord } = useDispatch( 'core' );
+	const pages = useMemo( () => records ?? [], [ records ] );
 
-	async function createPage() {
+	const tree = useMemo( () => buildTree( pages ), [ pages ] );
+
+	const [ expandedIds, setExpandedIds ] = useState( () => new Set() );
+	const [ draggedId, setDraggedId ] = useState( null );
+	const [ activeDrop, setActiveDrop ] = useState( null );
+	const [ autoRenameId, setAutoRenameId ] = useState( null );
+	const [ pendingDeleteId, setPendingDeleteId ] = useState( null );
+
+	const autoExpandTimerRef = useRef( null );
+
+	// Pull the source record straight from core-data for Duplicate (needs
+	// content.raw, which useEntityRecords above already fetches via
+	// context=edit).
+	const getRecordById = useSelect(
+		( select ) => ( id ) =>
+			select( 'core' ).getEntityRecord( 'postType', POST_TYPE, id ),
+		[]
+	);
+
+	const toggleExpand = useCallback( ( id ) => {
+		setExpandedIds( ( prev ) => {
+			const next = new Set( prev );
+			if ( next.has( id ) ) {
+				next.delete( id );
+			} else {
+				next.add( id );
+			}
+			return next;
+		} );
+	}, [] );
+
+	const expand = useCallback( ( id ) => {
+		setExpandedIds( ( prev ) => {
+			if ( prev.has( id ) ) {
+				return prev;
+			}
+			const next = new Set( prev );
+			next.add( id );
+			return next;
+		} );
+	}, [] );
+
+	// --- Row actions -------------------------------------------------------
+
+	const createRootPage = useCallback( async () => {
 		const created = await saveEntityRecord( 'postType', POST_TYPE, {
 			status: 'private',
 			title: __( 'Untitled', 'cortext' ),
 		} );
 		if ( created?.id ) {
 			onSelect( created.id );
+			setAutoRenameId( created.id );
 		}
-	}
+	}, [ saveEntityRecord, onSelect ] );
+
+	const createChildPage = useCallback(
+		async ( parentId ) => {
+			const created = await saveEntityRecord( 'postType', POST_TYPE, {
+				status: 'private',
+				title: __( 'Untitled', 'cortext' ),
+				parent: parentId,
+				menu_order: nextChildOrder( parentId, pages ),
+			} );
+			if ( created?.id ) {
+				expand( parentId );
+				onSelect( created.id );
+				setAutoRenameId( created.id );
+			}
+		},
+		[ saveEntityRecord, pages, expand, onSelect ]
+	);
+
+	const renamePage = useCallback(
+		async ( id, title ) => {
+			await saveEntityRecord( 'postType', POST_TYPE, { id, title } );
+		},
+		[ saveEntityRecord ]
+	);
+
+	const duplicatePage = useCallback(
+		async ( id ) => {
+			const source = getRecordById( id );
+			if ( ! source ) {
+				return;
+			}
+			const sourceTitle =
+				source.title?.raw ?? source.title?.rendered ?? '';
+			const created = await saveEntityRecord( 'postType', POST_TYPE, {
+				status: 'private',
+				title: sourceTitle
+					? /* translators: %s: source page title */
+					  /* eslint-disable-next-line @wordpress/i18n-no-variables */
+					  `${ sourceTitle } ${ __( '(copy)', 'cortext' ) }`
+					: __( 'Untitled (copy)', 'cortext' ),
+				content: source.content?.raw ?? '',
+				parent: source.parent || 0,
+				menu_order: ( source.menu_order || 0 ) + 1,
+			} );
+			if ( created?.id ) {
+				if ( source.parent ) {
+					expand( source.parent );
+				}
+				onSelect( created.id );
+			}
+		},
+		[ saveEntityRecord, getRecordById, expand, onSelect ]
+	);
+
+	const confirmDelete = useCallback( async () => {
+		const id = pendingDeleteId;
+		setPendingDeleteId( null );
+		if ( ! id ) {
+			return;
+		}
+		const descendants = collectDescendants( id, pages );
+		// Delete children first, then the root.
+		for ( const childId of descendants ) {
+			// eslint-disable-next-line no-await-in-loop
+			await deleteEntityRecord( 'postType', POST_TYPE, childId, {
+				force: true,
+			} );
+		}
+		await deleteEntityRecord( 'postType', POST_TYPE, id, { force: true } );
+		if ( selectedId === id || descendants.includes( selectedId ) ) {
+			onSelect( null );
+		}
+	}, [ pendingDeleteId, pages, deleteEntityRecord, selectedId, onSelect ] );
+
+	// --- Drag and drop -----------------------------------------------------
+
+	const sensors = useSensors(
+		useSensor( PointerSensor, { activationConstraint: { distance: 5 } } ),
+		useSensor( KeyboardSensor )
+	);
+
+	const clearAutoExpandTimer = useCallback( () => {
+		if ( autoExpandTimerRef.current ) {
+			clearTimeout( autoExpandTimerRef.current );
+			autoExpandTimerRef.current = null;
+		}
+	}, [] );
+
+	const handleDragStart = useCallback( ( { active } ) => {
+		const id = active?.data?.current?.pageId ?? null;
+		setDraggedId( id );
+	}, [] );
+
+	const handleDragOver = useCallback(
+		( { over } ) => {
+			const parsed = over ? parseDropId( over.id ) : null;
+			if (
+				parsed &&
+				draggedId &&
+				( parsed.targetId === draggedId ||
+					// Reject cycles cheaply here too — computeDropTarget is
+					// the source of truth, but hiding the indicator feels
+					// better than flashing one.
+					isDescendantOf( parsed.targetId, draggedId, pages ) )
+			) {
+				setActiveDrop( null );
+				clearAutoExpandTimer();
+				return;
+			}
+			setActiveDrop( parsed );
+
+			// Auto-expand collapsed parent after hovering its "inside" zone.
+			clearAutoExpandTimer();
+			if ( parsed?.zone === 'inside' ) {
+				const target = pages.find( ( p ) => p.id === parsed.targetId );
+				const hasKids = pages.some(
+					( p ) => ( p.parent || 0 ) === parsed.targetId
+				);
+				if (
+					target &&
+					hasKids &&
+					! expandedIds.has( parsed.targetId )
+				) {
+					autoExpandTimerRef.current = setTimeout( () => {
+						expand( parsed.targetId );
+					}, AUTO_EXPAND_DELAY );
+				}
+			}
+		},
+		[ draggedId, pages, expandedIds, expand, clearAutoExpandTimer ]
+	);
+
+	const handleDragEnd = useCallback(
+		async ( { over } ) => {
+			const parsed = over ? parseDropId( over.id ) : null;
+			const activeId = draggedId;
+			setDraggedId( null );
+			setActiveDrop( null );
+			clearAutoExpandTimer();
+
+			if ( ! parsed || ! activeId ) {
+				return;
+			}
+
+			const updates = computeDropTarget(
+				activeId,
+				parsed.targetId,
+				parsed.zone,
+				pages
+			);
+			if ( ! updates ) {
+				return;
+			}
+
+			// The dragged record's update first, then siblings. Fire them in
+			// parallel — they touch different records.
+			await Promise.all(
+				updates.map( ( u ) =>
+					saveEntityRecord( 'postType', POST_TYPE, u )
+				)
+			);
+
+			if ( parsed.zone === 'inside' ) {
+				expand( parsed.targetId );
+			}
+		},
+		[ draggedId, pages, saveEntityRecord, expand, clearAutoExpandTimer ]
+	);
+
+	const handleDragCancel = useCallback( () => {
+		setDraggedId( null );
+		setActiveDrop( null );
+		clearAutoExpandTimer();
+	}, [ clearAutoExpandTimer ] );
+
+	// --- Render ------------------------------------------------------------
+
+	const draggedPage = draggedId
+		? pages.find( ( p ) => p.id === draggedId )
+		: null;
 
 	return (
 		<aside className="cortext-sidebar">
@@ -32,7 +296,7 @@ export default function Sidebar( { selectedId, onSelect } ) {
 					label={ __( 'Back to WordPress', 'cortext' ) }
 					href="index.php"
 				/>
-				<Button variant="primary" onClick={ createPage }>
+				<Button variant="primary" onClick={ createRootPage }>
 					{ __( 'New page', 'cortext' ) }
 				</Button>
 			</div>
@@ -46,19 +310,69 @@ export default function Sidebar( { selectedId, onSelect } ) {
 					{ __( 'No pages yet.', 'cortext' ) }
 				</p>
 			) }
-			<ul className="cortext-sidebar__list">
-				{ pages.map( ( page ) => (
-					<li key={ page.id }>
-						<Button
-							isPressed={ page.id === selectedId }
-							onClick={ () => onSelect( page.id ) }
-						>
-							{ page.title?.rendered ||
+
+			<DndContext
+				sensors={ sensors }
+				collisionDetection={ pointerWithin }
+				onDragStart={ handleDragStart }
+				onDragOver={ handleDragOver }
+				onDragEnd={ handleDragEnd }
+				onDragCancel={ handleDragCancel }
+			>
+				<ul className="cortext-sidebar__list">
+					{ tree.map( ( node ) => (
+						<PageRow
+							key={ node.page.id }
+							node={ node }
+							depth={ 0 }
+							selectedId={ selectedId }
+							expandedIds={ expandedIds }
+							draggedId={ draggedId }
+							activeDrop={ activeDrop }
+							onSelect={ onSelect }
+							onToggleExpand={ toggleExpand }
+							onCreateChild={ createChildPage }
+							onRename={ renamePage }
+							onDuplicate={ duplicatePage }
+							onDelete={ ( id ) => setPendingDeleteId( id ) }
+							autoRenameId={ autoRenameId }
+							onAutoRenameConsumed={ () =>
+								setAutoRenameId( null )
+							}
+						/>
+					) ) }
+				</ul>
+
+				<DragOverlay>
+					{ draggedPage ? (
+						<div className="cortext-sidebar__drag-preview">
+							{ draggedPage.title?.rendered?.trim() ||
 								__( '(untitled)', 'cortext' ) }
-						</Button>
-					</li>
-				) ) }
-			</ul>
+						</div>
+					) : null }
+				</DragOverlay>
+			</DndContext>
+
+			{ pendingDeleteId !== null && (
+				<ConfirmDialog
+					onConfirm={ confirmDelete }
+					onCancel={ () => setPendingDeleteId( null ) }
+					confirmButtonText={ __( 'Delete', 'cortext' ) }
+				>
+					{ renderDeleteMessage( pendingDeleteId, pages ) }
+				</ConfirmDialog>
+			) }
 		</aside>
+	);
+}
+
+function renderDeleteMessage( id, pages ) {
+	const descendants = collectDescendants( id, pages );
+	if ( descendants.length === 0 ) {
+		return __( 'Delete this page? This cannot be undone.', 'cortext' );
+	}
+	return __(
+		'Delete this page and all its child pages? This cannot be undone.',
+		'cortext'
 	);
 }

--- a/src/components/pages-tree.js
+++ b/src/components/pages-tree.js
@@ -1,0 +1,193 @@
+/**
+ * Pure helpers for turning the flat list of pages returned by the REST API
+ * into a nested tree, and for computing the minimal set of parent/menu_order
+ * updates needed when a page is dragged to a new spot.
+ */
+
+/**
+ * Build a tree from a flat array of page records.
+ *
+ * @param {Array} pages Flat array of page records (with id, parent, menu_order).
+ * @return {Array} Root nodes: { page, children }. Orphans (whose parent is
+ *                 not in the set) are promoted to roots. Siblings are sorted
+ *                 by menu_order, then id.
+ */
+export function buildTree( pages ) {
+	const map = new Map();
+	pages.forEach( ( page ) => {
+		map.set( page.id, { page, children: [] } );
+	} );
+
+	const roots = [];
+	pages.forEach( ( page ) => {
+		const node = map.get( page.id );
+		if ( page.parent && map.has( page.parent ) ) {
+			map.get( page.parent ).children.push( node );
+		} else {
+			roots.push( node );
+		}
+	} );
+
+	const sortSiblings = ( nodes ) => {
+		nodes.sort( ( a, b ) => {
+			const ao = a.page.menu_order || 0;
+			const bo = b.page.menu_order || 0;
+			if ( ao !== bo ) {
+				return ao - bo;
+			}
+			return a.page.id - b.page.id;
+		} );
+		nodes.forEach( ( n ) => sortSiblings( n.children ) );
+	};
+	sortSiblings( roots );
+
+	return roots;
+}
+
+/**
+ * Collect all descendant page IDs of a root page (root not included).
+ * Used by the cascading delete path.
+ *
+ * @param {number} rootId Root page ID.
+ * @param {Array}  pages  Flat page list.
+ * @return {number[]} Descendant IDs in no guaranteed order.
+ */
+export function collectDescendants( rootId, pages ) {
+	const childrenByParent = new Map();
+	pages.forEach( ( p ) => {
+		const arr = childrenByParent.get( p.parent ) || [];
+		arr.push( p.id );
+		childrenByParent.set( p.parent, arr );
+	} );
+
+	const out = [];
+	const stack = [ ...( childrenByParent.get( rootId ) || [] ) ];
+	while ( stack.length ) {
+		const id = stack.pop();
+		out.push( id );
+		const kids = childrenByParent.get( id );
+		if ( kids ) {
+			stack.push( ...kids );
+		}
+	}
+	return out;
+}
+
+/**
+ * True iff `descendantId` is anywhere in the ancestor chain of `ancestorId`.
+ * Used to reject drops that would create a cycle.
+ *
+ * @param {number} descendantId Candidate descendant.
+ * @param {number} ancestorId   Candidate ancestor.
+ * @param {Array}  pages        Flat page list.
+ * @return {boolean} True if descendantId is a descendant of ancestorId.
+ */
+export function isDescendantOf( descendantId, ancestorId, pages ) {
+	const byId = new Map( pages.map( ( p ) => [ p.id, p ] ) );
+	let current = byId.get( descendantId );
+	while ( current && current.parent ) {
+		if ( current.parent === ancestorId ) {
+			return true;
+		}
+		current = byId.get( current.parent );
+	}
+	return false;
+}
+
+/**
+ * Given a drag source, a hover target, and a drop zone, return the minimal
+ * set of record updates needed to persist the move. Returns `null` if the
+ * drop would be a no-op or would create a cycle.
+ *
+ * @param {number}                    draggedId ID of the page being dragged.
+ * @param {number}                    overId    ID of the page the cursor is hovering over.
+ * @param {'before'|'after'|'inside'} zone
+ * @param {Array}                     pages     Flat page list.
+ * @return {null | Array<{id: number, parent?: number, menu_order?: number}>}
+ *         First entry is always the dragged page's update; remaining entries
+ *         are sibling reshuffles whose menu_order actually needs to change.
+ */
+export function computeDropTarget( draggedId, overId, zone, pages ) {
+	if ( draggedId === overId ) {
+		return null;
+	}
+	if ( isDescendantOf( overId, draggedId, pages ) ) {
+		return null;
+	}
+
+	const over = pages.find( ( p ) => p.id === overId );
+	if ( ! over ) {
+		return null;
+	}
+
+	const dragged = pages.find( ( p ) => p.id === draggedId );
+	if ( ! dragged ) {
+		return null;
+	}
+
+	let newParent;
+	let insertIndex;
+
+	if ( zone === 'inside' ) {
+		newParent = overId;
+		const children = pages
+			.filter( ( p ) => p.parent === newParent && p.id !== draggedId )
+			.sort( ( a, b ) => ( a.menu_order || 0 ) - ( b.menu_order || 0 ) );
+		insertIndex = children.length; // append as last child
+	} else {
+		newParent = over.parent || 0;
+		const siblings = pages
+			.filter(
+				( p ) => ( p.parent || 0 ) === newParent && p.id !== draggedId
+			)
+			.sort( ( a, b ) => ( a.menu_order || 0 ) - ( b.menu_order || 0 ) );
+		const overIdx = siblings.findIndex( ( s ) => s.id === overId );
+		insertIndex = zone === 'before' ? overIdx : overIdx + 1;
+	}
+
+	const destinationSiblings = pages
+		.filter(
+			( p ) => ( p.parent || 0 ) === newParent && p.id !== draggedId
+		)
+		.sort( ( a, b ) => ( a.menu_order || 0 ) - ( b.menu_order || 0 ) );
+
+	const updates = [
+		{ id: draggedId, parent: newParent, menu_order: insertIndex },
+	];
+
+	destinationSiblings.forEach( ( sibling, i ) => {
+		const nextOrder = i >= insertIndex ? i + 1 : i;
+		if ( ( sibling.menu_order || 0 ) !== nextOrder ) {
+			updates.push( { id: sibling.id, menu_order: nextOrder } );
+		}
+	} );
+
+	// No-op guard: same parent + same slot.
+	if (
+		( dragged.parent || 0 ) === newParent &&
+		( dragged.menu_order || 0 ) === insertIndex &&
+		updates.length === 1
+	) {
+		return null;
+	}
+
+	return updates;
+}
+
+/**
+ * Compute the menu_order for a new child appended under `parentId`.
+ * Used by the "Add child page" action.
+ *
+ * @param {number} parentId Parent page ID.
+ * @param {Array}  pages    Flat page list.
+ * @return {number} menu_order value to use for the new child.
+ */
+export function nextChildOrder( parentId, pages ) {
+	const children = pages.filter( ( p ) => ( p.parent || 0 ) === parentId );
+	if ( children.length === 0 ) {
+		return 0;
+	}
+	return (
+		children.reduce( ( m, c ) => Math.max( m, c.menu_order || 0 ), 0 ) + 1
+	);
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -55,16 +55,135 @@ html.wp-toolbar {
 		padding: $grid-unit-10;
 	}
 
-	&__list {
+	&__list,
+	&__children {
 		list-style: none;
 		margin: 0;
 		padding: 0;
+	}
 
-		// Let list buttons span the sidebar width.
-		.components-button {
-			width: 100%;
-			justify-content: flex-start;
+	&__node {
+		margin: 0;
+	}
+
+	&__row-wrapper {
+		position: relative;
+	}
+
+	&__row {
+		position: relative;
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		border-radius: 2px;
+		cursor: grab;
+		user-select: none;
+
+		&.is-selected {
+			background: $gray-100;
 		}
+
+		&.is-dragging {
+			opacity: 0.4;
+		}
+
+		// Drop indicators: 2px lines above/below, tinted background for inside.
+		&.is-drop-before::before,
+		&.is-drop-after::after {
+			content: "";
+			position: absolute;
+			inset-inline: 0;
+			height: 2px;
+			background: var(--wp-admin-theme-color, $gray-700);
+			pointer-events: none;
+		}
+
+		&.is-drop-before::before {
+			top: -1px;
+		}
+
+		&.is-drop-after::after {
+			bottom: -1px;
+		}
+
+		&.is-drop-inside {
+			background: rgba($gray-700, 0.08);
+			outline: 1px dashed var(--wp-admin-theme-color, $gray-700);
+			outline-offset: -1px;
+		}
+	}
+
+	&__chevron {
+		flex: 0 0 auto;
+
+		&--placeholder {
+			display: inline-block;
+			width: $grid-unit-30;
+			height: $grid-unit-30;
+		}
+	}
+
+	&__title.components-button {
+		flex: 1 1 auto;
+		min-width: 0;
+		justify-content: flex-start;
+		text-align: start;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__rename {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	&__menu {
+		flex: 0 0 auto;
+		opacity: 0;
+		transition: opacity 0.12s ease;
+	}
+
+	&__row:hover &__menu,
+	&__row:focus-within &__menu,
+	&__menu.is-opened {
+		opacity: 1;
+	}
+
+	// Overlay droppable strips. Pointer-events off so they don't swallow
+	// clicks when idle; dnd-kit hit-tests them via getBoundingClientRect.
+	&__drop-zone {
+		position: absolute;
+		inset-inline: 0;
+		pointer-events: none;
+
+		&--before {
+			top: 0;
+			height: 25%;
+		}
+
+		&--inside {
+			top: 25%;
+			height: 50%;
+		}
+
+		&--after {
+			bottom: 0;
+			height: 25%;
+		}
+	}
+
+	&__drag-preview {
+		padding: $grid-unit-05 $grid-unit-15;
+		background: $white;
+		border: $border-width solid $gray-200;
+		border-radius: 2px;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+		font-size: 13px;
+		max-width: 260px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 }
 


### PR DESCRIPTION
## What

Adds hierarchical page navigation with drag-and-drop reorder and reparenting to the Cortext sidebar.

## Why

A flat page list doesn't match how writers think about document structures. Nested pages let users group, outline, and organize work the way they already do in Notion or Google Docs, right inside WordPress.

## How

The sidebar renders as a recursive `PageRow` component. Pure helpers in `pages-tree.js` turn the flat `useEntityRecords` payload into a tree using WordPress's built-in `post_parent` and `menu_order`, so there are no schema, REST, or PHP changes.

Drag-and-drop runs through `@dnd-kit/core`. Each row has three overlay drop zones (before, inside, after) and `pointerWithin` collision detection, which handles sibling reorder, reparent, and cycle-safe drops. Hovering the inside zone for 700ms auto-expands a collapsed parent so you can drop into it.

Each row gets a three-dots `DropdownMenu` with Add child page, inline Rename, Duplicate, and Delete. Delete opens a confirm dialog and cascades the full subtree.

## Testing Instructions

1. In the Cortext admin screen, click "New page" to create a root page, then use a row's three-dots menu to add a child. The parent should auto-expand and the new child should enter inline rename mode.
2. Rename, Duplicate, and Delete from the menu. Deleting a page with children prompts a subtree-delete confirmation.
3. Drag a row above or below a sibling to reorder. Drag onto the middle of another row to reparent. Hover inside a collapsed row to trigger auto-expand.
4. Try dragging a page onto one of its own descendants. No drop indicator should appear.