### PR TITLE
Add Prettier config, lint scripts, and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    lint:
+        name: JS / Lint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+
+            - run: npm ci
+            - run: npm run lint:js
+            - run: npm run lint:style
+            - run: npm run format:check
+
+    build:
+        name: JS / Build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+
+            - run: npm ci
+            - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ yarn-error.log*
 .wp-env.override.json
 .wp-env-plugins/
 
+# Claude Code local state (worktrees, settings, etc.)
+.claude/
+
 # Playwright MCP verification snapshots
 .playwright-mcp/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Hidden directories (local tooling, editor state, etc.) — except .github/ for workflows
+.*/
+!.github/
+
+# Dependencies and build output
+node_modules/
+vendor/
+build/
+dist/
+
+# Lockfiles
+package-lock.json
+composer.lock

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = require( '@wordpress/prettier-config' );

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
 		"start": "wp-env start --runtime=playground && npm run dev",
 		"dev": "wp-scripts start",
 		"build": "wp-scripts build",
-		"format": "wp-scripts format"
+		"format": "wp-scripts format",
+		"format:check": "wp-scripts format --check",
+		"lint:js": "wp-scripts lint-js",
+		"lint:style": "wp-scripts lint-style"
 	},
 	"devDependencies": {
 		"@wordpress/env": "^10.0.0",

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -81,7 +81,7 @@ export default function Sidebar() {
 	// `pages` doesn't contain the new id and a plain lookup would no-op.
 	const onSelect = useCallback(
 		( id, pageHint ) => {
-			if ( id == null ) {
+			if ( id === null || id === undefined ) {
 				navigate( { to: '/' } );
 				return;
 			}

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,6 +5,7 @@
 // `is-fullscreen-mode` rules for these elements live in `wp-edit-post`'s
 // stylesheet, which we don't enqueue — so we apply them ourselves.
 body.is-fullscreen-mode {
+
 	#wpadminbar,
 	#adminmenuback,
 	#adminmenuwrap,


### PR DESCRIPTION
## What

Adds Prettier config, lint scripts, and a GitHub Actions workflow that enforces them on every push and PR.

## Why

Establishes a baseline of automated quality checks for the project, starting with JS/SCSS formatting and lint. A follow-up PR will add PHPCS for the PHP side.

## How

- Adds Prettier config (via `@wordpress/prettier-config`), a matching ignore file, and `lint:js`, `lint:style`, `format:check` scripts wrapping `wp-scripts`.
- Adds `.github/workflows/ci.yml` with two parallel jobs: `JS / Lint` (lint + format check) and `JS / Build` (webpack build)
- Ignores `.claude/` in `.gitignore` so local worktrees don't show up as untracked.
- Fixes two pre-existing violations so CI starts green.

## Testing Instructions

Run locally:

- `npm ci`
- `npm run format:check`
- `npm run lint:js`
- `npm run lint:style`
- `npm run build`

All should exit cleanly. On GitHub, confirm the `JS / Build` check runs and passes on the PR.