### PR TITLE
Tests: add JavaScript unit tests and CI job

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,3 +30,17 @@ jobs:
             - run: composer install --no-interaction --prefer-dist
 
             - run: composer run test:php
+
+    js:
+        name: JavaScript
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+
+            - run: npm ci
+            - run: npm run test:unit

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+const base = require( '@wordpress/scripts/config/jest-unit.config' );
+
+module.exports = {
+	...base,
+	rootDir: '.',
+	setupFilesAfterEnv: [
+		...( base.setupFilesAfterEnv ?? [] ),
+		'<rootDir>/tests/js/setup.js',
+	],
+	testMatch: [ '<rootDir>/tests/js/**/*.test.js' ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,19 @@
 				"@wordpress/editor": "^14.44.0"
 			},
 			"devDependencies": {
+				"@testing-library/dom": "^10.4.1",
+				"@testing-library/jest-dom": "^6.9.1",
+				"@testing-library/react": "^16.3.2",
 				"@wordpress/env": "^10.0.0",
 				"@wordpress/scripts": "^30.0.0"
 			}
+		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+			"integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
@@ -7011,6 +7021,126 @@
 				"url": "https://github.com/sponsors/tannerlinsley"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@testing-library/jest-dom": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+			"integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@adobe/css-tools": "^4.4.0",
+				"aria-query": "^5.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.6.3",
+				"picocolors": "^1.1.1",
+				"redent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@testing-library/react": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+			"integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": "^10.0.0",
+				"@types/react": "^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^18.0.0 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -7038,6 +7168,13 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/aws-lambda": {
 			"version": "8.10.161",
@@ -13948,6 +14085,13 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -14624,6 +14768,13 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -20583,6 +20734,16 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"lz-string": "bin/bin.js"
 			}
 		},
 		"node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,14 @@
 		"format": "wp-scripts format",
 		"format:check": "wp-scripts format --check",
 		"lint:js": "wp-scripts lint-js",
-		"lint:style": "wp-scripts lint-style"
+		"lint:style": "wp-scripts lint-style",
+		"test:unit": "wp-scripts test-unit-js --config jest.config.js",
+		"test:unit:watch": "wp-scripts test-unit-js --config jest.config.js --watch"
 	},
 	"devDependencies": {
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^16.3.2",
 		"@wordpress/env": "^10.0.0",
 		"@wordpress/scripts": "^30.0.0"
 	},

--- a/tests/js/components/PageRow.test.js
+++ b/tests/js/components/PageRow.test.js
@@ -1,0 +1,138 @@
+/**
+ * Render + props-contract tests for `src/components/PageRow.js`:
+ * title rendering, depth indentation, chevron/placeholder, selection and
+ * drag/drop CSS class wiring, title-click selection, and the auto-rename
+ * flow triggered by `autoRenameId`. DnD interaction itself is not simulated —
+ * `PageRow` is wrapped in a `DndContext` only so `useDraggable`/`useDroppable`
+ * don't throw.
+ */
+
+import { render, fireEvent } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+
+import PageRow from '../../../src/components/PageRow';
+
+function makeNode( overrides = {} ) {
+	const { page = {}, children = [] } = overrides;
+	return {
+		page: {
+			id: 1,
+			title: { rendered: 'Hello', raw: 'Hello' },
+			...page,
+		},
+		children,
+	};
+}
+
+function baseProps( overrides = {} ) {
+	return {
+		node: makeNode(),
+		depth: 0,
+		selectedId: null,
+		expandedIds: new Set(),
+		draggedId: null,
+		activeDrop: null,
+		onSelect: jest.fn(),
+		onToggleExpand: jest.fn(),
+		onCreateChild: jest.fn(),
+		onRename: jest.fn(),
+		onDuplicate: jest.fn(),
+		onDelete: jest.fn(),
+		autoRenameId: null,
+		onAutoRenameConsumed: jest.fn(),
+		...overrides,
+	};
+}
+
+function renderRow( overrides = {} ) {
+	const props = baseProps( overrides );
+	const utils = render(
+		<DndContext>
+			<ul>
+				<PageRow { ...props } />
+			</ul>
+		</DndContext>
+	);
+	return { ...utils, props };
+}
+
+describe( 'PageRow', () => {
+	it( 'renders the page title', () => {
+		const { container } = renderRow();
+		expect(
+			container.querySelector( '.cortext-sidebar__title' )
+		).toHaveTextContent( 'Hello' );
+	} );
+
+	it( 'falls back to "(untitled)" when the title is blank', () => {
+		const { container } = renderRow( {
+			node: makeNode( { page: { title: { rendered: '', raw: '' } } } ),
+		} );
+		expect(
+			container.querySelector( '.cortext-sidebar__title' )
+		).toHaveTextContent( '(untitled)' );
+	} );
+
+	it( 'sets padding-inline-start based on depth (20px grid unit)', () => {
+		const { container } = renderRow( { depth: 3 } );
+		const row = container.querySelector( '.cortext-sidebar__row' );
+		expect( row ).toHaveStyle( { paddingInlineStart: '60px' } );
+	} );
+
+	it( 'renders a chevron when the node has children', () => {
+		const { container } = renderRow( {
+			node: makeNode( {
+				children: [ { page: { id: 2 }, children: [] } ],
+			} ),
+		} );
+		expect(
+			container.querySelector(
+				'.cortext-sidebar__chevron:not(.cortext-sidebar__chevron--placeholder)'
+			)
+		).toBeTruthy();
+	} );
+
+	it( 'renders a chevron placeholder when the node has no children', () => {
+		const { container } = renderRow();
+		expect(
+			container.querySelector( '.cortext-sidebar__chevron--placeholder' )
+		).toBeTruthy();
+	} );
+
+	it( 'calls onSelect with the page id when the title is clicked', () => {
+		const { container, props } = renderRow();
+		fireEvent.click( container.querySelector( '.cortext-sidebar__title' ) );
+		expect( props.onSelect ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'adds is-selected when selectedId matches', () => {
+		const { container } = renderRow( { selectedId: 1 } );
+		expect(
+			container.querySelector( '.cortext-sidebar__row' )
+		).toHaveClass( 'is-selected' );
+	} );
+
+	it( 'adds is-dragging when draggedId matches', () => {
+		const { container } = renderRow( { draggedId: 1 } );
+		expect(
+			container.querySelector( '.cortext-sidebar__row' )
+		).toHaveClass( 'is-dragging' );
+	} );
+
+	it( 'adds is-drop-inside when activeDrop targets this row', () => {
+		const { container } = renderRow( {
+			activeDrop: { zone: 'inside', targetId: 1 },
+		} );
+		expect(
+			container.querySelector( '.cortext-sidebar__row' )
+		).toHaveClass( 'is-drop-inside' );
+	} );
+
+	it( 'enters rename mode and consumes autoRenameId when it matches', () => {
+		const { container, props } = renderRow( { autoRenameId: 1 } );
+		expect(
+			container.querySelector( '.cortext-sidebar__rename input' )
+		).toBeTruthy();
+		expect( props.onAutoRenameConsumed ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/tests/js/pages-tree.test.js
+++ b/tests/js/pages-tree.test.js
@@ -1,0 +1,182 @@
+/**
+ * Pure-function tests for `src/components/pages-tree.js`: flat-to-tree
+ * building, descendant collection, cycle detection, drag-drop reorder math,
+ * and next-child menu_order allocation.
+ */
+
+import {
+	buildTree,
+	collectDescendants,
+	isDescendantOf,
+	computeDropTarget,
+	nextChildOrder,
+} from '../../src/components/pages-tree';
+
+function makePage( id, parent = 0, menuOrder = 0 ) {
+	return { id, parent, menu_order: menuOrder };
+}
+
+describe( 'buildTree', () => {
+	it( 'nests children under their parents', () => {
+		const pages = [ makePage( 1 ), makePage( 2, 1 ), makePage( 3, 2 ) ];
+		const roots = buildTree( pages );
+
+		expect( roots ).toHaveLength( 1 );
+		expect( roots[ 0 ].page.id ).toBe( 1 );
+		expect( roots[ 0 ].children ).toHaveLength( 1 );
+		expect( roots[ 0 ].children[ 0 ].page.id ).toBe( 2 );
+		expect( roots[ 0 ].children[ 0 ].children[ 0 ].page.id ).toBe( 3 );
+	} );
+
+	it( 'promotes orphans (missing parent) to roots', () => {
+		const pages = [ makePage( 1 ), makePage( 2, 999 ) ];
+		const roots = buildTree( pages );
+
+		expect( roots.map( ( r ) => r.page.id ).sort() ).toEqual( [ 1, 2 ] );
+	} );
+
+	it( 'sorts siblings by menu_order, then id', () => {
+		const pages = [
+			makePage( 3, 0, 0 ),
+			makePage( 1, 0, 2 ),
+			makePage( 2, 0, 0 ),
+		];
+		const roots = buildTree( pages );
+
+		expect( roots.map( ( r ) => r.page.id ) ).toEqual( [ 2, 3, 1 ] );
+	} );
+} );
+
+describe( 'collectDescendants', () => {
+	it( 'collects descendants of a root but not the root itself', () => {
+		const pages = [
+			makePage( 1 ),
+			makePage( 2, 1 ),
+			makePage( 3, 2 ),
+			makePage( 4, 1 ),
+			makePage( 99 ), // unrelated
+		];
+
+		const ids = collectDescendants( 1, pages ).sort();
+		expect( ids ).toEqual( [ 2, 3, 4 ] );
+	} );
+
+	it( 'returns empty for a leaf', () => {
+		const pages = [ makePage( 1 ), makePage( 2, 1 ) ];
+		expect( collectDescendants( 2, pages ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'isDescendantOf', () => {
+	const pages = [
+		makePage( 1 ),
+		makePage( 2, 1 ),
+		makePage( 3, 2 ),
+		makePage( 4 ),
+	];
+
+	it( 'returns true across a multi-level chain', () => {
+		expect( isDescendantOf( 3, 1, pages ) ).toBe( true );
+	} );
+
+	it( 'returns false for siblings or unrelated pages', () => {
+		expect( isDescendantOf( 4, 1, pages ) ).toBe( false );
+	} );
+
+	it( 'returns false when the page is missing', () => {
+		expect( isDescendantOf( 999, 1, pages ) ).toBe( false );
+	} );
+} );
+
+describe( 'computeDropTarget', () => {
+	it( 'returns null when dragging onto itself', () => {
+		const pages = [ makePage( 1 ), makePage( 2 ) ];
+		expect( computeDropTarget( 1, 1, 'before', pages ) ).toBeNull();
+	} );
+
+	it( 'blocks cycles (ancestor dropped onto descendant)', () => {
+		const pages = [ makePage( 1 ), makePage( 2, 1 ), makePage( 3, 2 ) ];
+		expect( computeDropTarget( 1, 3, 'inside', pages ) ).toBeNull();
+	} );
+
+	it( '"before" on a root reshuffles root-sibling menu_order', () => {
+		const pages = [
+			makePage( 1, 0, 0 ),
+			makePage( 2, 0, 1 ),
+			makePage( 3, 0, 2 ),
+		];
+		const updates = computeDropTarget( 3, 1, 'before', pages );
+
+		expect( updates[ 0 ] ).toEqual( { id: 3, parent: 0, menu_order: 0 } );
+		expect( updates.slice( 1 ) ).toEqual(
+			expect.arrayContaining( [
+				{ id: 1, menu_order: 1 },
+				{ id: 2, menu_order: 2 },
+			] )
+		);
+	} );
+
+	it( '"after" on a root places the dragged page right after', () => {
+		const pages = [
+			makePage( 1, 0, 0 ),
+			makePage( 2, 0, 1 ),
+			makePage( 3, 0, 2 ),
+		];
+		const updates = computeDropTarget( 3, 1, 'after', pages );
+
+		expect( updates[ 0 ] ).toEqual( { id: 3, parent: 0, menu_order: 1 } );
+		expect( updates.slice( 1 ) ).toEqual(
+			expect.arrayContaining( [ { id: 2, menu_order: 2 } ] )
+		);
+	} );
+
+	it( '"inside" reparents and appends as last child', () => {
+		const pages = [
+			makePage( 1 ),
+			makePage( 2, 1, 0 ),
+			makePage( 3, 1, 1 ),
+			makePage( 4 ),
+		];
+		const updates = computeDropTarget( 4, 1, 'inside', pages );
+
+		expect( updates ).toEqual( [ { id: 4, parent: 1, menu_order: 2 } ] );
+	} );
+
+	it( 'returns null for a same-parent, same-slot move', () => {
+		const pages = [ makePage( 1, 0, 0 ), makePage( 2, 0, 1 ) ];
+		expect( computeDropTarget( 1, 2, 'before', pages ) ).toBeNull();
+	} );
+
+	it( 'puts the dragged update first and only includes siblings whose menu_order changes', () => {
+		const pages = [
+			makePage( 1, 0, 0 ),
+			makePage( 2, 0, 1 ),
+			makePage( 3, 0, 2 ),
+		];
+		// Drag page 1 to "after" page 2: page 3 stays at menu_order 2, so it
+		// should NOT appear in the update list, while page 2 shifts to 0.
+		const updates = computeDropTarget( 1, 2, 'after', pages );
+
+		expect( updates[ 0 ].id ).toBe( 1 );
+		expect( updates.map( ( u ) => u.id ) ).toEqual(
+			expect.arrayContaining( [ 1, 2 ] )
+		);
+		expect( updates.every( ( u ) => u.id !== 3 ) ).toBe( true );
+	} );
+} );
+
+describe( 'nextChildOrder', () => {
+	it( 'returns 0 for an empty parent', () => {
+		expect( nextChildOrder( 1, [ makePage( 1 ) ] ) ).toBe( 0 );
+	} );
+
+	it( 'returns max(menu_order) + 1 otherwise', () => {
+		const pages = [
+			makePage( 1 ),
+			makePage( 2, 1, 0 ),
+			makePage( 3, 1, 4 ),
+			makePage( 4, 1, 2 ),
+		];
+		expect( nextChildOrder( 1, pages ) ).toBe( 5 );
+	} );
+} );

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tests/js/useResolveEntity.test.js
+++ b/tests/js/useResolveEntity.test.js
@@ -1,0 +1,128 @@
+/**
+ * Tests for `src/router/useResolveEntity.js`: the segment-walking URI → page
+ * resolver hook and the `computeUri` slug-chain helper. `@wordpress/api-fetch`
+ * is mocked so each case controls the REST responses driving the walk.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import {
+	useResolveEntity,
+	computeUri,
+} from '../../src/router/useResolveEntity';
+
+beforeEach( () => {
+	apiFetch.mockReset();
+} );
+
+describe( 'useResolveEntity', () => {
+	it( 'returns not-resolving immediately when uri is empty', () => {
+		const { result } = renderHook( () => useResolveEntity( '' ) );
+
+		expect( result.current ).toEqual( {
+			entity: null,
+			isResolving: false,
+			notFound: false,
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'resolves a single-segment uri with parent=0', async () => {
+		apiFetch.mockResolvedValueOnce( [ { id: 7, slug: 'foo', parent: 0 } ] );
+
+		const { result } = renderHook( () => useResolveEntity( 'foo' ) );
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toMatch(
+			/slug=foo(?:&|$)/
+		);
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toMatch(
+			/parent=0(?:&|$)/
+		);
+		expect( result.current ).toEqual( {
+			entity: { id: 7, slug: 'foo', parent: 0 },
+			isResolving: false,
+			notFound: false,
+		} );
+	} );
+
+	it( 'walks a two-segment uri, using parent id from the first hop', async () => {
+		apiFetch
+			.mockResolvedValueOnce( [ { id: 7, slug: 'foo', parent: 0 } ] )
+			.mockResolvedValueOnce( [ { id: 8, slug: 'bar', parent: 7 } ] );
+
+		const { result } = renderHook( () => useResolveEntity( 'foo/bar' ) );
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( apiFetch.mock.calls[ 1 ][ 0 ].path ).toMatch(
+			/slug=bar(?:&|$)/
+		);
+		expect( apiFetch.mock.calls[ 1 ][ 0 ].path ).toMatch(
+			/parent=7(?:&|$)/
+		);
+		expect( result.current.entity ).toEqual( {
+			id: 8,
+			slug: 'bar',
+			parent: 7,
+		} );
+	} );
+
+	it( 'sets notFound when a segment has no results', async () => {
+		apiFetch.mockResolvedValueOnce( [] );
+
+		const { result } = renderHook( () => useResolveEntity( 'ghost' ) );
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		expect( result.current ).toEqual( {
+			entity: null,
+			isResolving: false,
+			notFound: true,
+		} );
+	} );
+
+	it( 'sets notFound when apiFetch rejects', async () => {
+		apiFetch.mockRejectedValueOnce( new Error( 'boom' ) );
+
+		const { result } = renderHook( () => useResolveEntity( 'broken' ) );
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		expect( result.current.notFound ).toBe( true );
+		expect( result.current.entity ).toBeNull();
+	} );
+} );
+
+describe( 'computeUri', () => {
+	it( 'joins slugs walking the parent chain', () => {
+		const pages = [
+			{ id: 1, slug: 'top', parent: 0 },
+			{ id: 2, slug: 'mid', parent: 1 },
+			{ id: 3, slug: 'leaf', parent: 2 },
+		];
+		expect( computeUri( pages[ 2 ], pages ) ).toBe( 'top/mid/leaf' );
+	} );
+
+	it( 'stops cleanly when a parent id is missing from allPages', () => {
+		const pages = [ { id: 3, slug: 'leaf', parent: 99 } ];
+		expect( computeUri( pages[ 0 ], pages ) ).toBe( 'leaf' );
+	} );
+} );


### PR DESCRIPTION
## What
Adds a JavaScript unit test suite and a CI job that runs it.

## Why
Gives the sidebar tree, drag-and-drop reordering, and URI resolution automated coverage so future refactors can land with confidence.

## How
- Wiring Jest through `@wordpress/scripts`.
- Adding `tests/js/` specs for `pages-tree.js`, `PageRow`, and `useResolveEntity`.
- Extending the Unit Tests workflow with a Node 22 `js` job that runs `npm run test:unit`.

## Testing Instructions
1. `npm ci`
2. `npm run test:unit` (34 tests across 3 suites should pass)