### PR TITLE
Linting: Scope lint:js and lint:style to src/

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 		"build": "wp-scripts build",
 		"format": "wp-scripts format",
 		"format:check": "wp-scripts format --check",
-		"lint:js": "wp-scripts lint-js",
-		"lint:style": "wp-scripts lint-style",
+		"lint:js": "wp-scripts lint-js src",
+		"lint:style": "wp-scripts lint-style 'src/**/*.{css,pcss,scss}'",
 		"test:unit": "wp-scripts test-unit-js --config jest.config.js",
 		"test:unit:watch": "wp-scripts test-unit-js --config jest.config.js --watch"
 	},


### PR DESCRIPTION
## What

Scopes `lint:js` and `lint:style` to `src/`.

## Why

Running lint locally emitted thousands of errors from third-party CSS/JS under `vendor/` and `wordpress/`. CI didn't catch it because those dirs aren't installed there.

## How

Passing `src` and `src/**/*.{css,pcss,scss}` as explicit path args to `wp-scripts lint-js` and `wp-scripts lint-style` in `package.json`.

## Testing Instructions

Run `npm run lint:style` and `npm run lint:js`. Both should exit clean.