### PR TITLE
Editor: autosave Cortext pages

### DIFF
--- a/includes/Editor/RevisionThrottle.php
+++ b/includes/Editor/RevisionThrottle.php
@@ -5,9 +5,9 @@
  * TODO (dormant code): This class is a no-op until the `cortext_page` CPT is
  * registered. While the app still points at the built-in `page` post type as a
  * stand-in, editing a Cortext page in dev will create a WP revision every ~2s
- * of typing. That's cosmetic clutter in `wp_posts`, not a correctness issue —
- * intentional, because scoping the throttle to `page` would alter core WP
- * behavior for other plugins/themes. Remove this TODO block and verify
+ * of typing. That's cosmetic clutter in `wp_posts`, not a correctness issue.
+ * This is intentional, because scoping the throttle to `page` would alter
+ * core WP behavior for other plugins/themes. Remove this TODO block and verify
  * end-to-end once the CPT lands.
  *
  * @package Cortext

--- a/includes/Editor/RevisionThrottle.php
+++ b/includes/Editor/RevisionThrottle.php
@@ -34,8 +34,8 @@ final class RevisionThrottle {
 	private const REVISIONS_TO_KEEP = 50;
 
 	public function register(): void {
-		add_filter( 'wp_save_post_revision_post_has_changed', [ $this, 'throttle_revision' ], 10, 3 );
-		add_filter( 'wp_revisions_to_keep', [ $this, 'cap_revisions' ], 10, 2 );
+		add_filter( 'wp_save_post_revision_post_has_changed', array( $this, 'throttle_revision' ), 10, 3 );
+		add_filter( 'wp_revisions_to_keep', array( $this, 'cap_revisions' ), 10, 2 );
 	}
 
 	/**
@@ -63,6 +63,8 @@ final class RevisionThrottle {
 	}
 
 	/**
+	 * Caps the number of revisions retained per Cortext page.
+	 *
 	 * @param int     $num  Default number of revisions to keep.
 	 * @param WP_Post $post The post being saved.
 	 */

--- a/includes/Editor/RevisionThrottle.php
+++ b/includes/Editor/RevisionThrottle.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Throttles WordPress revision creation for Cortext-managed post types.
+ *
+ * TODO (dormant code): This class is a no-op until the `cortext_page` CPT is
+ * registered. While the app still points at the built-in `page` post type as a
+ * stand-in, editing a Cortext page in dev will create a WP revision every ~2s
+ * of typing. That's cosmetic clutter in `wp_posts`, not a correctness issue —
+ * intentional, because scoping the throttle to `page` would alter core WP
+ * behavior for other plugins/themes. Remove this TODO block and verify
+ * end-to-end once the CPT lands.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Editor;
+
+use WP_Post;
+
+final class RevisionThrottle {
+
+	private const POST_TYPE = 'cortext_page';
+
+	/**
+	 * Minimum time between revision snapshots. Mirrors Notion's ~10 minute cadence.
+	 */
+	private const MIN_INTERVAL_SECONDS = 600;
+
+	/**
+	 * Total revisions to retain per Cortext page.
+	 */
+	private const REVISIONS_TO_KEEP = 50;
+
+	public function register(): void {
+		add_filter( 'wp_save_post_revision_post_has_changed', [ $this, 'throttle_revision' ], 10, 3 );
+		add_filter( 'wp_revisions_to_keep', [ $this, 'cap_revisions' ], 10, 2 );
+	}
+
+	/**
+	 * Suppresses revision creation if the last revision is newer than the throttle window.
+	 *
+	 * @param bool    $post_has_changed Whether WordPress detected content changes.
+	 * @param WP_Post $last_revision    The most recent prior revision.
+	 * @param WP_Post $post             The post being saved.
+	 */
+	public function throttle_revision( bool $post_has_changed, WP_Post $last_revision, WP_Post $post ): bool {
+		if ( self::POST_TYPE !== $post->post_type ) {
+			return $post_has_changed;
+		}
+
+		$last_revision_time = strtotime( $last_revision->post_modified_gmt . ' UTC' );
+		if ( false === $last_revision_time ) {
+			return $post_has_changed;
+		}
+
+		if ( ( time() - $last_revision_time ) < self::MIN_INTERVAL_SECONDS ) {
+			return false;
+		}
+
+		return $post_has_changed;
+	}
+
+	/**
+	 * @param int     $num  Default number of revisions to keep.
+	 * @param WP_Post $post The post being saved.
+	 */
+	public function cap_revisions( int $num, WP_Post $post ): int {
+		if ( self::POST_TYPE !== $post->post_type ) {
+			return $num;
+		}
+		return self::REVISIONS_TO_KEEP;
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Cortext;
 
 use Cortext\Admin\Screen;
+use Cortext\Editor\RevisionThrottle;
 
 final class Plugin {
 
@@ -24,6 +25,7 @@ final class Plugin {
 
 	public function boot(): void {
 		( new Screen() )->register();
+		( new RevisionThrottle() )->register();
 	}
 
 	private function __construct() {}

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -20,18 +20,37 @@ import {
 import { Button, Spinner } from '@wordpress/components';
 import { cog } from '@wordpress/icons';
 
+import useAutosave from '../hooks/useAutosave';
+
 const POST_TYPE = 'page';
 const SCOPE = 'cortext';
 const INSPECTOR = 'cortext/block-inspector';
 
+const STATUS_LABELS = {
+	idle: '',
+	saving: __( 'Saving…', 'cortext' ),
+	saved: __( 'Saved', 'cortext' ),
+	error: __( 'Failed to save', 'cortext' ),
+};
+
+function SaveStatus() {
+	const { status } = useAutosave();
+	const label = STATUS_LABELS[ status ] ?? '';
+
+	return (
+		<div
+			className={ `cortext-canvas__status cortext-canvas__status--${ status }` }
+			role="status"
+			aria-live="polite"
+		>
+			{ label }
+		</div>
+	);
+}
+
 function Header() {
-	const { savePost } = useDispatch( editorStore );
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
-	const isSaving = useSelect(
-		( select ) => select( editorStore ).isSavingPost(),
-		[]
-	);
 	const isInspectorOpen = useSelect(
 		( select ) =>
 			select( interfaceStore ).getActiveComplementaryArea( SCOPE ) ===
@@ -41,15 +60,7 @@ function Header() {
 
 	return (
 		<div className="cortext-canvas__header">
-			<Button
-				variant="primary"
-				isBusy={ isSaving }
-				onClick={ () => savePost() }
-			>
-				{ isSaving
-					? __( 'Saving…', 'cortext' )
-					: __( 'Save', 'cortext' ) }
-			</Button>
+			<SaveStatus />
 			<Button
 				icon={ cog }
 				label={ __( 'Settings', 'cortext' ) }

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+const DEBOUNCE_MS = 800;
+const MIN_SAVE_INTERVAL_MS = 2000;
+
+export default function useAutosave() {
+	const { savePost } = useDispatch( editorStore );
+
+	const { isDirty, isSaveable, isSaving, didSucceed, didFail } = useSelect(
+		( select ) => {
+			const editor = select( editorStore );
+			return {
+				isDirty: editor.isEditedPostDirty(),
+				isSaveable: editor.isEditedPostSaveable(),
+				isSaving: editor.isSavingPost(),
+				didSucceed: editor.didPostSaveRequestSucceed(),
+				didFail: editor.didPostSaveRequestFail(),
+			};
+		},
+		[]
+	);
+
+	const [ status, setStatus ] = useState( 'idle' );
+	const [ lastSavedAt, setLastSavedAt ] = useState( null );
+
+	const debounceRef = useRef( null );
+	const lastSaveAtRef = useRef( 0 );
+
+	const stateRef = useRef( { isDirty, isSaveable, isSaving, savePost } );
+	stateRef.current = { isDirty, isSaveable, isSaving, savePost };
+
+	const flushNow = () => {
+		if ( debounceRef.current ) {
+			clearTimeout( debounceRef.current );
+			debounceRef.current = null;
+		}
+		const {
+			isDirty: d,
+			isSaveable: s,
+			isSaving: saving,
+			savePost: save,
+		} = stateRef.current;
+		if ( d && s && ! saving ) {
+			lastSaveAtRef.current = Date.now();
+			save();
+		}
+	};
+
+	useEffect( () => {
+		if ( ! isDirty || ! isSaveable ) {
+			return undefined;
+		}
+		const elapsed = Date.now() - lastSaveAtRef.current;
+		const wait = Math.max( DEBOUNCE_MS, MIN_SAVE_INTERVAL_MS - elapsed );
+
+		if ( debounceRef.current ) {
+			clearTimeout( debounceRef.current );
+		}
+		debounceRef.current = setTimeout( () => {
+			debounceRef.current = null;
+			const {
+				isDirty: d,
+				isSaveable: s,
+				isSaving: saving,
+				savePost: save,
+			} = stateRef.current;
+			if ( d && s && ! saving ) {
+				lastSaveAtRef.current = Date.now();
+				save();
+			}
+		}, wait );
+
+		return () => {
+			if ( debounceRef.current ) {
+				clearTimeout( debounceRef.current );
+				debounceRef.current = null;
+			}
+		};
+	}, [ isDirty, isSaveable ] );
+
+	useEffect( () => {
+		if ( isSaving ) {
+			setStatus( 'saving' );
+		} else if ( didFail ) {
+			setStatus( 'error' );
+		} else if ( didSucceed ) {
+			setStatus( 'saved' );
+			setLastSavedAt( Date.now() );
+		}
+	}, [ isSaving, didSucceed, didFail ] );
+
+	useEffect( () => {
+		const onVisibilityChange = () => {
+			if ( document.visibilityState === 'hidden' ) {
+				flushNow();
+			}
+		};
+		const onBlur = () => flushNow();
+		const onBeforeUnload = () => flushNow();
+
+		document.addEventListener( 'visibilitychange', onVisibilityChange );
+		window.addEventListener( 'blur', onBlur );
+		window.addEventListener( 'beforeunload', onBeforeUnload );
+
+		return () => {
+			document.removeEventListener(
+				'visibilitychange',
+				onVisibilityChange
+			);
+			window.removeEventListener( 'blur', onBlur );
+			window.removeEventListener( 'beforeunload', onBeforeUnload );
+			flushNow();
+		};
+	}, [] );
+
+	return { status, lastSavedAt };
+}

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -1,0 +1,250 @@
+/**
+ * Tests for `src/hooks/useAutosave.js`: debounce + throttle cadence, the
+ * idle/saving/saved/error state machine, and flush triggers (window blur,
+ * visibilitychange, beforeunload, unmount). `@wordpress/data` and the editor
+ * store are mocked so each test controls what the hook reads from the store.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	store: { name: 'core/editor' },
+} ) );
+
+import { useSelect, useDispatch } from '@wordpress/data';
+import useAutosave from '../../src/hooks/useAutosave';
+
+const DEFAULT_STATE = {
+	isDirty: false,
+	isSaveable: true,
+	isSaving: false,
+	didSucceed: false,
+	didFail: false,
+};
+
+function setStoreState( state ) {
+	const merged = { ...DEFAULT_STATE, ...state };
+	useSelect.mockReturnValue( merged );
+}
+
+beforeEach( () => {
+	jest.useFakeTimers();
+	setStoreState( {} );
+	useDispatch.mockReturnValue( { savePost: jest.fn() } );
+} );
+
+afterEach( () => {
+	jest.clearAllTimers();
+	jest.useRealTimers();
+	jest.clearAllMocks();
+} );
+
+describe( 'useAutosave — debounce', () => {
+	it( 'does not save until DEBOUNCE_MS has elapsed after dirty', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 799 );
+		} );
+		expect( savePost ).not.toHaveBeenCalled();
+
+		act( () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'skips save when not dirty', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: false } );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+		expect( savePost ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips save when not saveable', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true, isSaveable: false } );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+		expect( savePost ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips save while a save is already in flight', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true, isSaving: true } );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+		expect( savePost ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'useAutosave — throttle', () => {
+	it( 'waits for the remainder of MIN_SAVE_INTERVAL after a recent save', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		const { rerender } = renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 800 );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+
+		// Clean state, then dirty again 400ms later — throttle should delay
+		// the next save to 2000 - 400 = 1600ms from the first save.
+		setStoreState( { isDirty: false } );
+		rerender();
+		act( () => {
+			jest.advanceTimersByTime( 400 );
+		} );
+		setStoreState( { isDirty: true } );
+		rerender();
+
+		act( () => {
+			jest.advanceTimersByTime( 1599 );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 2 );
+	} );
+} );
+
+describe( 'useAutosave — flush triggers', () => {
+	it( 'flushes immediately on window blur', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			window.dispatchEvent( new Event( 'blur' ) );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'flushes when document becomes hidden', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		renderHook( () => useAutosave() );
+
+		Object.defineProperty( document, 'visibilityState', {
+			configurable: true,
+			get: () => 'hidden',
+		} );
+
+		try {
+			act( () => {
+				document.dispatchEvent( new Event( 'visibilitychange' ) );
+			} );
+			expect( savePost ).toHaveBeenCalledTimes( 1 );
+		} finally {
+			// Remove the instance-level override so the prototype's
+			// default 'visible' getter takes over again.
+			delete document.visibilityState;
+		}
+	} );
+
+	it( 'does not flush on visibilitychange when document is visible', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		renderHook( () => useAutosave() );
+
+		// jsdom's default visibilityState is 'visible'.
+		act( () => {
+			document.dispatchEvent( new Event( 'visibilitychange' ) );
+		} );
+		expect( savePost ).not.toHaveBeenCalled();
+	} );
+
+	it( 'flushes on unmount', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		const { unmount } = renderHook( () => useAutosave() );
+
+		unmount();
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not flush on blur when not dirty', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: false } );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			window.dispatchEvent( new Event( 'blur' ) );
+		} );
+		expect( savePost ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'useAutosave — status', () => {
+	it( 'starts idle', () => {
+		const { result } = renderHook( () => useAutosave() );
+
+		expect( result.current.status ).toBe( 'idle' );
+		expect( result.current.lastSavedAt ).toBeNull();
+	} );
+
+	it( 'reports saving while a save is in flight', () => {
+		setStoreState( { isSaving: true } );
+
+		const { result } = renderHook( () => useAutosave() );
+
+		expect( result.current.status ).toBe( 'saving' );
+	} );
+
+	it( 'reports saved and captures lastSavedAt after a successful save', () => {
+		setStoreState( { didSucceed: true } );
+
+		const { result } = renderHook( () => useAutosave() );
+
+		expect( result.current.status ).toBe( 'saved' );
+		expect( typeof result.current.lastSavedAt ).toBe( 'number' );
+	} );
+
+	it( 'reports error after a failed save', () => {
+		setStoreState( { didFail: true } );
+
+		const { result } = renderHook( () => useAutosave() );
+
+		expect( result.current.status ).toBe( 'error' );
+	} );
+} );

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -44,7 +44,7 @@ afterEach( () => {
 	jest.clearAllMocks();
 } );
 
-describe( 'useAutosave — debounce', () => {
+describe( 'useAutosave: debounce', () => {
 	it( 'does not save until DEBOUNCE_MS has elapsed after dirty', () => {
 		const savePost = jest.fn();
 		useDispatch.mockReturnValue( { savePost } );
@@ -103,7 +103,7 @@ describe( 'useAutosave — debounce', () => {
 	} );
 } );
 
-describe( 'useAutosave — throttle', () => {
+describe( 'useAutosave: throttle', () => {
 	it( 'waits for the remainder of MIN_SAVE_INTERVAL after a recent save', () => {
 		const savePost = jest.fn();
 		useDispatch.mockReturnValue( { savePost } );
@@ -116,7 +116,7 @@ describe( 'useAutosave — throttle', () => {
 		} );
 		expect( savePost ).toHaveBeenCalledTimes( 1 );
 
-		// Clean state, then dirty again 400ms later — throttle should delay
+		// Clean state, then dirty again 400ms later; throttle should delay
 		// the next save to 2000 - 400 = 1600ms from the first save.
 		setStoreState( { isDirty: false } );
 		rerender();
@@ -138,7 +138,7 @@ describe( 'useAutosave — throttle', () => {
 	} );
 } );
 
-describe( 'useAutosave — flush triggers', () => {
+describe( 'useAutosave: flush triggers', () => {
 	it( 'flushes immediately on window blur', () => {
 		const savePost = jest.fn();
 		useDispatch.mockReturnValue( { savePost } );
@@ -215,7 +215,7 @@ describe( 'useAutosave — flush triggers', () => {
 	} );
 } );
 
-describe( 'useAutosave — status', () => {
+describe( 'useAutosave: status', () => {
 	it( 'starts idle', () => {
 		const { result } = renderHook( () => useAutosave() );
 

--- a/tests/php/test-revision-throttle.php
+++ b/tests/php/test-revision-throttle.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Tests for Cortext\Editor\RevisionThrottle.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Editor\RevisionThrottle;
+use WorDBless\BaseTestCase;
+use WP_Post;
+
+final class Test_Revision_Throttle extends BaseTestCase {
+
+	private const POST_TYPE = 'cortext_page';
+
+	private function make_post( string $post_type ): WP_Post {
+		return new WP_Post(
+			(object) array(
+				'ID'        => 1,
+				'post_type' => $post_type,
+			)
+		);
+	}
+
+	private function make_revision( int $seconds_ago ): WP_Post {
+		return new WP_Post(
+			(object) array(
+				'ID'                => 2,
+				'post_type'         => 'revision',
+				'post_modified_gmt' => gmdate( 'Y-m-d H:i:s', time() - $seconds_ago ),
+			)
+		);
+	}
+
+	public function test_register_hooks_both_filters(): void {
+		remove_all_filters( 'wp_save_post_revision_post_has_changed' );
+		remove_all_filters( 'wp_revisions_to_keep' );
+
+		( new RevisionThrottle() )->register();
+
+		$this->assertNotFalse(
+			has_filter( 'wp_save_post_revision_post_has_changed' ),
+			'throttle_revision filter should be registered.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'wp_revisions_to_keep' ),
+			'cap_revisions filter should be registered.'
+		);
+	}
+
+	public function test_throttle_passes_through_for_non_cortext_post_types(): void {
+		$throttle = new RevisionThrottle();
+		$post     = $this->make_post( 'page' );
+		$revision = $this->make_revision( 1 );
+
+		$this->assertTrue( $throttle->throttle_revision( true, $revision, $post ) );
+		$this->assertFalse( $throttle->throttle_revision( false, $revision, $post ) );
+	}
+
+	public function test_throttle_suppresses_cortext_page_within_interval_window(): void {
+		$throttle = new RevisionThrottle();
+		$post     = $this->make_post( self::POST_TYPE );
+		$revision = $this->make_revision( 60 );
+
+		$this->assertFalse(
+			$throttle->throttle_revision( true, $revision, $post ),
+			'Recent revisions should suppress the new revision even when the post changed.'
+		);
+	}
+
+	public function test_throttle_just_inside_window_still_suppresses(): void {
+		$throttle = new RevisionThrottle();
+		$post     = $this->make_post( self::POST_TYPE );
+		$revision = $this->make_revision( 599 );
+
+		$this->assertFalse( $throttle->throttle_revision( true, $revision, $post ) );
+	}
+
+	public function test_throttle_passes_through_once_interval_has_elapsed(): void {
+		$throttle = new RevisionThrottle();
+		$post     = $this->make_post( self::POST_TYPE );
+		$revision = $this->make_revision( 601 );
+
+		$this->assertTrue(
+			$throttle->throttle_revision( true, $revision, $post ),
+			'Old revisions should let a new revision through when the post changed.'
+		);
+		$this->assertFalse(
+			$throttle->throttle_revision( false, $revision, $post ),
+			'Old revisions should preserve the incoming "no change" verdict.'
+		);
+	}
+
+	public function test_throttle_passes_through_when_revision_timestamp_is_invalid(): void {
+		$throttle = new RevisionThrottle();
+		$post     = $this->make_post( self::POST_TYPE );
+		$revision = new WP_Post(
+			(object) array(
+				'ID'                => 2,
+				'post_type'         => 'revision',
+				'post_modified_gmt' => 'not-a-date',
+			)
+		);
+
+		$this->assertTrue( $throttle->throttle_revision( true, $revision, $post ) );
+	}
+
+	public function test_cap_revisions_passes_through_for_non_cortext_post_types(): void {
+		$throttle = new RevisionThrottle();
+		$post     = $this->make_post( 'page' );
+
+		$this->assertSame( 25, $throttle->cap_revisions( 25, $post ) );
+		$this->assertSame( -1, $throttle->cap_revisions( -1, $post ) );
+	}
+
+	public function test_cap_revisions_caps_cortext_page_regardless_of_incoming_value(): void {
+		$throttle = new RevisionThrottle();
+		$post     = $this->make_post( self::POST_TYPE );
+
+		$this->assertSame( 50, $throttle->cap_revisions( 5, $post ) );
+		$this->assertSame( 50, $throttle->cap_revisions( -1, $post ) );
+		$this->assertSame( 50, $throttle->cap_revisions( 999, $post ) );
+	}
+}


### PR DESCRIPTION
## What
Replaces the Save button with autosave on Cortext page edits.

## Why
Cortext targets a Notion-like flow where edits persist live.

## How
- Adding `useAutosave`, which debounces `savePost` 800ms after the last change, throttles to one save per 2s, and flushes on blur, visibility change, unmount, and `beforeunload`. Canvas now renders a small Saving…/Saved/error indicator where the button used to be.
- Adding `RevisionThrottle`, which suppresses `wp_save_post_revision_post_has_changed` unless the last revision is at least 10 minutes old and caps `wp_revisions_to_keep` at 50. Scoped to `cortext_page`, so it's dormant until that CPT lands.

## Testing Instructions
1. Open a Cortext page in the editor.
2. Type; the status indicator should go Saving… → Saved within ~1s after you stop.
3. Reload; edits persist.

 `npm run test:unit` and `composer test` both pass (new `useAutosave` and `RevisionThrottle` suites).