### PR TITLE
Tests: add Playwright e2e smoke tests for the shell

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,19 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+                  tools: composer:v2
+                  coverage: none
+
+            - uses: actions/cache@v4
+              with:
+                  path: ~/.composer/cache
+                  key: composer-${{ hashFiles('composer.lock') }}
+
+            - run: composer install --no-interaction --prefer-dist --no-dev
+
             - uses: actions/setup-node@v4
               with:
                   node-version: '22'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,44 @@
+name: E2E
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    playwright:
+        name: Playwright
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'npm'
+
+            - run: npm ci
+
+            - run: npx playwright install --with-deps chromium
+
+            - run: npm run build
+
+            - run: npm run env:start
+
+            - run: npm run test:e2e
+              env:
+                  WP_BASE_URL: http://localhost:8888
+
+            - if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-artifacts
+                  path: |
+                      artifacts/
+                      playwright-report/
+                  retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,10 @@ yarn-error.log*
 # Coverage
 coverage/
 
+# Playwright
+artifacts/
+playwright-report/
+test-results/
+
 # Serena project metadata
 .serena/

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,11 @@
 				"@wordpress/interface": "^9.0.0"
 			},
 			"devDependencies": {
+				"@playwright/test": "^1.48.0",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
+				"@wordpress/e2e-test-utils-playwright": "^1.44.0",
 				"@wordpress/env": "^10.0.0",
 				"@wordpress/scripts": "^30.0.0"
 			}
@@ -5726,7 +5728,6 @@
 			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"playwright": "1.59.1"
 			},
@@ -22506,7 +22507,6 @@
 			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"playwright-core": "1.59.1"
 			},
@@ -22526,7 +22526,6 @@
 			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -22545,7 +22544,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -12,13 +12,18 @@
 		"format:check": "wp-scripts format --check",
 		"lint:js": "wp-scripts lint-js src",
 		"lint:style": "wp-scripts lint-style 'src/**/*.{css,pcss,scss}'",
+		"env:start": "wp-env start --runtime=playground",
 		"test:unit": "wp-scripts test-unit-js --config jest.config.js",
-		"test:unit:watch": "wp-scripts test-unit-js --config jest.config.js --watch"
+		"test:unit:watch": "wp-scripts test-unit-js --config jest.config.js --watch",
+		"test:e2e": "wp-scripts test-playwright --config playwright.config.js",
+		"test:e2e:debug": "wp-scripts test-playwright --config playwright.config.js --ui"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.48.0",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
+		"@wordpress/e2e-test-utils-playwright": "^1.44.0",
 		"@wordpress/env": "^10.0.0",
 		"@wordpress/scripts": "^30.0.0"
 	},

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,41 @@
+/**
+ * Playwright config for Cortext e2e tests.
+ *
+ * Extends the @wordpress/scripts default config. Resolves WP_BASE_URL from:
+ *   1. env var (CI sets this explicitly)
+ *   2. .wp-env.override.json port (per-worktree local dev)
+ *   3. wp-env default 8888 (Playground has no separate tests env)
+ */
+
+// Resolve before requiring the base config, which reads WP_BASE_URL at load time.
+function resolveBaseURL() {
+	if ( process.env.WP_BASE_URL ) {
+		return process.env.WP_BASE_URL;
+	}
+	try {
+		// eslint-disable-next-line global-require
+		const override = require( './.wp-env.override.json' );
+		if ( override.port ) {
+			return `http://localhost:${ override.port }`;
+		}
+	} catch ( _error ) {
+		// File is gitignored; absent on CI.
+	}
+	return 'http://localhost:8888';
+}
+
+process.env.WP_BASE_URL = resolveBaseURL();
+
+const { defineConfig } = require( '@playwright/test' );
+const baseConfig = require( '@wordpress/scripts/config/playwright.config.js' );
+
+module.exports = defineConfig( {
+	...baseConfig,
+	testDir: './tests/e2e/specs',
+	// wp-env is started explicitly by the developer / CI.
+	webServer: undefined,
+	use: {
+		...baseConfig.use,
+		video: 'off',
+	},
+} );

--- a/tests/e2e/specs/shell.spec.js
+++ b/tests/e2e/specs/shell.spec.js
@@ -1,0 +1,78 @@
+/**
+ * Smoke tests for the Cortext wp-admin shell page.
+ *
+ * The shell is registered via add_menu_page() in Cortext\Admin\Screen, so the
+ * three behaviors we care about are enforced by wp-admin itself:
+ *   1. User with edit_posts → page renders with #cortext-root mounted.
+ *   2. Anonymous user → auth_redirect to wp-login.php.
+ *   3. Logged-in user without edit_posts → wp_die with 403.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SHELL_PATH = '/wp-admin/admin.php?page=cortext';
+
+test.describe( 'Cortext shell', () => {
+	test( 'admin reaches the shell via the admin menu', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+
+		await expect( page ).toHaveURL( /\/wp-admin\/admin\.php\?page=cortext$/ );
+
+		const root = page.locator( '#cortext-root' );
+		await expect( root ).toBeVisible();
+		// Assert React actually mounted content, not just the empty container.
+		await expect( root.locator( ':scope > *' ).first() ).toBeVisible( {
+			timeout: 15_000,
+		} );
+	} );
+
+	test( 'anonymous visitor is redirected to login', async ( { page } ) => {
+		// Keep Playground's `playground_auto_login_already_happened` cookie
+		// intact so the `--login` mu-plugin doesn't silently log us back in
+		// as admin when WP auth cookies are cleared.
+		await page.context().clearCookies( { name: /^wordpress_/ } );
+
+		await page.goto( SHELL_PATH );
+
+		await expect( page ).toHaveURL( /wp-login\.php/ );
+	} );
+
+	test( 'user without edit_posts gets 403', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const user = await requestUtils.createUser( {
+			username: 'cortext-subscriber',
+			email: 'cortext-subscriber@example.test',
+			password: 'cortext-sub-password',
+			roles: [ 'subscriber' ],
+		} );
+
+		try {
+			// Keep Playground's `playground_auto_login_already_happened` cookie
+		// intact so the `--login` mu-plugin doesn't silently log us back in
+		// as admin when WP auth cookies are cleared.
+		await page.context().clearCookies( { name: /^wordpress_/ } );
+			await page.request.post( '/wp-login.php', {
+				failOnStatusCode: true,
+				form: {
+					log: 'cortext-subscriber',
+					pwd: 'cortext-sub-password',
+				},
+			} );
+
+			const response = await page.goto( SHELL_PATH );
+
+			expect( response?.status() ).toBe( 403 );
+		} finally {
+			await requestUtils.rest( {
+				method: 'DELETE',
+				path: `/wp/v2/users/${ user.id }`,
+				params: { force: true, reassign: 1 },
+			} );
+		}
+	} );
+} );


### PR DESCRIPTION
## What
Adds a Playwright end-to-end test suite with three smoke tests for the `admin.php?page=cortext` shell.

## Why
Guards the shell against regressions in access control and bootstrap so broken builds are caught in CI.

## How
- Adding `@playwright/test` and `@wordpress/e2e-test-utils-playwright` as dev dependencies, plus `env:start`, `test:e2e`, and `test:e2e:debug` scripts.
- Extending the base `@wordpress/scripts` Playwright config to resolve `WP_BASE_URL` from env, `.wp-env.override.json`, or the default port.
- Covering three cases in `tests/e2e/specs/shell.spec.js`: admin reaches the page and `#cortext-root` renders, anonymous hits are redirected to `wp-login.php`, and a subscriber gets a 403.

Wiring a CI workflow that runs the suite against wp-env (Playground runtime) and uploads Playwright traces and HTML reports on failure.

## Testing Instructions
1. `npm ci`
2. `npm run env:start`
3. `npm run test:e2e`

Confirm all three specs pass.