### PR TITLE
Shell: persist the current app path in the URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
 				"@wordpress/dataviews": "^6.0.0",
 				"@wordpress/editor": "^14.44.0",
 				"@wordpress/icons": "^12.2.0",
-				"@wordpress/interface": "^9.0.0"
+				"@wordpress/interface": "^9.0.0",
+				"@wordpress/route": "^0.10.0"
 			},
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/dataviews": "^6.0.0",
 		"@wordpress/editor": "^14.44.0",
 		"@wordpress/icons": "^12.2.0",
-		"@wordpress/interface": "^9.0.0"
+		"@wordpress/interface": "^9.0.0",
+		"@wordpress/route": "^0.10.0"
 	}
 }

--- a/src/lock-unlock.js
+++ b/src/lock-unlock.js
@@ -1,0 +1,7 @@
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/edit-site'
+	);

--- a/src/router.js
+++ b/src/router.js
@@ -2,24 +2,25 @@
 // route renders the empty state; `$` is a splat that catches all sub-paths and
 // hands the URI to EntityRoute for entity resolution.
 //
-// Memory history: the shell mounts at `wp-admin/admin.php?page=cortext`, a
-// pathname browser-history can't usefully route against. Until Commit B adds
-// the rewrite rule + ?p= adapter, in-app navigation lives in memory only —
-// page reloads return to the empty state and browser back/forward navigates
-// the wp-admin history, not the app's.
+// URLs are canonical: `/wp-admin/admin.php?page=cortext&p=/<app-path>`. The
+// router emits those hrefs on navigation and parses them back on load.
 
-import {
-	createRouter,
-	createRootRoute,
-	createRoute,
-	createMemoryHistory,
-	Outlet,
-	RouterProvider,
-} from '@tanstack/react-router';
+import { privateApis as routePrivateApis } from '@wordpress/route';
 
 import Sidebar from './components/Sidebar';
 import EntityRoute from './router/EntityRoute';
 import EmptyState from './router/EmptyState';
+import { unlock } from './lock-unlock';
+
+const {
+	createRouter,
+	createRootRoute,
+	createRoute,
+	createBrowserHistory,
+	Outlet,
+	RouterProvider,
+	parseHref,
+} = unlock( routePrivateApis );
 
 function RootLayout() {
 	return (
@@ -48,9 +49,35 @@ const splatRoute = createRoute( {
 
 const routeTree = rootRoute.addChildren( [ indexRoute, splatRoute ] );
 
+const ADMIN_PATH = new URL(
+	window.cortextSettings?.adminUrl ?? '/wp-admin/',
+	window.location.origin
+).pathname;
+const MENU_SLUG = window.cortextSettings?.menuSlug ?? 'cortext';
+
+function parseLocation() {
+	const params = new URLSearchParams( window.location.search );
+	const appPath = params.get( 'p' ) || '/';
+	params.delete( 'page' );
+	params.delete( 'p' );
+	const rest = params.toString();
+	const appHref = appPath + ( rest ? '?' + rest : '' ) + window.location.hash;
+	return parseHref( appHref, window.history.state );
+}
+
+function createHref( appHref ) {
+	const url = new URL( appHref, 'http://_app_/' );
+	// `URLSearchParams.toString()` encodes slashes in `p`, which is ugly
+	// but round-trips correctly via `URLSearchParams.get` on the next read.
+	const params = new URLSearchParams( url.search );
+	params.set( 'page', MENU_SLUG );
+	params.set( 'p', url.pathname );
+	return `${ ADMIN_PATH }admin.php?${ params.toString() }${ url.hash }`;
+}
+
 export const router = createRouter( {
 	routeTree,
-	history: createMemoryHistory( { initialEntries: [ '/' ] } ),
+	history: createBrowserHistory( { parseLocation, createHref } ),
 } );
 
 export { RouterProvider };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,12 @@ const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extrac
 // `@wordpress/route` is not yet registered as a WP core script handle, so
 // wp-scripts' default externalization would emit a missing `wp-route`
 // dependency. Force it to be bundled into our build instead.
-const BUNDLED = new Set( [ '@wordpress/route' ] );
+//
+// `@wordpress/private-apis` is bundled alongside it so that `@wordpress/route`'s
+// internal opt-in call resolves against our up-to-date allowlist (which
+// includes `@wordpress/route`) rather than the older allowlist shipped with
+// `wp-private-apis` in the running WordPress.
+const BUNDLED = new Set( [ '@wordpress/route', '@wordpress/private-apis' ] );
 
 module.exports = {
 	...defaultConfig,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,23 @@
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+// `@wordpress/route` is not yet registered as a WP core script handle, so
+// wp-scripts' default externalization would emit a missing `wp-route`
+// dependency. Force it to be bundled into our build instead.
+const BUNDLED = new Set( [ '@wordpress/route' ] );
+
+module.exports = {
+	...defaultConfig,
+	plugins: defaultConfig.plugins.map( ( plugin ) => {
+		if ( plugin instanceof DependencyExtractionWebpackPlugin ) {
+			return new DependencyExtractionWebpackPlugin( {
+				requestToExternal( request ) {
+					if ( BUNDLED.has( request ) ) {
+						return false;
+					}
+				},
+			} );
+		}
+		return plugin;
+	} ),
+};


### PR DESCRIPTION
## What
Makes the Cortext URL remember where you are, so reloads and shared links land on the same page instead of bouncing back to the empty state.

## Why
Before this change, reloading the Cortext screen always sent you back to the start, and there was no way to share a link to a specific entity. Keeping the current path in the URL fixes both, so the shell now feels like a normal wp-admin screen.

## How
Swapping the router's memory history for a browser history, with a small adapter that writes the app path into `?page=cortext&p=/<path>` on navigation and reads it back on load.

The router primitives come from `@wordpress/route` (the same package `@wordpress/edit-site` uses), bundled locally because core does not yet ship it as a script handle. `@wordpress/private-apis` is bundled with it so `@wordpress/route`'s private-API opt-in matches a current allowlist.

## Testing Instructions
1. Open Cortext in wp-admin. The empty state should load at `?page=cortext`.
2. Click into an entity. The URL should update to `?page=cortext&p=/<path>`.
3. Reload. You should stay on the same entity.
4. Copy the URL into a new tab. It should open directly into that route.
5. Use browser back/forward. In-app navigation history should work as expected.