### PR TITLE
wp-env fix: Properly mount the Cortext plugin in wp-env Playground

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,7 +14,7 @@ hash=$(printf '%s' "$PWD" | "$hash_cmd" | awk '{print $1}')
 port=$(( 8000 + 16#${hash:0:6} % 1000 ))
 
 cat > .wp-env.override.json <<EOF
-{ "port": ${port}, "plugins": [ "./.wp-env-plugins/worktree-label" ] }
+{ "port": ${port}, "plugins": [ ".", "./.wp-env-plugins/worktree-label" ] }
 EOF
 
 "$(dirname "$0")/refresh-label.sh"


### PR DESCRIPTION
## What

Adds the workspace itself as a plugin in `.wp-env.override.json`, so Playground boots with Cortext mounted.

## Why

The override's `plugins` array replaces the base `.wp-env.json`'s array rather than extending it, so every worktree created by `scripts/setup.sh` was starting Playground without Cortext active.

## How

Updating `scripts/setup.sh` to include `"."` alongside `"./.wp-env-plugins/worktree-label"` in the generated array.

## Testing Instructions

1. In a fresh worktree, run `./scripts/setup.sh`.
2. Confirm `.wp-env.override.json`'s `plugins` array contains both `"."` and `"./.wp-env-plugins/worktree-label"`.
3. Run `npm start` and confirm Cortext activates in Playground.

In an existing worktree, stop Playground first (`./scripts/archive.sh`) before re-running setup.
