### PR TITLE
Register the `cortext_page` custom post type

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2,6 +2,16 @@
 
 Running log of significant design decisions. Newest first. Each entry captures *why* so future readers can evaluate whether the constraints still hold.
 
+## 2026-04-23 — Core admin is an escape hatch, not the primary UI
+
+**Decision.** `cortext_page` registers with `show_ui => true` and `show_in_menu => false`. `Admin\Screen` adds a "Manage Pages" submenu under the Cortext top-level that links to `edit.php?post_type=cortext_page`. The React shell remains the primary editing surface.
+
+**Why.** The shell is what users should reach for, but bulk operations (trash many, change status, reassign parent) are features core gives us for free and the shell doesn't have yet. Keeping core's list table + `post.php` editor reachable avoids dropping to `wp-cli` when the shell doesn't cover a chore. `show_in_menu => false` keeps the CPT from cluttering the top-level admin menu; `Admin\Screen` owns visibility.
+
+**Trade-off.** There are now two editing UIs for the same rows. Core's `post.php` editor loads without `window.cortextEditorSettings` and without the shell's autosave wiring, so editing behavior diverges between the two. Users who drop to core admin get the default WordPress experience, not Cortext's. Bulk actions that bypass the shell's hooks can still violate shell-side invariants if any are added later.
+
+**Revisit when.** The shell grows bulk-action affordances that cover the admin use cases, or the divergence between shell and core edits becomes a support problem. At that point flip `show_ui => false` and drop the submenu.
+
 ## 2026-04-23 — `cortext_page` uses core post capabilities
 
 **Decision.** `cortext_page` is registered with `capability_type => 'post'` and `map_meta_cap => true`. Caps map to `edit_posts` / `edit_others_posts` / `publish_posts` / etc.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,19 @@
+# Design decisions
+
+Running log of significant design decisions. Newest first. Each entry captures *why* so future readers can evaluate whether the constraints still hold.
+
+## 2026-04-23 — `cortext_page` uses core post capabilities
+
+**Decision.** `cortext_page` is registered with `capability_type => 'post'` and `map_meta_cap => true`. Caps map to `edit_posts` / `edit_others_posts` / `publish_posts` / etc.
+
+**Why.** The Cortext admin shell is gated on `edit_posts` in `Cortext\Admin\Screen::register_menu` (`includes/Admin/Screen.php`). Aligning the CPT with the same capability set means the shell and the REST endpoints share a single authorization surface, with zero activation-time plumbing. Capability mappings are derived at runtime — not stored in `wp_posts` — so the decision is reversible without a data migration.
+
+**Trade-off.** A future workspace-member role model (e.g. `edit_cortext_pages`, workspace-scoped sharing) will require:
+
+- An activation hook to grant the new caps to administrator and editor roles.
+- A `map_meta_cap` filter to derive meta caps from primitive caps.
+- Updating the admin menu cap in `Screen::register_menu`.
+
+None of this requires touching existing post rows.
+
+**Revisit when.** Cortext needs role-based sharing of workspace pages that diverges from WordPress's post-editor permission model — e.g. a "workspace viewer" role that can read but not edit, or per-page ACLs that don't fit the post-author model.

--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -15,6 +15,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Admin;
 
+use Cortext\PostType\Page;
+
 final class Screen {
 
 	public const MENU_SLUG      = 'cortext';
@@ -37,6 +39,16 @@ final class Screen {
 			array( $this, 'render' ),
 			'dashicons-welcome-write-blog',
 			3
+		);
+
+		// Escape hatch: core's list table + post.php editor for Cortext pages,
+		// nested under the shell menu. Primary UI stays the React shell.
+		add_submenu_page(
+			self::MENU_SLUG,
+			__( 'Manage Pages', 'cortext' ),
+			__( 'Manage Pages', 'cortext' ),
+			'edit_posts',
+			'edit.php?post_type=' . Page::POST_TYPE
 		);
 	}
 

--- a/includes/Editor/RevisionThrottle.php
+++ b/includes/Editor/RevisionThrottle.php
@@ -2,14 +2,6 @@
 /**
  * Throttles WordPress revision creation for Cortext-managed post types.
  *
- * TODO (dormant code): This class is a no-op until the `cortext_page` CPT is
- * registered. While the app still points at the built-in `page` post type as a
- * stand-in, editing a Cortext page in dev will create a WP revision every ~2s
- * of typing. That's cosmetic clutter in `wp_posts`, not a correctness issue.
- * This is intentional, because scoping the throttle to `page` would alter
- * core WP behavior for other plugins/themes. Remove this TODO block and verify
- * end-to-end once the CPT lands.
- *
  * @package Cortext
  */
 
@@ -17,11 +9,10 @@ declare( strict_types=1 );
 
 namespace Cortext\Editor;
 
+use Cortext\PostType\Page;
 use WP_Post;
 
 final class RevisionThrottle {
-
-	private const POST_TYPE = 'cortext_page';
 
 	/**
 	 * Minimum time between revision snapshots. Mirrors Notion's ~10 minute cadence.
@@ -46,7 +37,7 @@ final class RevisionThrottle {
 	 * @param WP_Post $post             The post being saved.
 	 */
 	public function throttle_revision( bool $post_has_changed, WP_Post $last_revision, WP_Post $post ): bool {
-		if ( self::POST_TYPE !== $post->post_type ) {
+		if ( Page::POST_TYPE !== $post->post_type ) {
 			return $post_has_changed;
 		}
 
@@ -69,7 +60,7 @@ final class RevisionThrottle {
 	 * @param WP_Post $post The post being saved.
 	 */
 	public function cap_revisions( int $num, WP_Post $post ): int {
-		if ( self::POST_TYPE !== $post->post_type ) {
+		if ( Page::POST_TYPE !== $post->post_type ) {
 			return $num;
 		}
 		return self::REVISIONS_TO_KEEP;

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -11,6 +11,7 @@ namespace Cortext;
 
 use Cortext\Admin\Screen;
 use Cortext\Editor\RevisionThrottle;
+use Cortext\PostType\Page;
 
 final class Plugin {
 
@@ -25,6 +26,7 @@ final class Plugin {
 
 	public function boot(): void {
 		( new Screen() )->register();
+		( new Page() )->register();
 		( new RevisionThrottle() )->register();
 	}
 

--- a/includes/PostType/Page.php
+++ b/includes/PostType/Page.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Registers the `cortext_page` custom post type.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\PostType;
+
+final class Page {
+
+	public const POST_TYPE = 'cortext_page';
+
+	public function register(): void {
+		add_action( 'init', array( $this, 'register_post_type' ) );
+	}
+
+	public function register_post_type(): void {
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'labels'                => array(
+					'name'          => __( 'Cortext Pages', 'cortext' ),
+					'singular_name' => __( 'Cortext Page', 'cortext' ),
+					'menu_name'     => __( 'Cortext Pages', 'cortext' ),
+					'add_new_item'  => __( 'Add New Cortext Page', 'cortext' ),
+					'edit_item'     => __( 'Edit Cortext Page', 'cortext' ),
+					'new_item'      => __( 'New Cortext Page', 'cortext' ),
+					'view_item'     => __( 'View Cortext Page', 'cortext' ),
+					'search_items'  => __( 'Search Cortext Pages', 'cortext' ),
+					'all_items'     => __( 'All Cortext Pages', 'cortext' ),
+				),
+				'public'                => false,
+				'publicly_queryable'    => false,
+				'exclude_from_search'   => true,
+				'show_ui'               => false,
+				'show_in_menu'          => false,
+				'show_in_rest'          => true,
+				// Matches useResolveEntity.js's `/wp/v2/${POST_TYPE}s?...` URL shape; core
+				// defaults rest_base to the CPT slug (`cortext_page`), which would 404 the
+				// segment-walk resolver. Keep explicit.
+				'rest_base'             => 'cortext_pages',
+				'rest_controller_class' => 'WP_REST_Posts_Controller',
+				'has_archive'           => false,
+				'hierarchical'          => true,
+				'supports'              => array(
+					'title',
+					'editor',
+					// Load-bearing: RevisionThrottle's filters only fire on post types that support revisions. Do not remove.
+					'revisions',
+					'page-attributes',
+				),
+				'capability_type'       => 'post',
+				'map_meta_cap'          => true,
+				'can_export'            => true,
+				'delete_with_user'      => false,
+			)
+		);
+	}
+}

--- a/includes/PostType/Page.php
+++ b/includes/PostType/Page.php
@@ -35,7 +35,10 @@ final class Page {
 				'public'                => false,
 				'publicly_queryable'    => false,
 				'exclude_from_search'   => true,
-				'show_ui'               => false,
+				// The React shell is the primary UI. Core's admin screens
+				// (edit.php list + post.php editor) stay enabled as an
+				// escape hatch, exposed through Admin\Screen's submenu.
+				'show_ui'               => true,
 				'show_in_menu'          => false,
 				'show_in_rest'          => true,
 				// Matches useResolveEntity.js's `/wp/v2/${POST_TYPE}s?...` URL shape; core

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -22,7 +22,7 @@ import { cog } from '@wordpress/icons';
 
 import useAutosave from '../hooks/useAutosave';
 
-const POST_TYPE = 'page';
+const POST_TYPE = 'cortext_page';
 const SCOPE = 'cortext';
 const INSPECTOR = 'cortext/block-inspector';
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -29,8 +29,7 @@ import {
 } from './pages-tree';
 import { computeUri } from '../router/useResolveEntity';
 
-// Stand-in until the `cortext_page` CPT lands — change this constant to swap.
-const POST_TYPE = 'page';
+const POST_TYPE = 'cortext_page';
 
 const AUTO_EXPAND_DELAY = 700;
 

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -18,11 +18,11 @@ import { addQueryArgs } from '@wordpress/url';
 // (`/cortext/v1/resolve?uri=...`) — which is also the natural shape for
 // phase 2 below, where URL-shape-to-entity-type rules stop being trivial.
 //
-// TODO(types): phase 1 only resolves `page` records. When cortext_page,
+// TODO(types): phase 1 only resolves `cortext_page` records. When
 // cortext_collection, cortext_collection_{slug}, and cortext_supertag land,
 // this hook grows branches that pick the right CPT/taxonomy per segment — or
 // is replaced by the server-side resolver described above.
-const POST_TYPE = 'page';
+const POST_TYPE = 'cortext_page';
 
 export function useResolveEntity( uri ) {
 	const [ state, setState ] = useState( {

--- a/tests/php/test-post-type-page.php
+++ b/tests/php/test-post-type-page.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for Cortext\PostType\Page.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Page;
+use WorDBless\BaseTestCase;
+
+final class Test_Post_Type_Page extends BaseTestCase {
+
+	public function test_post_type_constant_matches_expected_slug(): void {
+		$this->assertSame( 'cortext_page', Page::POST_TYPE );
+	}
+
+	public function test_register_hooks_init_action(): void {
+		remove_all_actions( 'init' );
+
+		( new Page() )->register();
+
+		$this->assertNotFalse(
+			has_action( 'init' ),
+			'register_post_type callback should be hooked on init.'
+		);
+	}
+
+	public function test_register_post_type_registers_cortext_page(): void {
+		( new Page() )->register_post_type();
+
+		$this->assertTrue( post_type_exists( Page::POST_TYPE ) );
+	}
+
+	public function test_registered_post_type_has_expected_properties(): void {
+		( new Page() )->register_post_type();
+
+		$object = get_post_type_object( Page::POST_TYPE );
+		$this->assertNotNull( $object );
+
+		$this->assertTrue( $object->hierarchical, 'cortext_page must be hierarchical for the page tree.' );
+		$this->assertTrue( $object->show_in_rest, 'cortext_page must be show_in_rest for @wordpress/core-data.' );
+		$this->assertSame( 'cortext_pages', $object->rest_base, 'rest_base must match the JS resolver URL shape.' );
+		$this->assertFalse( $object->public );
+		$this->assertFalse( $object->show_ui );
+		$this->assertFalse( $object->show_in_menu );
+		$this->assertFalse( $object->publicly_queryable );
+		$this->assertTrue( $object->exclude_from_search );
+		$this->assertFalse( $object->has_archive );
+	}
+
+	public function test_registered_post_type_supports_required_features(): void {
+		( new Page() )->register_post_type();
+
+		$this->assertTrue(
+			post_type_supports( Page::POST_TYPE, 'revisions' ),
+			'revisions support is load-bearing: RevisionThrottle filters only fire on post types that support revisions.'
+		);
+		$this->assertTrue( post_type_supports( Page::POST_TYPE, 'title' ) );
+		$this->assertTrue( post_type_supports( Page::POST_TYPE, 'editor' ) );
+		$this->assertTrue( post_type_supports( Page::POST_TYPE, 'page-attributes' ) );
+	}
+}

--- a/tests/php/test-post-type-page.php
+++ b/tests/php/test-post-type-page.php
@@ -45,8 +45,8 @@ final class Test_Post_Type_Page extends BaseTestCase {
 		$this->assertTrue( $object->show_in_rest, 'cortext_page must be show_in_rest for @wordpress/core-data.' );
 		$this->assertSame( 'cortext_pages', $object->rest_base, 'rest_base must match the JS resolver URL shape.' );
 		$this->assertFalse( $object->public );
-		$this->assertFalse( $object->show_ui );
-		$this->assertFalse( $object->show_in_menu );
+		$this->assertTrue( $object->show_ui, 'show_ui stays on so Admin\Screen\'s submenu can link to the core list table as an escape hatch.' );
+		$this->assertFalse( $object->show_in_menu, 'show_in_menu is false because Admin\Screen owns the top-level menu.' );
 		$this->assertFalse( $object->publicly_queryable );
 		$this->assertTrue( $object->exclude_from_search );
 		$this->assertFalse( $object->has_archive );


### PR DESCRIPTION
## What

Adds a Cortext Page content type so the plugin stores its own pages rather than reusing WordPress's built-in Pages. Admins can still reach them through WordPress's regular admin when they need to.

## Why

The plugin's REST integration, editor shell, and revision-throttle filters were all wired against a Cortext Page type, but the type itself was never registered. Without it, the shell reads and writes built-in Page rows and the revision throttler never fires. Core's admin stays reachable for bulk actions the shell doesn't cover yet.

## How

- Registers the new content type and wires it into the plugin boot sequence before the revision throttler so throttling takes effect.
- Switches the editor shell (sidebar, canvas, URL resolver) from built-in Pages to Cortext Pages.
- Adds a "Manage Pages" submenu under the Cortext admin menu that opens WordPress's standard list view for bulk actions.
- Records the capability and escape-hatch decisions in `docs/decisions.md`.

## Testing Instructions

1. `composer test:php` and `npm run test:unit` pass.
2. `GET /wp-json/wp/v2/types/cortext_page` returns the type descriptor; `POST /wp-json/wp/v2/cortext_pages` creates a row.
3. `wp-admin/admin.php?page=cortext`: create a page through the shell, confirm autosave persists it and revisions stay within the 10-minute window.
4. "Manage Pages" submenu loads core's list table with that page; `post.php?action=edit&post=<id>` opens core's editor.