### PR TITLE
Fix autosave debounce not resetting during continuous typing

### DIFF
--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import { store as coreDataStore } from '@wordpress/core-data';
 
 const DEBOUNCE_MS = 800;
 const MIN_SAVE_INTERVAL_MS = 2000;
@@ -8,19 +9,25 @@ const MIN_SAVE_INTERVAL_MS = 2000;
 export default function useAutosave() {
 	const { savePost } = useDispatch( editorStore );
 
-	const { isDirty, isSaveable, isSaving, didSucceed, didFail } = useSelect(
-		( select ) => {
-			const editor = select( editorStore );
-			return {
-				isDirty: editor.isEditedPostDirty(),
-				isSaveable: editor.isEditedPostSaveable(),
-				isSaving: editor.isSavingPost(),
-				didSucceed: editor.didPostSaveRequestSucceed(),
-				didFail: editor.didPostSaveRequestFail(),
-			};
-		},
-		[]
-	);
+	const {
+		isDirty,
+		isSaveable,
+		isSaving,
+		didSucceed,
+		didFail,
+		editsReference,
+	} = useSelect( ( select ) => {
+		const editor = select( editorStore );
+		return {
+			isDirty: editor.isEditedPostDirty(),
+			isSaveable: editor.isEditedPostSaveable(),
+			isSaving: editor.isSavingPost(),
+			didSucceed: editor.didPostSaveRequestSucceed(),
+			didFail: editor.didPostSaveRequestFail(),
+			editsReference:
+				select( coreDataStore ).getReferenceByDistinctEdits(),
+		};
+	}, [] );
 
 	const [ status, setStatus ] = useState( 'idle' );
 	const [ lastSavedAt, setLastSavedAt ] = useState( null );
@@ -78,7 +85,7 @@ export default function useAutosave() {
 				debounceRef.current = null;
 			}
 		};
-	}, [ isDirty, isSaveable ] );
+	}, [ isDirty, isSaveable, editsReference ] );
 
 	useEffect( () => {
 		if ( isSaving ) {

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -16,6 +16,10 @@ jest.mock( '@wordpress/editor', () => ( {
 	store: { name: 'core/editor' },
 } ) );
 
+jest.mock( '@wordpress/core-data', () => ( {
+	store: { name: 'core' },
+} ) );
+
 import { useSelect, useDispatch } from '@wordpress/data';
 import useAutosave from '../../src/hooks/useAutosave';
 
@@ -27,13 +31,40 @@ const DEFAULT_STATE = {
 	didFail: false,
 };
 
+let editsReference = {};
+
 function setStoreState( state ) {
 	const merged = { ...DEFAULT_STATE, ...state };
-	useSelect.mockReturnValue( merged );
+	const editorSelectors = {
+		isEditedPostDirty: () => merged.isDirty,
+		isEditedPostSaveable: () => merged.isSaveable,
+		isSavingPost: () => merged.isSaving,
+		didPostSaveRequestSucceed: () => merged.didSucceed,
+		didPostSaveRequestFail: () => merged.didFail,
+	};
+	const coreDataSelectors = {
+		getReferenceByDistinctEdits: () => editsReference,
+	};
+	useSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( ( storeName ) => {
+			if ( storeName.name === 'core/editor' ) {
+				return editorSelectors;
+			}
+			if ( storeName.name === 'core' ) {
+				return coreDataSelectors;
+			}
+			return {};
+		} )
+	);
+}
+
+function simulateEdit() {
+	editsReference = {};
 }
 
 beforeEach( () => {
 	jest.useFakeTimers();
+	editsReference = {};
 	setStoreState( {} );
 	useDispatch.mockReturnValue( { savePost: jest.fn() } );
 } );
@@ -59,6 +90,34 @@ describe( 'useAutosave: debounce', () => {
 
 		act( () => {
 			jest.advanceTimersByTime( 1 );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'resets the debounce timer on every edit during continuous typing', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		const { rerender } = renderHook( () => useAutosave() );
+
+		// Simulate continuous typing: every 200ms a new edit lands,
+		// each should reset the 800ms debounce timer.
+		for ( let i = 0; i < 10; i++ ) {
+			act( () => {
+				jest.advanceTimersByTime( 200 );
+			} );
+			simulateEdit();
+			setStoreState( { isDirty: true } );
+			rerender();
+		}
+
+		// 2000ms of typing elapsed, but no save should have fired.
+		expect( savePost ).not.toHaveBeenCalled();
+
+		// Now stop typing. After 800ms the debounce fires.
+		act( () => {
+			jest.advanceTimersByTime( 800 );
 		} );
 		expect( savePost ).toHaveBeenCalledTimes( 1 );
 	} );


### PR DESCRIPTION
## Summary

- The autosave debounce timer was not resetting on continued typing because the effect only depended on `isDirty` (a boolean that stays `true` after the first edit)
- Use core-data's `getReferenceByDistinctEdits()` as an effect dependency — it returns a new object reference on every `EDIT_ENTITY_RECORD`, `UNDO`, and `REDO` action, so the timer properly resets on each keystroke
- Add a unit test that simulates continuous typing (10 edits at 200ms intervals) and asserts no save fires until 800ms after the last edit

## Test plan

- [x] Run `npm run test:unit` — all tests pass, including the new continuous-typing case
- [x] Start the editor (`npm run start`), open a Cortext page, and type continuously for several seconds — verify no save fires mid-typing and one fires ~800ms after stopping

🤖 Generated with [Claude Code](https://claude.com/claude-code)