### PR TITLE
Sidebar: Only show spinner on initial load

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -342,7 +342,7 @@ export default function Sidebar() {
 					{ __( 'New page', 'cortext' ) }
 				</Button>
 			</div>
-			{ isResolving && (
+			{ isResolving && pages.length === 0 && (
 				<div className="cortext-sidebar__loading">
 					<Spinner />
 				</div>


### PR DESCRIPTION
Technically, only show it when there are no local records, but this effectively corresponds to only showing the spinner on initial load.
