### PR TITLE
Route pages by id, create pages as auto-draft

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,4 +98,4 @@ A single React SPA mounted on a full-screen admin page.
 └───────────────┴────────────────────────────────────┘
 ```
 
-Chrome is hidden via the `is-fullscreen-mode` body class (the Site Editor pattern). Phase 2 may move to a custom URL via rewrite rule and `template_redirect`. The React shell is URL-agnostic, so the move is plumbing rather than architecture.
+Chrome is hidden via the `is-fullscreen-mode` body class (the Site Editor pattern). Phase 2 may move to a custom URL via rewrite rule and `template_redirect`. The outer URL shape is confined to `parseLocation` and `createHref` in `src/router.js`, so the move is plumbing rather than architecture.

--- a/docs/architecture/shell.md
+++ b/docs/architecture/shell.md
@@ -17,7 +17,7 @@ Editor settings are built server-side from `WP_Block_Editor_Context('core/edit-p
 
 ## Client entry (React)
 
-Entry is `src/index.js`; routing lives in `src/router/` using TanStack Router. The shell is URL-agnostic, so moving to a custom rewrite-rule URL later is plumbing rather than an architectural change.
+Entry is `src/index.js`; routing lives in `src/router/` using TanStack Router. Page URLs use the shape `?page=cortext&p=/<slug>-<id>`, falling back to `?p=/<id>` for slug-less drafts; only the trailing id is authoritative, and `useResolveEntity` fetches the record by id. The slug prefix is cosmetic and `Sidebar` rewrites it via `history.replace` when autosave lands a new slug, so renames never break existing URLs. The outer wp-admin URL is confined to `parseLocation` and `createHref` in `src/router.js`, so switching to a rewrite-rule URL later is plumbing rather than an architectural change. See [design decisions](../decisions.md) for why id-based URLs and why new pages start as `draft`.
 
 `src/components/Canvas.js` renders a single page through `EditorProvider` with `useSubRegistry={ false }`. Keeping `core/editor` on the parent registry means stock editor components (`EditorAutosaveMonitor`, `PostLockedModal`, `EditorSnackbars`, `UnsavedChangesWarning`) can be dropped in directly if the shell wants them.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2,6 +2,33 @@
 
 Running log of significant design decisions. Newest first. Each entry captures *why* so future readers can evaluate whether the constraints still hold.
 
+## 2026-04-23 — Page URLs are id-based, slug is cosmetic
+
+**Decision.** Page URLs encode the post id as the authoritative identifier: `?page=cortext&p=/<slug>-<id>` (e.g. `?p=/about-us-42`), falling back to `?p=/<id>` when the slug is empty. `src/router/useResolveEntity.js` extracts the trailing digits via `parseIdFromUri` and fetches `GET /wp/v2/cortext_pages/<id>?context=edit`. The slug prefix is cosmetic. When autosave assigns a real slug, `Sidebar` rewrites the URL via `history.replace` so the visible URL reflects the latest title.
+
+**Why.** The previous URL shape was a hierarchical slug path (`?p=/about-us/team`) resolved by walking one segment at a time through the REST collection endpoint. That works for titled pages but fails in two ways the shell hit in practice:
+
+- Fresh drafts have an empty `post_name`, so the segment walker cannot address them. Creating a new page could not open it.
+- Core never regenerates `post_name` from `post_title` after the first committed slug, so renames leave the URL stuck on the original slug (see next entry).
+
+Id-based URLs sidestep both issues. The id is stable from creation, renames cannot break URLs, and cold-path resolution is one round-trip instead of N. Notion and Linear use the same pattern for the same reasons.
+
+**Trade-off.** URLs lose the "glance and know the page" property of slug paths. For a `public: false` admin workspace this is cosmetic: URLs are not shared externally, and the sidebar carries the hierarchy view. If Cortext ever exposes pages at public URLs, a slug-path resolver can be layered on top; the id remains in the URL as a fallback identifier.
+
+**Revisit when.** Cortext publishes pages at public URLs and wants SEO-friendly paths, or the URL shape becomes user-visible in a context (export, share link, breadcrumb display) where readability matters more than stability.
+
+## 2026-04-23 — New pages use `draft` status; slug is generated on first rename
+
+**Decision.** The "New page" action creates a post with `status: 'draft'` and no title. The first rename (or the first autosaved title change) promotes status to `private` via `Sidebar::renamePage` or `useAutosave::maybePromoteStatus`. Core runs `wp_unique_post_slug(sanitize_title(title))` on that transition and stores the result as `post_name`.
+
+**Why.** Core regenerates `post_name` from `post_title` only on the transition out of `draft`, `pending`, or `auto-draft`, and only when `post_name` is empty. The previous code created pages as `private` with a placeholder title (`Untitled`), which committed `post_name: 'untitled'` at creation. Since core never regenerates after that point, every page's URL was stuck on `untitled` forever. Deferring slug assignment until there is a real title gets slug generation, uniqueness, and localization for free from core.
+
+`draft` rather than `auto-draft` because `auto-draft` is registered as an internal status and excluded from the REST schema's `status` enum; `POST /wp/v2/cortext_pages` with `status: 'auto-draft'` returns 400. `draft` has identical slug-regeneration behavior and is REST-valid. `draft` is also not subject to `wp_scheduled_auto_draft_delete`'s 7-day GC, so abandoned blank pages stay until explicitly deleted.
+
+**Trade-off.** Pages already in the database with `post_name: 'untitled'` from before this change keep that slug. Renaming them does not regenerate it because at rename time they are `private`, not `draft`, so the status-gated promotion does not fire. No migration is planned; id-based URLs (previous entry) mean the stale slug no longer breaks navigation.
+
+**Revisit when.** Legacy `untitled`-slugged pages surface in a user-visible context where their slug matters (export, share link, breadcrumb), or product decides to hide abandoned blank drafts from the sidebar.
+
 ## 2026-04-23 — Core admin is an escape hatch, not the primary UI
 
 **Decision.** `cortext_page` registers with `show_ui => true` and `show_in_menu => false`. `Admin\Screen` adds a "Manage Pages" submenu under the Cortext top-level that links to `edit.php?post_type=cortext_page`. The React shell remains the primary editing surface.

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,7 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState, useMemo, useRef, useCallback } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	useRef,
+	useCallback,
+	useEffect,
+} from '@wordpress/element';
 import {
 	Button,
 	Spinner,
@@ -27,7 +33,7 @@ import {
 	isDescendantOf,
 	nextChildOrder,
 } from './pages-tree';
-import { computeUri } from '../router/useResolveEntity';
+import { computeUri, parseIdFromUri } from '../router/useResolveEntity';
 
 const POST_TYPE = 'cortext_page';
 
@@ -48,14 +54,11 @@ function parseDropId( id ) {
 export default function Sidebar() {
 	// TODO(scale): per_page: 100 is the REST collection endpoint's hard ceiling.
 	// Workspaces are expected to exceed 100 pages — pages past the cap won't
-	// appear in the tree, and computeUri() walks ancestors via this same list,
-	// so deep-nested items whose ancestors are past the cap produce truncated
-	// (wrong) URIs that then 404 through useResolveEntity. Followup needs a
-	// lazy-loaded tree (load children on expand) or a paginated fetch of the
-	// full page set.
+	// appear in the tree. Followup needs a lazy-loaded tree (load children on
+	// expand) or a paginated fetch of the full page set.
 	const { records, isResolving } = useEntityRecords( 'postType', POST_TYPE, {
 		per_page: 100,
-		status: [ 'auto-draft', 'private', 'publish' ],
+		status: [ 'draft', 'private', 'publish' ],
 		context: 'edit',
 	} );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( 'core' );
@@ -65,32 +68,48 @@ export default function Sidebar() {
 	const activeUri = params._splat ?? '';
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
 
-	const selectedId = useMemo( () => {
-		if ( ! activeUri ) {
-			return null;
+	const selectedId = useMemo(
+		() => parseIdFromUri( activeUri ),
+		[ activeUri ]
+	);
+
+	// Keep the URL canonical: once autosave assigns a slug to the active
+	// page (draft → private promotion on first titled save), rewrite
+	// `?p=/42` to `?p=/about-us-42` via history.replace so the id remains
+	// authoritative while the visible URL reflects the latest title.
+	useEffect( () => {
+		if ( selectedId === null ) {
+			return;
 		}
-		const match = pages.find(
-			( page ) => computeUri( page, pages ) === activeUri
-		);
-		return match?.id ?? null;
-	}, [ activeUri, pages ] );
+		const current = pages.find( ( p ) => p.id === selectedId );
+		if ( ! current ) {
+			return;
+		}
+		const canonical = computeUri( current );
+		if ( canonical !== activeUri ) {
+			navigate( {
+				to: '/$',
+				params: { _splat: canonical },
+				replace: true,
+			} );
+		}
+	}, [ selectedId, pages, activeUri, navigate ] );
 
 	// Callers that just created a record pass it as `pageHint` — after
 	// `await saveEntityRecord`, React hasn't re-rendered yet, so the closure's
-	// `pages` doesn't contain the new id and a plain lookup would no-op.
+	// `pages` doesn't contain the new id. With id-based URLs we can build a
+	// usable URL from `{ id }` alone; the slug prefix is cosmetic.
 	const onSelect = useCallback(
 		( id, pageHint ) => {
 			if ( id === null || id === undefined ) {
 				navigate( { to: '/' } );
 				return;
 			}
-			const page = pageHint ?? pages.find( ( p ) => p.id === id );
-			if ( ! page ) {
-				return;
-			}
+			const page = pageHint ??
+				pages.find( ( p ) => p.id === id ) ?? { id };
 			navigate( {
 				to: '/$',
-				params: { _splat: computeUri( page, pages ) },
+				params: { _splat: computeUri( page ) },
 			} );
 		},
 		[ navigate, pages ]
@@ -142,7 +161,7 @@ export default function Sidebar() {
 
 	const createRootPage = useCallback( async () => {
 		const created = await saveEntityRecord( 'postType', POST_TYPE, {
-			status: 'auto-draft',
+			status: 'draft',
 		} );
 		if ( created?.id ) {
 			onSelect( created.id, created );
@@ -153,7 +172,7 @@ export default function Sidebar() {
 	const createChildPage = useCallback(
 		async ( parentId ) => {
 			const created = await saveEntityRecord( 'postType', POST_TYPE, {
-				status: 'auto-draft',
+				status: 'draft',
 				parent: parentId,
 				menu_order: nextChildOrder( parentId, pages ),
 			} );
@@ -166,13 +185,13 @@ export default function Sidebar() {
 		[ saveEntityRecord, pages, expand, onSelect ]
 	);
 
-	// First rename promotes auto-draft to private so core regenerates post_name
+	// First rename promotes draft to private so core regenerates post_name
 	// from the new title via wp_unique_post_slug(sanitize_title(...)).
 	const renamePage = useCallback(
 		async ( id, title ) => {
 			const current = getRecordById( id );
 			const payload = { id, title };
-			if ( current?.status === 'auto-draft' ) {
+			if ( current?.status === 'draft' ) {
 				payload.status = 'private';
 			}
 			await saveEntityRecord( 'postType', POST_TYPE, payload );

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -55,7 +55,7 @@ export default function Sidebar() {
 	// full page set.
 	const { records, isResolving } = useEntityRecords( 'postType', POST_TYPE, {
 		per_page: 100,
-		status: [ 'private', 'publish' ],
+		status: [ 'auto-draft', 'private', 'publish' ],
 		context: 'edit',
 	} );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( 'core' );
@@ -142,8 +142,7 @@ export default function Sidebar() {
 
 	const createRootPage = useCallback( async () => {
 		const created = await saveEntityRecord( 'postType', POST_TYPE, {
-			status: 'private',
-			title: __( 'Untitled', 'cortext' ),
+			status: 'auto-draft',
 		} );
 		if ( created?.id ) {
 			onSelect( created.id, created );
@@ -154,8 +153,7 @@ export default function Sidebar() {
 	const createChildPage = useCallback(
 		async ( parentId ) => {
 			const created = await saveEntityRecord( 'postType', POST_TYPE, {
-				status: 'private',
-				title: __( 'Untitled', 'cortext' ),
+				status: 'auto-draft',
 				parent: parentId,
 				menu_order: nextChildOrder( parentId, pages ),
 			} );
@@ -168,11 +166,18 @@ export default function Sidebar() {
 		[ saveEntityRecord, pages, expand, onSelect ]
 	);
 
+	// First rename promotes auto-draft to private so core regenerates post_name
+	// from the new title via wp_unique_post_slug(sanitize_title(...)).
 	const renamePage = useCallback(
 		async ( id, title ) => {
-			await saveEntityRecord( 'postType', POST_TYPE, { id, title } );
+			const current = getRecordById( id );
+			const payload = { id, title };
+			if ( current?.status === 'auto-draft' ) {
+				payload.status = 'private';
+			}
+			await saveEntityRecord( 'postType', POST_TYPE, payload );
 		},
-		[ saveEntityRecord ]
+		[ saveEntityRecord, getRecordById ]
 	);
 
 	const duplicatePage = useCallback(

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -58,15 +58,15 @@ export default function useAutosave() {
 		postTitle,
 	};
 
-	// Promote auto-draft to private once the user has given the page a real
-	// title, so WP core regenerates post_name from the title on save.
+	// Promote draft to private once the user has given the page a real title,
+	// so WP core regenerates post_name from the title on save.
 	const maybePromoteStatus = () => {
 		const {
 			editPost: edit,
 			postStatus: s,
 			postTitle: t,
 		} = stateRef.current;
-		if ( s === 'auto-draft' && typeof t === 'string' && t.trim() !== '' ) {
+		if ( s === 'draft' && typeof t === 'string' && t.trim() !== '' ) {
 			edit( { status: 'private' } );
 		}
 	};

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -7,7 +7,7 @@ const DEBOUNCE_MS = 800;
 const MIN_SAVE_INTERVAL_MS = 2000;
 
 export default function useAutosave() {
-	const { savePost } = useDispatch( editorStore );
+	const { savePost, editPost } = useDispatch( editorStore );
 
 	const {
 		isDirty,
@@ -16,6 +16,8 @@ export default function useAutosave() {
 		didSucceed,
 		didFail,
 		editsReference,
+		postStatus,
+		postTitle,
 	} = useSelect( ( select ) => {
 		const editor = select( editorStore );
 		return {
@@ -26,6 +28,8 @@ export default function useAutosave() {
 			didFail: editor.didPostSaveRequestFail(),
 			editsReference:
 				select( coreDataStore ).getReferenceByDistinctEdits(),
+			postStatus: editor.getEditedPostAttribute( 'status' ),
+			postTitle: editor.getEditedPostAttribute( 'title' ),
 		};
 	}, [] );
 
@@ -35,8 +39,37 @@ export default function useAutosave() {
 	const debounceRef = useRef( null );
 	const lastSaveAtRef = useRef( 0 );
 
-	const stateRef = useRef( { isDirty, isSaveable, isSaving, savePost } );
-	stateRef.current = { isDirty, isSaveable, isSaving, savePost };
+	const stateRef = useRef( {
+		isDirty,
+		isSaveable,
+		isSaving,
+		savePost,
+		editPost,
+		postStatus,
+		postTitle,
+	} );
+	stateRef.current = {
+		isDirty,
+		isSaveable,
+		isSaving,
+		savePost,
+		editPost,
+		postStatus,
+		postTitle,
+	};
+
+	// Promote auto-draft to private once the user has given the page a real
+	// title, so WP core regenerates post_name from the title on save.
+	const maybePromoteStatus = () => {
+		const {
+			editPost: edit,
+			postStatus: s,
+			postTitle: t,
+		} = stateRef.current;
+		if ( s === 'auto-draft' && typeof t === 'string' && t.trim() !== '' ) {
+			edit( { status: 'private' } );
+		}
+	};
 
 	const flushNow = () => {
 		if ( debounceRef.current ) {
@@ -50,6 +83,7 @@ export default function useAutosave() {
 			savePost: save,
 		} = stateRef.current;
 		if ( d && s && ! saving ) {
+			maybePromoteStatus();
 			lastSaveAtRef.current = Date.now();
 			save();
 		}
@@ -74,6 +108,7 @@ export default function useAutosave() {
 				savePost: save,
 			} = stateRef.current;
 			if ( d && s && ! saving ) {
+				maybePromoteStatus();
 				lastSaveAtRef.current = Date.now();
 				save();
 			}

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreDataStore } from '@wordpress/core-data';
@@ -71,7 +71,7 @@ export default function useAutosave() {
 		}
 	};
 
-	const flushNow = () => {
+	const flushNow = useCallback( () => {
 		if ( debounceRef.current ) {
 			clearTimeout( debounceRef.current );
 			debounceRef.current = null;
@@ -87,7 +87,7 @@ export default function useAutosave() {
 			lastSaveAtRef.current = Date.now();
 			save();
 		}
-	};
+	}, [] );
 
 	useEffect( () => {
 		if ( ! isDirty || ! isSaveable ) {
@@ -155,7 +155,7 @@ export default function useAutosave() {
 			window.removeEventListener( 'beforeunload', onBeforeUnload );
 			flushNow();
 		};
-	}, [] );
+	}, [ flushNow ] );
 
 	return { status, lastSavedAt };
 }

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -1,28 +1,20 @@
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
 
-// Resolves a URI like "foo/bar/baz" to a page entity by walking the URL one
-// segment at a time, issuing a filtered REST query per segment (slug + parent).
-//
-// Why segment-walking instead of fetching the full page list once:
-// workspaces are expected to contain more than 100 pages, and the REST
-// collection endpoint caps `per_page` at 100. A list-then-find approach
-// silently 404s for pages past the cap. A filtered `?slug=X&parent=Y` query
-// returns at most one row regardless of total page count, so it scales.
-//
-// Trade-off: cold navigation to a never-visited N-segment URL costs N serial
-// round-trips (each is a tiny indexed lookup). In practice N is 1–3, and
-// repeat visits ride the browser's HTTP cache. If depth cost becomes visible,
-// replace this client walk with a single server-side resolver endpoint
-// (`/cortext/v1/resolve?uri=...`) — which is also the natural shape for
-// phase 2 below, where URL-shape-to-entity-type rules stop being trivial.
-//
-// TODO(types): phase 1 only resolves `cortext_page` records. When
-// cortext_collection, cortext_collection_{slug}, and cortext_supertag land,
-// this hook grows branches that pick the right CPT/taxonomy per segment — or
-// is replaced by the server-side resolver described above.
+// Resolves a URI like "about-us-42" or "42" to a page entity by extracting the
+// trailing numeric id and fetching that record directly. The slug prefix is
+// cosmetic: it keeps the URL human-readable without being authoritative, so
+// renaming a page can never break an existing link, and blank drafts (which
+// have no slug yet) remain addressable via their id alone.
 const POST_TYPE = 'cortext_page';
+
+// Pulls the trailing `<digits>` — optionally preceded by `-` — out of a URI.
+// Matches both `foo-42` and bare `42`. Returns null for anything else so
+// callers can treat a missing id as "route to empty state, not 404".
+export function parseIdFromUri( uri ) {
+	const match = ( uri ?? '' ).match( /(?:^|-)(\d+)$/ );
+	return match ? parseInt( match[ 1 ], 10 ) : null;
+}
 
 export function useResolveEntity( uri ) {
 	const [ state, setState ] = useState( {
@@ -32,68 +24,41 @@ export function useResolveEntity( uri ) {
 	} );
 
 	useEffect( () => {
-		const segments = ( uri ?? '' ).split( '/' ).filter( Boolean );
+		const id = parseIdFromUri( uri );
 
-		if ( segments.length === 0 ) {
-			setState( { entity: null, isResolving: false, notFound: false } );
-			return;
+		if ( ! id ) {
+			setState( {
+				entity: null,
+				isResolving: false,
+				notFound: Boolean( uri ),
+			} );
+			return undefined;
 		}
 
 		let cancelled = false;
 		setState( { entity: null, isResolving: true, notFound: false } );
 
-		( async () => {
-			let parent = 0;
-			let match = null;
-
-			for ( const slug of segments ) {
-				let results;
-				try {
-					results = await apiFetch( {
-						path: addQueryArgs( `/wp/v2/${ POST_TYPE }s`, {
-							slug,
-							parent,
-							status: 'publish,private',
-							per_page: 1,
-							_fields: 'id,slug,parent',
-						} ),
+		apiFetch( {
+			path: `/wp/v2/${ POST_TYPE }s/${ id }?context=edit&_fields=id,slug,parent`,
+		} )
+			.then( ( entity ) => {
+				if ( ! cancelled ) {
+					setState( {
+						entity,
+						isResolving: false,
+						notFound: false,
 					} );
-				} catch {
-					if ( ! cancelled ) {
-						setState( {
-							entity: null,
-							isResolving: false,
-							notFound: true,
-						} );
-					}
-					return;
 				}
-
-				if ( cancelled ) {
-					return;
-				}
-
-				if ( ! results || results.length === 0 ) {
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
 					setState( {
 						entity: null,
 						isResolving: false,
 						notFound: true,
 					} );
-					return;
 				}
-
-				match = results[ 0 ];
-				parent = match.id;
-			}
-
-			if ( ! cancelled ) {
-				setState( {
-					entity: match,
-					isResolving: false,
-					notFound: false,
-				} );
-			}
-		} )();
+			} );
 
 		return () => {
 			cancelled = true;
@@ -103,16 +68,10 @@ export function useResolveEntity( uri ) {
 	return state;
 }
 
-export function computeUri( page, allPages ) {
-	const chain = [ page.slug ];
-	let currentParent = page.parent;
-	while ( currentParent ) {
-		const parent = allPages.find( ( p ) => p.id === currentParent );
-		if ( ! parent ) {
-			break;
-		}
-		chain.unshift( parent.slug );
-		currentParent = parent.parent;
-	}
-	return chain.join( '/' );
+// Builds the URL segment for a page: `<slug>-<id>` when a slug exists, bare
+// `<id>` for fresh drafts. The id is the authoritative part — parseIdFromUri
+// only ever reads the trailing digits.
+export function computeUri( page ) {
+	const slug = typeof page.slug === 'string' ? page.slug.trim() : '';
+	return slug ? `${ slug }-${ page.id }` : `${ page.id }`;
 }

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -17,15 +17,18 @@ export function parseIdFromUri( uri ) {
 }
 
 export function useResolveEntity( uri ) {
+	const id = parseIdFromUri( uri );
 	const [ state, setState ] = useState( {
 		entity: null,
 		isResolving: true,
 		notFound: false,
 	} );
 
+	// Keyed on `id` rather than `uri` so that canonicalization rewrites
+	// (`/42` → `/about-us-42` for the same record) don't re-fetch and briefly
+	// flip state to `{ entity: null, isResolving: true }`, which would unmount
+	// the editor mid-typing.
 	useEffect( () => {
-		const id = parseIdFromUri( uri );
-
 		if ( ! id ) {
 			setState( {
 				entity: null,
@@ -63,7 +66,10 @@ export function useResolveEntity( uri ) {
 		return () => {
 			cancelled = true;
 		};
-	}, [ uri ] );
+		// `uri` is only read in the no-id branch to distinguish empty from
+		// malformed; we don't want a uri change with the same id to refetch.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ id ] );
 
 	return state;
 }

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -329,7 +329,7 @@ describe( 'useAutosave: auto-draft promotion', () => {
 		useDispatch.mockReturnValue( { savePost, editPost } );
 		setStoreState( {
 			isDirty: true,
-			postStatus: 'auto-draft',
+			postStatus: 'draft',
 			postTitle: 'About Us',
 		} );
 
@@ -349,7 +349,7 @@ describe( 'useAutosave: auto-draft promotion', () => {
 		useDispatch.mockReturnValue( { savePost, editPost } );
 		setStoreState( {
 			isDirty: true,
-			postStatus: 'auto-draft',
+			postStatus: 'draft',
 			postTitle: '',
 		} );
 
@@ -369,7 +369,7 @@ describe( 'useAutosave: auto-draft promotion', () => {
 		useDispatch.mockReturnValue( { savePost, editPost } );
 		setStoreState( {
 			isDirty: true,
-			postStatus: 'auto-draft',
+			postStatus: 'draft',
 			postTitle: '   ',
 		} );
 
@@ -409,7 +409,7 @@ describe( 'useAutosave: auto-draft promotion', () => {
 		useDispatch.mockReturnValue( { savePost, editPost } );
 		setStoreState( {
 			isDirty: true,
-			postStatus: 'auto-draft',
+			postStatus: 'draft',
 			postTitle: 'Team',
 		} );
 

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -29,6 +29,8 @@ const DEFAULT_STATE = {
 	isSaving: false,
 	didSucceed: false,
 	didFail: false,
+	postStatus: 'private',
+	postTitle: '',
 };
 
 let editsReference = {};
@@ -41,6 +43,15 @@ function setStoreState( state ) {
 		isSavingPost: () => merged.isSaving,
 		didPostSaveRequestSucceed: () => merged.didSucceed,
 		didPostSaveRequestFail: () => merged.didFail,
+		getEditedPostAttribute: ( name ) => {
+			if ( name === 'status' ) {
+				return merged.postStatus;
+			}
+			if ( name === 'title' ) {
+				return merged.postTitle;
+			}
+			return undefined;
+		},
 	};
 	const coreDataSelectors = {
 		getReferenceByDistinctEdits: () => editsReference,
@@ -66,7 +77,10 @@ beforeEach( () => {
 	jest.useFakeTimers();
 	editsReference = {};
 	setStoreState( {} );
-	useDispatch.mockReturnValue( { savePost: jest.fn() } );
+	useDispatch.mockReturnValue( {
+		savePost: jest.fn(),
+		editPost: jest.fn(),
+	} );
 } );
 
 afterEach( () => {
@@ -305,5 +319,107 @@ describe( 'useAutosave: status', () => {
 		const { result } = renderHook( () => useAutosave() );
 
 		expect( result.current.status ).toBe( 'error' );
+	} );
+} );
+
+describe( 'useAutosave: auto-draft promotion', () => {
+	it( 'promotes auto-draft to private before saving when title is non-empty', () => {
+		const savePost = jest.fn();
+		const editPost = jest.fn();
+		useDispatch.mockReturnValue( { savePost, editPost } );
+		setStoreState( {
+			isDirty: true,
+			postStatus: 'auto-draft',
+			postTitle: 'About Us',
+		} );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 800 );
+		} );
+
+		expect( editPost ).toHaveBeenCalledWith( { status: 'private' } );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not promote when title is empty', () => {
+		const savePost = jest.fn();
+		const editPost = jest.fn();
+		useDispatch.mockReturnValue( { savePost, editPost } );
+		setStoreState( {
+			isDirty: true,
+			postStatus: 'auto-draft',
+			postTitle: '',
+		} );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 800 );
+		} );
+
+		expect( editPost ).not.toHaveBeenCalled();
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not promote when title is whitespace only', () => {
+		const savePost = jest.fn();
+		const editPost = jest.fn();
+		useDispatch.mockReturnValue( { savePost, editPost } );
+		setStoreState( {
+			isDirty: true,
+			postStatus: 'auto-draft',
+			postTitle: '   ',
+		} );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 800 );
+		} );
+
+		expect( editPost ).not.toHaveBeenCalled();
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not promote when status is already private', () => {
+		const savePost = jest.fn();
+		const editPost = jest.fn();
+		useDispatch.mockReturnValue( { savePost, editPost } );
+		setStoreState( {
+			isDirty: true,
+			postStatus: 'private',
+			postTitle: 'About Us',
+		} );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 800 );
+		} );
+
+		expect( editPost ).not.toHaveBeenCalled();
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'promotes on flush triggers (blur)', () => {
+		const savePost = jest.fn();
+		const editPost = jest.fn();
+		useDispatch.mockReturnValue( { savePost, editPost } );
+		setStoreState( {
+			isDirty: true,
+			postStatus: 'auto-draft',
+			postTitle: 'Team',
+		} );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			window.dispatchEvent( new Event( 'blur' ) );
+		} );
+
+		expect( editPost ).toHaveBeenCalledWith( { status: 'private' } );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/tests/js/useResolveEntity.test.js
+++ b/tests/js/useResolveEntity.test.js
@@ -1,7 +1,7 @@
 /**
- * Tests for `src/router/useResolveEntity.js`: the segment-walking URI → page
- * resolver hook and the `computeUri` slug-chain helper. `@wordpress/api-fetch`
- * is mocked so each case controls the REST responses driving the walk.
+ * Tests for `src/router/useResolveEntity.js`: the id-based URI resolver,
+ * `computeUri` slug-plus-id builder, and `parseIdFromUri` extractor.
+ * `@wordpress/api-fetch` is mocked so each case controls the REST response.
  */
 
 import { renderHook, waitFor } from '@testing-library/react';
@@ -15,10 +15,38 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	useResolveEntity,
 	computeUri,
+	parseIdFromUri,
 } from '../../src/router/useResolveEntity';
 
 beforeEach( () => {
 	apiFetch.mockReset();
+} );
+
+describe( 'parseIdFromUri', () => {
+	it( 'extracts a bare numeric id', () => {
+		expect( parseIdFromUri( '42' ) ).toBe( 42 );
+	} );
+
+	it( 'extracts the trailing id from a slug-prefixed uri', () => {
+		expect( parseIdFromUri( 'about-us-42' ) ).toBe( 42 );
+	} );
+
+	it( 'takes the last numeric chunk when the slug itself ends in digits', () => {
+		expect( parseIdFromUri( 'v2-42' ) ).toBe( 42 );
+	} );
+
+	it( 'returns null for an empty uri', () => {
+		expect( parseIdFromUri( '' ) ).toBeNull();
+	} );
+
+	it( 'returns null for a uri without a trailing id', () => {
+		expect( parseIdFromUri( 'about-us' ) ).toBeNull();
+	} );
+
+	it( 'returns null for a nullish uri', () => {
+		expect( parseIdFromUri( undefined ) ).toBeNull();
+		expect( parseIdFromUri( null ) ).toBeNull();
+	} );
 } );
 
 describe( 'useResolveEntity', () => {
@@ -33,58 +61,8 @@ describe( 'useResolveEntity', () => {
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
 
-	it( 'resolves a single-segment uri with parent=0', async () => {
-		apiFetch.mockResolvedValueOnce( [ { id: 7, slug: 'foo', parent: 0 } ] );
-
-		const { result } = renderHook( () => useResolveEntity( 'foo' ) );
-
-		await waitFor( () =>
-			expect( result.current.isResolving ).toBe( false )
-		);
-
-		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
-		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toMatch(
-			/slug=foo(?:&|$)/
-		);
-		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toMatch(
-			/parent=0(?:&|$)/
-		);
-		expect( result.current ).toEqual( {
-			entity: { id: 7, slug: 'foo', parent: 0 },
-			isResolving: false,
-			notFound: false,
-		} );
-	} );
-
-	it( 'walks a two-segment uri, using parent id from the first hop', async () => {
-		apiFetch
-			.mockResolvedValueOnce( [ { id: 7, slug: 'foo', parent: 0 } ] )
-			.mockResolvedValueOnce( [ { id: 8, slug: 'bar', parent: 7 } ] );
-
-		const { result } = renderHook( () => useResolveEntity( 'foo/bar' ) );
-
-		await waitFor( () =>
-			expect( result.current.isResolving ).toBe( false )
-		);
-
-		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
-		expect( apiFetch.mock.calls[ 1 ][ 0 ].path ).toMatch(
-			/slug=bar(?:&|$)/
-		);
-		expect( apiFetch.mock.calls[ 1 ][ 0 ].path ).toMatch(
-			/parent=7(?:&|$)/
-		);
-		expect( result.current.entity ).toEqual( {
-			id: 8,
-			slug: 'bar',
-			parent: 7,
-		} );
-	} );
-
-	it( 'sets notFound when a segment has no results', async () => {
-		apiFetch.mockResolvedValueOnce( [] );
-
-		const { result } = renderHook( () => useResolveEntity( 'ghost' ) );
+	it( 'reports notFound for a non-empty uri with no extractable id', async () => {
+		const { result } = renderHook( () => useResolveEntity( 'about-us' ) );
 
 		await waitFor( () =>
 			expect( result.current.isResolving ).toBe( false )
@@ -95,12 +73,54 @@ describe( 'useResolveEntity', () => {
 			isResolving: false,
 			notFound: true,
 		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetches the record by id from a slug-prefixed uri', async () => {
+		apiFetch.mockResolvedValueOnce( { id: 42, slug: 'about-us', parent: 0 } );
+
+		const { result } = renderHook( () =>
+			useResolveEntity( 'about-us-42' )
+		);
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toMatch(
+			/\/wp\/v2\/cortext_pages\/42(?:\?|$)/
+		);
+		expect( result.current ).toEqual( {
+			entity: { id: 42, slug: 'about-us', parent: 0 },
+			isResolving: false,
+			notFound: false,
+		} );
+	} );
+
+	it( 'fetches the record by id from a bare numeric uri (fresh draft)', async () => {
+		apiFetch.mockResolvedValueOnce( { id: 7, slug: '', parent: 0 } );
+
+		const { result } = renderHook( () => useResolveEntity( '7' ) );
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toMatch(
+			/\/wp\/v2\/cortext_pages\/7(?:\?|$)/
+		);
+		expect( result.current.entity ).toEqual( {
+			id: 7,
+			slug: '',
+			parent: 0,
+		} );
 	} );
 
 	it( 'sets notFound when apiFetch rejects', async () => {
 		apiFetch.mockRejectedValueOnce( new Error( 'boom' ) );
 
-		const { result } = renderHook( () => useResolveEntity( 'broken' ) );
+		const { result } = renderHook( () => useResolveEntity( 'broken-99' ) );
 
 		await waitFor( () =>
 			expect( result.current.isResolving ).toBe( false )
@@ -112,17 +132,21 @@ describe( 'useResolveEntity', () => {
 } );
 
 describe( 'computeUri', () => {
-	it( 'joins slugs walking the parent chain', () => {
-		const pages = [
-			{ id: 1, slug: 'top', parent: 0 },
-			{ id: 2, slug: 'mid', parent: 1 },
-			{ id: 3, slug: 'leaf', parent: 2 },
-		];
-		expect( computeUri( pages[ 2 ], pages ) ).toBe( 'top/mid/leaf' );
+	it( 'joins slug and id with a dash', () => {
+		expect( computeUri( { id: 42, slug: 'about-us' } ) ).toBe(
+			'about-us-42'
+		);
 	} );
 
-	it( 'stops cleanly when a parent id is missing from allPages', () => {
-		const pages = [ { id: 3, slug: 'leaf', parent: 99 } ];
-		expect( computeUri( pages[ 0 ], pages ) ).toBe( 'leaf' );
+	it( 'returns a bare id when slug is empty', () => {
+		expect( computeUri( { id: 7, slug: '' } ) ).toBe( '7' );
+	} );
+
+	it( 'returns a bare id when slug is missing', () => {
+		expect( computeUri( { id: 7 } ) ).toBe( '7' );
+	} );
+
+	it( 'treats whitespace-only slugs as empty', () => {
+		expect( computeUri( { id: 7, slug: '   ' } ) ).toBe( '7' );
 	} );
 } );

--- a/tests/js/useResolveEntity.test.js
+++ b/tests/js/useResolveEntity.test.js
@@ -129,6 +129,30 @@ describe( 'useResolveEntity', () => {
 		expect( result.current.notFound ).toBe( true );
 		expect( result.current.entity ).toBeNull();
 	} );
+
+	it( 'does not refetch when the uri rewrites to a canonical form for the same id', async () => {
+		apiFetch.mockResolvedValueOnce( { id: 42, slug: '', parent: 0 } );
+
+		const { result, rerender } = renderHook(
+			( { uri } ) => useResolveEntity( uri ),
+			{ initialProps: { uri: '42' } }
+		);
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		rerender( { uri: 'about-us-42' } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.isResolving ).toBe( false );
+		expect( result.current.entity ).toEqual( {
+			id: 42,
+			slug: '',
+			parent: 0,
+		} );
+	} );
 } );
 
 describe( 'computeUri', () => {


### PR DESCRIPTION
## What
Fixes new pages getting a permanent `untitled` URL that never updates on rename.

## Why
Creating a new page locked its URL to `/untitled` forever. Renaming the page didn't fix it, so anyone sharing a link to a fresh page was sharing the wrong link. Create three pages in a row and you'd get `/untitled`, `/untitled-2`, `/untitled-3` in the sidebar with no way to tell them apart, and no way to clean it up later.

## How
New pages are now created as drafts with no title. WordPress only generates the URL slug from the title once, the first time a post leaves the draft state, so the old flow (creating with `title: "Untitled"` already set) was baking `untitled` in immediately. The draft is promoted on the first rename or first autosave with a real title, which is when WordPress generates a real slug.

Pages are also now routed by id rather than by slug path. URLs look like `<slug>-<id>` (or just `<id>` for untitled drafts), and the id is the part that matters. This means renames never break existing links, and drafts without a slug are still openable. As a side effect, the resolver no longer has to walk the URL segment by segment, which also removes the 100-page limit it used to hit and makes the pages load faster.

## Testing Instructions
1. Create a page. URL is a bare id (`?p=/47`).
2. Type a title; autosave rewrites the URL to `<slug>-<id>`.
3. Rename the page. URL updates; the previous URL still resolves.
4. Create several untitled pages in a row. No `untitled`/`untitled-2` collisions.
5. Reload on both a bare-id and `<slug>-<id>` URL. Both open.
6. `npm test -- useResolveEntity useAutosave` passes.