### PR TITLE
Add collection navigation in sidebar

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -33,7 +33,11 @@ import {
 	isDescendantOf,
 	nextChildOrder,
 } from './pages-tree';
-import { computeUri, parseIdFromUri } from '../router/useResolveEntity';
+import {
+	computeUri,
+	parseIdFromUri,
+	parseSplatUri,
+} from '../router/useResolveEntity';
 
 const POST_TYPE = 'cortext_page';
 
@@ -75,9 +79,16 @@ export default function Sidebar() {
 	const activeUri = params._splat ?? '';
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
 
-	const selectedId = useMemo(
-		() => parseIdFromUri( activeUri ),
+	const { prefix: activePrefix, tail: activeTail } = useMemo(
+		() => parseSplatUri( activeUri ),
 		[ activeUri ]
+	);
+	const selectedId = useMemo(
+		() =>
+			activePrefix === 'page' || activePrefix === null
+				? parseIdFromUri( activeTail )
+				: null,
+		[ activePrefix, activeTail ]
 	);
 
 	// Keep the URL canonical: once autosave assigns a slug to the active
@@ -92,7 +103,7 @@ export default function Sidebar() {
 		if ( ! current ) {
 			return;
 		}
-		const canonical = computeUri( current );
+		const canonical = computeUri( current, 'page' );
 		if ( canonical !== activeUri ) {
 			navigate( {
 				to: '/$',
@@ -116,7 +127,7 @@ export default function Sidebar() {
 				pages.find( ( p ) => p.id === id ) ?? { id };
 			navigate( {
 				to: '/$',
-				params: { _splat: computeUri( page ) },
+				params: { _splat: computeUri( page, 'page' ) },
 			} );
 		},
 		[ navigate, pages ]
@@ -453,6 +464,17 @@ export default function Sidebar() {
 								<Button
 									className="cortext-sidebar__title"
 									variant="tertiary"
+									onClick={ () =>
+										navigate( {
+											to: '/$',
+											params: {
+												_splat: computeUri(
+													collection,
+													'collection'
+												),
+											},
+										} )
+									}
 								>
 									{ collection.title.rendered }
 								</Button>

--- a/src/index.scss
+++ b/src/index.scss
@@ -225,4 +225,8 @@ body.cortext-fullscreen {
 		color: $gray-700;
 		height: 100%;
 	}
+
+    &__table {
+      margin: 2rem;
+    }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -226,7 +226,7 @@ body.cortext-fullscreen {
 		height: 100%;
 	}
 
-    &__table {
-      margin: 2rem;
-    }
+	&__table {
+		margin: 2rem;
+	}
 }

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -3,13 +3,16 @@ import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import Canvas from '../components/Canvas';
-import { useResolveEntity } from './useResolveEntity';
+import CollectionTable from '../components/CollectionTable';
+import {
+	parseIdFromUri,
+	parseSplatUri,
+	useResolveEntity,
+	useResolveCollection,
+} from './useResolveEntity';
 
-export default function EntityRoute() {
-	const params = useParams( { strict: false } );
-	const { entity, isResolving, notFound } = useResolveEntity(
-		params._splat ?? ''
-	);
+function PageRoute( { uri } ) {
+	const { entity, isResolving, notFound } = useResolveEntity( uri );
 
 	if ( isResolving ) {
 		return (
@@ -28,4 +31,42 @@ export default function EntityRoute() {
 	}
 
 	return <Canvas postId={ entity.id } key={ entity.id } />;
+}
+
+function CollectionRoute( { uri } ) {
+	const id = parseIdFromUri( uri );
+	const { entity, isResolving, notFound } = useResolveCollection( id );
+
+	if ( isResolving ) {
+		return (
+			<div className="cortext-canvas__loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( notFound || ! entity ) {
+		return (
+			<div className="cortext-canvas__empty">
+				<p>{ __( "That collection doesn't exist.", 'cortext' ) }</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="cortext-canvas__table">
+			<CollectionTable slug={ entity.slug } key={ entity.id } />
+		</div>
+	);
+}
+
+export default function EntityRoute() {
+	const params = useParams( { strict: false } );
+	const { prefix, tail } = parseSplatUri( params._splat ?? '' );
+
+	if ( prefix === 'collection' ) {
+		return <CollectionRoute uri={ tail } key={ `c-${ tail }` } />;
+	}
+
+	return <PageRoute uri={ tail } />;
 }

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -74,10 +74,75 @@ export function useResolveEntity( uri ) {
 	return state;
 }
 
-// Builds the URL segment for a page: `<slug>-<id>` when a slug exists, bare
-// `<id>` for fresh drafts. The id is the authoritative part — parseIdFromUri
-// only ever reads the trailing digits.
-export function computeUri( page ) {
-	const slug = typeof page.slug === 'string' ? page.slug.trim() : '';
-	return slug ? `${ slug }-${ page.id }` : `${ page.id }`;
+const COLLECTION_TYPE = 'cortext_collection';
+
+export function useResolveCollection( id ) {
+	const [ state, setState ] = useState( {
+		entity: null,
+		isResolving: true,
+		notFound: false,
+	} );
+
+	useEffect( () => {
+		if ( ! id ) {
+			setState( {
+				entity: null,
+				isResolving: false,
+				notFound: true,
+			} );
+			return undefined;
+		}
+
+		let cancelled = false;
+		setState( { entity: null, isResolving: true, notFound: false } );
+
+		apiFetch( {
+			path: `/wp/v2/${ COLLECTION_TYPE }s/${ id }?context=edit&_fields=id,slug`,
+		} )
+			.then( ( entity ) => {
+				if ( ! cancelled ) {
+					setState( {
+						entity,
+						isResolving: false,
+						notFound: false,
+					} );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setState( {
+						entity: null,
+						isResolving: false,
+						notFound: true,
+					} );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ id ] );
+
+	return state;
+}
+
+// Builds the URL segment: `<prefix>/<slug>-<id>` when a slug exists, or
+// `<prefix>/<id>` for fresh drafts. The id is the authoritative part —
+// parseIdFromUri only ever reads the trailing digits.
+export function computeUri( entity, prefix = 'page' ) {
+	const slug = typeof entity.slug === 'string' ? entity.slug.trim() : '';
+	const tail = slug ? `${ slug }-${ entity.id }` : `${ entity.id }`;
+	return `${ prefix }/${ tail }`;
+}
+
+// Strips the prefix from a splat URI and returns { prefix, tail }.
+export function parseSplatUri( uri ) {
+	const slash = ( uri ?? '' ).indexOf( '/' );
+	if ( slash === -1 ) {
+		return { prefix: null, tail: uri ?? '' };
+	}
+	return {
+		prefix: uri.slice( 0, slash ),
+		tail: uri.slice( slash + 1 ),
+	};
 }

--- a/tests/e2e/specs/shell.spec.js
+++ b/tests/e2e/specs/shell.spec.js
@@ -19,7 +19,9 @@ test.describe( 'Cortext shell', () => {
 	} ) => {
 		await admin.visitAdminPage( 'admin.php', 'page=cortext' );
 
-		await expect( page ).toHaveURL( /\/wp-admin\/admin\.php\?page=cortext$/ );
+		await expect( page ).toHaveURL(
+			/\/wp-admin\/admin\.php\?page=cortext$/
+		);
 
 		const root = page.locator( '#cortext-root' );
 		await expect( root ).toBeVisible();
@@ -53,9 +55,9 @@ test.describe( 'Cortext shell', () => {
 
 		try {
 			// Keep Playground's `playground_auto_login_already_happened` cookie
-		// intact so the `--login` mu-plugin doesn't silently log us back in
-		// as admin when WP auth cookies are cleared.
-		await page.context().clearCookies( { name: /^wordpress_/ } );
+			// intact so the `--login` mu-plugin doesn't silently log us back in
+			// as admin when WP auth cookies are cleared.
+			await page.context().clearCookies( { name: /^wordpress_/ } );
 			await page.request.post( '/wp-login.php', {
 				failOnStatusCode: true,
 				form: {

--- a/tests/js/useResolveEntity.test.js
+++ b/tests/js/useResolveEntity.test.js
@@ -160,21 +160,27 @@ describe( 'useResolveEntity', () => {
 } );
 
 describe( 'computeUri', () => {
-	it( 'joins slug and id with a dash', () => {
+	it( 'joins slug and id with a dash, prefixed by type', () => {
 		expect( computeUri( { id: 42, slug: 'about-us' } ) ).toBe(
-			'about-us-42'
+			'page/about-us-42'
 		);
 	} );
 
-	it( 'returns a bare id when slug is empty', () => {
-		expect( computeUri( { id: 7, slug: '' } ) ).toBe( '7' );
+	it( 'returns prefix/id when slug is empty', () => {
+		expect( computeUri( { id: 7, slug: '' } ) ).toBe( 'page/7' );
 	} );
 
-	it( 'returns a bare id when slug is missing', () => {
-		expect( computeUri( { id: 7 } ) ).toBe( '7' );
+	it( 'returns prefix/id when slug is missing', () => {
+		expect( computeUri( { id: 7 } ) ).toBe( 'page/7' );
 	} );
 
 	it( 'treats whitespace-only slugs as empty', () => {
-		expect( computeUri( { id: 7, slug: '   ' } ) ).toBe( '7' );
+		expect( computeUri( { id: 7, slug: '   ' } ) ).toBe( 'page/7' );
+	} );
+
+	it( 'accepts a custom prefix', () => {
+		expect(
+			computeUri( { id: 3, slug: 'books' }, 'collection' )
+		).toBe( 'collection/books-3' );
 	} );
 } );

--- a/tests/js/useResolveEntity.test.js
+++ b/tests/js/useResolveEntity.test.js
@@ -77,7 +77,11 @@ describe( 'useResolveEntity', () => {
 	} );
 
 	it( 'fetches the record by id from a slug-prefixed uri', async () => {
-		apiFetch.mockResolvedValueOnce( { id: 42, slug: 'about-us', parent: 0 } );
+		apiFetch.mockResolvedValueOnce( {
+			id: 42,
+			slug: 'about-us',
+			parent: 0,
+		} );
 
 		const { result } = renderHook( () =>
 			useResolveEntity( 'about-us-42' )


### PR DESCRIPTION
_This isn't meant to force a hard distinction in the view model between Pages and Collections, but is rather meant to help visualise — with a simple `<table>` and no attempt to introduce DataViews yet — any collection data already present on the site instance._


https://github.com/user-attachments/assets/7ea7ec71-d42f-4047-bf08-2314afc610ca




## Summary
- Introduce `page/` and `collection/` URI prefixes in the splat route (`?p=/page/slug-id`, `?p=/collection/slug-id`)
- Clicking a collection in the sidebar navigates to its collection route, rendering `CollectionTable`
- Add `useResolveCollection` hook and `parseSplatUri` helper to support the new routing

## Test plan
- [ ] Click a page in the sidebar — verify it navigates to `?p=/page/<slug>-<id>` and opens the editor
- [ ] Click a collection in the sidebar — verify it navigates to `?p=/collection/<slug>-<id>` and renders the collection table
- [ ] Verify URL canonicalization still works (draft page gets slug appended after first save)
- [ ] Navigate to a non-existent collection URL — verify "doesn't exist" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)