### PR TITLE
Use 'private' as the default post status for internal CPTs

### DIFF
--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -116,7 +116,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				array(
 					'post_type'   => Collection::POST_TYPE,
 					'post_title'  => $spec['title'],
-					'post_status' => 'publish',
+					'post_status' => 'private',
 				),
 				true
 			);
@@ -152,7 +152,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				array(
 					'post_type'   => Field::POST_TYPE,
 					'post_title'  => $title,
-					'post_status' => 'publish',
+					'post_status' => 'private',
 				),
 				true
 			);
@@ -206,7 +206,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				array(
 					'post_type'   => $entry_cpt,
 					'post_title'  => $entry['title'],
-					'post_status' => 'publish',
+					'post_status' => 'private',
 				),
 				true
 			);

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -36,7 +36,7 @@ final class CollectionEntries {
 		$collections = get_posts(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => array( 'draft', 'private', 'publish' ),
 				'numberposts' => -1,
 			)
 		);

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -65,7 +65,7 @@ export default function Sidebar() {
 	const { records: collections, isResolving: isResolvingCollections } =
 		useEntityRecords( 'postType', 'cortext_collection', {
 			per_page: 100,
-			status: 'publish',
+			status: [ 'draft', 'private', 'publish' ],
 			context: 'edit',
 		} );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( 'core' );

--- a/tests/php/test-collection-entries.php
+++ b/tests/php/test-collection-entries.php
@@ -41,7 +41,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$collection_id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Venues',
 				'meta_input'  => array( 'slug' => 'venues' ),
 			)
@@ -57,7 +57,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$collection_id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Meetings',
 				'meta_input'  => array( 'slug' => 'meetings' ),
 			)
@@ -78,7 +78,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$collection_id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Tasks',
 				'meta_input'  => array( 'slug' => 'tasks' ),
 			)
@@ -95,7 +95,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$collection_id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Projects',
 				'meta_input'  => array( 'slug' => 'projects' ),
 			)
@@ -104,7 +104,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$field_id = wp_insert_post(
 			array(
 				'post_type'   => Field::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Status',
 				'meta_input'  => array( 'type' => 'select' ),
 			)
@@ -126,7 +126,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$collection_id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Tags',
 				'meta_input'  => array( 'slug' => 'tags' ),
 			)
@@ -135,7 +135,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$field_id = wp_insert_post(
 			array(
 				'post_type'   => Field::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Categories',
 				'meta_input'  => array( 'type' => 'multiselect' ),
 			)
@@ -158,7 +158,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$collection_id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Too Long',
 				'meta_input'  => array( 'slug' => $long_slug ),
 			)
@@ -180,7 +180,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$collection_id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'Just Right',
 				'meta_input'  => array( 'slug' => $max_slug ),
 			)
@@ -199,7 +199,7 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$collection_id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
-				'post_status' => 'publish',
+				'post_status' => 'private',
 				'post_title'  => 'No Slug',
 			)
 		);


### PR DESCRIPTION
## Summary
- **Queries** for collections/pages now accept `draft`, `private`, and `publish` statuses (liberal reads)
- **Creation** of collections, fields, and entries (seed CLI + Sidebar collection fetch) now defaults to `private` so content is never publicly accessible
- Test fixtures updated to match

## Test plan
- [ ] Verify `wp cortext seed` creates collections/fields/entries with `private` status
- [ ] Verify Sidebar loads collections and pages across all three statuses
- [ ] Run `composer test` — all collection-entries tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)