### PR TITLE
Refactor static CPTs to `crtxt` namespace and reserve colliding slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Because it is still WordPress, Cortext picks up things Notion cannot: publishing
 
 ## How it works, in one paragraph
 
-Two post types handle storage: `cortext_page` for workspace documents, and `crtxt_{slug}` for collection rows (one dynamically-registered CPT per collection; the abbreviated prefix fits WordPress's 20-character post type slug limit). A global taxonomy (internally `cortext_supertag`, final user-facing name TBD) attaches to every collection CPT, enabling cross-collection polymorphism inspired by Tana's super tags. Typed properties register as post meta with UUID-based keys. One REST field, `cortext_row_resolved_schema`, returns the effective property set for a given row (union of collection and supertag properties) and is the only contract clients read. A React shell mounts Gutenberg's `EditorProvider` alongside `@wordpress/dataviews` on a full-screen admin page.
+Storage uses `crtxt_page` for workspace documents, `crtxt_collection` for collection definitions, `crtxt_field` for field definitions, and `crtxt_{slug}` for collection rows (one dynamically-registered CPT per collection). A global taxonomy (internally `cortext_supertag`, final user-facing name TBD) attaches to every collection CPT, enabling cross-collection polymorphism inspired by Tana's super tags. Typed properties register as post meta with UUID-based keys. One REST field, `cortext_row_resolved_schema`, returns the effective property set for a given row (union of collection and supertag properties) and is the only contract clients read. A React shell mounts Gutenberg's `EditorProvider` alongside `@wordpress/dataviews` on a full-screen admin page.
 
 ## Docs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,8 +4,8 @@
 
 Nomenclature | WordPress primitive
 -|-
-Collection   | `cortext_collection` CPT
-Field        | `cortext_field` CPT
+Collection   | `crtxt_collection` CPT
+Field        | `crtxt_field` CPT
 Entry        | `crtxt_{$slug}` CPT
 Field value  | `crtxt_{$slug}` post meta
 
@@ -14,7 +14,7 @@ Field value  | `crtxt_{$slug}` post meta
 - we create a new database
 
 ```php
-$collection_id = wp_insert_post( 'cortext_collection', [ ... ] );
+$collection_id = wp_insert_post( 'crtxt_collection', [ ... ] );
 register_post_type( 'crtxt_books', [ ... ] );
 ```
 
@@ -27,7 +27,7 @@ $book_id = wp_insert_post( 'crtxt_books', $data );
 - we add a new column
 
 ```php
-$field_id = wp_insert_post( 'cortext_field', $field_details );
+$field_id = wp_insert_post( 'crtxt_field', $field_details );
 add_post_meta( $field_id, 'type', 'text' );
 add_post_meta( $collection_id, 'fields', $field_id );
 
@@ -44,7 +44,7 @@ update_post_meta( $book_id, "field-{$field_id}", $value );
 ### Loading a collection on the client
 
 ```php
-$collection_object = get_posts( 'cortext_collection', [ 'slug' => 'book' ] );
+$collection_object = get_posts( 'crtxt_collection', [ 'slug' => 'book' ] );
 $collection_id = $collection->ID;
 
 $collection_items = get_posts( "crtxt_{$slug}" );

--- a/docs/architecture/data-model-intermediate-json.md
+++ b/docs/architecture/data-model-intermediate-json.md
@@ -27,7 +27,7 @@ extra network calls.
 ```
 
 `slug` is derived from `title` (lowercase, spaces → hyphens). It is used as the CPT
-suffix in WordPress (`cortext_collection_{slug}`).
+suffix in WordPress (`crtxt_{slug}`).
 
 ## FieldObject
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -4,9 +4,9 @@ The parent-level [architecture.md](../architecture.md) is the authoritative sket
 
 ## Target summary
 
-- `cortext_page` CPT for hierarchical workspace documents.
-- `cortext_collection` CPT, one post per collection definition. For each collection, a row CPT is dynamically registered as `crtxt_{slug}` (`crtxt_` is a vowel-stripped abbreviation of "cortext", chosen because WordPress's 20-character post type slug limit rules out the full `cortext_collection_` prefix).
-- `cortext_field` CPT for field definitions, assigned to a collection via post meta and surfaced on each row CPT as dynamic meta keys.
+- `crtxt_page` CPT for hierarchical workspace documents.
+- `crtxt_collection` CPT, one post per collection definition. For each collection, a row CPT is dynamically registered as `crtxt_{slug}` (`crtxt_` is the shared data prefix and leaves room for the collection slug under WordPress's 20-character post type limit).
+- `crtxt_field` CPT for field definitions, assigned to a collection via post meta and surfaced on each row CPT as dynamic meta keys.
 - `cortext_supertag` global taxonomy attached to every collection CPT, so terms can cross collection boundaries.
 
 ## Single client contract
@@ -23,9 +23,9 @@ Field identity is stable, but labels are not. Meta keys are UUIDs rather than sl
 
 Registered CPTs:
 
-- `cortext_page` — hierarchical workspace documents.
-- `cortext_collection` — collection definitions, with `notion_id` and `slug` meta. Fields are attached via multi-value `fields` meta (each value is a `cortext_field` post ID).
-- `cortext_field` — field definitions, with `type`, `options`, `number_format`, `expression`, and `related_collection_id` meta.
+- `crtxt_page` — hierarchical workspace documents.
+- `crtxt_collection` — collection definitions, with `notion_id` and `slug` meta. Fields are attached via multi-value `fields` meta (each value is a `crtxt_field` post ID).
+- `crtxt_field` — field definitions, with `type`, `options`, `number_format`, `expression`, and `related_collection_id` meta.
 - `crtxt_{slug}` — dynamically registered at `init` priority 20, one per published collection. Entry posts carry `notion_id` meta and `field-{$field_id}` meta per attached field.
 
 Not yet registered: `cortext_supertag` taxonomy, `cortext_row_resolved_schema` REST field.
@@ -40,8 +40,8 @@ A future importer should consume the intermediate JSON format defined in [data-m
 
 Relations between databases require the related entry's WP post ID to already exist. Always import in this order:
 
-1. For each database: create the `cortext_collection` post, then call `CollectionEntries::register_for_collection()` so the entry CPT is available in the same request.
-2. For each database: create `cortext_field` posts, attach to collection via `add_post_meta( $collection_id, 'fields', $field_id )`, and register their entry-level meta.
+1. For each database: create the `crtxt_collection` post, then call `CollectionEntries::register_for_collection()` so the entry CPT is available in the same request.
+2. For each database: create `crtxt_field` posts, attach to collection via `add_post_meta( $collection_id, 'fields', $field_id )`, and register their entry-level meta.
 3. Insert all entries **without** relation values. Build a lookup map `notion_entry_id → wp_post_id`.
 4. Resolve and write relation values using the lookup map.
 

--- a/docs/architecture/shell.md
+++ b/docs/architecture/shell.md
@@ -37,4 +37,4 @@ The pages tree in `src/components/Sidebar.js` uses `@dnd-kit` for drag-and-drop 
 
 ## Current scope
 
-The canvas is wired to core `page` posts as a stand-in for `cortext_page` while the target data model lands. Collection CPTs and the supertag taxonomy are not registered yet. See [architecture.md](../architecture.md) for the intended storage sketch and [data-model.md](./data-model.md) for the REST contract.
+The canvas is wired to `crtxt_page`. Collection definition, field definition, and dynamic row CPTs are registered; the collection table in the empty state is still a temporary demo surface. The supertag taxonomy and resolved row-schema REST field are not registered yet. See [architecture.md](../architecture.md) for the storage sketch and [data-model.md](./data-model.md) for the REST contract.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,7 +4,7 @@ Running log of significant design decisions. Newest first. Each entry captures *
 
 ## 2026-04-23 — Page URLs are id-based, slug is cosmetic
 
-**Decision.** Page URLs encode the post id as the authoritative identifier: `?page=cortext&p=/<slug>-<id>` (e.g. `?p=/about-us-42`), falling back to `?p=/<id>` when the slug is empty. `src/router/useResolveEntity.js` extracts the trailing digits via `parseIdFromUri` and fetches `GET /wp/v2/cortext_pages/<id>?context=edit`. The slug prefix is cosmetic. When autosave assigns a real slug, `Sidebar` rewrites the URL via `history.replace` so the visible URL reflects the latest title.
+**Decision.** Page URLs encode the post id as the authoritative identifier: `?page=cortext&p=/<slug>-<id>` (e.g. `?p=/about-us-42`), falling back to `?p=/<id>` when the slug is empty. `src/router/useResolveEntity.js` extracts the trailing digits via `parseIdFromUri` and fetches `GET /wp/v2/crtxt_pages/<id>?context=edit`. The slug prefix is cosmetic. When autosave assigns a real slug, `Sidebar` rewrites the URL via `history.replace` so the visible URL reflects the latest title.
 
 **Why.** The previous URL shape was a hierarchical slug path (`?p=/about-us/team`) resolved by walking one segment at a time through the REST collection endpoint. That works for titled pages but fails in two ways the shell hit in practice:
 
@@ -23,7 +23,7 @@ Id-based URLs sidestep both issues. The id is stable from creation, renames cann
 
 **Why.** Core regenerates `post_name` from `post_title` only on the transition out of `draft`, `pending`, or `auto-draft`, and only when `post_name` is empty. The previous code created pages as `private` with a placeholder title (`Untitled`), which committed `post_name: 'untitled'` at creation. Since core never regenerates after that point, every page's URL was stuck on `untitled` forever. Deferring slug assignment until there is a real title gets slug generation, uniqueness, and localization for free from core.
 
-`draft` rather than `auto-draft` because `auto-draft` is registered as an internal status and excluded from the REST schema's `status` enum; `POST /wp/v2/cortext_pages` with `status: 'auto-draft'` returns 400. `draft` has identical slug-regeneration behavior and is REST-valid. `draft` is also not subject to `wp_scheduled_auto_draft_delete`'s 7-day GC, so abandoned blank pages stay until explicitly deleted.
+`draft` rather than `auto-draft` because `auto-draft` is registered as an internal status and excluded from the REST schema's `status` enum; `POST /wp/v2/crtxt_pages` with `status: 'auto-draft'` returns 400. `draft` has identical slug-regeneration behavior and is REST-valid. `draft` is also not subject to `wp_scheduled_auto_draft_delete`'s 7-day GC, so abandoned blank pages stay until explicitly deleted.
 
 **Trade-off.** Pages already in the database with `post_name: 'untitled'` from before this change keep that slug. Renaming them does not regenerate it because at rename time they are `private`, not `draft`, so the status-gated promotion does not fire. No migration is planned; id-based URLs (previous entry) mean the stale slug no longer breaks navigation.
 
@@ -31,7 +31,7 @@ Id-based URLs sidestep both issues. The id is stable from creation, renames cann
 
 ## 2026-04-23 — Core admin is an escape hatch, not the primary UI
 
-**Decision.** `cortext_page` registers with `show_ui => true` and `show_in_menu => false`. `Admin\Screen` adds a "Manage Pages" submenu under the Cortext top-level that links to `edit.php?post_type=cortext_page`. The React shell remains the primary editing surface.
+**Decision.** `crtxt_page` registers with `show_ui => true` and `show_in_menu => false`. `Admin\Screen` adds a "Manage Pages" submenu under the Cortext top-level that links to `edit.php?post_type=crtxt_page`. The React shell remains the primary editing surface.
 
 **Why.** The shell is what users should reach for, but bulk operations (trash many, change status, reassign parent) are features core gives us for free and the shell doesn't have yet. Keeping core's list table + `post.php` editor reachable avoids dropping to `wp-cli` when the shell doesn't cover a chore. `show_in_menu => false` keeps the CPT from cluttering the top-level admin menu; `Admin\Screen` owns visibility.
 
@@ -39,13 +39,13 @@ Id-based URLs sidestep both issues. The id is stable from creation, renames cann
 
 **Revisit when.** The shell grows bulk-action affordances that cover the admin use cases, or the divergence between shell and core edits becomes a support problem. At that point flip `show_ui => false` and drop the submenu.
 
-## 2026-04-23 — `cortext_page` uses core post capabilities
+## 2026-04-23 — `crtxt_page` uses core post capabilities
 
-**Decision.** `cortext_page` is registered with `capability_type => 'post'` and `map_meta_cap => true`. Caps map to `edit_posts` / `edit_others_posts` / `publish_posts` / etc.
+**Decision.** `crtxt_page` is registered with `capability_type => 'post'` and `map_meta_cap => true`. Caps map to `edit_posts` / `edit_others_posts` / `publish_posts` / etc.
 
 **Why.** The Cortext admin shell is gated on `edit_posts` in `Cortext\Admin\Screen::register_menu` (`includes/Admin/Screen.php`). Aligning the CPT with the same capability set means the shell and the REST endpoints share a single authorization surface, with zero activation-time plumbing. Capability mappings are derived at runtime — not stored in `wp_posts` — so the decision is reversible without a data migration.
 
-**Trade-off.** A future workspace-member role model (e.g. `edit_cortext_pages`, workspace-scoped sharing) will require:
+**Trade-off.** A future workspace-member role model (e.g. `edit_crtxt_pages`, workspace-scoped sharing) will require:
 
 - An activation hook to grant the new caps to administrator and editor roles.
 - A `map_meta_cap` filter to derive meta caps from primitive caps.

--- a/includes/PostType/Collection.php
+++ b/includes/PostType/Collection.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Registers the `cortext_collection` custom post type.
+ * Registers the `crtxt_collection` custom post type.
  *
  * @package Cortext
  */
@@ -11,7 +11,7 @@ namespace Cortext\PostType;
 
 final class Collection {
 
-	public const POST_TYPE = 'cortext_collection';
+	public const POST_TYPE = 'crtxt_collection';
 
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_post_type' ) );
@@ -37,7 +37,7 @@ final class Collection {
 				'show_ui'            => true,
 				'show_in_menu'       => false,
 				'show_in_rest'       => true,
-				'rest_base'          => 'cortext_collections',
+				'rest_base'          => 'crtxt_collections',
 				'has_archive'        => false,
 				'hierarchical'       => false,
 				'supports'           => array( 'title', 'custom-fields' ),

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -24,8 +24,16 @@ final class CollectionEntries {
 	 * row CPTs use the shared `crtxt_` prefix and leave 14 characters for the
 	 * collection slug.
 	 */
-	public const CPT_PREFIX  = 'crtxt_';
-	public const MAX_CPT_LEN = 20;
+	public const CPT_PREFIX      = 'crtxt_';
+	public const MAX_CPT_LEN     = 20;
+	private const RESERVED_SLUGS = array(
+		'collection',
+		'collections',
+		'field',
+		'fields',
+		'page',
+		'pages',
+	);
 
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_all' ), 20 );
@@ -48,6 +56,21 @@ final class CollectionEntries {
 	public function register_for_collection( WP_Post $collection ): void {
 		$slug = get_post_meta( $collection->ID, 'slug', true );
 		if ( ! $slug ) {
+			return;
+		}
+
+		if ( in_array( $slug, self::RESERVED_SLUGS, true ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html(
+					sprintf(
+						/* translators: %s: collection slug */
+						__( 'Collection slug "%s" is reserved and was not registered.', 'cortext' ),
+						$slug
+					)
+				),
+				'0.0.1'
+			);
 			return;
 		}
 

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -2,9 +2,9 @@
 /**
  * Dynamically registers one CPT per published collection.
  *
- * Each `cortext_collection` post produces a `crtxt_{slug}` post type
+ * Each `crtxt_collection` post produces a `crtxt_{slug}` post type
  * whose entries are the rows of that collection. Field-level post meta
- * is registered for each attached `cortext_field`.
+ * is registered for each attached `crtxt_field`.
  *
  * @package Cortext
  */
@@ -20,10 +20,9 @@ final class CollectionEntries {
 	/**
 	 * Prefix for dynamically registered entry CPTs.
 	 *
-	 * WordPress enforces a 20-character limit on post type slugs.
-	 * `cortext_collection_` (20 chars) leaves no room for the slug,
-	 * so we use `crtxt_` — a vowel-stripped abbreviation of "cortext"
-	 * that stays recognisable while leaving 14 characters for the slug.
+	 * WordPress enforces a 20-character limit on post type slugs, so dynamic
+	 * row CPTs use the shared `crtxt_` prefix and leave 14 characters for the
+	 * collection slug.
 	 */
 	public const CPT_PREFIX  = 'crtxt_';
 	public const MAX_CPT_LEN = 20;

--- a/includes/PostType/Field.php
+++ b/includes/PostType/Field.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Registers the `cortext_field` custom post type.
+ * Registers the `crtxt_field` custom post type.
  *
  * @package Cortext
  */
@@ -11,7 +11,7 @@ namespace Cortext\PostType;
 
 final class Field {
 
-	public const POST_TYPE = 'cortext_field';
+	public const POST_TYPE = 'crtxt_field';
 
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_post_type' ) );
@@ -37,7 +37,7 @@ final class Field {
 				'show_ui'            => true,
 				'show_in_menu'       => false,
 				'show_in_rest'       => true,
-				'rest_base'          => 'cortext_fields',
+				'rest_base'          => 'crtxt_fields',
 				'has_archive'        => false,
 				'hierarchical'       => false,
 				'supports'           => array( 'title', 'custom-fields' ),

--- a/includes/PostType/Page.php
+++ b/includes/PostType/Page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Registers the `cortext_page` custom post type.
+ * Registers the `crtxt_page` custom post type.
  *
  * @package Cortext
  */
@@ -11,7 +11,7 @@ namespace Cortext\PostType;
 
 final class Page {
 
-	public const POST_TYPE = 'cortext_page';
+	public const POST_TYPE = 'crtxt_page';
 
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_post_type' ) );
@@ -42,9 +42,9 @@ final class Page {
 				'show_in_menu'          => false,
 				'show_in_rest'          => true,
 				// Matches useResolveEntity.js's `/wp/v2/${POST_TYPE}s?...` URL shape; core
-				// defaults rest_base to the CPT slug (`cortext_page`), which would 404 the
+				// defaults rest_base to the CPT slug (`crtxt_page`), which would 404 the
 				// segment-walk resolver. Keep explicit.
-				'rest_base'             => 'cortext_pages',
+				'rest_base'             => 'crtxt_pages',
 				'rest_controller_class' => 'WP_REST_Posts_Controller',
 				'has_archive'           => false,
 				'hierarchical'          => true,

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -9,7 +9,7 @@ import CollectionDataViews from '../../components/CollectionDataViews';
 function CollectionPicker( { onSelect } ) {
 	const { records, isResolving } = useEntityRecords(
 		'postType',
-		'cortext_collection',
+		'crtxt_collection',
 		{
 			per_page: 100,
 			context: 'edit',

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -22,7 +22,7 @@ import { cog } from '@wordpress/icons';
 
 import useAutosave from '../hooks/useAutosave';
 
-const POST_TYPE = 'cortext_page';
+const POST_TYPE = 'crtxt_page';
 const SCOPE = 'cortext';
 const INSPECTOR = 'cortext/block-inspector';
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -39,7 +39,7 @@ import {
 	parseSplatUri,
 } from '../router/useResolveEntity';
 
-const POST_TYPE = 'cortext_page';
+const POST_TYPE = 'crtxt_page';
 
 const AUTO_EXPAND_DELAY = 700;
 
@@ -67,7 +67,7 @@ export default function Sidebar() {
 	} );
 
 	const { records: collections, isResolving: isResolvingCollections } =
-		useEntityRecords( 'postType', 'cortext_collection', {
+		useEntityRecords( 'postType', 'crtxt_collection', {
 			per_page: 100,
 			status: [ 'draft', 'private', 'publish' ],
 			context: 'edit',

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -67,14 +67,14 @@ function mapField( field ) {
 }
 
 // Reads a collection's fields from main's contract: `meta.fields` is an array
-// of `cortext_field` post IDs in display order. Fetch those records, then
+// of `crtxt_field` post IDs in display order. Fetch those records, then
 // map each to a DataViews field. Row meta keys are `field-<post_id>`.
 export default function useCollectionFields( collectionId ) {
 	const {
 		record: collection,
 		isResolving: collectionResolving,
 		hasResolved: collectionResolved,
-	} = useEntityRecord( 'postType', 'cortext_collection', collectionId ?? 0 );
+	} = useEntityRecord( 'postType', 'crtxt_collection', collectionId ?? 0 );
 
 	const fieldIds = useMemo( () => {
 		const raw = collection?.meta?.fields;
@@ -90,12 +90,12 @@ export default function useCollectionFields( collectionId ) {
 		hasResolved: fieldsResolved,
 	} = useEntityRecords(
 		'postType',
-		'cortext_field',
+		'crtxt_field',
 		{
 			include: fieldIds,
 			per_page: 100,
 			orderby: 'include',
-			// `cortext_field` posts are stored as `private`; without an
+			// `crtxt_field` posts are stored as `private`; without an
 			// explicit `status` REST defaults to `publish` and returns
 			// zero rows.
 			status: [ 'draft', 'private', 'publish' ],
@@ -103,7 +103,7 @@ export default function useCollectionFields( collectionId ) {
 		},
 		// Skip the resolver when there are no IDs to look up. Passing
 		// `undefined`/`{}` would fall through to a default empty query,
-		// which fetches every `cortext_field` in the system.
+		// which fetches every `crtxt_field` in the system.
 		{ enabled: fieldIds.length > 0 }
 	);
 

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -6,7 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 // cosmetic: it keeps the URL human-readable without being authoritative, so
 // renaming a page can never break an existing link, and blank drafts (which
 // have no slug yet) remain addressable via their id alone.
-const POST_TYPE = 'cortext_page';
+const POST_TYPE = 'crtxt_page';
 
 // Pulls the trailing `<digits>` — optionally preceded by `-` — out of a URI.
 // Matches both `foo-42` and bare `42`. Returns null for anything else so
@@ -74,7 +74,7 @@ export function useResolveEntity( uri ) {
 	return state;
 }
 
-const COLLECTION_TYPE = 'cortext_collection';
+const COLLECTION_TYPE = 'crtxt_collection';
 
 export function useResolveCollection( id ) {
 	const [ state, setState ] = useState( {

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -25,7 +25,7 @@ async function createCollectionFixture( requestUtils ) {
 
 	const collection = await requestUtils.rest( {
 		method: 'POST',
-		path: '/wp/v2/cortext_collections',
+		path: '/wp/v2/crtxt_collections',
 		data: {
 			title: `E2E Books ${ suffix }`,
 			status: 'private',
@@ -35,7 +35,7 @@ async function createCollectionFixture( requestUtils ) {
 
 	const field = await requestUtils.rest( {
 		method: 'POST',
-		path: '/wp/v2/cortext_fields',
+		path: '/wp/v2/crtxt_fields',
 		data: {
 			title: 'Author',
 			status: 'private',
@@ -45,7 +45,7 @@ async function createCollectionFixture( requestUtils ) {
 
 	await requestUtils.rest( {
 		method: 'POST',
-		path: `/wp/v2/cortext_collections/${ collection.id }`,
+		path: `/wp/v2/crtxt_collections/${ collection.id }`,
 		data: {
 			meta: { fields: [ String( field.id ) ] },
 		},
@@ -100,7 +100,7 @@ test.describe( 'Collection view block', () => {
 
 			fixture.page = await requestUtils.rest( {
 				method: 'POST',
-				path: '/wp/v2/cortext_pages',
+				path: '/wp/v2/crtxt_pages',
 				data: {
 					title: 'DataView block test page',
 					status: 'private',
@@ -140,7 +140,7 @@ test.describe( 'Collection view block', () => {
 			);
 
 			const saved = await requestUtils.rest( {
-				path: `/wp/v2/cortext_pages/${ fixture.page.id }`,
+				path: `/wp/v2/crtxt_pages/${ fixture.page.id }`,
 				params: { context: 'edit' },
 			} );
 			expect( saved.content.raw ).toContain( 'wp:cortext/data-view' );
@@ -166,16 +166,16 @@ test.describe( 'Collection view block', () => {
 			);
 			await deleteIfCreated(
 				requestUtils,
-				fixture.page && `/wp/v2/cortext_pages/${ fixture.page.id }`
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
 			);
 			await deleteIfCreated(
 				requestUtils,
-				fixture.field && `/wp/v2/cortext_fields/${ fixture.field.id }`
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
 			);
 			await deleteIfCreated(
 				requestUtils,
 				fixture.collection &&
-					`/wp/v2/cortext_collections/${ fixture.collection.id }`
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
 			);
 		}
 	} );

--- a/tests/js/useResolveEntity.test.js
+++ b/tests/js/useResolveEntity.test.js
@@ -93,7 +93,7 @@ describe( 'useResolveEntity', () => {
 
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toMatch(
-			/\/wp\/v2\/cortext_pages\/42(?:\?|$)/
+			/\/wp\/v2\/crtxt_pages\/42(?:\?|$)/
 		);
 		expect( result.current ).toEqual( {
 			entity: { id: 42, slug: 'about-us', parent: 0 },
@@ -112,7 +112,7 @@ describe( 'useResolveEntity', () => {
 		);
 
 		expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toMatch(
-			/\/wp\/v2\/cortext_pages\/7(?:\?|$)/
+			/\/wp\/v2\/crtxt_pages\/7(?:\?|$)/
 		);
 		expect( result.current.entity ).toEqual( {
 			id: 7,

--- a/tests/php/test-collection-entries.php
+++ b/tests/php/test-collection-entries.php
@@ -173,6 +173,44 @@ final class Test_Collection_Entries extends BaseTestCase {
 		);
 	}
 
+	public function test_rejects_reserved_static_cpt_slug(): void {
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Reserved',
+				'meta_input'  => array( 'slug' => 'page' ),
+			)
+		);
+
+		$collection = get_post( $collection_id );
+		( new CollectionEntries() )->register_for_collection( $collection );
+
+		$this->assertFalse(
+			post_type_exists( 'crtxt_page' ),
+			'Reserved slugs must not produce dynamic CPTs that collide with static CPTs.'
+		);
+	}
+
+	public function test_rejects_reserved_static_rest_base_slug(): void {
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Reserved Rest Base',
+				'meta_input'  => array( 'slug' => 'pages' ),
+			)
+		);
+
+		$collection = get_post( $collection_id );
+		( new CollectionEntries() )->register_for_collection( $collection );
+
+		$this->assertFalse(
+			post_type_exists( 'crtxt_pages' ),
+			'Reserved slugs must not produce dynamic CPTs that collide with static REST bases.'
+		);
+	}
+
 	public function test_accepts_slug_at_max_length(): void {
 		$max_slug_len = CollectionEntries::MAX_CPT_LEN - strlen( CollectionEntries::CPT_PREFIX );
 		$max_slug     = str_repeat( 'b', $max_slug_len );

--- a/tests/php/test-post-type-collection.php
+++ b/tests/php/test-post-type-collection.php
@@ -15,7 +15,7 @@ use WorDBless\BaseTestCase;
 final class Test_Post_Type_Collection extends BaseTestCase {
 
 	public function test_post_type_constant_matches_expected_slug(): void {
-		$this->assertSame( 'cortext_collection', Collection::POST_TYPE );
+		$this->assertSame( 'crtxt_collection', Collection::POST_TYPE );
 	}
 
 	public function test_register_hooks_init_action(): void {
@@ -29,7 +29,7 @@ final class Test_Post_Type_Collection extends BaseTestCase {
 		);
 	}
 
-	public function test_register_post_type_registers_cortext_collection(): void {
+	public function test_register_post_type_registers_crtxt_collection(): void {
 		( new Collection() )->register_post_type();
 
 		$this->assertTrue( post_type_exists( Collection::POST_TYPE ) );
@@ -41,9 +41,9 @@ final class Test_Post_Type_Collection extends BaseTestCase {
 		$object = get_post_type_object( Collection::POST_TYPE );
 		$this->assertNotNull( $object );
 
-		$this->assertFalse( $object->hierarchical, 'cortext_collection is not hierarchical.' );
-		$this->assertTrue( $object->show_in_rest, 'cortext_collection must be show_in_rest for @wordpress/core-data.' );
-		$this->assertSame( 'cortext_collections', $object->rest_base );
+		$this->assertFalse( $object->hierarchical, 'crtxt_collection is not hierarchical.' );
+		$this->assertTrue( $object->show_in_rest, 'crtxt_collection must be show_in_rest for @wordpress/core-data.' );
+		$this->assertSame( 'crtxt_collections', $object->rest_base );
 		$this->assertFalse( $object->public );
 		$this->assertTrue( $object->show_ui );
 		$this->assertFalse( $object->show_in_menu );

--- a/tests/php/test-post-type-field.php
+++ b/tests/php/test-post-type-field.php
@@ -15,7 +15,7 @@ use WorDBless\BaseTestCase;
 final class Test_Post_Type_Field extends BaseTestCase {
 
 	public function test_post_type_constant_matches_expected_slug(): void {
-		$this->assertSame( 'cortext_field', Field::POST_TYPE );
+		$this->assertSame( 'crtxt_field', Field::POST_TYPE );
 	}
 
 	public function test_register_hooks_init_action(): void {
@@ -29,7 +29,7 @@ final class Test_Post_Type_Field extends BaseTestCase {
 		);
 	}
 
-	public function test_register_post_type_registers_cortext_field(): void {
+	public function test_register_post_type_registers_crtxt_field(): void {
 		( new Field() )->register_post_type();
 
 		$this->assertTrue( post_type_exists( Field::POST_TYPE ) );
@@ -43,7 +43,7 @@ final class Test_Post_Type_Field extends BaseTestCase {
 
 		$this->assertFalse( $object->hierarchical );
 		$this->assertTrue( $object->show_in_rest );
-		$this->assertSame( 'cortext_fields', $object->rest_base );
+		$this->assertSame( 'crtxt_fields', $object->rest_base );
 		$this->assertFalse( $object->public );
 		$this->assertTrue( $object->show_ui );
 		$this->assertFalse( $object->show_in_menu );

--- a/tests/php/test-post-type-page.php
+++ b/tests/php/test-post-type-page.php
@@ -15,7 +15,7 @@ use WorDBless\BaseTestCase;
 final class Test_Post_Type_Page extends BaseTestCase {
 
 	public function test_post_type_constant_matches_expected_slug(): void {
-		$this->assertSame( 'cortext_page', Page::POST_TYPE );
+		$this->assertSame( 'crtxt_page', Page::POST_TYPE );
 	}
 
 	public function test_register_hooks_init_action(): void {
@@ -29,7 +29,7 @@ final class Test_Post_Type_Page extends BaseTestCase {
 		);
 	}
 
-	public function test_register_post_type_registers_cortext_page(): void {
+	public function test_register_post_type_registers_crtxt_page(): void {
 		( new Page() )->register_post_type();
 
 		$this->assertTrue( post_type_exists( Page::POST_TYPE ) );
@@ -41,9 +41,9 @@ final class Test_Post_Type_Page extends BaseTestCase {
 		$object = get_post_type_object( Page::POST_TYPE );
 		$this->assertNotNull( $object );
 
-		$this->assertTrue( $object->hierarchical, 'cortext_page must be hierarchical for the page tree.' );
-		$this->assertTrue( $object->show_in_rest, 'cortext_page must be show_in_rest for @wordpress/core-data.' );
-		$this->assertSame( 'cortext_pages', $object->rest_base, 'rest_base must match the JS resolver URL shape.' );
+		$this->assertTrue( $object->hierarchical, 'crtxt_page must be hierarchical for the page tree.' );
+		$this->assertTrue( $object->show_in_rest, 'crtxt_page must be show_in_rest for @wordpress/core-data.' );
+		$this->assertSame( 'crtxt_pages', $object->rest_base, 'rest_base must match the JS resolver URL shape.' );
 		$this->assertFalse( $object->public );
 		$this->assertTrue( $object->show_ui, 'show_ui stays on so Admin\Screen\'s submenu can link to the core list table as an escape hatch.' );
 		$this->assertFalse( $object->show_in_menu, 'show_in_menu is false because Admin\Screen owns the top-level menu.' );

--- a/tests/php/test-revision-throttle.php
+++ b/tests/php/test-revision-throttle.php
@@ -15,7 +15,7 @@ use WP_Post;
 
 final class Test_Revision_Throttle extends BaseTestCase {
 
-	private const POST_TYPE = 'cortext_page';
+	private const POST_TYPE = 'crtxt_page';
 
 	private function make_post( string $post_type ): WP_Post {
 		return new WP_Post(
@@ -61,7 +61,7 @@ final class Test_Revision_Throttle extends BaseTestCase {
 		$this->assertFalse( $throttle->throttle_revision( false, $revision, $post ) );
 	}
 
-	public function test_throttle_suppresses_cortext_page_within_interval_window(): void {
+	public function test_throttle_suppresses_crtxt_page_within_interval_window(): void {
 		$throttle = new RevisionThrottle();
 		$post     = $this->make_post( self::POST_TYPE );
 		$revision = $this->make_revision( 60 );
@@ -117,7 +117,7 @@ final class Test_Revision_Throttle extends BaseTestCase {
 		$this->assertSame( -1, $throttle->cap_revisions( -1, $post ) );
 	}
 
-	public function test_cap_revisions_caps_cortext_page_regardless_of_incoming_value(): void {
+	public function test_cap_revisions_caps_crtxt_page_regardless_of_incoming_value(): void {
 		$throttle = new RevisionThrottle();
 		$post     = $this->make_post( self::POST_TYPE );
 


### PR DESCRIPTION
## What

Renames the three static CPTs (`cortext_page`, `cortext_collection`, `cortext_field`) and their REST bases to use the shared `crtxt_` prefix, and reserves the slugs that would now collide with them.

## Why

The dynamic row CPTs are already forced into the abbreviated `crtxt_` prefix by WordPress's 20-character post type slug limit, so the storage layer was running under two parallel namespaces. Folding the static CPTs into the same prefix gives the data model a single, consistent namespace and makes the trade-off behind the abbreviation visible in one place instead of two. Once the prefix is shared, a collection slug like `page` would silently overwrite the static `crtxt_page`, so reserving those slugs is part of the same change.

## How

- Updating `POST_TYPE` and `rest_base` on `Page`, `Collection`, and `Field`, and propagating the new values through every consumer.

- Adding a `RESERVED_SLUGS` constant.

## Testing Instructions

1. In the WP admin, confirm the React shell still loads pages, the sidebar lists collections, and the collection table renders rows. URLs should resolve via `/wp/v2/crtxt_pages/<id>`.
3. Create a `crtxt_collection` post with meta set to `page`, then reload. Verify no `crtxt_page` dynamic CPT is registered and a `_doing_it_wrong` notice is logged.