### PR TITLE
Avoid re-renders by stabilising getRecordById reference

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -143,13 +143,16 @@ export default function Sidebar() {
 
 	const autoExpandTimerRef = useRef( null );
 
-	// Pull the source record straight from core-data for Duplicate (needs
-	// content.raw, which useEntityRecords above already fetches via
-	// context=edit).
-	const getRecordById = useSelect(
-		( select ) => ( id ) =>
-			select( 'core' ).getEntityRecord( 'postType', POST_TYPE, id ),
+	const getEntityRecord = useSelect(
+		( select ) => select( 'core' ).getEntityRecord,
 		[]
+	);
+
+	// Pull the source record straight from core-data for id-based actions like
+	// Duplicate and Rename.
+	const getRecordById = useCallback(
+		( id ) => getEntityRecord( 'postType', POST_TYPE, id ),
+		[ getEntityRecord ]
 	);
 
 	const toggleExpand = useCallback( ( id ) => {


### PR DESCRIPTION
Fixes React warning:

```
The `useSelect` hook returns different values when called with the same state and parameters.
This can lead to unnecessary re-renders and performance issues if not fixed.

Non-equal value keys: 

 Error Component Stack
    at Sidebar (Sidebar.js:63:51)
    at div (<anonymous>)
    at RootLayout (<anonymous>)
    at MatchInnerImpl (Match.js:128:57)
    at SafeFragment (SafeFragment.js:5:41)
    at SafeFragment (SafeFragment.js:5:41)
    at SafeFragment (SafeFragment.js:5:41)
    at SafeFragment (SafeFragment.js:5:41)
    at MatchView (Match.js:67:22)
    at MatchImpl (Match.js:17:47)
    at CatchBoundaryImpl (CatchBoundary.js:21:1)
    at CatchBoundary (CatchBoundary.js:6:1)
    at MatchesInner (Matches.js:29:26)
    at Suspense (<anonymous>)
    at Matches (Matches.js:19:26)
    at RouterContextProvider (RouterProvider.js:11:34)
    at RouterProvider (RouterProvider.js:36:27)
```