### PR TITLE
Collections: Add inline collection creation to the DataView block

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -15,6 +15,7 @@ use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\Field;
 use Cortext\PostType\Page;
+use Cortext\Rest\CollectionsController;
 
 final class Plugin {
 
@@ -34,6 +35,7 @@ final class Plugin {
 		( new Field() )->register();
 		( new CollectionEntries() )->register();
 		( new RevisionThrottle() )->register();
+		( new CollectionsController() )->register();
 	}
 
 	private function __construct() {}

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -35,6 +35,10 @@ final class CollectionEntries {
 		'pages',
 	);
 
+	public static function is_reserved_slug( string $slug ): bool {
+		return in_array( $slug, self::RESERVED_SLUGS, true );
+	}
+
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_all' ), 20 );
 	}
@@ -59,7 +63,7 @@ final class CollectionEntries {
 			return;
 		}
 
-		if ( in_array( $slug, self::RESERVED_SLUGS, true ) ) {
+		if ( self::is_reserved_slug( $slug ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				esc_html(

--- a/includes/Rest/CollectionsController.php
+++ b/includes/Rest/CollectionsController.php
@@ -111,7 +111,7 @@ final class CollectionsController {
 
 	private function unique_slug( string $raw_slug ): string {
 		$max_length = CollectionEntries::MAX_CPT_LEN - strlen( CollectionEntries::CPT_PREFIX );
-		$base       = sanitize_title( $raw_slug );
+		$base       = sanitize_key( sanitize_title( $raw_slug ) );
 
 		if ( '' === $base ) {
 			$base = 'items';
@@ -154,6 +154,8 @@ final class CollectionsController {
 	}
 
 	/**
+	 * Gets existing collection slugs.
+	 *
 	 * @return array<string, true> Set of slugs already in use, keyed by slug.
 	 */
 	private function existing_slugs(): array {

--- a/includes/Rest/CollectionsController.php
+++ b/includes/Rest/CollectionsController.php
@@ -122,6 +122,8 @@ final class CollectionsController {
 			$base = 'items';
 		}
 
+		$taken = $this->existing_slugs();
+
 		for ( $suffix = 0; $suffix < 1000; $suffix++ ) {
 			$suffix_text = $suffix > 0 ? '-' . ( $suffix + 1 ) : '';
 			$stem_length = $max_length - strlen( $suffix_text );
@@ -131,7 +133,7 @@ final class CollectionsController {
 			}
 
 			$candidate = $stem . $suffix_text;
-			if ( ! $this->slug_exists( $candidate ) ) {
+			if ( ! $this->slug_taken( $candidate, $taken ) ) {
 				return $candidate;
 			}
 		}
@@ -139,7 +141,7 @@ final class CollectionsController {
 		return substr( uniqid( 'c', false ), 0, $max_length );
 	}
 
-	private function slug_exists( string $slug ): bool {
+	private function slug_taken( string $slug, array $taken ): bool {
 		if ( CollectionEntries::is_reserved_slug( $slug ) ) {
 			return true;
 		}
@@ -148,7 +150,14 @@ final class CollectionsController {
 			return true;
 		}
 
-		$collections = get_posts(
+		return isset( $taken[ $slug ] );
+	}
+
+	/**
+	 * @return array<string, true> Set of slugs already in use, keyed by slug.
+	 */
+	private function existing_slugs(): array {
+		$collection_ids = get_posts(
 			array(
 				'post_type'   => Collection::POST_TYPE,
 				'post_status' => 'any',
@@ -157,12 +166,14 @@ final class CollectionsController {
 			)
 		);
 
-		foreach ( $collections as $collection_id ) {
-			if ( get_post_meta( (int) $collection_id, 'slug', true ) === $slug ) {
-				return true;
+		$slugs = array();
+		foreach ( $collection_ids as $collection_id ) {
+			$slug = get_post_meta( (int) $collection_id, 'slug', true );
+			if ( is_string( $slug ) && '' !== $slug ) {
+				$slugs[ $slug ] = true;
 			}
 		}
 
-		return false;
+		return $slugs;
 	}
 }

--- a/includes/Rest/CollectionsController.php
+++ b/includes/Rest/CollectionsController.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * REST endpoint for creating Cortext collections.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class CollectionsController {
+
+	private const NAMESPACE = 'cortext/v1';
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/collections',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'create' ),
+					'permission_callback' => array( $this, 'can_create' ),
+					'args'                => array(
+						'title' => array(
+							'type'     => 'string',
+							'required' => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function can_create(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	public function create( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$title = trim( sanitize_text_field( (string) $request->get_param( 'title' ) ) );
+
+		if ( '' === $title ) {
+			return new WP_Error(
+				'cortext_collection_title_required',
+				__( 'Collection name is required.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$slug = $this->unique_slug( $title );
+
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => array(
+					'slug' => $slug,
+				),
+			),
+			true
+		);
+
+		if ( is_wp_error( $collection_id ) ) {
+			return $collection_id;
+		}
+
+		$collection = get_post( (int) $collection_id );
+		if ( ! $collection ) {
+			wp_delete_post( (int) $collection_id, true );
+			return new WP_Error(
+				'cortext_collection_create_failed',
+				__( 'Collection could not be created.', 'cortext' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		( new CollectionEntries() )->register_for_collection( $collection );
+
+		$rest_base = CollectionEntries::CPT_PREFIX . $slug;
+		if ( ! post_type_exists( $rest_base ) ) {
+			wp_delete_post( (int) $collection_id, true );
+			return new WP_Error(
+				'cortext_collection_cpt_failed',
+				__( 'Collection rows could not be registered.', 'cortext' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'id'       => (int) $collection_id,
+				'title'    => $title,
+				'slug'     => $slug,
+				'restBase' => $rest_base,
+			),
+			201
+		);
+	}
+
+	private function unique_slug( string $raw_slug ): string {
+		$max_length = CollectionEntries::MAX_CPT_LEN - strlen( CollectionEntries::CPT_PREFIX );
+		$base       = sanitize_title( $raw_slug );
+
+		if ( '' === $base ) {
+			$base = 'items';
+		}
+
+		$base = trim( substr( $base, 0, $max_length ), '-' );
+		if ( '' === $base ) {
+			$base = 'items';
+		}
+
+		for ( $suffix = 0; $suffix < 1000; $suffix++ ) {
+			$suffix_text = $suffix > 0 ? '-' . ( $suffix + 1 ) : '';
+			$stem_length = $max_length - strlen( $suffix_text );
+			$stem        = trim( substr( $base, 0, $stem_length ), '-' );
+			if ( '' === $stem ) {
+				$stem = 'items';
+			}
+
+			$candidate = $stem . $suffix_text;
+			if ( ! $this->slug_exists( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return substr( uniqid( 'c', false ), 0, $max_length );
+	}
+
+	private function slug_exists( string $slug ): bool {
+		if ( CollectionEntries::is_reserved_slug( $slug ) ) {
+			return true;
+		}
+
+		if ( post_type_exists( CollectionEntries::CPT_PREFIX . $slug ) ) {
+			return true;
+		}
+
+		$collections = get_posts(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+
+		foreach ( $collections as $collection_id ) {
+			if ( get_post_meta( (int) $collection_id, 'slug', true ) === $slug ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -1,45 +1,176 @@
 import { __ } from '@wordpress/i18n';
-import { useBlockProps } from '@wordpress/block-editor';
-import { Placeholder, SelectControl, Spinner } from '@wordpress/components';
+import { BlockControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	Button,
+	Dropdown,
+	Notice,
+	Placeholder,
+	Spinner,
+	TextControl,
+	ToolbarButton,
+} from '@wordpress/components';
 import { useEntityRecords } from '@wordpress/core-data';
-import { useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { replace } from '@wordpress/icons';
 
 import CollectionDataViews from '../../components/CollectionDataViews';
+import { COLLECTION_QUERY } from '../../collections';
 
-function CollectionPicker( { onSelect } ) {
-	const { records, isResolving } = useEntityRecords(
+function createDefaultView() {
+	return {
+		type: 'table',
+		fields: [],
+		sort: null,
+		filters: [],
+		perPage: 25,
+		page: 1,
+		search: '',
+		layout: {},
+	};
+}
+
+function CollectionPicker( { selectedId = '', onSelect } ) {
+	const { records, isResolving, hasResolved } = useEntityRecords(
 		'postType',
 		'crtxt_collection',
-		{
-			per_page: 100,
-			context: 'edit',
-			status: [ 'draft', 'private', 'publish' ],
-		}
+		COLLECTION_QUERY
 	);
 
-	const options = [
-		{ value: '', label: __( 'Select a collection…', 'cortext' ) },
-		...( records ?? [] ).map( ( c ) => ( {
-			value: String( c.id ),
-			label: c.title?.rendered || c.title?.raw || `#${ c.id }`,
-		} ) ),
-	];
+	const hasCollections = Boolean( records?.length );
+
+	if ( isResolving && ! hasCollections ) {
+		return <Spinner />;
+	}
+
+	if ( hasResolved && ! hasCollections ) {
+		return (
+			<p className="cortext-data-view-picker__empty">
+				{ __( 'No collections yet.', 'cortext' ) }
+			</p>
+		);
+	}
 
 	return (
-		<SelectControl
-			label={ __( 'Collection', 'cortext' ) }
-			value=""
-			options={ options }
-			onChange={ ( value ) => {
-				const id = parseInt( value, 10 );
-				if ( id ) {
-					onSelect( id );
-				}
-			} }
-			disabled={ isResolving }
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-		/>
+		<div className="cortext-collection-chooser">
+			{ /* TODO: Add search once collection lists are long enough to make scanning noisy. */ }
+			{ ( records ?? [] ).map( ( collection ) => {
+				const title =
+					collection.title?.rendered ||
+					collection.title?.raw ||
+					`#${ collection.id }`;
+				const isSelected =
+					selectedId && Number( selectedId ) === collection.id;
+
+				return (
+					<Button
+						key={ collection.id }
+						className="cortext-collection-chooser__item"
+						variant={ isSelected ? 'secondary' : 'tertiary' }
+						isPressed={ isSelected }
+						onClick={ () => onSelect( collection.id ) }
+					>
+						{ title }
+					</Button>
+				);
+			} ) }
+		</div>
+	);
+}
+
+function CollectionCreator( { onCreate } ) {
+	const [ title, setTitle ] = useState( '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ error, setError ] = useState( '' );
+	const { invalidateResolution } = useDispatch( 'core' );
+	const canCreate = title.trim() && ! isSaving;
+
+	const createCollection = async () => {
+		if ( ! canCreate ) {
+			return;
+		}
+
+		setIsSaving( true );
+		setError( '' );
+
+		try {
+			const collection = await apiFetch( {
+				path: '/cortext/v1/collections',
+				method: 'POST',
+				data: {
+					title: title.trim(),
+				},
+			} );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'crtxt_collection',
+				COLLECTION_QUERY,
+			] );
+			onCreate( collection );
+		} catch ( apiError ) {
+			setError(
+				apiError?.message ||
+					__( 'Collection could not be created.', 'cortext' )
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	return (
+		<div className="cortext-data-view-create">
+			{ error ? (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) : null }
+			<TextControl
+				label={ __( 'Name', 'cortext' ) }
+				value={ title }
+				onChange={ setTitle }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			<Button
+				variant="primary"
+				onClick={ createCollection }
+				isBusy={ isSaving }
+				disabled={ ! canCreate }
+			>
+				{ __( 'Create collection', 'cortext' ) }
+			</Button>
+		</div>
+	);
+}
+
+function CollectionToolbarControl( { collectionId, onSelect } ) {
+	return (
+		<BlockControls group="other">
+			<Dropdown
+				contentClassName="cortext-data-view-toolbar-popover"
+				popoverProps={ { placement: 'bottom-start' } }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<ToolbarButton
+						icon={ replace }
+						label={ __( 'Change collection', 'cortext' ) }
+						onClick={ onToggle }
+						isPressed={ isOpen }
+					/>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<div className="cortext-data-view-toolbar-popover__content">
+						<CollectionPicker
+							selectedId={ collectionId }
+							onSelect={ ( id ) => {
+								onSelect( id );
+								onClose();
+							} }
+						/>
+					</div>
+				) }
+			/>
+		</BlockControls>
 	);
 }
 
@@ -49,6 +180,12 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	const setView = useCallback(
 		( next ) => setAttributes( { view: next } ),
+		[ setAttributes ]
+	);
+
+	const selectCollection = useCallback(
+		( id ) =>
+			setAttributes( { collectionId: id, view: createDefaultView() } ),
 		[ setAttributes ]
 	);
 
@@ -62,11 +199,14 @@ export default function Edit( { attributes, setAttributes } ) {
 						'cortext'
 					) }
 				>
-					<CollectionPicker
-						onSelect={ ( id ) =>
-							setAttributes( { collectionId: id } )
-						}
-					/>
+					<CollectionPicker onSelect={ selectCollection } />
+					<div className="cortext-data-view-placeholder__create">
+						<CollectionCreator
+							onCreate={ ( collection ) =>
+								selectCollection( collection.id )
+							}
+						/>
+					</div>
 				</Placeholder>
 			</div>
 		);
@@ -74,11 +214,35 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	return (
 		<div { ...blockProps }>
+			<CollectionToolbarControl
+				collectionId={ collectionId }
+				onSelect={ ( id ) => {
+					if ( id !== collectionId ) {
+						selectCollection( id );
+					}
+				} }
+			/>
 			<CollectionDataViews
 				collectionId={ collectionId }
 				view={ view }
 				onChangeView={ setView }
 				loading={ <Spinner /> }
+				invalid={
+					<Notice status="warning" isDismissible={ false }>
+						{ __(
+							'This collection is no longer available. Choose another collection.',
+							'cortext'
+						) }
+					</Notice>
+				}
+				error={
+					<Notice status="error" isDismissible={ false }>
+						{ __(
+							'Collection rows could not be loaded.',
+							'cortext'
+						) }
+					</Notice>
+				}
 			/>
 		</div>
 	);

--- a/src/collections.js
+++ b/src/collections.js
@@ -1,0 +1,5 @@
+export const COLLECTION_QUERY = {
+	per_page: 100,
+	context: 'edit',
+	status: [ 'draft', 'private', 'publish' ],
+};

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -18,9 +18,17 @@ export default function CollectionDataViews( {
 	onChangeView,
 	loading = null,
 	empty,
+	invalid,
+	error,
 } ) {
-	const { fields, slug, isResolving } = useCollectionFields( collectionId );
-	const { data, paginationInfo, isLoading } = useCollectionRows( slug, view );
+	const { fields, collection, slug, isResolving } =
+		useCollectionFields( collectionId );
+	const {
+		data,
+		paginationInfo,
+		isLoading,
+		error: rowError,
+	} = useCollectionRows( slug, view );
 	const dataViewFields = useMemo(
 		() => [ TITLE_FIELD, ...fields ],
 		[ fields ]
@@ -55,6 +63,29 @@ export default function CollectionDataViews( {
 
 	if ( isResolving ) {
 		return loading;
+	}
+
+	if ( collectionId && ! collection ) {
+		return (
+			invalid ?? (
+				<p>
+					{ __(
+						'This collection is no longer available.',
+						'cortext'
+					) }
+				</p>
+			)
+		);
+	}
+
+	if ( rowError ) {
+		return (
+			error ?? (
+				<p>
+					{ __( 'Collection rows could not be loaded.', 'cortext' ) }
+				</p>
+			)
+		);
 	}
 
 	return (

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -38,6 +38,7 @@ import {
 	parseIdFromUri,
 	parseSplatUri,
 } from '../router/useResolveEntity';
+import { COLLECTION_QUERY } from '../collections';
 
 const POST_TYPE = 'crtxt_page';
 
@@ -67,11 +68,7 @@ export default function Sidebar() {
 	} );
 
 	const { records: collections, isResolving: isResolvingCollections } =
-		useEntityRecords( 'postType', 'crtxt_collection', {
-			per_page: 100,
-			status: [ 'draft', 'private', 'publish' ],
-			context: 'edit',
-		} );
+		useEntityRecords( 'postType', 'crtxt_collection', COLLECTION_QUERY );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( 'core' );
 	const pages = useMemo( () => records ?? [], [ records ] );
 	const navigate = useNavigate();

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -26,6 +26,7 @@ export default function useCollectionRows( collectionSlug, view ) {
 		data: [],
 		paginationInfo: { totalItems: 0, totalPages: 0 },
 		isLoading: false,
+		error: null,
 	} );
 
 	const requestIdRef = useRef( 0 );
@@ -39,6 +40,7 @@ export default function useCollectionRows( collectionSlug, view ) {
 				data: [],
 				paginationInfo: { totalItems: 0, totalPages: 0 },
 				isLoading: false,
+				error: null,
 			} );
 			return undefined;
 		}
@@ -52,7 +54,7 @@ export default function useCollectionRows( collectionSlug, view ) {
 			buildQueryArgs( view )
 		);
 
-		setState( ( prev ) => ( { ...prev, isLoading: true } ) );
+		setState( ( prev ) => ( { ...prev, isLoading: true, error: null } ) );
 
 		apiFetch( { path, parse: false } )
 			.then( async ( response ) => {
@@ -70,9 +72,10 @@ export default function useCollectionRows( collectionSlug, view ) {
 					data: Array.isArray( rows ) ? rows : [],
 					paginationInfo: { totalItems, totalPages },
 					isLoading: false,
+					error: null,
 				} );
 			} )
-			.catch( () => {
+			.catch( ( error ) => {
 				if ( requestId !== requestIdRef.current ) {
 					return;
 				}
@@ -80,6 +83,7 @@ export default function useCollectionRows( collectionSlug, view ) {
 					data: [],
 					paginationInfo: { totalItems: 0, totalPages: 0 },
 					isLoading: false,
+					error,
 				} );
 			} );
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -246,3 +246,42 @@ body.cortext-fullscreen {
 		padding: $grid-unit-30 0;
 	}
 }
+
+.cortext-data-view-picker__empty {
+	color: $gray-700;
+	margin: 0;
+}
+
+.cortext-data-view-placeholder__create {
+	border-top: $border-width solid $gray-200;
+	margin-top: $grid-unit-15;
+	padding-top: $grid-unit-15;
+	width: 100%;
+}
+
+.cortext-data-view-create {
+	display: grid;
+	gap: $grid-unit-15;
+	width: min(100%, 420px);
+}
+
+.cortext-data-view-toolbar-popover__content {
+	min-width: 260px;
+	padding: $grid-unit-15;
+}
+
+.cortext-collection-chooser {
+	display: grid;
+	gap: $grid-unit-05;
+	width: min(100%, 420px);
+}
+
+.cortext-collection-chooser__item.components-button {
+	justify-content: flex-start;
+	min-height: 36px;
+	overflow: hidden;
+	text-align: start;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: 100%;
+}

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -84,6 +84,15 @@ function createDataViewBlockMarkup( collectionId ) {
 	return `<!-- wp:cortext/data-view ${ JSON.stringify( attributes ) } /-->`;
 }
 
+function createEmptyDataViewBlockMarkup() {
+	return '<!-- wp:cortext/data-view /-->';
+}
+
+function parseCollectionIdFromContent( content ) {
+	const match = content.match( /"collectionId":(\d+)/ );
+	return match ? Number( match[ 1 ] ) : 0;
+}
+
 test.describe( 'Collection view block', () => {
 	test( 'renders a selected collection and persists block attributes', async ( {
 		admin,
@@ -176,6 +185,143 @@ test.describe( 'Collection view block', () => {
 				requestUtils,
 				fixture.collection &&
 					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+
+	test( 'creates a collection from the placeholder and can switch collections', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture( requestUtils )
+			);
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Inline collection creation page',
+					status: 'private',
+					content: createEmptyDataViewBlockMarkup(),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			await canvas.getByLabel( 'Name' ).fill( 'Inline Books' );
+			await canvas
+				.getByRole( 'button', { name: 'Create collection' } )
+				.click();
+
+			await expect( canvas.getByText( 'Title' ) ).toBeVisible();
+			await expect(
+				page
+					.locator( '.cortext-sidebar' )
+					.getByText( 'Inline Books', { exact: true } )
+			).toBeVisible();
+
+			await page.evaluate( async () => {
+				await window.wp.data.dispatch( 'core/editor' ).savePost();
+			} );
+			await page.waitForFunction(
+				() => ! window.wp.data.select( 'core/editor' ).isSavingPost()
+			);
+
+			let saved = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_pages/${ fixture.page.id }`,
+				params: { context: 'edit' },
+			} );
+
+			fixture.createdCollectionId = parseCollectionIdFromContent(
+				saved.content.raw
+			);
+			expect( fixture.createdCollectionId ).toBeGreaterThan( 0 );
+
+			const createdCollection = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_collections/${ fixture.createdCollectionId }`,
+				params: { context: 'edit' },
+			} );
+			fixture.createdFieldIds = createdCollection.meta.fields || [];
+			expect( createdCollection.meta.slug ).toBe( 'inline-books' );
+			expect( fixture.createdFieldIds ).toEqual( [] );
+
+			await page
+				.getByRole( 'button', { name: 'Change collection' } )
+				.click();
+			await page
+				.locator( '.cortext-data-view-toolbar-popover' )
+				.getByRole( 'button', { name: /E2E Books/ } )
+				.click();
+
+			await expect(
+				canvas.getByText( 'The Left Hand of Darkness' )
+			).toBeVisible();
+
+			await page.evaluate( async () => {
+				await window.wp.data.dispatch( 'core/editor' ).savePost();
+			} );
+			await page.waitForFunction(
+				() => ! window.wp.data.select( 'core/editor' ).isSavingPost()
+			);
+
+			saved = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_pages/${ fixture.page.id }`,
+				params: { context: 'edit' },
+			} );
+
+			expect( saved.content.raw ).toContain(
+				`"collectionId":${ fixture.collection.id }`
+			);
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+			if ( fixture.createdFieldIds ) {
+				for ( const fieldId of fixture.createdFieldIds ) {
+					await deleteIfCreated(
+						requestUtils,
+						`/wp/v2/crtxt_fields/${ fieldId }`
+					);
+				}
+			}
+			await deleteIfCreated(
+				requestUtils,
+				fixture.createdCollectionId &&
+					`/wp/v2/crtxt_collections/${ fixture.createdCollectionId }`
 			);
 		}
 	} );

--- a/tests/php/test-rest-collections-controller.php
+++ b/tests/php/test-rest-collections-controller.php
@@ -125,6 +125,19 @@ final class Test_Rest_Collections_Controller extends BaseTestCase {
 		$this->assertTrue( post_type_exists( 'crtxt_page-2' ) );
 	}
 
+	public function test_normalizes_non_latin_slug_for_post_type_name(): void {
+		$method = new \ReflectionMethod( CollectionsController::class, 'unique_slug' );
+		$method->setAccessible( true );
+		$slug = $method->invoke( new CollectionsController(), '你好' );
+
+		$this->assertSame( 'e4bda0e5a5bd', $slug );
+		$this->assertLessThanOrEqual(
+			CollectionEntries::MAX_CPT_LEN,
+			strlen( CollectionEntries::CPT_PREFIX . $slug )
+		);
+		$this->assertSame( CollectionEntries::CPT_PREFIX . $slug, sanitize_key( CollectionEntries::CPT_PREFIX . $slug ) );
+	}
+
 	public function test_rejects_empty_title(): void {
 		wp_set_current_user( $this->create_user( 'author' ) );
 

--- a/tests/php/test-rest-collections-controller.php
+++ b/tests/php/test-rest-collections-controller.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Tests for Cortext\Rest\CollectionsController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Field;
+use Cortext\Rest\CollectionsController;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Collections_Controller extends BaseTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->unregister_dynamic_collection_post_types();
+		( new Collection() )->register_post_type();
+		( new Field() )->register_post_type();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new CollectionsController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	public function test_creates_collection_and_registers_row_cpt_from_title(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$response = $this->create_collection(
+			array(
+				'title' => 'Project Tasks',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$data          = $response->get_data();
+		$collection_id = (int) $data['id'];
+
+		$this->assertSame( 'project-tasks', $data['slug'] );
+		$this->assertSame( 'crtxt_project-tasks', $data['restBase'] );
+		$this->assertTrue( post_type_exists( 'crtxt_project-tasks' ) );
+		$this->assertSame( 'Project Tasks', get_post( $collection_id )->post_title );
+		$this->assertSame( 'project-tasks', get_post_meta( $collection_id, 'slug', true ) );
+		$this->assertSame( array(), get_post_meta( $collection_id, 'fields', false ) );
+	}
+
+	public function test_auto_suffixes_conflicting_slug_within_cpt_limit(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Existing',
+				'meta_input'  => array( 'slug' => 'abcdefghijklmn' ),
+			)
+		);
+		register_post_type( 'crtxt_abcdefghijklmn' );
+
+		$response = $this->create_collection(
+			array(
+				'title' => 'abcdefghijklmnop',
+			)
+		);
+
+		$data = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'abcdefghijkl-2', $data['slug'] );
+		$this->assertLessThanOrEqual(
+			CollectionEntries::MAX_CPT_LEN,
+			strlen( CollectionEntries::CPT_PREFIX . $data['slug'] )
+		);
+		$this->assertTrue( post_type_exists( 'crtxt_abcdefghijkl-2' ) );
+	}
+
+	public function test_ignores_slug_and_fields_request_params(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$response = $this->create_collection(
+			array(
+				'title'  => 'Reading List',
+				'slug'   => 'ignored',
+				'fields' => array( 'Ignored Field' ),
+			)
+		);
+
+		$data          = $response->get_data();
+		$collection_id = (int) $data['id'];
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'reading-list', $data['slug'] );
+		$this->assertSame( array(), get_post_meta( $collection_id, 'fields', false ) );
+		$this->assertTrue( post_type_exists( 'crtxt_reading-list' ) );
+	}
+
+	public function test_auto_suffixes_reserved_slug(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$response = $this->create_collection(
+			array(
+				'title' => 'Page',
+			)
+		);
+
+		$data = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'page-2', $data['slug'] );
+		$this->assertTrue( post_type_exists( 'crtxt_page-2' ) );
+	}
+
+	public function test_rejects_empty_title(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$response = $this->create_collection(
+			array(
+				'title' => ' ',
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_requires_edit_posts_capability(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$response = $this->create_collection(
+			array(
+				'title' => 'People',
+			)
+		);
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	private function create_collection( array $body ) {
+		$request = new WP_REST_Request( 'POST', '/cortext/v1/collections' );
+		$request->set_body_params( $body );
+
+		return rest_do_request( $request );
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+
+	private function unregister_dynamic_collection_post_types(): void {
+		foreach ( get_post_types() as $post_type ) {
+			if (
+				str_starts_with( $post_type, CollectionEntries::CPT_PREFIX ) &&
+				! in_array( $post_type, array( Collection::POST_TYPE, Field::POST_TYPE ), true )
+			) {
+				unregister_post_type( $post_type );
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Closes #97

Adds an inline way to create a collection from the DataView block placeholder, backed by a new `cortext/v1/collections` REST endpoint that creates the collection from just a title.

## Why

Today, inserting a Collection view means leaving the editor to create the collection first, then coming back to pick it. This makes it a single step.

## How

- Adding a `CollectionsController` that turns the title into a unique, CPT-safe slug, inserts the `crtxt_collection` post, and registers the row CPT during the same request so the response can return a working `restBase`. Slug derivation reads existing slugs once and falls back to numeric suffixes when the desired slug is reserved, already taken, or would push past the 20-character post-type limit.

- Reworking the block placeholder so the picker and a "Create collection" form sit together, and adding a toolbar dropdown to swap the active collection without removing the block. Splitting out invalid and error states in `CollectionDataViews` so a deleted collection or a failed row fetch shows a notice instead of an empty table. Pulling the collection list query into a shared constant so the sidebar and the block share a cache entry.

## Testing Instructions

1. Insert a Collection view block on a page that has no collections yet.
2. Type a name, click "Create collection", and check that a data view renders for the new (empty) collection and that it shows up in the sidebar.
3. Reload the page and check the saved `collectionId` resolves.
4. From the block toolbar, open "Change collection" and pick a different one.
5. Delete a collection that a saved block references, reopen the page, and check for the "no longer available" notice.
6. Try titles that collide with reserved slugs ("Page", "Fields") or run longer than 14 characters. The slug should be auto-suffixed and stay inside the CPT length limit.
7. Run `composer test -- --filter=Test_Rest_Collections_Controller` and the `data-view-block.spec.js` Playwright spec.

https://github.com/user-attachments/assets/845d9fd5-49f2-4360-9bba-1b07351b7929