### PR TITLE
Clean up DataView saved view on schema changes

### DIFF
--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1,5 +1,5 @@
 import { DataViews } from '@wordpress/dataviews';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import useCollectionFields from '../hooks/useCollectionFields';
@@ -34,32 +34,60 @@ export default function CollectionDataViews( {
 		[ fields ]
 	);
 
-	// Seed visible columns once the collection's fields resolve. Without
-	// this, an empty `view.fields` makes DataViews render zero columns.
-	// DataViews core prevents hiding every column, so the "empty === just
-	// inserted" heuristic won't fight later edits.
+	const viewRef = useRef( view );
+	viewRef.current = view;
+	const onChangeViewRef = useRef( onChangeView );
+	onChangeViewRef.current = onChangeView;
+
+	// Reconcile saved view state with the live schema whenever the field
+	// set changes: drop visible columns, sort, and filters that reference
+	// fields that no longer exist (so a deleted field doesn't ghost in the
+	// saved attribute), pin Title visible, and seed defaults on first
+	// render. Other view settings (perPage, search, layout) are left alone.
 	useEffect( () => {
 		if ( isResolving ) {
 			return;
 		}
+		const validIds = new Set( dataViewFields.map( ( f ) => f.id ) );
+		const currentView = viewRef.current;
+		const currentFields = currentView?.fields ?? [];
 
-		const visibleFields = view?.fields ?? [];
-		const defaultFields = dataViewFields.map( ( f ) => f.id );
-		let nextFields = null;
-
-		if ( ! visibleFields.length ) {
-			nextFields = defaultFields;
-		} else if ( ! visibleFields.includes( TITLE_FIELD.id ) ) {
-			nextFields = [ TITLE_FIELD.id, ...visibleFields ];
+		let nextFields;
+		if ( currentFields.length === 0 ) {
+			nextFields = dataViewFields.map( ( f ) => f.id );
+		} else {
+			nextFields = currentFields.filter( ( id ) => validIds.has( id ) );
+			if ( ! nextFields.includes( TITLE_FIELD.id ) ) {
+				nextFields = [ TITLE_FIELD.id, ...nextFields ];
+			}
 		}
 
-		if ( nextFields ) {
-			onChangeView( {
-				...view,
+		const currentSort = currentView?.sort ?? null;
+		const nextSort =
+			currentSort && validIds.has( currentSort.field )
+				? currentSort
+				: null;
+
+		const currentFilters = currentView?.filters ?? [];
+		const nextFilters = currentFilters.filter( ( filter ) =>
+			validIds.has( filter.field )
+		);
+
+		const fieldsChanged =
+			currentFields.length !== nextFields.length ||
+			currentFields.some( ( id, i ) => id !== nextFields[ i ] );
+		const sortChanged = currentSort !== nextSort;
+		const filtersChanged = currentFilters.length !== nextFilters.length;
+
+		if ( fieldsChanged || sortChanged || filtersChanged ) {
+			onChangeViewRef.current( {
+				...currentView,
 				fields: nextFields,
+				sort: nextSort,
+				filters: nextFilters,
 			} );
 		}
-	}, [ dataViewFields, isResolving, view, onChangeView ] );
+	}, [ dataViewFields, isResolving ] );
 
 	if ( isResolving ) {
 		return loading;

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -325,4 +325,173 @@ test.describe( 'Collection view block', () => {
 			);
 		}
 	} );
+
+	test( 'drops dead field references from the view when a field is deleted', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			const suffix = Date.now().toString( 36 ).slice( -4 );
+			const slug = `e2eclean${ suffix }`;
+			fixture.slug = slug;
+
+			fixture.collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_collections',
+				data: {
+					title: `Cleanup ${ suffix }`,
+					status: 'private',
+					meta: { slug },
+				},
+			} );
+
+			fixture.fieldA = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_fields',
+				data: {
+					title: 'Author',
+					status: 'private',
+					meta: { type: 'text' },
+				},
+			} );
+
+			fixture.fieldB = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_fields',
+				data: {
+					title: 'Notes',
+					status: 'private',
+					meta: { type: 'text' },
+				},
+			} );
+
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_collections/${ fixture.collection.id }`,
+				data: {
+					meta: {
+						fields: [
+							String( fixture.fieldA.id ),
+							String( fixture.fieldB.id ),
+						],
+					},
+				},
+			} );
+
+			const fieldAKey = `field-${ fixture.fieldA.id }`;
+			const fieldBKey = `field-${ fixture.fieldB.id }`;
+			const staleView = {
+				type: 'table',
+				fields: [ 'title', fieldAKey, fieldBKey ],
+				sort: { field: fieldAKey, direction: 'asc' },
+				filters: [
+					{
+						field: fieldAKey,
+						operator: 'is',
+						value: 'X',
+					},
+					{
+						field: fieldBKey,
+						operator: 'is',
+						value: 'Y',
+					},
+				],
+				perPage: 25,
+				page: 1,
+				search: 'preserved',
+				layout: { density: 'comfortable' },
+			};
+			const blockMarkup = `<!-- wp:cortext/data-view ${ JSON.stringify( {
+				collectionId: fixture.collection.id,
+				view: staleView,
+			} ) } /-->`;
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'View cleanup test page',
+					status: 'private',
+					content: blockMarkup,
+				},
+			} );
+
+			await requestUtils.rest( {
+				method: 'DELETE',
+				path: `/wp/v2/crtxt_fields/${ fixture.fieldA.id }`,
+				params: { force: true },
+			} );
+			fixture.fieldADeleted = true;
+
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_collections/${ fixture.collection.id }`,
+				data: {
+					meta: { fields: [ String( fixture.fieldB.id ) ] },
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			await expect( canvas.getByText( 'Notes' ) ).toBeVisible();
+
+			await page.evaluate( async () => {
+				await window.wp.data.dispatch( 'core/editor' ).savePost();
+			} );
+			await page.waitForFunction(
+				() => ! window.wp.data.select( 'core/editor' ).isSavingPost()
+			);
+
+			const saved = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_pages/${ fixture.page.id }`,
+				params: { context: 'edit' },
+			} );
+
+			expect( saved.content.raw ).not.toContain( fieldAKey );
+			expect( saved.content.raw ).toContain( fieldBKey );
+			expect( saved.content.raw ).toContain( '"title"' );
+			expect( saved.content.raw ).toContain( '"sort":null' );
+			expect( saved.content.raw ).toContain( '"search":"preserved"' );
+			expect( saved.content.raw ).toContain(
+				'"layout":{"density":"comfortable"}'
+			);
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			if ( ! fixture.fieldADeleted ) {
+				await deleteIfCreated(
+					requestUtils,
+					fixture.fieldA &&
+						`/wp/v2/crtxt_fields/${ fixture.fieldA.id }`
+				);
+			}
+			await deleteIfCreated(
+				requestUtils,
+				fixture.fieldB && `/wp/v2/crtxt_fields/${ fixture.fieldB.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
 } );


### PR DESCRIPTION
## What

Part of #99

Drops dead field references from the DataView block's saved view. After a field is deleted, it no longer appears in `fields`, `sort`, or `filters`.

## Why

Not a visible bug, it's hygiene in preparation for inline Field management: DataViews already ignores unknown ids at render time, so the UI looks fine. The problem is on disk: with `view.fields: ['title', 'field-A', 'field-B']` and a sort/filter on `field-A`, deleting field A left all three references in the saved view forever. The block should reconcile against the live schema regardless of how the field was deleted (inline editing, wp-admin, REST, an importer).

## Testing Instructions

E2E:

```bash
npm run test:env:start
WP_BASE_URL=http://localhost:8889 npm run test:e2e -- tests/e2e/specs/data-view-block.spec.js