### PR TITLE
Env: don't specify core version, defaulting to stable (6.9.4 as of now)

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,4 @@
 {
-	"core": "WordPress/WordPress#6.9",
 	"phpVersion": "8.1",
 	"port": 8888,
 	"testsEnvironment": false,


### PR DESCRIPTION
Per the [documentation on `.wp-env.json`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#wp-env-json), an unspecified `core` field corresponds to the latest production release of WordPress.

Prior to this change, the provided value (`WordPress/WordPress#6.9`) was taken too literally and resulted in the provisioning of 6.9.0, despite the current stable being 6.9.4.