### PR TITLE
Cascade trash and restore through page descendants

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -15,6 +15,7 @@ use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\Field;
 use Cortext\PostType\Page;
+use Cortext\PostType\PageTrashCascade;
 use Cortext\Rest\CollectionsController;
 use Cortext\Rest\RowsController;
 
@@ -32,6 +33,7 @@ final class Plugin {
 	public function boot(): void {
 		( new Screen() )->register();
 		( new Page() )->register();
+		( new PageTrashCascade() )->register();
 		( new Collection() )->register();
 		( new Field() )->register();
 		( new CollectionEntries() )->register();

--- a/includes/PostType/PageTrashCascade.php
+++ b/includes/PostType/PageTrashCascade.php
@@ -12,9 +12,12 @@ namespace Cortext\PostType;
 final class PageTrashCascade {
 
 	/**
-	 * Per-post marker stamped on every descendant trashed by a cascade. Restoring
-	 * a parent only revives children carrying its id, so children that were
-	 * already in trash before the cascade are left alone.
+	 * Per-post marker stamped on each child trashed by its parent's cascade.
+	 * The value is the immediate parent's id, not the cascade root, so
+	 * restoring any node walks just its tagged direct children. Recursion
+	 * through deeper levels happens via the `untrashed_post` action firing
+	 * for each restored child. Pages already in trash before the cascade are
+	 * not stamped, so an unrelated parent restore leaves them alone.
 	 */
 	public const META_KEY = '_cortext_trashed_by_parent';
 
@@ -27,15 +30,21 @@ final class PageTrashCascade {
 		// our CPT so a private/published page comes back with the status it
 		// had before being trashed.
 		add_filter( 'wp_untrash_post_status', array( $this, 'restore_previous_status' ), 10, 3 );
+		// Replace the admin Pages list bulk trash/untrash actions with custom
+		// ones so they route through `handle_bulk_actions-{screen}` (core only
+		// fires that filter on its `default:` switch branch). Our handler
+		// tolerates `wp_trash_post`/`wp_untrash_post` returning `false` for
+		// pages that the cascade already handled, where core would `wp_die()`.
+		add_filter( 'bulk_actions-edit-' . Page::POST_TYPE, array( $this, 'replace_bulk_actions' ) );
+		add_filter( 'handle_bulk_actions-edit-' . Page::POST_TYPE, array( $this, 'handle_admin_bulk_action' ), 10, 3 );
 	}
 
 	/**
-	 * Trashes every descendant of a page about to be trashed and stamps each
-	 * with a marker so the matching restore can scope itself.
-	 *
+	 * Trashes the page's direct children and stamps each with the page's id.
 	 * Hooked on `wp_trash_post`, which fires before the parent's status flips.
-	 * Pages that already carry the marker are skipped: they are mid-cascade
-	 * from an ancestor and will be processed by that outer call.
+	 * The recursive `wp_trash_post` calls fire this same action again for each
+	 * child, so deeper levels stamp themselves with their own immediate parent
+	 * and the cascade unrolls naturally without an explicit BFS.
 	 *
 	 * @param int $post_id ID of the page about to be trashed.
 	 */
@@ -44,26 +53,21 @@ final class PageTrashCascade {
 			return;
 		}
 
-		// Already inside a parent's cascade; the outer call walks all descendants.
-		if ( '' !== (string) get_post_meta( $post_id, self::META_KEY, true ) ) {
-			return;
-		}
-
-		$descendants = $this->non_trashed_descendants_of( $post_id );
-		foreach ( $descendants as $child_id ) {
+		$children = $this->non_trashed_children_of( $post_id );
+		foreach ( $children as $child_id ) {
 			update_post_meta( $child_id, self::META_KEY, $post_id );
 			wp_trash_post( $child_id );
 		}
 	}
 
 	/**
-	 * Restores descendants tagged by the parent's cascade and clears the
-	 * marker on the page being restored.
+	 * Restores the direct children that this page's earlier cascade trashed,
+	 * and clears the marker on this page so a later ancestor-restore does
+	 * not try to bring it back a second time.
 	 *
-	 * Clearing the marker is what protects against the case where a user
-	 * restores a child individually before the parent: a later parent-restore
-	 * will not find the child in its tagged set, so nothing tries to revive
-	 * a page that is already active.
+	 * Recursion through deeper levels happens implicitly: each
+	 * `wp_untrash_post( $child_id )` fires `untrashed_post`, this handler
+	 * runs again for the child, and walks its own tagged direct children.
 	 *
 	 * @param int $post_id ID of the page that was just restored.
 	 */
@@ -108,43 +112,123 @@ final class PageTrashCascade {
 	}
 
 	/**
-	 * Walks the page tree and returns every descendant id whose status is not
-	 * already `trash`. Trashed descendants are skipped so that a later restore
-	 * does not pull them back in alongside the cascade.
+	 * Replaces the admin Pages list's `trash` and `untrash` bulk actions with
+	 * cortext-prefixed equivalents so they route through
+	 * `handle_bulk_actions-{screen}` instead of core's wp_die-prone branches.
 	 *
-	 * @param int $post_id Root page whose descendants we want.
+	 * @param array $actions Bulk-action dropdown entries.
 	 *
-	 * @return int[]
+	 * @return array
 	 */
-	private function non_trashed_descendants_of( int $post_id ): array {
-		$active_statuses = array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft' );
+	public function replace_bulk_actions( array $actions ): array {
+		if ( isset( $actions['trash'] ) ) {
+			unset( $actions['trash'] );
+			$actions['cortext_trash'] = __( 'Move to Trash', 'cortext' );
+		}
+		if ( isset( $actions['untrash'] ) ) {
+			unset( $actions['untrash'] );
+			$actions['cortext_untrash'] = __( 'Restore', 'cortext' );
+		}
+		return $actions;
+	}
 
-		$queue = array( $post_id );
-		$ids   = array();
+	/**
+	 * Handles the cortext-prefixed bulk actions. Counts how many of the
+	 * selected pages ended up in (or out of) trash regardless of whether
+	 * the work happened via this loop or a cascade triggered earlier in it.
+	 *
+	 * @param mixed  $sendback URL the admin will redirect to after processing.
+	 * @param string $action   Bulk action identifier.
+	 * @param array  $post_ids Selected post ids.
+	 *
+	 * @return mixed
+	 */
+	public function handle_admin_bulk_action( $sendback, string $action, array $post_ids ) {
+		if ( 'cortext_trash' === $action ) {
+			return $this->run_admin_bulk( (string) $sendback, $post_ids, 'trash' );
+		}
+		if ( 'cortext_untrash' === $action ) {
+			return $this->run_admin_bulk( (string) $sendback, $post_ids, 'untrash' );
+		}
+		return $sendback;
+	}
 
-		while ( ! empty( $queue ) ) {
-			$current = (int) array_shift( $queue );
+	/**
+	 * Shared body for the trash and untrash bulk handlers.
+	 *
+	 * @param string $sendback URL the admin will redirect to after processing.
+	 * @param array  $post_ids Selected post ids.
+	 * @param string $action   Either 'trash' or 'untrash'.
+	 */
+	private function run_admin_bulk( string $sendback, array $post_ids, string $action ): string {
+		$count  = 0;
+		$locked = 0;
 
-			$children = get_posts(
-				array(
-					'post_type'      => Page::POST_TYPE,
-					'post_parent'    => $current,
-					'post_status'    => $active_statuses,
-					'posts_per_page' => -1,
-					'fields'         => 'ids',
-					'no_found_rows'  => true,
-					'orderby'        => 'ID',
-					'order'          => 'ASC',
-				)
-			);
+		foreach ( $post_ids as $post_id ) {
+			$post_id = (int) $post_id;
+			if ( ! current_user_can( 'delete_post', $post_id ) ) {
+				wp_die(
+					'trash' === $action
+						? esc_html__( 'Sorry, you are not allowed to move this item to the Trash.', 'cortext' )
+						: esc_html__( 'Sorry, you are not allowed to restore this item from the Trash.', 'cortext' )
+				);
+			}
 
-			foreach ( $children as $child_id ) {
-				$child_id = (int) $child_id;
-				$ids[]    = $child_id;
-				$queue[]  = $child_id;
+			if ( 'trash' === $action ) {
+				if ( wp_check_post_lock( $post_id ) ) {
+					++$locked;
+					continue;
+				}
+				// Ignore the return value: a `false` here just means the page
+				// was already trashed by the cascade firing on a parent earlier
+				// in the loop. Verify the resulting status instead.
+				wp_trash_post( $post_id );
+				if ( 'trash' === get_post_status( $post_id ) ) {
+					++$count;
+				}
+			} else {
+				wp_untrash_post( $post_id );
+				if ( 'trash' !== get_post_status( $post_id ) ) {
+					++$count;
+				}
 			}
 		}
 
-		return $ids;
+		$count_key = 'trash' === $action ? 'trashed' : 'untrashed';
+		$args      = array(
+			$count_key => $count,
+			'ids'      => implode( ',', array_map( 'intval', $post_ids ) ),
+		);
+		if ( 'trash' === $action ) {
+			$args['locked'] = $locked;
+		}
+
+		return add_query_arg( $args, $sendback );
+	}
+
+	/**
+	 * Returns the direct children of a page whose status is not already
+	 * `trash`. Trashed siblings are skipped so a later restore of this page
+	 * does not pull them back in alongside the cascade.
+	 *
+	 * @param int $post_id Page whose direct children we want.
+	 *
+	 * @return int[]
+	 */
+	private function non_trashed_children_of( int $post_id ): array {
+		$ids = get_posts(
+			array(
+				'post_type'      => Page::POST_TYPE,
+				'post_parent'    => $post_id,
+				'post_status'    => array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft' ),
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		return array_map( 'intval', $ids );
 	}
 }

--- a/includes/PostType/PageTrashCascade.php
+++ b/includes/PostType/PageTrashCascade.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Cascades trash and restore across `crtxt_page` parent/child trees.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\PostType;
+
+final class PageTrashCascade {
+
+	/**
+	 * Per-post marker stamped on every descendant trashed by a cascade. Restoring
+	 * a parent only revives children carrying its id, so children that were
+	 * already in trash before the cascade are left alone.
+	 */
+	public const META_KEY = '_cortext_trashed_by_parent';
+
+	public function register(): void {
+		add_action( 'wp_trash_post', array( $this, 'cascade_trash' ), 10, 1 );
+		add_action( 'untrashed_post', array( $this, 'cascade_restore' ), 10, 1 );
+		// Core only registers `wp_untrash_post_set_previous_status` from
+		// wp-admin/edit.php's bulk-untrash action, so programmatic restores
+		// (REST, WP-CLI, our cascade) default to `draft`. Re-register it for
+		// our CPT so a private/published page comes back with the status it
+		// had before being trashed.
+		add_filter( 'wp_untrash_post_status', array( $this, 'restore_previous_status' ), 10, 3 );
+	}
+
+	/**
+	 * Trashes every descendant of a page about to be trashed and stamps each
+	 * with a marker so the matching restore can scope itself.
+	 *
+	 * Hooked on `wp_trash_post`, which fires before the parent's status flips.
+	 * Pages that already carry the marker are skipped: they are mid-cascade
+	 * from an ancestor and will be processed by that outer call.
+	 *
+	 * @param int $post_id ID of the page about to be trashed.
+	 */
+	public function cascade_trash( int $post_id ): void {
+		if ( Page::POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		// Already inside a parent's cascade; the outer call walks all descendants.
+		if ( '' !== (string) get_post_meta( $post_id, self::META_KEY, true ) ) {
+			return;
+		}
+
+		$descendants = $this->non_trashed_descendants_of( $post_id );
+		foreach ( $descendants as $child_id ) {
+			update_post_meta( $child_id, self::META_KEY, $post_id );
+			wp_trash_post( $child_id );
+		}
+	}
+
+	/**
+	 * Restores descendants tagged by the parent's cascade and clears the
+	 * marker on the page being restored.
+	 *
+	 * Clearing the marker is what protects against the case where a user
+	 * restores a child individually before the parent: a later parent-restore
+	 * will not find the child in its tagged set, so nothing tries to revive
+	 * a page that is already active.
+	 *
+	 * @param int $post_id ID of the page that was just restored.
+	 */
+	public function cascade_restore( int $post_id ): void {
+		if ( Page::POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		delete_post_meta( $post_id, self::META_KEY );
+
+		$tagged = get_posts(
+			array(
+				'post_type'      => Page::POST_TYPE,
+				'post_status'    => 'trash',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_key'       => self::META_KEY,   // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => (string) $post_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+
+		foreach ( $tagged as $child_id ) {
+			wp_untrash_post( (int) $child_id );
+		}
+	}
+
+	/**
+	 * Restores a `crtxt_page` to the status it had before being trashed.
+	 * Falls back to the default (typically `draft`) when no previous status
+	 * was recorded.
+	 *
+	 * @param string $new_status      Status WordPress would otherwise assign on restore.
+	 * @param int    $post_id         ID of the page being restored.
+	 * @param string $previous_status Status the page held before it was trashed.
+	 */
+	public function restore_previous_status( string $new_status, int $post_id, string $previous_status ): string {
+		if ( Page::POST_TYPE !== get_post_type( $post_id ) ) {
+			return $new_status;
+		}
+		return '' !== $previous_status ? $previous_status : $new_status;
+	}
+
+	/**
+	 * Walks the page tree and returns every descendant id whose status is not
+	 * already `trash`. Trashed descendants are skipped so that a later restore
+	 * does not pull them back in alongside the cascade.
+	 *
+	 * @param int $post_id Root page whose descendants we want.
+	 *
+	 * @return int[]
+	 */
+	private function non_trashed_descendants_of( int $post_id ): array {
+		$active_statuses = array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft' );
+
+		$queue = array( $post_id );
+		$ids   = array();
+
+		while ( ! empty( $queue ) ) {
+			$current = (int) array_shift( $queue );
+
+			$children = get_posts(
+				array(
+					'post_type'      => Page::POST_TYPE,
+					'post_parent'    => $current,
+					'post_status'    => $active_statuses,
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					'no_found_rows'  => true,
+					'orderby'        => 'ID',
+					'order'          => 'ASC',
+				)
+			);
+
+			foreach ( $children as $child_id ) {
+				$child_id = (int) $child_id;
+				$ids[]    = $child_id;
+				$queue[]  = $child_id;
+			}
+		}
+
+		return $ids;
+	}
+}

--- a/includes/PostType/PageTrashCascade.php
+++ b/includes/PostType/PageTrashCascade.php
@@ -12,39 +12,32 @@ namespace Cortext\PostType;
 final class PageTrashCascade {
 
 	/**
-	 * Per-post marker stamped on each child trashed by its parent's cascade.
-	 * The value is the immediate parent's id, not the cascade root, so
-	 * restoring any node walks just its tagged direct children. Recursion
-	 * through deeper levels happens via the `untrashed_post` action firing
-	 * for each restored child. Pages already in trash before the cascade are
-	 * not stamped, so an unrelated parent restore leaves them alone.
+	 * Marks a child as trashed by its parent. The value is the immediate
+	 * parent's id, so restoring any node finds its own children. Children
+	 * already in trash when the cascade reaches them stay unmarked and
+	 * don't ride along on a later parent-restore.
 	 */
 	public const META_KEY = '_cortext_trashed_by_parent';
 
 	public function register(): void {
 		add_action( 'wp_trash_post', array( $this, 'cascade_trash' ), 10, 1 );
 		add_action( 'untrashed_post', array( $this, 'cascade_restore' ), 10, 1 );
-		// Core only registers `wp_untrash_post_set_previous_status` from
-		// wp-admin/edit.php's bulk-untrash action, so programmatic restores
-		// (REST, WP-CLI, our cascade) default to `draft`. Re-register it for
-		// our CPT so a private/published page comes back with the status it
-		// had before being trashed.
+		// Core only wires wp_untrash_post_set_previous_status inside
+		// wp-admin/edit.php's bulk-untrash. Every other caller (REST, WP-CLI,
+		// our cascade) gets 'draft' on restore without this.
 		add_filter( 'wp_untrash_post_status', array( $this, 'restore_previous_status' ), 10, 3 );
-		// Replace the admin Pages list bulk trash/untrash actions with custom
-		// ones so they route through `handle_bulk_actions-{screen}` (core only
-		// fires that filter on its `default:` switch branch). Our handler
-		// tolerates `wp_trash_post`/`wp_untrash_post` returning `false` for
-		// pages that the cascade already handled, where core would `wp_die()`.
+		// edit.php's bulk loop wp_die()s when wp_trash_post returns false,
+		// which is what happens after the cascade already trashed the page.
+		// Rename trash/untrash so they land in the default branch where
+		// handle_bulk_actions-{screen} fires and we can absorb the no-op.
 		add_filter( 'bulk_actions-edit-' . Page::POST_TYPE, array( $this, 'replace_bulk_actions' ) );
 		add_filter( 'handle_bulk_actions-edit-' . Page::POST_TYPE, array( $this, 'handle_admin_bulk_action' ), 10, 3 );
 	}
 
 	/**
-	 * Trashes the page's direct children and stamps each with the page's id.
-	 * Hooked on `wp_trash_post`, which fires before the parent's status flips.
-	 * The recursive `wp_trash_post` calls fire this same action again for each
-	 * child, so deeper levels stamp themselves with their own immediate parent
-	 * and the cascade unrolls naturally without an explicit BFS.
+	 * Trashes a page's direct children and stamps each with the parent's id.
+	 * Each `wp_trash_post` call fires this hook for the child, so the subtree
+	 * comes down without an explicit walk.
 	 *
 	 * @param int $post_id ID of the page about to be trashed.
 	 */
@@ -61,13 +54,10 @@ final class PageTrashCascade {
 	}
 
 	/**
-	 * Restores the direct children that this page's earlier cascade trashed,
-	 * and clears the marker on this page so a later ancestor-restore does
-	 * not try to bring it back a second time.
-	 *
-	 * Recursion through deeper levels happens implicitly: each
-	 * `wp_untrash_post( $child_id )` fires `untrashed_post`, this handler
-	 * runs again for the child, and walks its own tagged direct children.
+	 * Restores any direct children this page's earlier cascade trashed and
+	 * clears the marker on this page so a later ancestor-restore doesn't
+	 * revive it twice. Each `wp_untrash_post` call fires this hook for the
+	 * child, walking its own tagged children.
 	 *
 	 * @param int $post_id ID of the page that was just restored.
 	 */
@@ -96,9 +86,9 @@ final class PageTrashCascade {
 	}
 
 	/**
-	 * Restores a `crtxt_page` to the status it had before being trashed.
-	 * Falls back to the default (typically `draft`) when no previous status
-	 * was recorded.
+	 * Restores a `crtxt_page` to the status it had before being trashed,
+	 * falling back to the default ('draft') when no previous status is
+	 * recorded.
 	 *
 	 * @param string $new_status      Status WordPress would otherwise assign on restore.
 	 * @param int    $post_id         ID of the page being restored.
@@ -112,9 +102,9 @@ final class PageTrashCascade {
 	}
 
 	/**
-	 * Replaces the admin Pages list's `trash` and `untrash` bulk actions with
-	 * cortext-prefixed equivalents so they route through
-	 * `handle_bulk_actions-{screen}` instead of core's wp_die-prone branches.
+	 * Renames trash and untrash so they route through
+	 * `handle_bulk_actions-{screen}` instead of edit.php's wp_die-prone
+	 * built-in branches.
 	 *
 	 * @param array $actions Bulk-action dropdown entries.
 	 *
@@ -133,9 +123,9 @@ final class PageTrashCascade {
 	}
 
 	/**
-	 * Handles the cortext-prefixed bulk actions. Counts how many of the
-	 * selected pages ended up in (or out of) trash regardless of whether
-	 * the work happened via this loop or a cascade triggered earlier in it.
+	 * Handles the renamed bulk actions. A selected page counts as processed
+	 * once its end status matches the action, whether this loop or a cascade
+	 * got there first.
 	 *
 	 * @param mixed  $sendback URL the admin will redirect to after processing.
 	 * @param string $action   Bulk action identifier.
@@ -179,9 +169,9 @@ final class PageTrashCascade {
 					++$locked;
 					continue;
 				}
-				// Ignore the return value: a `false` here just means the page
-				// was already trashed by the cascade firing on a parent earlier
-				// in the loop. Verify the resulting status instead.
+				// A false return usually means the cascade already trashed
+				// this page earlier in the loop, not that anything went wrong.
+				// Check the resulting status.
 				wp_trash_post( $post_id );
 				if ( 'trash' === get_post_status( $post_id ) ) {
 					++$count;
@@ -207,11 +197,11 @@ final class PageTrashCascade {
 	}
 
 	/**
-	 * Returns the direct children of a page whose status is not already
-	 * `trash`. Trashed siblings are skipped so a later restore of this page
-	 * does not pull them back in alongside the cascade.
+	 * Returns the page's direct children that aren't already in trash.
+	 * Already-trashed ones stay unmarked so a later parent-restore doesn't
+	 * pull them back too.
 	 *
-	 * @param int $post_id Page whose direct children we want.
+	 * @param int $post_id Page whose children we want.
 	 *
 	 * @return int[]
 	 */

--- a/tests/php/test-page-trash-cascade.php
+++ b/tests/php/test-page-trash-cascade.php
@@ -26,6 +26,8 @@ final class Test_Page_Trash_Cascade extends BaseTestCase {
 		remove_all_actions( 'wp_trash_post' );
 		remove_all_actions( 'untrashed_post' );
 		remove_all_filters( 'wp_untrash_post_status' );
+		remove_all_filters( 'bulk_actions-edit-' . Page::POST_TYPE );
+		remove_all_filters( 'handle_bulk_actions-edit-' . Page::POST_TYPE );
 
 		// WorDBless's wpdb mock returns empty for any query that is not a
 		// single-row primary-key lookup; cascade operations rely on
@@ -54,6 +56,14 @@ final class Test_Page_Trash_Cascade extends BaseTestCase {
 			has_filter( 'wp_untrash_post_status' ),
 			'restore_previous_status should be hooked on wp_untrash_post_status so programmatic restores return to the pre-trash status.'
 		);
+		$this->assertNotFalse(
+			has_filter( 'bulk_actions-edit-' . Page::POST_TYPE ),
+			'replace_bulk_actions should be hooked so admin Pages list trash/untrash route through our handler.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'handle_bulk_actions-edit-' . Page::POST_TYPE ),
+			'handle_admin_bulk_action should be hooked to process the cortext-prefixed bulk actions.'
+		);
 	}
 
 	public function test_trashing_parent_cascades_to_descendants_and_stamps_meta(): void {
@@ -67,9 +77,32 @@ final class Test_Page_Trash_Cascade extends BaseTestCase {
 		$this->assertSame( 'trash', get_post_status( $child_id ) );
 		$this->assertSame( 'trash', get_post_status( $grandchild_id ) );
 
+		// Each descendant's marker is its immediate parent, not the cascade root,
+		// so restoring an intermediate node can locate its own subtree.
 		$this->assertSame( '', (string) get_post_meta( $parent_id, PageTrashCascade::META_KEY, true ) );
 		$this->assertSame( (string) $parent_id, (string) get_post_meta( $child_id, PageTrashCascade::META_KEY, true ) );
-		$this->assertSame( (string) $parent_id, (string) get_post_meta( $grandchild_id, PageTrashCascade::META_KEY, true ) );
+		$this->assertSame( (string) $child_id, (string) get_post_meta( $grandchild_id, PageTrashCascade::META_KEY, true ) );
+	}
+
+	public function test_restoring_intermediate_node_revives_its_subtree(): void {
+		$parent_id     = $this->create_page();
+		$child_id      = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$grandchild_id = $this->create_page( array( 'post_parent' => $child_id ) );
+
+		wp_trash_post( $parent_id );
+
+		// Restore just the child; the parent stays in trash. Grandchild was
+		// trashed alongside the child by the cascade and should come back too.
+		wp_untrash_post( $child_id );
+
+		$this->assertSame( 'trash', get_post_status( $parent_id ) );
+		$this->assertNotSame( 'trash', get_post_status( $child_id ) );
+		$this->assertNotSame( 'trash', get_post_status( $grandchild_id ) );
+
+		// Markers on the restored subtree are cleared so a later parent-restore
+		// does not re-trigger anything.
+		$this->assertSame( '', (string) get_post_meta( $child_id, PageTrashCascade::META_KEY, true ) );
+		$this->assertSame( '', (string) get_post_meta( $grandchild_id, PageTrashCascade::META_KEY, true ) );
 	}
 
 	public function test_trashing_non_page_post_does_not_touch_other_post_types(): void {
@@ -154,6 +187,92 @@ final class Test_Page_Trash_Cascade extends BaseTestCase {
 		wp_untrash_post( $parent_id );
 		$this->assertNotSame( 'trash', get_post_status( $child_id ) );
 		$this->assertNotSame( 'trash', get_post_status( $parent_id ) );
+	}
+
+	public function test_replace_bulk_actions_swaps_built_in_trash_and_untrash(): void {
+		$cascade = new PageTrashCascade();
+
+		$swapped = $cascade->replace_bulk_actions(
+			array(
+				'edit'    => 'Edit',
+				'trash'   => 'Move to Trash',
+				'untrash' => 'Restore',
+				'delete'  => 'Delete permanently',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'trash', $swapped );
+		$this->assertArrayNotHasKey( 'untrash', $swapped );
+		$this->assertArrayHasKey( 'cortext_trash', $swapped );
+		$this->assertArrayHasKey( 'cortext_untrash', $swapped );
+		// Other actions pass through.
+		$this->assertSame( 'Edit', $swapped['edit'] );
+		$this->assertSame( 'Delete permanently', $swapped['delete'] );
+	}
+
+	public function test_bulk_trash_handler_does_not_error_when_parent_and_child_are_both_selected(): void {
+		wp_set_current_user( $this->create_user_with_cap() );
+
+		$parent_id = $this->create_page();
+		$child_id  = $this->create_page( array( 'post_parent' => $parent_id ) );
+
+		$cascade = new PageTrashCascade();
+
+		// Core's bulk handler would wp_die() on the second wp_trash_post call.
+		// Our handler tolerates the cascade-already-trashed state.
+		$sendback = $cascade->handle_admin_bulk_action(
+			'http://example.com/wp-admin/edit.php?post_type=' . Page::POST_TYPE,
+			'cortext_trash',
+			array( $parent_id, $child_id )
+		);
+
+		$this->assertSame( 'trash', get_post_status( $parent_id ) );
+		$this->assertSame( 'trash', get_post_status( $child_id ) );
+		$this->assertStringContainsString( 'trashed=2', (string) $sendback );
+	}
+
+	public function test_bulk_untrash_handler_does_not_error_when_parent_and_child_are_both_selected(): void {
+		wp_set_current_user( $this->create_user_with_cap() );
+
+		$parent_id = $this->create_page();
+		$child_id  = $this->create_page( array( 'post_parent' => $parent_id ) );
+
+		wp_trash_post( $parent_id );
+		$this->assertSame( 'trash', get_post_status( $parent_id ) );
+		$this->assertSame( 'trash', get_post_status( $child_id ) );
+
+		$cascade = new PageTrashCascade();
+
+		$sendback = $cascade->handle_admin_bulk_action(
+			'http://example.com/wp-admin/edit.php?post_status=trash&post_type=' . Page::POST_TYPE,
+			'cortext_untrash',
+			array( $parent_id, $child_id )
+		);
+
+		$this->assertNotSame( 'trash', get_post_status( $parent_id ) );
+		$this->assertNotSame( 'trash', get_post_status( $child_id ) );
+		$this->assertStringContainsString( 'untrashed=2', (string) $sendback );
+	}
+
+	public function test_handle_admin_bulk_action_passes_through_unrelated_actions(): void {
+		$cascade  = new PageTrashCascade();
+		$sendback = 'http://example.com/wp-admin/edit.php?post_type=' . Page::POST_TYPE;
+
+		$result = $cascade->handle_admin_bulk_action( $sendback, 'edit', array( 1, 2 ) );
+
+		$this->assertSame( $sendback, $result );
+	}
+
+	private function create_user_with_cap(): int {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'editor_' . wp_generate_uuid4(),
+				'user_pass'  => 'pass',
+				'role'       => 'administrator',
+			)
+		);
+		$this->assertIsInt( $user_id );
+		return (int) $user_id;
 	}
 
 	private function create_page( array $args = array() ): int {

--- a/tests/php/test-page-trash-cascade.php
+++ b/tests/php/test-page-trash-cascade.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Tests for Cortext\PostType\PageTrashCascade.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Page;
+use Cortext\PostType\PageTrashCascade;
+use WorDBless\BaseTestCase;
+use WorDBless\Posts as WorDBlessPosts;
+use WP_Post;
+use WP_Query;
+
+final class Test_Page_Trash_Cascade extends BaseTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Page() )->register_post_type();
+
+		remove_all_actions( 'wp_trash_post' );
+		remove_all_actions( 'untrashed_post' );
+		remove_all_filters( 'wp_untrash_post_status' );
+
+		// WorDBless's wpdb mock returns empty for any query that is not a
+		// single-row primary-key lookup; cascade operations rely on
+		// `post_parent` and meta_key joins. Intercept WP_Query before it
+		// builds SQL and answer from WorDBless's in-memory store instead.
+		add_filter( 'posts_pre_query', array( $this, 'serve_posts_from_memory' ), 10, 2 );
+
+		( new PageTrashCascade() )->register();
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'posts_pre_query', array( $this, 'serve_posts_from_memory' ), 10 );
+		parent::tear_down();
+	}
+
+	public function test_register_hooks_trash_and_untrash_actions(): void {
+		$this->assertNotFalse(
+			has_action( 'wp_trash_post' ),
+			'cascade_trash should be hooked on wp_trash_post.'
+		);
+		$this->assertNotFalse(
+			has_action( 'untrashed_post' ),
+			'cascade_restore should be hooked on untrashed_post.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'wp_untrash_post_status' ),
+			'restore_previous_status should be hooked on wp_untrash_post_status so programmatic restores return to the pre-trash status.'
+		);
+	}
+
+	public function test_trashing_parent_cascades_to_descendants_and_stamps_meta(): void {
+		$parent_id     = $this->create_page( array( 'post_status' => 'private' ) );
+		$child_id      = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$grandchild_id = $this->create_page( array( 'post_parent' => $child_id ) );
+
+		wp_trash_post( $parent_id );
+
+		$this->assertSame( 'trash', get_post_status( $parent_id ) );
+		$this->assertSame( 'trash', get_post_status( $child_id ) );
+		$this->assertSame( 'trash', get_post_status( $grandchild_id ) );
+
+		$this->assertSame( '', (string) get_post_meta( $parent_id, PageTrashCascade::META_KEY, true ) );
+		$this->assertSame( (string) $parent_id, (string) get_post_meta( $child_id, PageTrashCascade::META_KEY, true ) );
+		$this->assertSame( (string) $parent_id, (string) get_post_meta( $grandchild_id, PageTrashCascade::META_KEY, true ) );
+	}
+
+	public function test_trashing_non_page_post_does_not_touch_other_post_types(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'A regular post',
+			)
+		);
+
+		$cortext_page_id = $this->create_page( array( 'post_parent' => (int) $post_id ) );
+
+		wp_trash_post( $post_id );
+
+		$this->assertSame( 'publish', get_post_status( $cortext_page_id ) );
+		$this->assertSame( '', (string) get_post_meta( $cortext_page_id, PageTrashCascade::META_KEY, true ) );
+	}
+
+	public function test_pre_trashed_child_is_not_restamped_when_parent_is_trashed(): void {
+		$parent_id = $this->create_page();
+		$child_id  = $this->create_page( array( 'post_parent' => $parent_id ) );
+
+		// Trash the child directly first; it now carries no marker (it is the
+		// root of its own one-page cascade).
+		wp_trash_post( $child_id );
+		$this->assertSame( 'trash', get_post_status( $child_id ) );
+		$this->assertSame( '', (string) get_post_meta( $child_id, PageTrashCascade::META_KEY, true ) );
+
+		// Trashing the parent must not re-stamp the already-trashed child.
+		wp_trash_post( $parent_id );
+
+		$this->assertSame( '', (string) get_post_meta( $child_id, PageTrashCascade::META_KEY, true ) );
+	}
+
+	public function test_restoring_parent_revives_only_descendants_marked_by_its_cascade(): void {
+		$parent_id  = $this->create_page();
+		$child_id   = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$sibling_id = $this->create_page();
+
+		// Sibling lives in trash from its own delete, not the cascade.
+		wp_trash_post( $sibling_id );
+		wp_trash_post( $parent_id );
+
+		wp_untrash_post( $parent_id );
+
+		$this->assertNotSame( 'trash', get_post_status( $parent_id ) );
+		$this->assertNotSame( 'trash', get_post_status( $child_id ) );
+		$this->assertSame( 'trash', get_post_status( $sibling_id ), 'Independent trash should not be revived by an unrelated parent restore.' );
+	}
+
+	public function test_restoring_returns_pages_to_their_pre_trash_status(): void {
+		$private_parent_id = $this->create_page( array( 'post_status' => 'private' ) );
+		$published_child_id = $this->create_page(
+			array(
+				'post_parent' => $private_parent_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_trash_post( $private_parent_id );
+
+		wp_untrash_post( $private_parent_id );
+
+		$this->assertSame( 'private', get_post_status( $private_parent_id ) );
+		$this->assertSame( 'publish', get_post_status( $published_child_id ) );
+	}
+
+	public function test_individual_child_restore_clears_its_marker(): void {
+		$parent_id = $this->create_page();
+		$child_id  = $this->create_page( array( 'post_parent' => $parent_id ) );
+
+		wp_trash_post( $parent_id );
+		$this->assertSame( (string) $parent_id, (string) get_post_meta( $child_id, PageTrashCascade::META_KEY, true ) );
+
+		// Restore just the child while the parent stays in trash.
+		wp_untrash_post( $child_id );
+
+		$this->assertSame( '', (string) get_post_meta( $child_id, PageTrashCascade::META_KEY, true ) );
+
+		// A later parent-restore must not try to revive an already-active child.
+		wp_untrash_post( $parent_id );
+		$this->assertNotSame( 'trash', get_post_status( $child_id ) );
+		$this->assertNotSame( 'trash', get_post_status( $parent_id ) );
+	}
+
+	private function create_page( array $args = array() ): int {
+		$defaults = array(
+			'post_type'   => Page::POST_TYPE,
+			'post_status' => 'publish',
+			'post_title'  => 'Test page ' . wp_generate_uuid4(),
+		);
+
+		$id = wp_insert_post( array_merge( $defaults, $args ) );
+
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+
+		return (int) $id;
+	}
+
+	/**
+	 * Short-circuits WP_Query for the queries the cascade emits, answering
+	 * from WorDBless's in-memory post store. Only handles the filters the
+	 * cascade uses: post_type, post_parent, post_status, meta_key+meta_value.
+	 *
+	 * @param mixed    $pre   Existing filter return; passed through unchanged when null.
+	 * @param WP_Query $query The query being short-circuited.
+	 *
+	 * @return mixed
+	 */
+	public function serve_posts_from_memory( $pre, WP_Query $query ) {
+		$vars = $query->query_vars;
+
+		$wants_parent_filter = ! empty( $vars['post_parent'] );
+		$wants_meta_filter   = ! empty( $vars['meta_key'] );
+		if ( ! $wants_parent_filter && ! $wants_meta_filter ) {
+			return $pre;
+		}
+
+		$candidates = $this->all_in_memory_posts();
+
+		if ( ! empty( $vars['post_type'] ) ) {
+			$types      = (array) $vars['post_type'];
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => in_array( $post->post_type, $types, true )
+			);
+		}
+
+		if ( $wants_parent_filter ) {
+			$parent     = (int) $vars['post_parent'];
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => (int) $post->post_parent === $parent
+			);
+		}
+
+		if ( ! empty( $vars['post_status'] ) ) {
+			$statuses   = (array) $vars['post_status'];
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => in_array( $post->post_status, $statuses, true )
+			);
+		}
+
+		if ( $wants_meta_filter ) {
+			$key        = (string) $vars['meta_key'];
+			$value      = (string) ( $vars['meta_value'] ?? '' );
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => (string) get_post_meta( (int) $post->ID, $key, true ) === $value
+			);
+		}
+
+		$candidates = array_values( $candidates );
+
+		if ( 'ids' === ( $vars['fields'] ?? '' ) ) {
+			return array_map( static fn( WP_Post $post ): int => (int) $post->ID, $candidates );
+		}
+
+		return $candidates;
+	}
+
+	/**
+	 * @return WP_Post[]
+	 */
+	private function all_in_memory_posts(): array {
+		$store = WorDBlessPosts::init()->posts;
+		$out   = array();
+		foreach ( $store as $row ) {
+			$out[] = new WP_Post( $row );
+		}
+		return $out;
+	}
+}


### PR DESCRIPTION
## What

Part of #136

Cascades trash and restore across `crtxt_page` descendants, restores pages to their pre-trash status, and stops the admin Pages list's bulk trash from erroring when a parent and child are selected together.

Note: this doesn't add anything UI-wise to Cortext! It's mainly the backend plumbing to enable Cortext's tree-trashing.

## Why

Sidebar delete is permanent today (`force: true`). For recoverable trash to work, a parent and its descendants have to move to trash together; otherwise, children get stranded with `post_parent` pointing at a trashed post.

## How

- `PageTrashCascade` hooks `wp_trash_post` and `untrashed_post` to walk the page's direct children, stamping each with the parent's id on the way down and clearing the marker on the way back. Each `wp_trash_post`/`wp_untrash_post` call fires the hook again for the child, so deeper levels handle themselves. Children trashed earlier on their own never get the marker, so a later parent-restore leaves them put; restoring an intermediate node walks its own tagged children and brings the subtree along.

- Re-registering `wp_untrash_post_status` for `crtxt_page`. Core only wires that filter from `wp-admin/edit.php`'s bulk-untrash, so programmatic restores (REST, WP-CLI, our cascade) come back as `draft` without it.

- Renaming the admin Pages list's `trash`/`untrash` bulk actions to `cortext_trash`/`cortext_untrash` (same user-visible labels). The renamed actions land in edit.php's default switch branch where `handle_bulk_actions-{screen}` fires, and our handler counts based on resulting `post_status` instead of `wp_trash_post`'s return value.

## Testing Instructions

1. `composer test:php`.
2. `composer phpcs`.
3. With wp-env running, create a parent with a child and a grandchild. `wp eval "wp_trash_post(<parent_id>);"`. All three should appear in `wp post list --post_type=crtxt_page --post_status=trash`. The child's `_cortext_trashed_by_parent` meta is the parent's id; the grandchild's is the child's id.
4. `wp eval "wp_untrash_post(<parent_id>);"`. All three come back at their pre-trash status.
5. Trash the tree again, then `wp eval "wp_untrash_post(<child_id>);"`. The child and grandchild come back; the parent stays in trash.
6. In wp-admin, open the Cortext Pages list, select a parent and one of its children, choose "Move to Trash". Both end up in trash, no wp_die error page.