### PR TITLE
Add `Created`, `Created by`, `Last edited`, `Last edited by` columns

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -103,3 +103,27 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 **Where.** `elementsFromOptions` in `src/hooks/fieldMapping.js`. Read by `Chip` (`src/components/fields/Chip.js`) via `formatDisplay` in `src/components/EditableCell.js`.
 
 **Solution.** Add `color` (or a generic decoration slot) to DataViews's `Option` type upstream, then drop the piggyback. File a Gutenberg issue with the chip-render use case.
+
+## 12. `_modified_by` is plugin-stored, not native `[internal]`
+
+**What.** WordPress core stores `post_modified` (timestamp) but not who last edited the post. The "Last edited by" system column needs that information, so a `save_post` hook on entry CPTs records `_modified_by` post meta with the current user ID on every save. Skipped when no user is signed in (CLI imports, cron, seeds, unauthenticated REST) so background writes don't clobber the last real editor with `0`. Risk: third-party plugins that bypass `save_post` (direct DB writes) won't update `_modified_by`. Acceptable for the block's scope; entries created before this PR fall back to the post author when the meta is absent.
+
+**Where.** `record_modified_by` in `includes/PostType/CollectionEntries.php`, read by `format_row` in `includes/Rest/RowsController.php`.
+
+**Solution.** Either core grows native "last editor" tracking (unlikely; long-standing wishlist), or we accept the hook as the canonical answer. No upstream issue to file — this is just a small piece of plugin-managed state.
+
+## 13. System field filtering is deferred `[internal]`
+
+**What.** Filters route through `meta_query`, but system fields (`created_at`, `modified_at`, `created_by`, `modified_by`) live on the post table or in user data, not in post meta. The filter validator rejects all four with a clean 400 rather than silently no-op'ing through the meta_query branch. Users can sort by `created_at` and `modified_at` (free WP_Query orderby) but can't filter on any system field today.
+
+**Where.** `validate_filter_fields` and `build_query_args` in `includes/Rest/RowsController.php`.
+
+**Solution.** Add date-range filter operators with native `date_query` for `created_at` / `modified_at`, and JOIN-to-users filtering for `created_by` / `modified_by` (paired with #14, since the JOIN cost is shared with display-value sorting).
+
+## 14. Sort on display-value properties is an open architectural decision `[internal]`
+
+**What.** `created_by`, `modified_by`, future Person properties, Relation, value-Rollup, and Files all share the same pattern: stored value is an internal handle (user ID, post ID, attachment ID), useful sort is on the displayed string (display name, related-row title, filename). Sort by stored is meaningless from the UI; sort by display requires a JOIN (or in-memory sort). PR C ships sort only on the timestamp system fields and rejects sort on `_by` keys at the validator. The same problem will hit Relation and Rollup when those types ship (RSM-1468), so the architecture should be settled once.
+
+**Where.** `validate_sort_field` in `includes/Rest/RowsController.php` (rejects `_by` keys today). `enableSorting: false` for the `_by` system fields in `systemFields` (`src/hooks/fieldMapping.js`).
+
+**Solution.** A single decision shared with the relations/rollups work: JOIN-and-sort in `build_query_args`, in-memory sort after fetch, or a custom REST query path. Pick when picking up RSM-1468; until then, sort UI on display-value properties stays disabled. Tracked in RSM-1793.

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -43,6 +43,12 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
+		// Run as an administrator so seeded entries get a real `post_author`
+		// (otherwise CLI's user-0 context produces empty Created by /
+		// Last edited by columns) and the save_post hook records
+		// `_modified_by` against the same user.
+		wp_set_current_user( $this->default_seed_user_id() );
+
 		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'reset', false ) ) {
 			WP_CLI::confirm(
 				'This will delete all Cortext collections, fields, and entries. Continue?',
@@ -193,6 +199,23 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		WP_CLI::success( 'Seeding complete.' );
+	}
+
+	/**
+	 * Returns the ID of the first administrator, or 1 as a fallback.
+	 *
+	 * Used to give the seed run a real user context so seeded entries
+	 * have a recognizable `post_author` and `_modified_by`.
+	 */
+	private function default_seed_user_id(): int {
+		$users = get_users(
+			array(
+				'role'   => 'administrator',
+				'number' => 1,
+				'fields' => array( 'ID' ),
+			)
+		);
+		return $users ? (int) $users[0]->ID : 1;
 	}
 
 	private function seed_collection( array $spec ): void {

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -41,6 +41,40 @@ final class CollectionEntries {
 
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_all' ), 20 );
+		add_action( 'save_post', array( $this, 'record_modified_by' ), 10, 2 );
+	}
+
+	/**
+	 * Records the current user as the last editor of an entry.
+	 *
+	 * WordPress core stores `post_modified` (timestamp) but not who edited.
+	 * The plugin records `_modified_by` post meta on every entry save so the
+	 * "Last edited by" system column has a value to read. Skipped when no
+	 * user is signed in (CLI imports, cron, seeds, unauthenticated REST)
+	 * so background writes don't clobber the last real editor with `0`.
+	 *
+	 * @param int     $post_id Post ID being saved.
+	 * @param WP_Post $post    Post object being saved.
+	 */
+	public function record_modified_by( int $post_id, WP_Post $post ): void {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
+		if ( strpos( $post->post_type, self::CPT_PREFIX ) !== 0 ) {
+			return;
+		}
+
+		if ( Collection::POST_TYPE === $post->post_type || Field::POST_TYPE === $post->post_type ) {
+			return;
+		}
+
+		$user_id = get_current_user_id();
+		if ( $user_id < 1 ) {
+			return;
+		}
+
+		update_post_meta( $post_id, '_modified_by', $user_id );
 	}
 
 	public function register_all(): void {

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -116,11 +116,26 @@ final class RowsController {
 		$slug      = (string) get_post_meta( $collection->ID, 'slug', true );
 		$field_ids = $this->collection_field_ids( $collection->ID );
 
-		// Validate field references in sort/filters.
-		$referenced = $this->referenced_fields( $request );
-		$validation = $this->validate_fields( $referenced, $field_ids, $collection_id );
-		if ( is_wp_error( $validation ) ) {
-			return $validation;
+		// Validate sort and filter references separately. Sort accepts
+		// 'title', 'field-N', and the sortable system fields; filters
+		// accept 'field-N' only — system field filtering is deferred
+		// (tech-debt.md#13).
+		$sort_validation = $this->validate_sort_field(
+			$request->get_param( 'sort' ),
+			$field_ids,
+			$collection_id
+		);
+		if ( is_wp_error( $sort_validation ) ) {
+			return $sort_validation;
+		}
+
+		$filter_validation = $this->validate_filter_fields(
+			$request->get_param( 'filters' ),
+			$field_ids,
+			$collection_id
+		);
+		if ( is_wp_error( $filter_validation ) ) {
+			return $filter_validation;
 		}
 
 		// Precompute which fields are multi-value so format_row does not
@@ -129,6 +144,11 @@ final class RowsController {
 
 		$query_args = $this->build_query_args( $request, $slug );
 		$query      = new WP_Query( $query_args );
+
+		// Prime the user object cache once before mapping rows so per-row
+		// display name lookups in format_row hit the cache instead of
+		// running N+1 queries.
+		$this->prime_user_cache( $query->posts );
 
 		$rows = array_map(
 			function ( WP_Post $post ) use ( $field_ids, $multi_field_ids ) {
@@ -191,53 +211,79 @@ final class RowsController {
 	}
 
 	/**
-	 * Extracts all field references from sort and filter params.
+	 * Validates the `sort` param's field key.
 	 *
-	 * @param WP_REST_Request $request Full request object.
-	 * @return string[] Field keys like "field-123".
+	 * Accepts `'title'`, any `field-N` belonging to the collection, and the
+	 * sortable system field keys (`'created_at'`, `'modified_at'`). Rejects
+	 * the `*_by` system field keys and any other identifier — sort on
+	 * display-value properties is an open architectural decision shared
+	 * with relations and rollups (tech-debt.md#14).
+	 *
+	 * @param mixed $sort           Sort param from the request.
+	 * @param int[] $field_ids      Valid field IDs for the collection.
+	 * @param int   $collection_id  Collection ID for error messages.
+	 * @return true|WP_Error
 	 */
-	private function referenced_fields( WP_REST_Request $request ): array {
-		$refs = array();
-
-		$sort = $request->get_param( 'sort' );
-		if ( is_array( $sort ) && ! empty( $sort['field'] ) && 'title' !== $sort['field'] ) {
-			$refs[] = $sort['field'];
+	private function validate_sort_field( $sort, array $field_ids, int $collection_id ) {
+		if ( ! is_array( $sort ) || empty( $sort['field'] ) ) {
+			return true;
 		}
 
-		$filters = $request->get_param( 'filters' );
-		if ( is_array( $filters ) ) {
-			foreach ( $filters as $filter ) {
-				if ( is_array( $filter ) && ! empty( $filter['field'] ) ) {
-					$refs[] = $filter['field'];
-				}
-			}
+		$allowed = array( 'title', 'created_at', 'modified_at' );
+		foreach ( $field_ids as $id ) {
+			$allowed[] = "field-{$id}";
 		}
 
-		return array_unique( $refs );
+		if ( ! in_array( $sort['field'], $allowed, true ) ) {
+			return new WP_Error(
+				'cortext_invalid_sort_field',
+				sprintf(
+					/* translators: 1: field key, 2: collection ID */
+					__( 'Field "%1$s" cannot be used to sort collection %2$d.', 'cortext' ),
+					$sort['field'],
+					$collection_id
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
 	}
 
 	/**
-	 * Validates that every referenced field key belongs to the collection.
+	 * Validates every `filters[].field` reference.
 	 *
-	 * @param string[] $referenced     Field keys like "field-123".
-	 * @param int[]    $field_ids      Valid field IDs for the collection.
-	 * @param int      $collection_id  Collection ID for error messages.
+	 * Accepts only `field-N` keys belonging to the collection. Title and
+	 * system fields are intentionally excluded: title isn't filterable
+	 * today (preserved from prior behavior), and system field filtering
+	 * is deferred (tech-debt.md#13). Rejection produces a clean 400.
+	 *
+	 * @param mixed $filters        Filters param from the request.
+	 * @param int[] $field_ids      Valid field IDs for the collection.
+	 * @param int   $collection_id  Collection ID for error messages.
 	 * @return true|WP_Error
 	 */
-	private function validate_fields( array $referenced, array $field_ids, int $collection_id ) {
-		$valid_keys = array();
-		foreach ( $field_ids as $id ) {
-			$valid_keys[] = "field-{$id}";
+	private function validate_filter_fields( $filters, array $field_ids, int $collection_id ) {
+		if ( ! is_array( $filters ) || count( $filters ) === 0 ) {
+			return true;
 		}
 
-		foreach ( $referenced as $key ) {
-			if ( ! in_array( $key, $valid_keys, true ) ) {
+		$allowed = array();
+		foreach ( $field_ids as $id ) {
+			$allowed[] = "field-{$id}";
+		}
+
+		foreach ( $filters as $filter ) {
+			if ( ! is_array( $filter ) || empty( $filter['field'] ) ) {
+				continue;
+			}
+			if ( ! in_array( $filter['field'], $allowed, true ) ) {
 				return new WP_Error(
-					'cortext_invalid_field',
+					'cortext_invalid_filter_field',
 					sprintf(
 						/* translators: 1: field key, 2: collection ID */
-						__( 'Field "%1$s" does not belong to collection %2$d.', 'cortext' ),
-						$key,
+						__( 'Field "%1$s" cannot be used to filter collection %2$d.', 'cortext' ),
+						$filter['field'],
 						$collection_id
 					),
 					array( 'status' => 400 )
@@ -279,6 +325,12 @@ final class RowsController {
 
 			if ( 'title' === $sort['field'] ) {
 				$args['orderby'] = 'title';
+				$args['order']   = $direction;
+			} elseif ( 'created_at' === $sort['field'] ) {
+				$args['orderby'] = 'date';
+				$args['order']   = $direction;
+			} elseif ( 'modified_at' === $sort['field'] ) {
+				$args['orderby'] = 'modified';
 				$args['order']   = $direction;
 			} else {
 				$field_id   = $this->field_id_from_key( $sort['field'] );
@@ -365,15 +417,85 @@ final class RowsController {
 				: get_post_meta( $post->ID, $key, true );
 		}
 
+		$created_by_id  = (int) $post->post_author;
+		$modified_by_id = (int) get_post_meta( $post->ID, '_modified_by', true );
+
 		return array(
-			'id'     => $post->ID,
-			'title'  => array(
+			'id'          => $post->ID,
+			'title'       => array(
 				'raw'      => $post->post_title,
 				'rendered' => $post->post_title,
 			),
-			'status' => $post->post_status,
-			'meta'   => $meta,
+			'status'      => $post->post_status,
+			'created_at'  => $this->format_gmt_date( $post->post_date_gmt ),
+			'modified_at' => $this->format_gmt_date( $post->post_modified_gmt ),
+			'created_by'  => $this->display_name_for( $created_by_id ),
+			'modified_by' => $this->display_name_for( $modified_by_id > 0 ? $modified_by_id : $created_by_id ),
+			'meta'        => $meta,
 		);
+	}
+
+	/**
+	 * Formats a GMT MySQL datetime as RFC3339 with explicit UTC offset.
+	 *
+	 * `mysql_to_rfc3339` strips the timezone, leaving the client to guess
+	 * whether the value is local or UTC. Since `_gmt` columns are always
+	 * UTC, render them as `+00:00` so the client formats them correctly.
+	 *
+	 * @param string|null $mysql_gmt MySQL datetime string in UTC.
+	 * @return string RFC3339 string, or empty string if the input is empty.
+	 */
+	private function format_gmt_date( ?string $mysql_gmt ): string {
+		if ( ! $mysql_gmt || '0000-00-00 00:00:00' === $mysql_gmt ) {
+			return '';
+		}
+		$timestamp = strtotime( $mysql_gmt . ' UTC' );
+		return false === $timestamp ? '' : gmdate( DATE_RFC3339, $timestamp );
+	}
+
+	/**
+	 * Resolves a user ID to a display name, or empty string when missing.
+	 *
+	 * Reads from the WP user object cache primed by `prime_user_cache` so
+	 * row pages stay at two user-related queries regardless of row count.
+	 *
+	 * @param int $user_id User ID to resolve.
+	 * @return string Display name, or empty string when the user is missing.
+	 */
+	private function display_name_for( int $user_id ): string {
+		if ( $user_id < 1 ) {
+			return '';
+		}
+		$user = get_userdata( $user_id );
+		return $user ? (string) $user->display_name : '';
+	}
+
+	/**
+	 * Pre-populates the user object cache with every author and last-editor
+	 * referenced by the current row page, so per-row `get_userdata` calls in
+	 * `format_row` resolve from cache. Without this, display name lookup is
+	 * N+1 on cold caches; with it, two batch queries cover any row count.
+	 *
+	 * @param WP_Post[] $posts Posts in the current row page.
+	 */
+	private function prime_user_cache( array $posts ): void {
+		if ( count( $posts ) === 0 ) {
+			return;
+		}
+
+		$ids = array();
+		foreach ( $posts as $post ) {
+			$ids[]       = (int) $post->post_author;
+			$modified_by = (int) get_post_meta( $post->ID, '_modified_by', true );
+			if ( $modified_by > 0 ) {
+				$ids[] = $modified_by;
+			}
+		}
+
+		$ids = array_values( array_unique( array_filter( $ids ) ) );
+		if ( count( $ids ) > 0 ) {
+			cache_users( $ids );
+		}
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@wordpress/core-data": "^7.44.0",
 				"@wordpress/data": "^10.44.0",
 				"@wordpress/dataviews": "^6.0.0",
+				"@wordpress/date": "^5.44.0",
 				"@wordpress/editor": "^14.44.0",
 				"@wordpress/element": "^6.44.0",
 				"@wordpress/i18n": "^6.17.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@wordpress/core-data": "^7.44.0",
 		"@wordpress/data": "^10.44.0",
 		"@wordpress/dataviews": "^6.0.0",
+		"@wordpress/date": "^5.44.0",
 		"@wordpress/editor": "^14.44.0",
 		"@wordpress/element": "^6.44.0",
 		"@wordpress/i18n": "^6.17.0",

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -1,3 +1,6 @@
+import { __ } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+
 import EditableCell from '../components/EditableCell';
 
 // Parses stored option records into the DataViews `elements` shape.
@@ -59,6 +62,79 @@ function buildRender( id, type, label, elements ) {
 			readOnly={ readOnly }
 		/>
 	);
+}
+
+// Returns the four read-only system fields surfaced alongside each
+// collection's custom fields: created at, last edited at, created by,
+// last edited by. The values come straight off the row payload (the
+// REST controller injects them in `format_row`); these definitions just
+// describe how they're rendered and which ones are sortable.
+//
+// `editable: false` keeps them out of the default `view.fields` seed
+// (CollectionDataViews seeds editable columns only), so they appear in
+// the column visibility menu default-hidden, addable like any other
+// field. Sort is enabled only on the timestamps — sort on display-value
+// properties (Person, Relation, Rollup) is an open architectural
+// decision shared with relations and rollups (tech-debt.md#14).
+export function systemFields() {
+	const formatDate = ( value ) =>
+		value ? dateI18n( 'M j, Y g:i a', value ) : '';
+	const formatText = ( value ) => ( value ? String( value ) : '' );
+
+	return [
+		{
+			id: 'created_at',
+			label: __( 'Created', 'cortext' ),
+			type: 'datetime',
+			editable: false,
+			enableSorting: true,
+			getValue: ( { item } ) => item?.created_at ?? null,
+			render: ( { item } ) => (
+				<span className="cortext-cell-readonly">
+					{ formatDate( item?.created_at ) }
+				</span>
+			),
+		},
+		{
+			id: 'created_by',
+			label: __( 'Created by', 'cortext' ),
+			type: 'text',
+			editable: false,
+			enableSorting: false,
+			getValue: ( { item } ) => item?.created_by ?? null,
+			render: ( { item } ) => (
+				<span className="cortext-cell-readonly">
+					{ formatText( item?.created_by ) }
+				</span>
+			),
+		},
+		{
+			id: 'modified_at',
+			label: __( 'Last edited', 'cortext' ),
+			type: 'datetime',
+			editable: false,
+			enableSorting: true,
+			getValue: ( { item } ) => item?.modified_at ?? null,
+			render: ( { item } ) => (
+				<span className="cortext-cell-readonly">
+					{ formatDate( item?.modified_at ) }
+				</span>
+			),
+		},
+		{
+			id: 'modified_by',
+			label: __( 'Last edited by', 'cortext' ),
+			type: 'text',
+			editable: false,
+			enableSorting: false,
+			getValue: ( { item } ) => item?.modified_by ?? null,
+			render: ( { item } ) => (
+				<span className="cortext-cell-readonly">
+					{ formatText( item?.modified_by ) }
+				</span>
+			),
+		},
+	];
 }
 
 export function mapField( field ) {

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -1,7 +1,7 @@
 import { useMemo } from '@wordpress/element';
 import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 
-import { mapField } from './fieldMapping';
+import { mapField, systemFields } from './fieldMapping';
 
 // Reads a collection's fields from main's contract: `meta.fields` is an array
 // of `crtxt_field` post IDs in display order. Fetch those records, then
@@ -45,10 +45,14 @@ export default function useCollectionFields( collectionId ) {
 	);
 
 	const fields = useMemo( () => {
-		if ( ! Array.isArray( fieldRecords ) ) {
-			return [];
-		}
-		return fieldRecords.map( mapField );
+		const custom = Array.isArray( fieldRecords )
+			? fieldRecords.map( mapField )
+			: [];
+		// System fields (created/modified timestamps + authors) sit at
+		// the bottom of the column visibility menu, default-hidden via
+		// `editable: false`. The REST controller injects their values
+		// into each row payload in `format_row`.
+		return [ ...custom, ...systemFields() ];
 	}, [ fieldRecords ] );
 
 	return {

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -883,4 +883,140 @@ test.describe( 'Collection view block', () => {
 			);
 		}
 	} );
+
+	test( 'renders system field columns as read-only when visible', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			const suffix = Date.now().toString( 36 ).slice( -4 );
+			const slug = `e2esys${ suffix }`;
+			fixture.slug = slug;
+
+			fixture.collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_collections',
+				data: {
+					title: `System fields ${ suffix }`,
+					status: 'private',
+					meta: { slug },
+				},
+			} );
+
+			fixture.field = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_fields',
+				data: {
+					title: 'Note',
+					status: 'private',
+					meta: { type: 'text' },
+				},
+			} );
+
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_collections/${ fixture.collection.id }`,
+				data: {
+					meta: { fields: [ String( fixture.field.id ) ] },
+				},
+			} );
+
+			fixture.entry = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_${ slug }`,
+				data: {
+					title: 'Sample row',
+					status: 'private',
+					meta: {
+						[ `field-${ fixture.field.id }` ]: 'a note',
+					},
+				},
+			} );
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'System field page',
+					status: 'private',
+					content: createDataViewBlockMarkup(
+						fixture.collection.id,
+						{
+							fields: [
+								'title',
+								'created_at',
+								'created_by',
+								'modified_at',
+								'modified_by',
+							],
+						}
+					),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			await expect( canvas.getByText( 'Sample row' ) ).toBeVisible();
+
+			// Each system field cell renders inside a read-only span; no
+			// EditableCell mounts, no inline edit affordance.
+			const readOnlyCells = canvas.locator(
+				'.cortext-data-view td .cortext-cell-readonly'
+			);
+			// At least one read-only cell per system column should be
+			// present (the row may also have read-only cells from any
+			// non-editable custom field types, but we configured none of
+			// those here).
+			await expect( readOnlyCells.first() ).toBeVisible();
+			expect( await readOnlyCells.count() ).toBeGreaterThanOrEqual( 4 );
+
+			// `created_by` resolves to a non-empty author name.
+			const createdByCell = readOnlyCells.nth( 1 );
+			await expect( createdByCell ).not.toHaveText( '' );
+
+			// Read-only cells don't expose an editable shell; clicking
+			// them must not produce a CheckboxControl, TextControl, or
+			// any of EditableCell's edit affordances.
+			await createdByCell.click();
+			await expect(
+				canvas.locator( '.cortext-editable-cell--editing' )
+			).toHaveCount( 0 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field &&
+					`/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
 } );

--- a/tests/js/hooks/fieldMapping.test.js
+++ b/tests/js/hooks/fieldMapping.test.js
@@ -1,4 +1,10 @@
-import { elementsFromOptions, mapField } from '../../../src/hooks/fieldMapping';
+import { render } from '@testing-library/react';
+
+import {
+	elementsFromOptions,
+	mapField,
+	systemFields,
+} from '../../../src/hooks/fieldMapping';
 
 describe( 'elementsFromOptions', () => {
 	it( 'returns undefined for falsy input', () => {
@@ -85,6 +91,89 @@ describe( 'mapField', () => {
 		);
 		expect( mapField( baseField( { type: 'datetime' } ) ).type ).toBe(
 			'datetime'
+		);
+	} );
+} );
+
+describe( 'systemFields', () => {
+	const fields = systemFields();
+	const byId = ( id ) => fields.find( ( f ) => f.id === id );
+
+	it( 'returns the four system fields with stable ids', () => {
+		expect( fields ).toHaveLength( 4 );
+		expect( fields.map( ( f ) => f.id ) ).toEqual( [
+			'created_at',
+			'created_by',
+			'modified_at',
+			'modified_by',
+		] );
+	} );
+
+	it( 'marks every system field as not editable', () => {
+		fields.forEach( ( f ) => expect( f.editable ).toBe( false ) );
+	} );
+
+	it( 'enables sorting only on the timestamp fields', () => {
+		expect( byId( 'created_at' ).enableSorting ).toBe( true );
+		expect( byId( 'modified_at' ).enableSorting ).toBe( true );
+		expect( byId( 'created_by' ).enableSorting ).toBe( false );
+		expect( byId( 'modified_by' ).enableSorting ).toBe( false );
+	} );
+
+	it( 'maps timestamps to DataViews datetime and names to text', () => {
+		expect( byId( 'created_at' ).type ).toBe( 'datetime' );
+		expect( byId( 'modified_at' ).type ).toBe( 'datetime' );
+		expect( byId( 'created_by' ).type ).toBe( 'text' );
+		expect( byId( 'modified_by' ).type ).toBe( 'text' );
+	} );
+
+	it( 'reads each value from the row payload', () => {
+		const item = {
+			created_at: '2026-04-30T09:48:54+00:00',
+			modified_at: '2026-04-30T10:00:00+00:00',
+			created_by: 'Ada Lovelace',
+			modified_by: 'Grace Hopper',
+		};
+		expect( byId( 'created_at' ).getValue( { item } ) ).toBe(
+			'2026-04-30T09:48:54+00:00'
+		);
+		expect( byId( 'modified_at' ).getValue( { item } ) ).toBe(
+			'2026-04-30T10:00:00+00:00'
+		);
+		expect( byId( 'created_by' ).getValue( { item } ) ).toBe( 'Ada Lovelace' );
+		expect( byId( 'modified_by' ).getValue( { item } ) ).toBe( 'Grace Hopper' );
+	} );
+
+	it( 'returns null when the row is missing the value', () => {
+		fields.forEach( ( f ) =>
+			expect( f.getValue( { item: {} } ) ).toBeNull()
+		);
+	} );
+
+	it( 'renders names as plain text', () => {
+		const Render = byId( 'created_by' ).render;
+		const { container } = render(
+			<Render item={ { created_by: 'Ada Lovelace' } } />
+		);
+		expect( container.textContent ).toBe( 'Ada Lovelace' );
+	} );
+
+	it( 'renders empty when the value is missing', () => {
+		const Render = byId( 'modified_by' ).render;
+		const { container } = render( <Render item={ {} } /> );
+		expect( container.textContent ).toBe( '' );
+	} );
+
+	it( 'renders timestamps as a non-empty formatted string', () => {
+		const Render = byId( 'created_at' ).render;
+		const { container } = render(
+			<Render item={ { created_at: '2026-04-30T09:48:54+00:00' } } />
+		);
+		// We don't assert the exact format (locale-dependent), only that
+		// something formatted comes out and the empty branch isn't hit.
+		expect( container.textContent.length ).toBeGreaterThan( 0 );
+		expect( container.textContent ).not.toBe(
+			'2026-04-30T09:48:54+00:00'
 		);
 	} );
 } );

--- a/tests/php/test-collection-entries.php
+++ b/tests/php/test-collection-entries.php
@@ -249,6 +249,133 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$this->assertTrue( true );
 	}
 
+	public function test_record_modified_by_writes_meta_on_entry_save(): void {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'mb_user',
+				'user_pass'  => 'password',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$entries = new CollectionEntries();
+		$entries->register();
+
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Logs',
+				'meta_input'  => array( 'slug' => 'logs' ),
+			)
+		);
+		$entries->register_for_collection( get_post( $collection_id ) );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_logs',
+				'post_status' => 'publish',
+				'post_title'  => 'A log',
+			)
+		);
+
+		$this->assertSame( (int) $user_id, (int) get_post_meta( $post_id, '_modified_by', true ) );
+
+		wp_set_current_user( 0 );
+	}
+
+	public function test_record_modified_by_skips_when_no_user(): void {
+		wp_set_current_user( 0 );
+
+		$entries = new CollectionEntries();
+		$entries->register();
+
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Cron',
+				'meta_input'  => array( 'slug' => 'cron' ),
+			)
+		);
+		$entries->register_for_collection( get_post( $collection_id ) );
+
+		// First save records a real user.
+		$author_id = wp_insert_user(
+			array(
+				'user_login' => 'mb_author',
+				'user_pass'  => 'password',
+				'role'       => 'author',
+			)
+		);
+		wp_set_current_user( $author_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_cron',
+				'post_status' => 'publish',
+				'post_title'  => 'Recorded',
+			)
+		);
+
+		$this->assertSame( (int) $author_id, (int) get_post_meta( $post_id, '_modified_by', true ) );
+
+		// Subsequent unauthenticated save (CLI / cron) must not clobber the
+		// last real editor with `0`.
+		wp_set_current_user( 0 );
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Updated by cron',
+			)
+		);
+
+		$this->assertSame(
+			(int) $author_id,
+			(int) get_post_meta( $post_id, '_modified_by', true ),
+			'Unauthenticated saves must leave _modified_by intact.'
+		);
+	}
+
+	public function test_record_modified_by_ignores_non_entry_post_types(): void {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'mb_skip',
+				'user_pass'  => 'password',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$entries = new CollectionEntries();
+		$entries->register();
+
+		// Saving a Collection or Field post must not record _modified_by:
+		// they aren't entry CPTs.
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Container',
+				'meta_input'  => array( 'slug' => 'container' ),
+			)
+		);
+		$field_id = wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Some field',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+
+		$this->assertSame( '', get_post_meta( $collection_id, '_modified_by', true ) );
+		$this->assertSame( '', get_post_meta( $field_id, '_modified_by', true ) );
+
+		wp_set_current_user( 0 );
+	}
+
 	public function test_wp_meta_type_for_returns_correct_types(): void {
 		$this->assertSame( 'number', CollectionEntries::wp_meta_type_for( 'number' ) );
 		$this->assertSame( 'boolean', CollectionEntries::wp_meta_type_for( 'checkbox' ) );

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -458,7 +458,308 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertSame( array( 'blue', 'green' ), $args['meta_query'][1]['value'] );
 	}
 
+	// -- System field tests ---------------------------------------------
+
+	public function test_format_row_includes_system_fields(): void {
+		$author_id = $this->create_user( 'author' );
+		$fixture   = $this->create_collection_fixture( 'sysfmt' );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_sysfmt',
+				'post_status' => 'publish',
+				'post_title'  => 'Entry',
+				'post_author' => $author_id,
+			)
+		);
+
+		$row = $this->invoke_format_row( $post_id, $fixture['field_id'] );
+
+		$this->assertArrayHasKey( 'created_at', $row );
+		$this->assertArrayHasKey( 'modified_at', $row );
+		$this->assertArrayHasKey( 'created_by', $row );
+		$this->assertArrayHasKey( 'modified_by', $row );
+	}
+
+	public function test_format_row_dates_are_rfc3339(): void {
+		$fixture = $this->create_collection_fixture( 'sysdates' );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_sysdates',
+				'post_status' => 'publish',
+				'post_title'  => 'Dated',
+			)
+		);
+
+		$row = $this->invoke_format_row( $post_id, $fixture['field_id'] );
+
+		// RFC3339 with offset: YYYY-MM-DDTHH:MM:SS+00:00 (or with timezone offset).
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/',
+			$row['created_at']
+		);
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/',
+			$row['modified_at']
+		);
+	}
+
+	public function test_format_row_resolves_author_display_name(): void {
+		$author_id = wp_insert_user(
+			array(
+				'user_login'   => 'sys_author',
+				'user_pass'    => 'password',
+				'display_name' => 'Ada Lovelace',
+				'role'         => 'author',
+			)
+		);
+		$fixture   = $this->create_collection_fixture( 'sysauthor' );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_sysauthor',
+				'post_status' => 'publish',
+				'post_title'  => 'Entry',
+				'post_author' => $author_id,
+			)
+		);
+
+		$row = $this->invoke_format_row( $post_id, $fixture['field_id'] );
+
+		$this->assertSame( 'Ada Lovelace', $row['created_by'] );
+	}
+
+	public function test_format_row_modified_by_falls_back_to_created_by(): void {
+		$author_id = wp_insert_user(
+			array(
+				'user_login'   => 'sys_fallback',
+				'user_pass'    => 'password',
+				'display_name' => 'Author Only',
+				'role'         => 'author',
+			)
+		);
+		$fixture   = $this->create_collection_fixture( 'sysfallback' );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_sysfallback',
+				'post_status' => 'publish',
+				'post_title'  => 'No edit history',
+				'post_author' => $author_id,
+			)
+		);
+		// Note: no _modified_by meta is set.
+
+		$row = $this->invoke_format_row( $post_id, $fixture['field_id'] );
+
+		$this->assertSame( 'Author Only', $row['created_by'] );
+		$this->assertSame( 'Author Only', $row['modified_by'] );
+	}
+
+	public function test_format_row_resolves_distinct_modified_by(): void {
+		$author_id = wp_insert_user(
+			array(
+				'user_login'   => 'sys_creator',
+				'user_pass'    => 'password',
+				'display_name' => 'Creator',
+				'role'         => 'author',
+			)
+		);
+		$editor_id = wp_insert_user(
+			array(
+				'user_login'   => 'sys_editor',
+				'user_pass'    => 'password',
+				'display_name' => 'Editor',
+				'role'         => 'editor',
+			)
+		);
+		$fixture   = $this->create_collection_fixture( 'sysdistinct' );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_sysdistinct',
+				'post_status' => 'publish',
+				'post_title'  => 'Edited',
+				'post_author' => $author_id,
+			)
+		);
+		update_post_meta( $post_id, '_modified_by', $editor_id );
+
+		$row = $this->invoke_format_row( $post_id, $fixture['field_id'] );
+
+		$this->assertSame( 'Creator', $row['created_by'] );
+		$this->assertSame( 'Editor', $row['modified_by'] );
+	}
+
+	// Multi-author flow through the REST endpoint isn't testable in
+	// WorDBless: `wp_insert_post` works via the object cache but
+	// `WP_Query` SQL returns zero results (tech-debt.md#9). The
+	// `test_format_row_resolves_distinct_modified_by` test above
+	// already covers display-name resolution for distinct users at the
+	// `format_row` layer; the full REST flow is exercised in e2e.
+
+	public function test_sort_accepts_created_at(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$fixture = $this->create_collection_fixture( 'syssortc' );
+
+		$response = $this->query_rows(
+			array(
+				'collection' => $fixture['collection_id'],
+				'sort'       => array(
+					'field'     => 'created_at',
+					'direction' => 'desc',
+				),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_sort_accepts_modified_at(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$fixture = $this->create_collection_fixture( 'syssortm' );
+
+		$response = $this->query_rows(
+			array(
+				'collection' => $fixture['collection_id'],
+				'sort'       => array(
+					'field'     => 'modified_at',
+					'direction' => 'asc',
+				),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_sort_rejects_created_by(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$fixture = $this->create_collection_fixture( 'sysrjcb' );
+
+		$response = $this->query_rows(
+			array(
+				'collection' => $fixture['collection_id'],
+				'sort'       => array(
+					'field'     => 'created_by',
+					'direction' => 'asc',
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_sort_rejects_modified_by(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$fixture = $this->create_collection_fixture( 'sysrjmb' );
+
+		$response = $this->query_rows(
+			array(
+				'collection' => $fixture['collection_id'],
+				'sort'       => array(
+					'field'     => 'modified_by',
+					'direction' => 'asc',
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_filter_rejects_all_system_fields(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$fixture = $this->create_collection_fixture( 'sysfilt' );
+
+		foreach ( array( 'created_at', 'modified_at', 'created_by', 'modified_by' ) as $key ) {
+			$response = $this->query_rows(
+				array(
+					'collection' => $fixture['collection_id'],
+					'filters'    => array(
+						array(
+							'field'    => $key,
+							'operator' => 'is',
+							'value'    => 'whatever',
+						),
+					),
+				)
+			);
+
+			$this->assertSame( 400, $response->get_status(), "Filter on {$key} must return 400." );
+		}
+	}
+
+	public function test_build_query_args_with_created_at_sort(): void {
+		$fixture = $this->create_collection_fixture( 'bqact' );
+
+		$args = $this->invoke_build_query_args(
+			$fixture['collection_id'],
+			'bqact',
+			array(
+				'field'     => 'created_at',
+				'direction' => 'desc',
+			)
+		);
+
+		$this->assertSame( 'date', $args['orderby'] );
+		$this->assertSame( 'DESC', $args['order'] );
+	}
+
+	public function test_build_query_args_with_modified_at_sort(): void {
+		$fixture = $this->create_collection_fixture( 'bqamod' );
+
+		$args = $this->invoke_build_query_args(
+			$fixture['collection_id'],
+			'bqamod',
+			array(
+				'field'     => 'modified_at',
+				'direction' => 'asc',
+			)
+		);
+
+		$this->assertSame( 'modified', $args['orderby'] );
+		$this->assertSame( 'ASC', $args['order'] );
+	}
+
 	// -- Helpers --------------------------------------------------------
+
+	private function invoke_format_row( int $post_id, int $field_id ): array {
+		$controller = new RowsController();
+		$method     = new \ReflectionMethod( $controller, 'format_row' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $controller, get_post( $post_id ), array( $field_id ), array() );
+	}
+
+	private function invoke_build_query_args( int $collection_id, string $slug, array $sort ): array {
+		$request = new WP_REST_Request( 'GET', '/cortext/v1/rows' );
+		$request->set_query_params(
+			array(
+				'collection' => $collection_id,
+				'sort'       => $sort,
+			)
+		);
+		$request->set_default_params(
+			array(
+				'per_page' => 25,
+				'page'     => 1,
+				'search'   => '',
+				'sort'     => null,
+				'filters'  => array(),
+			)
+		);
+
+		$controller = new RowsController();
+		$method     = new \ReflectionMethod( $controller, 'build_query_args' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $controller, $request, $slug );
+	}
 
 	private function query_rows( array $params ): \WP_REST_Response {
 		$request = new WP_REST_Request( 'GET', '/cortext/v1/rows' );


### PR DESCRIPTION
## What

Part of #99

Adds `Created`, `Created by`, `Last edited`, and `Last edited by` as read-only columns. Default-hidden, addable from the column visibility menu.

## Why

The block didn't expose who created or last edited a row.

## How

- `save_post` hook on entry CPTs writes `_modified_by` post meta. Skipped when no user is signed in, so CLI and cron writes don't clobber it with 0.

- `format_row` returns the four keys (RFC3339 UTC timestamps and resolved display names). `cache_users` primes once per page so name lookup stays at two queries regardless of row count.

- `validate_fields` splits into sort-context and filter-context helpers; without the split, a filter on `created_at` would no-op through `meta_query`.

## Testing

1. `wp cortext seed --reset --force`.
2. Open a seeded collection. Toggle the four system fields on via View options.
3. Cells render formatted dates and a display name; clicking doesn't open an editor.
4. Sort by Created or Last edited works; `_by` columns expose no sort.
5. Edit a row as a second user. Last edited by switches; Created by stays.
6. `wp post update <id> --post_title="cli edit"`. `Last edited by` stays at the previous editor.