### PR TITLE
Use filterSortAndPaginate for client-side filtering, sorting, and pagination

### DIFF
--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Button, Notice } from '@wordpress/components';
-import { DataViews } from '@wordpress/dataviews';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import {
 	useCallback,
 	useEffect,
@@ -170,15 +170,20 @@ export default function CollectionDataViews( {
 			.filter( ( f ) => f && f.editable );
 	}, [ dataViewFields, view?.fields ] );
 
+	const { data: dataFiltered, paginationInfo: clientPaginationInfo } =
+		useMemo( () => {
+			return filterSortAndPaginate( data, view, dataViewFields );
+		}, [ data, view, dataViewFields ] );
+
 	const requestNext = useCallback(
 		( rowId, fieldId, direction ) => {
-			if ( ! data.length || ! editableVisibleFields.length ) {
+			if ( ! dataFiltered.length || ! editableVisibleFields.length ) {
 				return;
 			}
 			const fieldIdx = editableVisibleFields.findIndex(
 				( f ) => f.id === fieldId
 			);
-			const rowIdx = data.findIndex( ( r ) => r.id === rowId );
+			const rowIdx = dataFiltered.findIndex( ( r ) => r.id === rowId );
 			if ( fieldIdx < 0 || rowIdx < 0 ) {
 				return;
 			}
@@ -192,18 +197,18 @@ export default function CollectionDataViews( {
 				nextField = editableVisibleFields.length - 1;
 				nextRow -= 1;
 			}
-			if ( nextRow < 0 || nextRow >= data.length ) {
+			if ( nextRow < 0 || nextRow >= dataFiltered.length ) {
 				// Off the table edge; stop. Pagination crossings are out of
 				// scope for v1.
 				return;
 			}
 
 			setEditRequest( {
-				rowId: data[ nextRow ].id,
+				rowId: dataFiltered[ nextRow ].id,
 				fieldId: editableVisibleFields[ nextField ].id,
 			} );
 		},
-		[ data, editableVisibleFields ]
+		[ dataFiltered, editableVisibleFields ]
 	);
 
 	const saveRowField = useCallback(
@@ -363,11 +368,11 @@ export default function CollectionDataViews( {
 		<RowMutationContext.Provider value={ mutationContext }>
 			<div className="cortext-data-view">
 				<DataViews
-					data={ data }
+					data={ dataFiltered }
 					fields={ dataViewFields }
 					view={ view }
 					onChangeView={ onChangeView }
-					paginationInfo={ paginationInfo }
+					paginationInfo={ clientPaginationInfo }
 					defaultLayouts={ DEFAULT_LAYOUTS }
 					getItemId={ ( item ) => String( item.id ) }
 					isLoading={ isLoading }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -170,9 +170,18 @@ export default function CollectionDataViews( {
 			.filter( ( f ) => f && f.editable );
 	}, [ dataViewFields, view?.fields ] );
 
+	// Search is already handled server-side, so strip it from the view
+	// before passing to filterSortAndPaginate. Without this, the client
+	// re-filters against enableGlobalSearch (which no fields set), dropping
+	// every row.
 	const { data: dataFiltered, paginationInfo: clientPaginationInfo } =
 		useMemo( () => {
-			return filterSortAndPaginate( data, view, dataViewFields );
+			const { search, ...viewWithoutSearch } = view;
+			return filterSortAndPaginate(
+				data,
+				viewWithoutSearch,
+				dataViewFields
+			);
 		}, [ data, view, dataViewFields ] );
 
 	const requestNext = useCallback(

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -84,12 +84,15 @@ function mapField( field ) {
 				type: 'text',
 				elements,
 				isMultiple: true,
+				filterBy: {
+					operators: [ 'isAny', 'isNone', 'isAll', 'isNotAll' ],
+				},
 			};
 		case 'date':
 		case 'datetime':
 			return { ...base, type: 'datetime' };
 		case 'checkbox':
-			return { ...base, type: 'text' };
+			return { ...base, type: 'boolean' };
 		case 'text':
 		default:
 			return { ...base, type: 'text' };

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -8,33 +8,11 @@ import apiFetch from '@wordpress/api-fetch';
 function buildQueryArgs( collectionId, view ) {
 	const args = {
 		collection: collectionId,
-		per_page: view?.perPage ?? 25,
-		page: view?.page ?? 1,
+		per_page: -1,
 	};
 
 	if ( view?.search ) {
 		args.search = view.search;
-	}
-
-	if ( view?.sort?.field && view?.sort?.direction ) {
-		args[ 'sort[field]' ] = view.sort.field;
-		args[ 'sort[direction]' ] = view.sort.direction;
-	}
-
-	if ( view?.filters?.length ) {
-		view.filters.forEach( ( filter, i ) => {
-			if ( filter.field && filter.operator ) {
-				args[ `filters[${ i }][field]` ] = filter.field;
-				args[ `filters[${ i }][operator]` ] = filter.operator;
-				if ( Array.isArray( filter.value ) ) {
-					filter.value.forEach( ( v, j ) => {
-						args[ `filters[${ i }][value][${ j }]` ] = v;
-					} );
-				} else {
-					args[ `filters[${ i }][value]` ] = filter.value;
-				}
-			}
-		} );
 	}
 
 	return args;

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -5,6 +5,8 @@ import apiFetch from '@wordpress/api-fetch';
 // tech-debt.md#2: rows live outside core-data, so this hook manages
 // its own fetch state and exposes a manual refresh() handle.
 
+const SERVER_OPERATORS = new Set( [ 'is', 'isNot', 'isAny', 'isNone' ] );
+
 function buildQueryArgs( collectionId, view ) {
 	const args = {
 		collection: collectionId,
@@ -14,6 +16,24 @@ function buildQueryArgs( collectionId, view ) {
 	if ( view?.search ) {
 		args.search = view.search;
 	}
+
+	// Ignore filters that the server isn't equipped to honor, otherwise
+	// changes in `view` will result in a new query to be requested from the
+	// server, even though the results will be the same.
+	const serverFilters = ( view?.filters ?? [] ).filter(
+		( f ) => f.field && f.operator && SERVER_OPERATORS.has( f.operator )
+	);
+	serverFilters.forEach( ( filter, i ) => {
+		args[ `filters[${ i }][field]` ] = filter.field;
+		args[ `filters[${ i }][operator]` ] = filter.operator;
+		if ( Array.isArray( filter.value ) ) {
+			filter.value.forEach( ( v, j ) => {
+				args[ `filters[${ i }][value][${ j }]` ] = v;
+			} );
+		} else {
+			args[ `filters[${ i }][value]` ] = filter.value;
+		}
+	} );
 
 	return args;
 }


### PR DESCRIPTION
## Summary

Closes #126

- Implements filtering, sorting, and pagination to the client via `filterSortAndPaginate` from `@wordpress/dataviews`, giving full operator coverage (contains, before/after, lessThan, between, etc.) regardless of server-side filtering support
- Fixes checkbox field type mapping (`text` → `boolean`) and adds explicit `filterBy` operators for multiselect fields

### Open question

- In this first (Claude) pass, we now fetch all rows from the server (`per_page: -1`), removing sort/filter query params from the REST request. But the server _should_ still do what it can to trim the results, but the challenge here is to not break client-side pagination.

## Test plan

- [ ] Create a collection with fields of each type (text, number, date, select, multiselect, checkbox)
- [ ] Add several rows with varied values
- [ ] Verify column header menu shows appropriate filter operators per type
- [ ] Verify applying filters narrows visible rows correctly
- [ ] Verify sorting works for each field type
- [ ] Verify pagination updates correctly when filters reduce row count
- [ ] Verify Tab navigation across cells still works after filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)