### PR TITLE
Add page Trash UI, cascade-aware REST endpoints, and locked editor for trashed pages

### DIFF
--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -12,20 +12,22 @@ namespace Cortext\CLI;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\Field;
+use Cortext\PostType\Page;
 use WP_CLI;
 use WP_CLI_Command;
 
 final class SeedDummyCollections extends WP_CLI_Command {
 
 	/**
-	 * Seeds sample collections (Books, Paintings, Demo) with fields and entries.
+	 * Seeds sample collections (Books, Paintings, Demo) plus a small page
+	 * hierarchy that exercises the trash + cascade flows.
 	 *
-	 * Idempotent: skips any collection, field, or entry that already exists, unless --reset is passed.
+	 * Idempotent: skips anything that already exists, unless --reset is passed.
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--reset]
-	 * : Delete all Cortext data except for pages (collections, fields, entries) before seeding.
+	 * : Delete all Cortext data (collections, fields, entries, pages) before seeding.
 	 * Prompts for confirmation unless --force is also passed.
 	 *
 	 * [--force]
@@ -198,6 +200,8 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			$this->seed_collection( $spec );
 		}
 
+		$this->seed_pages();
+
 		WP_CLI::success( 'Seeding complete.' );
 	}
 
@@ -216,6 +220,84 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			)
 		);
 		return $users ? (int) $users[0]->ID : 1;
+	}
+
+	/**
+	 * Seeds a small page hierarchy useful for exercising the sidebar Trash
+	 * flow: a root with mixed-depth children, plus a sibling at the root so
+	 * cascade trash and intermediate-node restore can be tried end-to-end.
+	 */
+	private function seed_pages(): void {
+		$tree = array(
+			array(
+				'title'    => 'Workspace',
+				'children' => array(
+					array(
+						'title'    => 'Engineering',
+						'children' => array(
+							array( 'title' => 'Onboarding' ),
+							array(
+								'title'    => 'Standards',
+								'children' => array(
+									array( 'title' => 'PHP' ),
+									array( 'title' => 'JavaScript' ),
+								),
+							),
+						),
+					),
+					array(
+						'title'    => 'Design',
+						'children' => array(
+							array( 'title' => 'System' ),
+							array( 'title' => 'Mockups' ),
+						),
+					),
+				),
+			),
+			array( 'title' => 'Notes' ),
+		);
+
+		foreach ( $tree as $node ) {
+			$this->seed_page_tree( $node, 0 );
+		}
+	}
+
+	private function seed_page_tree( array $node, int $parent_id ): void {
+		$existing = get_posts(
+			array(
+				'post_type'   => Page::POST_TYPE,
+				'post_status' => array( 'draft', 'private', 'publish' ),
+				'post_parent' => $parent_id,
+				'title'       => $node['title'],
+				'numberposts' => 1,
+				'fields'      => 'ids',
+			)
+		);
+
+		if ( $existing ) {
+			$page_id = (int) $existing[0];
+			WP_CLI::log( "Page '{$node['title']}' already exists (ID {$page_id})." );
+		} else {
+			$page_id = wp_insert_post(
+				array(
+					'post_type'   => Page::POST_TYPE,
+					'post_status' => 'private',
+					'post_title'  => $node['title'],
+					'post_parent' => $parent_id,
+				),
+				true
+			);
+
+			if ( is_wp_error( $page_id ) ) {
+				WP_CLI::error( "Failed to create page '{$node['title']}': " . $page_id->get_error_message() );
+			}
+
+			WP_CLI::log( "Created page '{$node['title']}' (ID {$page_id})." );
+		}
+
+		foreach ( $node['children'] ?? array() as $child ) {
+			$this->seed_page_tree( $child, (int) $page_id );
+		}
 	}
 
 	private function seed_collection( array $spec ): void {
@@ -437,6 +519,25 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 		if ( $collections ) {
 			WP_CLI::log( sprintf( 'Deleted %d collections.', count( $collections ) ) );
+		}
+
+		// 4. Delete all pages, including trashed ones. WP_Query's 'any'
+		// excludes internal statuses like 'trash', so list them explicitly.
+		$pages = get_posts(
+			array(
+				'post_type'   => Page::POST_TYPE,
+				'post_status' => array( 'draft', 'private', 'publish', 'pending', 'future', 'trash' ),
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+
+		foreach ( $pages as $page_id ) {
+			wp_delete_post( (int) $page_id, true );
+		}
+
+		if ( $pages ) {
+			WP_CLI::log( sprintf( 'Deleted %d pages.', count( $pages ) ) );
 		}
 
 		WP_CLI::success( 'Reset complete.' );

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -17,6 +17,7 @@ use Cortext\PostType\Field;
 use Cortext\PostType\Page;
 use Cortext\PostType\PageTrashCascade;
 use Cortext\Rest\CollectionsController;
+use Cortext\Rest\PageTrashController;
 use Cortext\Rest\RowsController;
 
 final class Plugin {
@@ -39,6 +40,7 @@ final class Plugin {
 		( new CollectionEntries() )->register();
 		( new RevisionThrottle() )->register();
 		( new CollectionsController() )->register();
+		( new PageTrashController() )->register();
 		( new RowsController() )->register();
 	}
 

--- a/includes/PostType/Page.php
+++ b/includes/PostType/Page.php
@@ -54,6 +54,11 @@ final class Page {
 					// Load-bearing: RevisionThrottle's filters only fire on post types that support revisions. Do not remove.
 					'revisions',
 					'page-attributes',
+					// `meta` only appears in the REST schema when a CPT
+					// supports custom-fields; PageTrashCascade's marker meta
+					// (registered with `show_in_rest`) needs this so the
+					// sidebar Trash filter can read it on the client.
+					'custom-fields',
 				),
 				'capability_type'       => 'post',
 				'map_meta_cap'          => true,

--- a/includes/PostType/PageTrashCascade.php
+++ b/includes/PostType/PageTrashCascade.php
@@ -20,6 +20,7 @@ final class PageTrashCascade {
 	public const META_KEY = '_cortext_trashed_by_parent';
 
 	public function register(): void {
+		add_action( 'init', array( $this, 'register_meta' ) );
 		add_action( 'wp_trash_post', array( $this, 'cascade_trash' ), 10, 1 );
 		add_action( 'untrashed_post', array( $this, 'cascade_restore' ), 10, 1 );
 		// Core only wires wp_untrash_post_set_previous_status inside
@@ -32,6 +33,25 @@ final class PageTrashCascade {
 		// handle_bulk_actions-{screen} fires and we can absorb the no-op.
 		add_filter( 'bulk_actions-edit-' . Page::POST_TYPE, array( $this, 'replace_bulk_actions' ) );
 		add_filter( 'handle_bulk_actions-edit-' . Page::POST_TYPE, array( $this, 'handle_admin_bulk_action' ), 10, 3 );
+	}
+
+	/**
+	 * Exposes the cascade marker via REST so the sidebar Trash section can
+	 * filter rows down to cascade roots and walk the subtree client-side.
+	 */
+	public function register_meta(): void {
+		register_post_meta(
+			Page::POST_TYPE,
+			self::META_KEY,
+			array(
+				'type'          => 'integer',
+				'single'        => true,
+				'show_in_rest'  => true,
+				'auth_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+			)
+		);
 	}
 
 	/**

--- a/includes/Rest/PageTrashController.php
+++ b/includes/Rest/PageTrashController.php
@@ -58,6 +58,16 @@ final class PageTrashController {
 		);
 	}
 
+	/**
+	 * Permission gate. Returns a `WP_Error` with status 404 when the post id
+	 * is unknown or not a `crtxt_page` so the consumer can tell "not found"
+	 * from "not allowed" without leaking permission semantics into the route
+	 * callback. WP REST honours `WP_Error` returns from permission callbacks.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 *
+	 * @return bool|WP_Error
+	 */
 	public function check_trashed_page( WP_REST_Request $request ) {
 		$id   = (int) $request->get_param( 'id' );
 		$post = get_post( $id );
@@ -117,9 +127,26 @@ final class PageTrashController {
 		return new WP_REST_Response(
 			array(
 				'restored' => array_values( array_unique( array_merge( array( $id ), $revived ) ) ),
+				'post'     => $this->prepared_post( $id ),
 			),
 			200
 		);
+	}
+
+	/**
+	 * Runs the standard `WP_REST_Posts_Controller` against the given page so
+	 * the response payload matches what `useEntityRecord` already knows how to
+	 * consume. Lets clients drop a follow-up GET after a successful restore.
+	 *
+	 * @param int $id Page id to render.
+	 *
+	 * @return mixed
+	 */
+	private function prepared_post( int $id ) {
+		$rest_request = new WP_REST_Request( 'GET', '/wp/v2/crtxt_pages/' . $id );
+		$rest_request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $rest_request );
+		return $response->is_error() ? null : $response->get_data();
 	}
 
 	public function permanent_delete( WP_REST_Request $request ) {

--- a/includes/Rest/PageTrashController.php
+++ b/includes/Rest/PageTrashController.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * REST endpoint for restoring trashed Cortext pages.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use Cortext\PostType\Page;
+use Cortext\PostType\PageTrashCascade;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class PageTrashController {
+
+	private const NAMESPACE = 'cortext/v1';
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		$id_arg = array(
+			'id' => array(
+				'type'     => 'integer',
+				'required' => true,
+			),
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/pages/(?P<id>\d+)/restore',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'restore' ),
+					'permission_callback' => array( $this, 'check_trashed_page' ),
+					'args'                => $id_arg,
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/pages/(?P<id>\d+)/permanent-delete',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'permanent_delete' ),
+					'permission_callback' => array( $this, 'check_trashed_page' ),
+					'args'                => $id_arg,
+				),
+			)
+		);
+	}
+
+	public function check_trashed_page( WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$post = get_post( $id );
+
+		if ( ! $post || Page::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'cortext_page_not_found',
+				__( 'Page not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Trash, restore, and permanent-delete are gated on `delete_post` in
+		// core's admin Pages list; keep the same convention here.
+		if ( ! current_user_can( 'delete_post', $id ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public function restore( WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$post = get_post( $id );
+
+		if ( 'trash' !== $post->post_status ) {
+			return new WP_Error(
+				'cortext_page_not_trashed',
+				__( 'Page is not in trash.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Snapshot the tagged subtree before the cascade runs. The
+		// `untrashed_post` action fires synchronously inside `wp_untrash_post`,
+		// so a post-call query alone could not tell which descendants this
+		// restore brought back versus which were already out of trash. The
+		// cascade marker is per-immediate-parent, so we walk down the chain.
+		$candidates = $this->tagged_subtree_ids( $id );
+
+		$result = wp_untrash_post( $id );
+		if ( ! $result ) {
+			return new WP_Error(
+				'cortext_page_restore_failed',
+				__( 'Page could not be restored.', 'cortext' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$revived = array();
+		foreach ( $candidates as $candidate_id ) {
+			if ( 'trash' !== get_post_status( $candidate_id ) ) {
+				$revived[] = $candidate_id;
+			}
+		}
+
+		return new WP_REST_Response(
+			array(
+				'restored' => array_values( array_unique( array_merge( array( $id ), $revived ) ) ),
+			),
+			200
+		);
+	}
+
+	public function permanent_delete( WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$post = get_post( $id );
+
+		if ( 'trash' !== $post->post_status ) {
+			return new WP_Error(
+				'cortext_page_not_trashed',
+				__( 'Page is not in trash.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Snapshot the subtree up front, then delete leaves-first so WP's
+		// hierarchical-delete reparenting (`post_parent = $deleted->post_parent`)
+		// has nothing to do for any non-leaf.
+		$descendants = $this->tagged_subtree_ids( $id );
+
+		$deleted = array();
+		foreach ( array_reverse( $descendants ) as $descendant_id ) {
+			if ( wp_delete_post( $descendant_id, true ) ) {
+				$deleted[] = $descendant_id;
+			}
+		}
+
+		if ( ! wp_delete_post( $id, true ) ) {
+			return new WP_Error(
+				'cortext_page_delete_failed',
+				__( 'Page could not be deleted.', 'cortext' ),
+				array( 'status' => 500 )
+			);
+		}
+		$deleted[] = $id;
+
+		return new WP_REST_Response(
+			array(
+				'deleted' => $deleted,
+			),
+			200
+		);
+	}
+
+	/**
+	 * BFS over the cascade-marker tree rooted at `$root_id`, returning every
+	 * trashed descendant whose marker chain ties back to the root. The marker
+	 * stores each child's immediate parent, so the walk expands one level at
+	 * a time.
+	 *
+	 * @param int $root_id Page id to walk from.
+	 *
+	 * @return int[] Trashed descendant ids (root excluded), no guaranteed order.
+	 */
+	private function tagged_subtree_ids( int $root_id ): array {
+		$collected = array();
+		$frontier  = array( $root_id );
+
+		while ( ! empty( $frontier ) ) {
+			$next = array();
+			foreach ( $frontier as $current ) {
+				foreach ( $this->trashed_children_tagged_with( $current ) as $child_id ) {
+					if ( ! in_array( $child_id, $collected, true ) ) {
+						$collected[] = $child_id;
+						$next[]      = $child_id;
+					}
+				}
+			}
+			$frontier = $next;
+		}
+
+		return $collected;
+	}
+
+	/**
+	 * Returns trashed pages currently tagged with the given parent id.
+	 *
+	 * @param int $parent_id Page id to match against the cascade marker.
+	 *
+	 * @return int[]
+	 */
+	private function trashed_children_tagged_with( int $parent_id ): array {
+		$ids = get_posts(
+			array(
+				'post_type'      => Page::POST_TYPE,
+				'post_status'    => 'trash',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_key'       => PageTrashCascade::META_KEY,   // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => (string) $parent_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+}

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -123,17 +123,17 @@ function TrashedNotice( { postId } ) {
 		setError( null );
 		setIsRestoring( true );
 		try {
-			await apiFetch( {
+			const response = await apiFetch( {
 				path: `/cortext/v1/pages/${ postId }/restore`,
 				method: 'POST',
 			} );
-			// `wp_untrash_post` returned the page to its pre-trash status;
-			// pull a fresh copy into the store so the canvas drops the
-			// trashed banner without a navigation roundtrip.
-			const fresh = await apiFetch( {
-				path: `/wp/v2/crtxt_pages/${ postId }?context=edit`,
-			} );
-			receiveEntityRecords( 'postType', POST_TYPE, [ fresh ] );
+			// The endpoint returns the freshly-untrashed post so the canvas
+			// can drop the trashed banner without a follow-up GET.
+			if ( response?.post ) {
+				receiveEntityRecords( 'postType', POST_TYPE, [
+					response.post,
+				] );
+			}
 			invalidateResolution( 'getEntityRecords', [
 				'postType',
 				POST_TYPE,

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -17,12 +17,18 @@ import {
 	ComplementaryArea,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import { Button, Spinner } from '@wordpress/components';
+import { Button, Disabled, Notice, Spinner } from '@wordpress/components';
 import { cog } from '@wordpress/icons';
+import apiFetch from '@wordpress/api-fetch';
+import { useState } from '@wordpress/element';
 
 import useAutosave from '../hooks/useAutosave';
+import {
+	ACTIVE_PAGES_QUERY,
+	POST_TYPE,
+	TRASHED_PAGES_QUERY,
+} from './page-queries';
 
-const POST_TYPE = 'crtxt_page';
 const SCOPE = 'cortext';
 const INSPECTOR = 'cortext/block-inspector';
 
@@ -76,6 +82,17 @@ function Header() {
 }
 
 function InspectorSidebar() {
+	// Mirror the canvas: when the post is in trash, the inspector becomes
+	// read-only too. Otherwise users could still edit block attributes
+	// (alignment, colors, etc.) from the sidebar even though the canvas
+	// itself is locked.
+	const isTrashed = useSelect(
+		( select ) =>
+			select( editorStore ).getCurrentPostAttribute( 'status' ) ===
+			'trash',
+		[]
+	);
+
 	return (
 		<ComplementaryArea
 			scope={ SCOPE }
@@ -85,8 +102,73 @@ function InspectorSidebar() {
 			isPinnable={ false }
 			isActiveByDefault
 		>
-			<BlockInspector />
+			{ isTrashed ? (
+				<Disabled>
+					<BlockInspector />
+				</Disabled>
+			) : (
+				<BlockInspector />
+			) }
 		</ComplementaryArea>
+	);
+}
+
+function TrashedNotice( { postId } ) {
+	const { invalidateResolution, receiveEntityRecords } =
+		useDispatch( 'core' );
+	const [ isRestoring, setIsRestoring ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const restore = async () => {
+		setError( null );
+		setIsRestoring( true );
+		try {
+			await apiFetch( {
+				path: `/cortext/v1/pages/${ postId }/restore`,
+				method: 'POST',
+			} );
+			// `wp_untrash_post` returned the page to its pre-trash status;
+			// pull a fresh copy into the store so the canvas drops the
+			// trashed banner without a navigation roundtrip.
+			const fresh = await apiFetch( {
+				path: `/wp/v2/crtxt_pages/${ postId }?context=edit`,
+			} );
+			receiveEntityRecords( 'postType', POST_TYPE, [ fresh ] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				POST_TYPE,
+				ACTIVE_PAGES_QUERY,
+			] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				POST_TYPE,
+				TRASHED_PAGES_QUERY,
+			] );
+		} catch ( err ) {
+			setError(
+				err?.message ?? __( 'Could not restore page.', 'cortext' )
+			);
+		} finally {
+			setIsRestoring( false );
+		}
+	};
+
+	return (
+		<Notice
+			className="cortext-canvas__notice"
+			status="warning"
+			isDismissible={ false }
+			actions={ [
+				{
+					label: __( 'Restore', 'cortext' ),
+					onClick: restore,
+					disabled: isRestoring,
+					variant: 'primary',
+				},
+			] }
+		>
+			{ error ? error : __( 'This page is in trash.', 'cortext' ) }
+		</Notice>
 	);
 }
 
@@ -146,6 +228,8 @@ export default function Canvas( { postId } ) {
 		);
 	}
 
+	const isTrashed = post.status === 'trash';
+
 	return (
 		<EditorProvider
 			post={ post }
@@ -155,7 +239,18 @@ export default function Canvas( { postId } ) {
 			<InterfaceSkeleton
 				className="cortext-canvas"
 				header={ <Header /> }
-				content={ <VisualCanvas /> }
+				content={
+					<>
+						{ isTrashed && <TrashedNotice postId={ post.id } /> }
+						{ isTrashed ? (
+							<Disabled className="cortext-canvas__locked">
+								<VisualCanvas />
+							</Disabled>
+						) : (
+							<VisualCanvas />
+						) }
+					</>
+				}
 				sidebar={ <ComplementaryArea.Slot scope={ SCOPE } /> }
 			/>
 			<InspectorSidebar />

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -250,7 +250,7 @@ export default function PageRow( {
 										onClose();
 									} }
 								>
-									{ __( 'Delete', 'cortext' ) }
+									{ __( 'Trash', 'cortext' ) }
 								</MenuItem>
 							</MenuGroup>
 						) }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -8,12 +8,7 @@ import {
 	useCallback,
 	useEffect,
 } from '@wordpress/element';
-import {
-	Button,
-	Spinner,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalConfirmDialog as ConfirmDialog,
-} from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import {
 	DndContext,
 	DragOverlay,
@@ -26,21 +21,24 @@ import {
 import { useNavigate, useParams } from '@tanstack/react-router';
 
 import PageRow from './PageRow';
+import SidebarTrash from './SidebarTrash';
 import {
 	buildTree,
-	collectDescendants,
 	computeDropTarget,
 	isDescendantOf,
 	nextChildOrder,
 } from './pages-tree';
+import {
+	ACTIVE_PAGES_QUERY,
+	POST_TYPE,
+	TRASHED_PAGES_QUERY,
+} from './page-queries';
 import {
 	computeUri,
 	parseIdFromUri,
 	parseSplatUri,
 } from '../router/useResolveEntity';
 import { COLLECTION_QUERY } from '../collections';
-
-const POST_TYPE = 'crtxt_page';
 
 const AUTO_EXPAND_DELAY = 700;
 
@@ -61,15 +59,20 @@ export default function Sidebar() {
 	// Workspaces are expected to exceed 100 pages — pages past the cap won't
 	// appear in the tree. Followup needs a lazy-loaded tree (load children on
 	// expand) or a paginated fetch of the full page set.
-	const { records, isResolving } = useEntityRecords( 'postType', POST_TYPE, {
-		per_page: 100,
-		status: [ 'draft', 'private', 'publish' ],
-		context: 'edit',
-	} );
+	const { records, isResolving } = useEntityRecords(
+		'postType',
+		POST_TYPE,
+		ACTIVE_PAGES_QUERY
+	);
 
 	const { records: collections, isResolving: isResolvingCollections } =
 		useEntityRecords( 'postType', 'crtxt_collection', COLLECTION_QUERY );
-	const { saveEntityRecord, deleteEntityRecord } = useDispatch( 'core' );
+	const {
+		saveEntityRecord,
+		deleteEntityRecord,
+		invalidateResolution,
+		receiveEntityRecords,
+	} = useDispatch( 'core' );
 	const pages = useMemo( () => records ?? [], [ records ] );
 	const navigate = useNavigate();
 	const params = useParams( { strict: false } );
@@ -136,7 +139,6 @@ export default function Sidebar() {
 	const [ draggedId, setDraggedId ] = useState( null );
 	const [ activeDrop, setActiveDrop ] = useState( null );
 	const [ autoRenameId, setAutoRenameId ] = useState( null );
-	const [ pendingDeleteId, setPendingDeleteId ] = useState( null );
 
 	const autoExpandTimerRef = useRef( null );
 
@@ -246,24 +248,39 @@ export default function Sidebar() {
 		[ saveEntityRecord, getRecordById, expand, onSelect ]
 	);
 
-	const confirmDelete = useCallback( async () => {
-		const id = pendingDeleteId;
-		setPendingDeleteId( null );
-		if ( ! id ) {
-			return;
-		}
-		const descendants = collectDescendants( id, pages );
-		// Delete children first, then the root.
-		for ( const childId of descendants ) {
-			await deleteEntityRecord( 'postType', POST_TYPE, childId, {
-				force: true,
-			} );
-		}
-		await deleteEntityRecord( 'postType', POST_TYPE, id, { force: true } );
-		if ( selectedId === id || descendants.includes( selectedId ) ) {
-			onSelect( null );
-		}
-	}, [ pendingDeleteId, pages, deleteEntityRecord, selectedId, onSelect ] );
+	// Soft-delete: the server-side cascade trashes descendants. Trash is
+	// reversible (the user can restore from the Trash section), so no
+	// confirmation. The editor stays on the trashed page so the user can
+	// review what they trashed before deciding whether to restore.
+	//
+	// `deleteEntityRecord` always calls `removeItems` after the DELETE
+	// response, even for soft-delete, so the trashed record is yanked from
+	// the store and the canvas's `useEntityRecord( id )` would render an
+	// indefinite spinner. Put the trashed record (returned by the REST
+	// response) back into the store so the canvas can keep showing it.
+	const trashPage = useCallback(
+		async ( id ) => {
+			const trashed = await deleteEntityRecord(
+				'postType',
+				POST_TYPE,
+				id
+			);
+			if ( trashed ) {
+				receiveEntityRecords( 'postType', POST_TYPE, [ trashed ] );
+			}
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				POST_TYPE,
+				ACTIVE_PAGES_QUERY,
+			] );
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				POST_TYPE,
+				TRASHED_PAGES_QUERY,
+			] );
+		},
+		[ deleteEntityRecord, invalidateResolution, receiveEntityRecords ]
+	);
 
 	// --- Drag and drop -----------------------------------------------------
 
@@ -421,7 +438,7 @@ export default function Sidebar() {
 							onCreateChild={ createChildPage }
 							onRename={ renamePage }
 							onDuplicate={ duplicatePage }
-							onDelete={ ( id ) => setPendingDeleteId( id ) }
+							onDelete={ trashPage }
 							autoRenameId={ autoRenameId }
 							onAutoRenameConsumed={ () =>
 								setAutoRenameId( null )
@@ -484,26 +501,11 @@ export default function Sidebar() {
 				</ul>
 			) }
 
-			{ pendingDeleteId !== null && (
-				<ConfirmDialog
-					onConfirm={ confirmDelete }
-					onCancel={ () => setPendingDeleteId( null ) }
-					confirmButtonText={ __( 'Delete', 'cortext' ) }
-				>
-					{ renderDeleteMessage( pendingDeleteId, pages ) }
-				</ConfirmDialog>
-			) }
+			<SidebarTrash
+				activePages={ pages }
+				selectedId={ selectedId }
+				onSelect={ onSelect }
+			/>
 		</aside>
-	);
-}
-
-function renderDeleteMessage( id, pages ) {
-	const descendants = collectDescendants( id, pages );
-	if ( descendants.length === 0 ) {
-		return __( 'Delete this page? This cannot be undone.', 'cortext' );
-	}
-	return __(
-		'Delete this page and all its child pages? This cannot be undone.',
-		'cortext'
 	);
 }

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -17,6 +17,8 @@ import {
 	TRASHED_PAGES_QUERY,
 } from './page-queries';
 
+// Must stay in sync with `PageTrashCascade::META_KEY` in PHP. The meta is
+// exposed via REST as part of the `meta` field on each page record.
 const MARKER_META = '_cortext_trashed_by_parent';
 
 /**
@@ -180,10 +182,18 @@ export default function SidebarTrash( { activePages, selectedId, onSelect } ) {
 		setRowError( null );
 		setBusyId( id );
 		try {
-			await apiFetch( {
+			const response = await apiFetch( {
 				path: `/cortext/v1/pages/${ id }/permanent-delete`,
 				method: 'POST',
 			} );
+			// If the canvas was showing one of the deleted pages, navigate
+			// away. Without this `useEntityRecord` would return undefined
+			// and the canvas would spin forever (the page is genuinely gone
+			// now, not just trashed).
+			const deletedIds = response?.deleted ?? [];
+			if ( selectedId && deletedIds.includes( selectedId ) ) {
+				onSelect( null );
+			}
 			refreshQueries();
 		} catch ( error ) {
 			setRowError( {
@@ -194,7 +204,7 @@ export default function SidebarTrash( { activePages, selectedId, onSelect } ) {
 		} finally {
 			setBusyId( null );
 		}
-	}, [ pendingDeleteId, refreshQueries ] );
+	}, [ pendingDeleteId, refreshQueries, selectedId, onSelect ] );
 
 	const isLoading = ! hasResolved;
 	const hasError = status === 'ERROR';

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -1,0 +1,361 @@
+import { __, sprintf, _n } from '@wordpress/i18n';
+import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import {
+	Button,
+	Spinner,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { rotateLeft, trash } from '@wordpress/icons';
+
+import {
+	ACTIVE_PAGES_QUERY,
+	POST_TYPE,
+	TRASHED_PAGES_QUERY,
+} from './page-queries';
+
+const MARKER_META = '_cortext_trashed_by_parent';
+
+/**
+ * Renders the sidebar Trash section: a flat list of trashed pages with a
+ * breadcrumb on each row plus inline Restore and Delete-permanently actions.
+ *
+ * Only cascade roots are listed. Subpages dragged into trash by a parent's
+ * cascade ride along when the root is restored or permanently deleted, and
+ * are intentionally hidden so the user manages whole trees rather than
+ * fragments. Pages whose recorded parent has since been permanently deleted
+ * (orphans with stale markers) get promoted back to roots so they remain
+ * reachable.
+ *
+ * Restore goes through `/cortext/v1/pages/<id>/restore` and permanent delete
+ * through `/cortext/v1/pages/<id>/permanent-delete`. Both endpoints invoke
+ * `PageTrashCascade`'s subtree handling on the server; the client only needs
+ * to invalidate the page queries afterwards.
+ *
+ * @param {Object}      props
+ * @param {Array}       props.activePages Active page records, used for
+ *                                        breadcrumb ancestor lookup.
+ * @param {number|null} props.selectedId  Currently-selected page id, used
+ *                                        to highlight a trashed row when
+ *                                        the canvas is showing it.
+ * @param {Function}    props.onSelect    Called with a page id when a row
+ *                                        is clicked, navigating the canvas
+ *                                        to that page (read-only view).
+ */
+export default function SidebarTrash( { activePages, selectedId, onSelect } ) {
+	const {
+		records: trashed,
+		status,
+		hasResolved,
+	} = useEntityRecords( 'postType', POST_TYPE, TRASHED_PAGES_QUERY );
+
+	const { invalidateResolution } = useDispatch( 'core' );
+
+	const [ pendingDeleteId, setPendingDeleteId ] = useState( null );
+	const [ rowError, setRowError ] = useState( null );
+	const [ busyId, setBusyId ] = useState( null );
+
+	const ancestorById = useMemo( () => {
+		const map = new Map();
+		( activePages ?? [] ).forEach( ( page ) => map.set( page.id, page ) );
+		// Trashed records take a back seat: a page that exists in both lists
+		// (shouldn't happen, but guard anyway) is shown by its active title.
+		( trashed ?? [] ).forEach( ( page ) => {
+			if ( ! map.has( page.id ) ) {
+				map.set( page.id, page );
+			}
+		} );
+		return map;
+	}, [ activePages, trashed ] );
+
+	// Cascade roots: pages with no marker, plus pages whose marker points at
+	// a page that's no longer in trash (its tagged parent was permanently
+	// deleted). Without the second clause those orphans would be hidden.
+	const { roots, descendantCountById } = useMemo( () => {
+		const all = trashed ?? [];
+		const trashedById = new Map( all.map( ( p ) => [ p.id, p ] ) );
+		const childrenByMarker = new Map();
+
+		const markerOf = ( page ) => Number( page.meta?.[ MARKER_META ] ?? 0 );
+
+		all.forEach( ( page ) => {
+			const marker = markerOf( page );
+			if ( marker > 0 && trashedById.has( marker ) ) {
+				if ( ! childrenByMarker.has( marker ) ) {
+					childrenByMarker.set( marker, [] );
+				}
+				childrenByMarker.get( marker ).push( page );
+			}
+		} );
+
+		const computedRoots = all.filter( ( page ) => {
+			const marker = markerOf( page );
+			return marker === 0 || ! trashedById.has( marker );
+		} );
+
+		const counts = new Map();
+		computedRoots.forEach( ( root ) => {
+			let count = 0;
+			const stack = [ ...( childrenByMarker.get( root.id ) ?? [] ) ];
+			while ( stack.length ) {
+				const node = stack.pop();
+				count++;
+				const kids = childrenByMarker.get( node.id );
+				if ( kids ) {
+					stack.push( ...kids );
+				}
+			}
+			counts.set( root.id, count );
+		} );
+
+		return { roots: computedRoots, descendantCountById: counts };
+	}, [ trashed ] );
+
+	const buildBreadcrumb = useCallback(
+		( page ) => {
+			const titles = [];
+			let current = page.parent ? ancestorById.get( page.parent ) : null;
+			const seen = new Set( [ page.id ] );
+			while ( current && ! seen.has( current.id ) ) {
+				seen.add( current.id );
+				titles.unshift(
+					current.title?.rendered?.trim() ||
+						__( '(untitled)', 'cortext' )
+				);
+				current = current.parent
+					? ancestorById.get( current.parent )
+					: null;
+			}
+			return titles;
+		},
+		[ ancestorById ]
+	);
+
+	const refreshQueries = useCallback( () => {
+		invalidateResolution( 'getEntityRecords', [
+			'postType',
+			POST_TYPE,
+			ACTIVE_PAGES_QUERY,
+		] );
+		invalidateResolution( 'getEntityRecords', [
+			'postType',
+			POST_TYPE,
+			TRASHED_PAGES_QUERY,
+		] );
+	}, [ invalidateResolution ] );
+
+	const restore = useCallback(
+		async ( id ) => {
+			setRowError( null );
+			setBusyId( id );
+			try {
+				await apiFetch( {
+					path: `/cortext/v1/pages/${ id }/restore`,
+					method: 'POST',
+				} );
+				refreshQueries();
+			} catch ( error ) {
+				setRowError( {
+					id,
+					message:
+						error?.message ??
+						__( 'Could not restore page.', 'cortext' ),
+				} );
+			} finally {
+				setBusyId( null );
+			}
+		},
+		[ refreshQueries ]
+	);
+
+	const confirmPermanentDelete = useCallback( async () => {
+		const id = pendingDeleteId;
+		setPendingDeleteId( null );
+		if ( ! id ) {
+			return;
+		}
+		setRowError( null );
+		setBusyId( id );
+		try {
+			await apiFetch( {
+				path: `/cortext/v1/pages/${ id }/permanent-delete`,
+				method: 'POST',
+			} );
+			refreshQueries();
+		} catch ( error ) {
+			setRowError( {
+				id,
+				message:
+					error?.message ?? __( 'Could not delete page.', 'cortext' ),
+			} );
+		} finally {
+			setBusyId( null );
+		}
+	}, [ pendingDeleteId, refreshQueries ] );
+
+	const isLoading = ! hasResolved;
+	const hasError = status === 'ERROR';
+	const hasItems = roots.length > 0;
+	const pendingDescendantCount = pendingDeleteId
+		? descendantCountById.get( pendingDeleteId ) ?? 0
+		: 0;
+
+	return (
+		<>
+			<h2 className="cortext-sidebar__section-title">
+				{ __( 'Trash', 'cortext' ) }
+			</h2>
+
+			{ isLoading && (
+				<div className="cortext-sidebar__loading">
+					<Spinner />
+				</div>
+			) }
+
+			{ ! isLoading && hasError && (
+				<div className="cortext-sidebar__error" role="alert">
+					<p>{ __( 'Could not load trashed pages.', 'cortext' ) }</p>
+					<Button
+						variant="secondary"
+						onClick={ () =>
+							invalidateResolution( 'getEntityRecords', [
+								'postType',
+								POST_TYPE,
+								TRASHED_PAGES_QUERY,
+							] )
+						}
+					>
+						{ __( 'Retry', 'cortext' ) }
+					</Button>
+				</div>
+			) }
+
+			{ ! isLoading && ! hasError && ! hasItems && (
+				<p className="cortext-sidebar__empty">
+					{ __( 'No trashed pages.', 'cortext' ) }
+				</p>
+			) }
+
+			{ ! isLoading && ! hasError && hasItems && (
+				<ul className="cortext-sidebar__list cortext-sidebar__trash-list">
+					{ roots.map( ( page ) => {
+						const title =
+							page.title?.rendered?.trim() ||
+							__( '(untitled)', 'cortext' );
+						const breadcrumb = buildBreadcrumb( page );
+						const isBusy = busyId === page.id;
+						const isSelected = selectedId === page.id;
+						const error =
+							rowError?.id === page.id ? rowError : null;
+						const subpages =
+							descendantCountById.get( page.id ) ?? 0;
+						const meta = subpages
+							? sprintf(
+									/* translators: %d: number of subpages */
+									_n(
+										'%d subpage',
+										'%d subpages',
+										subpages,
+										'cortext'
+									),
+									subpages
+							  )
+							: '';
+						const rowClasses = [ 'cortext-sidebar__row' ];
+						if ( isSelected ) {
+							rowClasses.push( 'is-selected' );
+						}
+
+						return (
+							<li
+								key={ page.id }
+								className="cortext-sidebar__node cortext-sidebar__trash-row"
+							>
+								<div className={ rowClasses.join( ' ' ) }>
+									<Button
+										className="cortext-sidebar__title cortext-sidebar__trash-text"
+										variant="tertiary"
+										onClick={ () =>
+											onSelect( page.id, page )
+										}
+									>
+										<span className="cortext-sidebar__trash-title">
+											{ title }
+										</span>
+										{ ( breadcrumb.length > 0 || meta ) && (
+											<span className="cortext-sidebar__breadcrumb">
+												{ [
+													breadcrumb.join( ' / ' ),
+													meta,
+												]
+													.filter( Boolean )
+													.join( ' · ' ) }
+											</span>
+										) }
+									</Button>
+									<div className="cortext-sidebar__trash-actions">
+										<Button
+											size="small"
+											icon={ rotateLeft }
+											label={ __( 'Restore', 'cortext' ) }
+											disabled={ isBusy }
+											onClick={ () => restore( page.id ) }
+										/>
+										<Button
+											size="small"
+											icon={ trash }
+											isDestructive
+											label={ __(
+												'Delete permanently',
+												'cortext'
+											) }
+											disabled={ isBusy }
+											onClick={ () =>
+												setPendingDeleteId( page.id )
+											}
+										/>
+									</div>
+								</div>
+								{ error && (
+									<p
+										className="cortext-sidebar__row-error"
+										role="alert"
+									>
+										{ error.message }
+									</p>
+								) }
+							</li>
+						);
+					} ) }
+				</ul>
+			) }
+
+			{ pendingDeleteId !== null && (
+				<ConfirmDialog
+					onConfirm={ confirmPermanentDelete }
+					onCancel={ () => setPendingDeleteId( null ) }
+					confirmButtonText={ __( 'Delete permanently', 'cortext' ) }
+				>
+					{ pendingDescendantCount > 0
+						? sprintf(
+								/* translators: %d: number of subpages that will be deleted along with the page. */
+								_n(
+									'Permanently delete this page and %d subpage? This cannot be undone.',
+									'Permanently delete this page and %d subpages? This cannot be undone.',
+									pendingDescendantCount,
+									'cortext'
+								),
+								pendingDescendantCount
+						  )
+						: __(
+								'Permanently delete this page? This cannot be undone.',
+								'cortext'
+						  ) }
+				</ConfirmDialog>
+			) }
+		</>
+	);
+}

--- a/src/components/page-queries.js
+++ b/src/components/page-queries.js
@@ -1,0 +1,20 @@
+/**
+ * Shared query constants for the `crtxt_page` lists in the sidebar. Both the
+ * active list and the Trash section use these objects, and the same identity
+ * is passed to `invalidateResolution` after lifecycle actions so the entries
+ * deep-match the resolved selector args.
+ */
+
+export const POST_TYPE = 'crtxt_page';
+
+export const ACTIVE_PAGES_QUERY = {
+	per_page: 100,
+	status: [ 'draft', 'private', 'publish' ],
+	context: 'edit',
+};
+
+export const TRASHED_PAGES_QUERY = {
+	per_page: 100,
+	status: 'trash',
+	context: 'edit',
+};

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -80,9 +80,10 @@ export default function useAutosave() {
 			isDirty: d,
 			isSaveable: s,
 			isSaving: saving,
+			postStatus: ps,
 			savePost: save,
 		} = stateRef.current;
-		if ( d && s && ! saving ) {
+		if ( d && s && ! saving && ps !== 'trash' ) {
 			maybePromoteStatus();
 			lastSaveAtRef.current = Date.now();
 			save();
@@ -91,6 +92,12 @@ export default function useAutosave() {
 
 	useEffect( () => {
 		if ( ! isDirty || ! isSaveable ) {
+			return undefined;
+		}
+		// Trashed pages are read-only in the canvas; never autosave them.
+		// The UI is locked via `<Disabled>`, but a stray edit through any
+		// other path (drag-drop, programmatic) shouldn't persist either.
+		if ( postStatus === 'trash' ) {
 			return undefined;
 		}
 		const elapsed = Date.now() - lastSaveAtRef.current;
@@ -105,9 +112,10 @@ export default function useAutosave() {
 				isDirty: d,
 				isSaveable: s,
 				isSaving: saving,
+				postStatus: ps,
 				savePost: save,
 			} = stateRef.current;
-			if ( d && s && ! saving ) {
+			if ( d && s && ! saving && ps !== 'trash' ) {
 				maybePromoteStatus();
 				lastSaveAtRef.current = Date.now();
 				save();
@@ -120,7 +128,7 @@ export default function useAutosave() {
 				debounceRef.current = null;
 			}
 		};
-	}, [ isDirty, isSaveable, editsReference ] );
+	}, [ isDirty, isSaveable, editsReference, postStatus ] );
 
 	useEffect( () => {
 		if ( isSaving ) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -299,6 +299,10 @@ body.cortext-fullscreen {
 	// The trashed-page banner stacks above the BlockCanvas. Make the
 	// content slot a flex column so the canvas keeps its `height: 100%`
 	// behavior (it now fills the remaining space).
+	//
+	// Couples to a Gutenberg-internal class (`.interface-interface-skeleton__content`).
+	// Stable for now; revisit if `@wordpress/interface` ever exposes a slot
+	// for a notice region above the content.
 	.interface-interface-skeleton__content {
 		display: flex;
 		flex-direction: column;

--- a/src/index.scss
+++ b/src/index.scss
@@ -298,11 +298,9 @@ body.cortext-fullscreen {
 
 	// The trashed-page banner stacks above the BlockCanvas. Make the
 	// content slot a flex column so the canvas keeps its `height: 100%`
-	// behavior (it now fills the remaining space).
-	//
-	// Couples to a Gutenberg-internal class (`.interface-interface-skeleton__content`).
-	// Stable for now; revisit if `@wordpress/interface` ever exposes a slot
-	// for a notice region above the content.
+	// behavior (it now fills the remaining space). Couples to a
+	// Gutenberg-internal class; revisit if `@wordpress/interface` ever
+	// exposes a slot for a notice region above the content.
 	.interface-interface-skeleton__content {
 		display: flex;
 		flex-direction: column;

--- a/src/index.scss
+++ b/src/index.scss
@@ -195,6 +195,71 @@ body.cortext-fullscreen {
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
+
+	&__trash-row .cortext-sidebar__row {
+		padding: $grid-unit-05;
+		align-items: flex-start;
+	}
+
+	// The whole trash row's title/breadcrumb is one Button so the user can
+	// click anywhere on the text to open the trashed page in the canvas.
+	// Override the default inline-flex / center alignment so the two lines
+	// stack vertically with the title on top.
+	&__trash-text.components-button {
+		flex: 1 1 auto;
+		min-width: 0;
+		height: auto;
+		padding: 2px $grid-unit-05;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 2px;
+		text-align: start;
+	}
+
+	&__trash-title {
+		font-weight: 500;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
+	}
+
+	&__breadcrumb {
+		font-size: 11px;
+		color: $gray-700;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__trash-actions {
+		flex: 0 0 auto;
+		display: flex;
+		gap: 2px;
+		opacity: 0;
+		transition: opacity 0.12s ease;
+	}
+
+	&__trash-row:hover &__trash-actions,
+	&__trash-row:focus-within &__trash-actions {
+		opacity: 1;
+	}
+
+	&__error {
+		padding: $grid-unit-10;
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-05;
+		color: $gray-700;
+	}
+
+	&__row-error {
+		margin: 0;
+		padding: 0 $grid-unit-05;
+		font-size: 11px;
+		color: #cc1818;
+	}
 }
 
 .cortext-shell__canvas {
@@ -229,6 +294,29 @@ body.cortext-fullscreen {
 		justify-content: center;
 		color: $gray-700;
 		height: 100%;
+	}
+
+	// The trashed-page banner stacks above the BlockCanvas. Make the
+	// content slot a flex column so the canvas keeps its `height: 100%`
+	// behavior (it now fills the remaining space).
+	.interface-interface-skeleton__content {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+	}
+
+	&__notice.components-notice {
+		flex: 0 0 auto;
+		margin: 0;
+		border-radius: 0;
+	}
+
+	// `<Disabled>` already neutralises pointer events for the trashed
+	// canvas; the muted opacity is the visual cue that editing is locked.
+	&__locked {
+		flex: 1 1 auto;
+		min-height: 0;
+		opacity: 0.7;
 	}
 
 	&__table {

--- a/tests/e2e/specs/page-trash.spec.js
+++ b/tests/e2e/specs/page-trash.spec.js
@@ -1,0 +1,127 @@
+/**
+ * E2E coverage for the page trash flow in the Cortext shell.
+ *
+ * Walks the user-visible path the unit tests can't: open a page, trash it
+ * from the sidebar dropdown, see the Trash section pick it up with the
+ * cascade subpage count, the canvas locked behind a notice, and Restore
+ * via the banner unwinding the whole thing.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SUFFIX = Date.now().toString( 36 ).slice( -4 );
+const PARENT_TITLE = `E2E Trash Parent ${ SUFFIX }`;
+const CHILD_TITLE = `E2E Trash Child ${ SUFFIX }`;
+
+async function deleteIfCreated( requestUtils, id ) {
+	if ( ! id ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path: `/wp/v2/crtxt_pages/${ id }`,
+			params: { force: true },
+		} );
+	} catch ( _error ) {
+		// Best-effort cleanup; the test may have already deleted the page.
+	}
+}
+
+test.describe( 'Page trash flow', () => {
+	test( 'trash a parent from the sidebar, restore via the canvas banner', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let parent;
+		let child;
+
+		try {
+			parent = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: { title: PARENT_TITLE, status: 'private' },
+			} );
+			child = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: CHILD_TITLE,
+					status: 'private',
+					parent: parent.id,
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ parent.id }`
+			);
+
+			// Wait for the editor to load the parent.
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				parent.id,
+				{ timeout: 15_000 }
+			);
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			const parentTitle = sidebar.getByRole( 'button', {
+				name: PARENT_TITLE,
+				exact: true,
+			} );
+			await expect( parentTitle ).toBeVisible();
+
+			// Hover the row to reveal the dropdown trigger (opacity-0 idle).
+			await parentTitle.hover();
+
+			// `force: true` bypasses Playwright's actionability check, which
+			// trips on the ellipsis button: the row's drop-zone overlays sit
+			// on top in stacking order even though `pointer-events: none` lets
+			// the click through at the browser level.
+			await sidebar
+				.getByRole( 'button', {
+					name: `Actions for ${ PARENT_TITLE }`,
+					exact: true,
+				} )
+				.click( { force: true } );
+			await page
+				.getByRole( 'menuitem', { name: 'Trash' } )
+				.click();
+
+			// Active sidebar drops the whole subtree; the Trash section
+			// shows the cascade root with the subpage count.
+			await expect(
+				sidebar.getByRole( 'button', { name: PARENT_TITLE, exact: true } )
+			).toHaveCount( 0 );
+			await expect(
+				sidebar.getByRole( 'button', { name: CHILD_TITLE, exact: true } )
+			).toHaveCount( 0 );
+
+			const trashList = page.locator( '.cortext-sidebar__trash-list' );
+			await expect( trashList ).toContainText( PARENT_TITLE );
+			await expect( trashList ).toContainText( '1 subpage' );
+
+			// Canvas keeps the parent open with a trashed banner.
+			const notice = page.locator( '.cortext-canvas__notice' );
+			await expect( notice ).toContainText(
+				'This page is in trash.'
+			);
+
+			// Restore via the banner. Subtree returns; banner disappears.
+			await notice.getByRole( 'button', { name: 'Restore' } ).click();
+
+			await expect( notice ).toHaveCount( 0 );
+			await expect(
+				sidebar.getByRole( 'button', { name: PARENT_TITLE, exact: true } )
+			).toBeVisible();
+			await expect( trashList ).toHaveCount( 0 );
+		} finally {
+			await deleteIfCreated( requestUtils, child?.id );
+			await deleteIfCreated( requestUtils, parent?.id );
+		}
+	} );
+} );

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -287,6 +287,55 @@ describe( 'SidebarTrash', () => {
 		);
 	} );
 
+	it( 'navigates the canvas away when the open page is permanent-deleted (root or descendant)', async () => {
+		const onSelect = jest.fn();
+		setTrashRecords( { records: [ makePage( { id: 1 } ) ] } );
+		// Server-side cascade also deletes id 5 (a tagged descendant); the
+		// response lists every id that's gone now.
+		apiFetch.mockResolvedValue( { deleted: [ 1, 5 ] } );
+
+		render(
+			<SidebarTrash
+				activePages={ [] }
+				selectedId={ 5 }
+				onSelect={ onSelect }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Delete permanently' } )
+		);
+		clickConfirm();
+
+		await waitFor( () => {
+			expect( onSelect ).toHaveBeenCalledWith( null );
+		} );
+	} );
+
+	it( 'leaves the canvas alone when permanent-delete does not include the open page', async () => {
+		const onSelect = jest.fn();
+		setTrashRecords( { records: [ makePage( { id: 1 } ) ] } );
+		apiFetch.mockResolvedValue( { deleted: [ 1 ] } );
+
+		render(
+			<SidebarTrash
+				activePages={ [] }
+				selectedId={ 99 }
+				onSelect={ onSelect }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Delete permanently' } )
+		);
+		clickConfirm();
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalled();
+		} );
+		expect( onSelect ).not.toHaveBeenCalled();
+	} );
+
 	it( 'hides cascade descendants and lists only roots', () => {
 		const root = makePage( {
 			id: 1,

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -1,0 +1,401 @@
+/**
+ * Render and behavior tests for `src/components/SidebarTrash.js`.
+ *
+ * Mocks `@wordpress/core-data`, `@wordpress/data`, and `@wordpress/api-fetch`
+ * so each case can drive the trash query state, capture dispatched actions,
+ * and assert the REST calls SidebarTrash makes.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Stub @wordpress/components so the test does not transitively pull in
+// rich-text → block-editor → parsel-js (an ESM-only package the jest CJS
+// transformer chokes on).
+jest.mock( '@wordpress/components', () => {
+	const ReactLib = require( 'react' );
+	const Button = ( {
+		children,
+		onClick,
+		label,
+		disabled,
+		icon, // eslint-disable-line no-unused-vars
+		isDestructive, // eslint-disable-line no-unused-vars
+		variant, // eslint-disable-line no-unused-vars
+		size, // eslint-disable-line no-unused-vars
+		...rest
+	} ) =>
+		ReactLib.createElement(
+			'button',
+			{
+				onClick,
+				disabled,
+				'aria-label': label,
+				...rest,
+			},
+			children ?? label
+		);
+	const Spinner = () =>
+		ReactLib.createElement( 'div', { 'data-testid': 'spinner' } );
+	const ConfirmDialog = ( {
+		children,
+		onConfirm,
+		onCancel,
+		confirmButtonText,
+	} ) =>
+		ReactLib.createElement(
+			'div',
+			{ role: 'dialog' },
+			ReactLib.createElement( 'div', null, children ),
+			ReactLib.createElement(
+				'button',
+				{ onClick: onConfirm, 'data-testid': 'confirm-dialog-confirm' },
+				confirmButtonText
+			),
+			ReactLib.createElement( 'button', { onClick: onCancel }, 'Cancel' )
+		);
+	return {
+		__esModule: true,
+		Button,
+		Spinner,
+		__experimentalConfirmDialog: ConfirmDialog,
+	};
+} );
+
+jest.mock( '@wordpress/icons', () => ( {
+	__esModule: true,
+	rotateLeft: 'rotate-left-icon',
+	trash: 'trash-icon',
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	__esModule: true,
+	useEntityRecords: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+import SidebarTrash from '../../../src/components/SidebarTrash';
+import {
+	ACTIVE_PAGES_QUERY,
+	POST_TYPE,
+	TRASHED_PAGES_QUERY,
+} from '../../../src/components/page-queries';
+
+const dispatchMocks = {
+	deleteEntityRecord: jest.fn(),
+	invalidateResolution: jest.fn(),
+};
+
+beforeEach( () => {
+	useEntityRecords.mockReset();
+	useDispatch.mockReset();
+	apiFetch.mockReset();
+	dispatchMocks.deleteEntityRecord.mockReset();
+	dispatchMocks.invalidateResolution.mockReset();
+	useDispatch.mockReturnValue( dispatchMocks );
+} );
+
+function setTrashRecords( { records = [], status = 'SUCCESS', hasResolved = true } = {} ) {
+	useEntityRecords.mockReturnValue( {
+		records,
+		status,
+		hasResolved,
+	} );
+}
+
+function clickConfirm() {
+	fireEvent.click( screen.getByTestId( 'confirm-dialog-confirm' ) );
+}
+
+function makePage( overrides = {} ) {
+	const { meta, ...rest } = overrides;
+	return {
+		id: 1,
+		title: { rendered: 'A page', raw: 'A page' },
+		parent: 0,
+		meta: { _cortext_trashed_by_parent: 0, ...( meta ?? {} ) },
+		...rest,
+	};
+}
+
+describe( 'SidebarTrash', () => {
+	it( 'shows a spinner while the trash query resolves', () => {
+		setTrashRecords( {
+			records: undefined,
+			hasResolved: false,
+			status: 'RESOLVING',
+		} );
+
+		const { container } = render( <SidebarTrash activePages={ [] } /> );
+
+		expect( container.querySelector( '.cortext-sidebar__loading' ) ).toBeTruthy();
+		expect(
+			container.querySelector( '.cortext-sidebar__empty' )
+		).toBeFalsy();
+	} );
+
+	it( 'shows the empty state when the trash is empty', () => {
+		setTrashRecords( { records: [] } );
+
+		render( <SidebarTrash activePages={ [] } /> );
+
+		expect( screen.getByText( 'No trashed pages.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows an error state with a Retry button when the fetch failed', () => {
+		setTrashRecords( { records: undefined, status: 'ERROR' } );
+
+		render( <SidebarTrash activePages={ [] } /> );
+
+		expect(
+			screen.getByText( 'Could not load trashed pages.' )
+		).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+
+		expect( dispatchMocks.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			[ 'postType', POST_TYPE, TRASHED_PAGES_QUERY ]
+		);
+	} );
+
+	it( 'renders each trashed page with a breadcrumb of ancestor titles', () => {
+		const grandparent = makePage( {
+			id: 10,
+			title: { rendered: 'Workspace', raw: 'Workspace' },
+		} );
+		const parent = makePage( {
+			id: 11,
+			parent: 10,
+			title: { rendered: 'Project', raw: 'Project' },
+		} );
+		const child = makePage( {
+			id: 12,
+			parent: 11,
+			title: { rendered: 'Notes', raw: 'Notes' },
+		} );
+
+		setTrashRecords( { records: [ child ] } );
+
+		const { container } = render(
+			<SidebarTrash activePages={ [ grandparent, parent ] } />
+		);
+
+		expect( screen.getByText( 'Notes' ) ).toBeInTheDocument();
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toHaveTextContent( 'Workspace / Project' );
+	} );
+
+	it( 'falls back to no breadcrumb when ancestors are missing (orphan)', () => {
+		const orphan = makePage( { id: 5, parent: 99 } );
+
+		setTrashRecords( { records: [ orphan ] } );
+
+		const { container } = render(
+			<SidebarTrash activePages={ [] } />
+		);
+
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toBeFalsy();
+	} );
+
+	it( 'POSTs to /cortext/v1/pages/<id>/restore and refreshes both page queries', async () => {
+		setTrashRecords( {
+			records: [ makePage( { id: 7, title: { rendered: 'Doc', raw: 'Doc' } } ) ],
+		} );
+		apiFetch.mockResolvedValue( { restored: [ 7 ] } );
+
+		render( <SidebarTrash activePages={ [] } /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Restore' } )
+		);
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/cortext/v1/pages/7/restore',
+				method: 'POST',
+			} );
+		} );
+
+		expect( dispatchMocks.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			[ 'postType', POST_TYPE, ACTIVE_PAGES_QUERY ]
+		);
+		expect( dispatchMocks.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			[ 'postType', POST_TYPE, TRASHED_PAGES_QUERY ]
+		);
+	} );
+
+	it( 'surfaces a row-level error when restore fails and leaves the row in trash', async () => {
+		setTrashRecords( {
+			records: [ makePage( { id: 8 } ) ],
+		} );
+		apiFetch.mockRejectedValue( { message: 'Server exploded' } );
+
+		render( <SidebarTrash activePages={ [] } /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Restore' } )
+		);
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Server exploded' ) ).toBeInTheDocument();
+		} );
+
+		expect( dispatchMocks.invalidateResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'POSTs to /cortext/v1/pages/<id>/permanent-delete after confirmation', async () => {
+		setTrashRecords( {
+			records: [ makePage( { id: 9 } ) ],
+		} );
+		apiFetch.mockResolvedValue( { deleted: [ 9 ] } );
+
+		render( <SidebarTrash activePages={ [] } /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Delete permanently' } )
+		);
+		clickConfirm();
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/cortext/v1/pages/9/permanent-delete',
+				method: 'POST',
+			} );
+		} );
+
+		expect( dispatchMocks.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			[ 'postType', POST_TYPE, TRASHED_PAGES_QUERY ]
+		);
+	} );
+
+	it( 'hides cascade descendants and lists only roots', () => {
+		const root = makePage( {
+			id: 1,
+			title: { rendered: 'Workspace', raw: 'Workspace' },
+		} );
+		const child = makePage( {
+			id: 2,
+			parent: 1,
+			title: { rendered: 'Engineering', raw: 'Engineering' },
+			meta: { _cortext_trashed_by_parent: 1 },
+		} );
+		const grandchild = makePage( {
+			id: 3,
+			parent: 2,
+			title: { rendered: 'PHP', raw: 'PHP' },
+			meta: { _cortext_trashed_by_parent: 2 },
+		} );
+
+		setTrashRecords( { records: [ root, child, grandchild ] } );
+
+		render( <SidebarTrash activePages={ [] } /> );
+
+		expect( screen.getByText( 'Workspace' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Engineering' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'PHP' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the cascade subtree count beside the root', () => {
+		const root = makePage( { id: 1, title: { rendered: 'Workspace', raw: 'Workspace' } } );
+		const child = makePage( {
+			id: 2,
+			parent: 1,
+			meta: { _cortext_trashed_by_parent: 1 },
+		} );
+		const grandchild = makePage( {
+			id: 3,
+			parent: 2,
+			meta: { _cortext_trashed_by_parent: 2 },
+		} );
+
+		setTrashRecords( { records: [ root, child, grandchild ] } );
+
+		const { container } = render( <SidebarTrash activePages={ [] } /> );
+
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toHaveTextContent( '2 subpages' );
+	} );
+
+	it( 'promotes orphaned descendants (stale marker) back to roots', () => {
+		// Marker points at a parent that's no longer in trash (it was
+		// permanently deleted before this PR's cascade was wired in, or by
+		// some other path). The orphan should still appear in the list.
+		const orphan = makePage( {
+			id: 7,
+			title: { rendered: 'Stranded', raw: 'Stranded' },
+			parent: 99,
+			meta: { _cortext_trashed_by_parent: 99 },
+		} );
+
+		setTrashRecords( { records: [ orphan ] } );
+
+		render( <SidebarTrash activePages={ [] } /> );
+
+		expect( screen.getByText( 'Stranded' ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls onSelect when a trashed row title is clicked', () => {
+		const onSelect = jest.fn();
+		const root = makePage( {
+			id: 42,
+			title: { rendered: 'Stranded', raw: 'Stranded' },
+		} );
+
+		setTrashRecords( { records: [ root ] } );
+
+		render(
+			<SidebarTrash
+				activePages={ [] }
+				selectedId={ null }
+				onSelect={ onSelect }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Stranded' ) );
+
+		expect( onSelect ).toHaveBeenCalledWith( 42, expect.objectContaining( { id: 42 } ) );
+	} );
+
+	it( 'announces subtree size in the permanent-delete confirmation', () => {
+		const root = makePage( { id: 1, title: { rendered: 'Workspace', raw: 'Workspace' } } );
+		const child = makePage( {
+			id: 2,
+			parent: 1,
+			meta: { _cortext_trashed_by_parent: 1 },
+		} );
+
+		setTrashRecords( { records: [ root, child ] } );
+
+		render( <SidebarTrash activePages={ [] } /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Delete permanently' } )
+		);
+
+		expect(
+			screen.getByText(
+				'Permanently delete this page and 1 subpage? This cannot be undone.'
+			)
+		).toBeInTheDocument();
+	} );
+} );

--- a/tests/php/test-rest-page-trash-controller.php
+++ b/tests/php/test-rest-page-trash-controller.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * Tests for Cortext\Rest\PageTrashController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Page;
+use Cortext\PostType\PageTrashCascade;
+use Cortext\Rest\PageTrashController;
+use WorDBless\BaseTestCase;
+use WorDBless\Posts as WorDBlessPosts;
+use WP_Post;
+use WP_Query;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Page_Trash_Controller extends BaseTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Page() )->register_post_type();
+
+		remove_all_actions( 'wp_trash_post' );
+		remove_all_actions( 'untrashed_post' );
+		remove_all_filters( 'wp_untrash_post_status' );
+
+		// Same WorDBless workaround the cascade tests use: the wpdb mock
+		// returns empty for non-PK queries, so the controller's marker
+		// lookup needs an in-memory shim.
+		add_filter( 'posts_pre_query', array( $this, 'serve_posts_from_memory' ), 10, 2 );
+
+		( new PageTrashCascade() )->register();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new PageTrashController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'posts_pre_query', array( $this, 'serve_posts_from_memory' ), 10 );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_restores_a_trashed_page_and_returns_its_id(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$page_id = $this->create_page();
+		wp_trash_post( $page_id );
+		$this->assertSame( 'trash', get_post_status( $page_id ) );
+
+		$response = $this->restore( $page_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotSame( 'trash', get_post_status( $page_id ) );
+		$this->assertSame( array( $page_id ), $response->get_data()['restored'] );
+	}
+
+	public function test_returns_revived_descendants_in_restored_array(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id     = $this->create_page();
+		$child_id      = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$grandchild_id = $this->create_page( array( 'post_parent' => $child_id ) );
+
+		wp_trash_post( $parent_id );
+
+		$response = $this->restore( $parent_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$restored = $response->get_data()['restored'];
+		$this->assertCount( 3, $restored );
+		$this->assertContains( $parent_id, $restored );
+		$this->assertContains( $child_id, $restored );
+		$this->assertContains( $grandchild_id, $restored );
+	}
+
+	public function test_restore_omits_descendants_that_were_independently_trashed(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id  = $this->create_page();
+		$sibling_id = $this->create_page();
+
+		// Sibling lives in trash from its own delete, untagged.
+		wp_trash_post( $sibling_id );
+		wp_trash_post( $parent_id );
+
+		$response = $this->restore( $parent_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( $parent_id ), $response->get_data()['restored'] );
+		$this->assertSame( 'trash', get_post_status( $sibling_id ), 'Independent trash should not be revived.' );
+	}
+
+	public function test_rejects_unknown_post_id(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$response = $this->restore( 99999 );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'cortext_page_not_found', $response->get_data()['code'] );
+	}
+
+	public function test_rejects_non_cortext_page_post_type(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$post_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'A regular post',
+			)
+		);
+		wp_trash_post( $post_id );
+
+		$response = $this->restore( $post_id );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'cortext_page_not_found', $response->get_data()['code'] );
+	}
+
+	public function test_rejects_page_that_is_not_in_trash(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$page_id = $this->create_page();
+
+		$response = $this->restore( $page_id );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_page_not_trashed', $response->get_data()['code'] );
+	}
+
+	public function test_requires_delete_post_capability(): void {
+		// Subscriber lacks delete_post on any post.
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$page_id = $this->create_page();
+		wp_trash_post( $page_id );
+
+		$response = $this->restore( $page_id );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_permanent_delete_removes_a_trashed_page(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$page_id = $this->create_page();
+		wp_trash_post( $page_id );
+
+		$response = $this->permanent_delete( $page_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( $page_id ), $response->get_data()['deleted'] );
+		$this->assertNull( get_post( $page_id ) );
+	}
+
+	public function test_permanent_delete_cascades_through_tagged_descendants(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id     = $this->create_page();
+		$child_id      = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$grandchild_id = $this->create_page( array( 'post_parent' => $child_id ) );
+
+		wp_trash_post( $parent_id );
+
+		$response = $this->permanent_delete( $parent_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$deleted = $response->get_data()['deleted'];
+		$this->assertCount( 3, $deleted );
+		$this->assertContains( $parent_id, $deleted );
+		$this->assertContains( $child_id, $deleted );
+		$this->assertContains( $grandchild_id, $deleted );
+
+		// Parent is the last entry, so descendants are gone before WP's
+		// hierarchical reparenting could fire on the parent's deletion.
+		$this->assertSame( $parent_id, end( $deleted ) );
+
+		$this->assertNull( get_post( $parent_id ) );
+		$this->assertNull( get_post( $child_id ) );
+		$this->assertNull( get_post( $grandchild_id ) );
+	}
+
+	public function test_permanent_delete_leaves_independently_trashed_siblings_alone(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id  = $this->create_page();
+		$sibling_id = $this->create_page();
+
+		wp_trash_post( $sibling_id );
+		wp_trash_post( $parent_id );
+
+		$this->permanent_delete( $parent_id );
+
+		$this->assertSame( 'trash', get_post_status( $sibling_id ), 'Independently trashed sibling stays untouched.' );
+	}
+
+	public function test_permanent_delete_rejects_page_that_is_not_in_trash(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$page_id = $this->create_page();
+
+		$response = $this->permanent_delete( $page_id );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_page_not_trashed', $response->get_data()['code'] );
+	}
+
+	public function test_permanent_delete_requires_delete_post_capability(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$page_id = $this->create_page();
+		wp_trash_post( $page_id );
+
+		$response = $this->permanent_delete( $page_id );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	private function restore( int $id ) {
+		$request = new WP_REST_Request( 'POST', '/cortext/v1/pages/' . $id . '/restore' );
+		return rest_do_request( $request );
+	}
+
+	private function permanent_delete( int $id ) {
+		$request = new WP_REST_Request( 'POST', '/cortext/v1/pages/' . $id . '/permanent-delete' );
+		return rest_do_request( $request );
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+
+	private function create_page( array $args = array() ): int {
+		$defaults = array(
+			'post_type'   => Page::POST_TYPE,
+			'post_status' => 'publish',
+			'post_title'  => 'Test page ' . wp_generate_uuid4(),
+		);
+
+		$id = wp_insert_post( array_merge( $defaults, $args ) );
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+		return (int) $id;
+	}
+
+	/**
+	 * Identical to the cascade test's shim. WorDBless's wpdb mock returns
+	 * empty for any query that isn't a primary-key lookup; the controller's
+	 * subtree walk relies on `meta_key` joins.
+	 *
+	 * @param mixed    $pre   Existing filter return; passed through unchanged when null.
+	 * @param WP_Query $query The query being short-circuited.
+	 *
+	 * @return mixed
+	 */
+	public function serve_posts_from_memory( $pre, WP_Query $query ) {
+		$vars = $query->query_vars;
+
+		$wants_parent_filter = ! empty( $vars['post_parent'] );
+		$wants_meta_filter   = ! empty( $vars['meta_key'] );
+		if ( ! $wants_parent_filter && ! $wants_meta_filter ) {
+			return $pre;
+		}
+
+		$candidates = $this->all_in_memory_posts();
+
+		if ( ! empty( $vars['post_type'] ) ) {
+			$types      = (array) $vars['post_type'];
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => in_array( $post->post_type, $types, true )
+			);
+		}
+
+		if ( $wants_parent_filter ) {
+			$parent     = (int) $vars['post_parent'];
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => (int) $post->post_parent === $parent
+			);
+		}
+
+		if ( ! empty( $vars['post_status'] ) ) {
+			$statuses   = (array) $vars['post_status'];
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => in_array( $post->post_status, $statuses, true )
+			);
+		}
+
+		if ( $wants_meta_filter ) {
+			$key        = (string) $vars['meta_key'];
+			$value      = (string) ( $vars['meta_value'] ?? '' );
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => (string) get_post_meta( (int) $post->ID, $key, true ) === $value
+			);
+		}
+
+		$candidates = array_values( $candidates );
+
+		if ( 'ids' === ( $vars['fields'] ?? '' ) ) {
+			return array_map( static fn( WP_Post $post ): int => (int) $post->ID, $candidates );
+		}
+
+		return $candidates;
+	}
+
+	/**
+	 * @return WP_Post[]
+	 */
+	private function all_in_memory_posts(): array {
+		$store = WorDBlessPosts::init()->posts;
+		$out   = array();
+		foreach ( $store as $row ) {
+			$out[] = new WP_Post( $row );
+		}
+		return $out;
+	}
+}

--- a/tests/php/test-rest-page-trash-controller.php
+++ b/tests/php/test-rest-page-trash-controller.php
@@ -59,7 +59,14 @@ final class Test_Rest_Page_Trash_Controller extends BaseTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertNotSame( 'trash', get_post_status( $page_id ) );
-		$this->assertSame( array( $page_id ), $response->get_data()['restored'] );
+
+		$data = $response->get_data();
+		$this->assertSame( array( $page_id ), $data['restored'] );
+		// The freshly-untrashed post is included so the canvas can drop the
+		// banner without a follow-up GET.
+		$this->assertIsArray( $data['post'] );
+		$this->assertSame( $page_id, $data['post']['id'] );
+		$this->assertNotSame( 'trash', $data['post']['status'] );
 	}
 
 	public function test_returns_revived_descendants_in_restored_array(): void {
@@ -258,9 +265,13 @@ final class Test_Rest_Page_Trash_Controller extends BaseTestCase {
 	}
 
 	/**
-	 * Identical to the cascade test's shim. WorDBless's wpdb mock returns
-	 * empty for any query that isn't a primary-key lookup; the controller's
-	 * subtree walk relies on `meta_key` joins.
+	 * Identical to the shim in `test-page-trash-cascade.php`. WorDBless's
+	 * wpdb mock returns empty for any query that isn't a primary-key lookup;
+	 * the controller's subtree walk relies on `meta_key` joins.
+	 *
+	 * Duplicated rather than extracted because two callers don't justify a
+	 * trait yet. Lift into a shared `WorDBlessPostsQueryStub` trait when a
+	 * third test (e.g. PR 3's revisions controller) needs it.
 	 *
 	 * @param mixed    $pre   Existing filter return; passed through unchanged when null.
 	 * @param WP_Query $query The query being short-circuited.


### PR DESCRIPTION
## What

Closes #136

Sidebar delete is now soft. Trashed pages collect in a "Trash" section at the bottom of the sidebar; opening one in the canvas locks the editor with a Restore banner.

## Why

The cascade hooks from #37 made trash safe at the data layer; this connects them to the UI. Matches other knowledge base software: you trash, restore, and permanently delete a tree as a unit.

## How

Two REST routes under `cortext/v1`, both gated on `delete_post`: restore snapshots the marker subtree before `wp_untrash_post` and returns `{ restored: [...] }`; permanent-delete walks the subtree leaves-first to skip WP's hierarchical reparenting.

`SidebarTrash` lists only cascade roots, with title, breadcrumb, and subpage count. Subpages are hidden — exposing them lets users restore a leaf into orphan-at-root, which is surprising. Soft-delete needs no confirmation (it's reversible). Permanent-delete keeps one and announces the subtree size.

When the open page is trashed, a warning sits above the canvas, canvas + inspector are wrapped in `<Disabled>`, and `useAutosave` is skipped.

Two non-obvious bits worth flagging:

- The Page CPT now declares `'custom-fields'` support. Without it, `WP_REST_Posts_Controller` strips the `meta` schema property even when `register_post_meta` says `show_in_rest`, and the client can't see the cascade marker.
- After soft-delete, the trashed record is `receiveEntityRecords`'d back. `deleteEntityRecord` always calls `removeItems` regardless of force, so `useEntityRecord` would otherwise return undefined and the canvas would spin forever.

`wp cortext seed` also creates a small page hierarchy. `--reset` clears pages too, including trashed ones.

## Testing

`composer test:php`, `composer phpcs`, `npm run test:unit`, `npm run lint:js`, `npm run lint:style`.

In wp-env after `wp cortext seed --reset --force`:

1. Trash "Workspace". The subtree leaves the sidebar; Trash section shows "Workspace · 8 subpages". Canvas stays put, locked, with the Restore banner. Click Restore: subtree returns.
2. Trash Workspace again, click it in the Trash section to open it locked, then Delete permanently. Dialog says "and 8 subpages."
3. wp-admin's Cortext Pages list: select a parent + child + grandchild → Move to Trash. No wp_die.