### PR TITLE
Render Cortext pages on the public side

### DIFF
--- a/cortext.php
+++ b/cortext.php
@@ -41,6 +41,14 @@ add_action(
 	}
 );
 
+register_activation_hook(
+	__FILE__,
+	static function () {
+		( new \Cortext\PostType\Page() )->register_post_type();
+		flush_rewrite_rules();
+	}
+);
+
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command( 'cortext seed', \Cortext\CLI\SeedDummyCollections::class );
 }

--- a/includes/Frontend/Assets.php
+++ b/includes/Frontend/Assets.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Enqueues styles for public-facing Cortext pages.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Frontend;
+
+use Cortext\PostType\Page;
+
+final class Assets {
+
+	public function register(): void {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ) );
+	}
+
+	public function enqueue(): void {
+		if ( ! is_singular( Page::POST_TYPE ) ) {
+			return;
+		}
+
+		// Core block styles (paragraphs, headings, images, lists, etc.).
+		wp_enqueue_style( 'wp-block-library' );
+
+		$asset_path = CORTEXT_PATH . 'build/frontend.asset.php';
+		$version    = file_exists( $asset_path )
+			? ( require $asset_path )['version'] ?? CORTEXT_VERSION
+			: CORTEXT_VERSION;
+
+		wp_enqueue_style(
+			'cortext-frontend',
+			CORTEXT_URL . 'build/frontend.css',
+			array( 'wp-block-library' ),
+			$version
+		);
+	}
+}

--- a/includes/Frontend/Template.php
+++ b/includes/Frontend/Template.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Provides a plugin-owned template for public Cortext pages.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Frontend;
+
+use Cortext\PostType\Page;
+
+final class Template {
+
+	public function register(): void {
+		add_filter( 'template_include', array( $this, 'override_template' ) );
+	}
+
+	public function override_template( string $template ): string {
+		if ( is_singular( Page::POST_TYPE ) ) {
+			return CORTEXT_PATH . 'templates/single-crtxt_page.php';
+		}
+		return $template;
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -11,6 +11,8 @@ namespace Cortext;
 
 use Cortext\Admin\Screen;
 use Cortext\Editor\RevisionThrottle;
+use Cortext\Frontend\Assets;
+use Cortext\Frontend\Template;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\Field;
@@ -42,6 +44,8 @@ final class Plugin {
 		( new CollectionsController() )->register();
 		( new PageTrashController() )->register();
 		( new RowsController() )->register();
+		( new Template() )->register();
+		( new Assets() )->register();
 	}
 
 	private function __construct() {}

--- a/includes/PostType/Page.php
+++ b/includes/PostType/Page.php
@@ -33,8 +33,12 @@ final class Page {
 					'all_items'     => __( 'All Cortext Pages', 'cortext' ),
 				),
 				'public'                => false,
-				'publicly_queryable'    => false,
+				'publicly_queryable'    => true,
 				'exclude_from_search'   => true,
+				'rewrite'               => array(
+					'slug'       => 'cortext',
+					'with_front' => false,
+				),
 				// The React shell is the primary UI. Core's admin screens
 				// (edit.php list + post.php editor) stay enabled as an
 				// escape hatch, exposed through Admin\Screen's submenu.

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -28,6 +28,7 @@ import {
 	POST_TYPE,
 	TRASHED_PAGES_QUERY,
 } from './page-queries';
+import PublishToggle from './PublishToggle';
 
 const SCOPE = 'cortext';
 const INSPECTOR = 'cortext/block-inspector';
@@ -67,6 +68,7 @@ function Header() {
 	return (
 		<div className="cortext-canvas__header">
 			<SaveStatus />
+			<PublishToggle />
 			<Button
 				icon={ cog }
 				label={ __( 'Settings', 'cortext' ) }

--- a/src/components/PublishToggle.js
+++ b/src/components/PublishToggle.js
@@ -20,11 +20,6 @@ export default function PublishToggle() {
 
 	const isPublic = status === 'publish';
 
-	// Don't show the toggle for draft pages (no title yet).
-	if ( status === 'draft' ) {
-		return null;
-	}
-
 	const toggle = useCallback( async () => {
 		editPost( { status: isPublic ? 'private' : 'publish' } );
 		savePost();
@@ -37,6 +32,11 @@ export default function PublishToggle() {
 			setTimeout( () => setCopied( false ), 2000 );
 		}
 	}, [ link ] );
+
+	// Don't show the toggle for draft pages (no title yet).
+	if ( status === 'draft' ) {
+		return null;
+	}
 
 	return (
 		<div className="cortext-publish-toggle">

--- a/src/components/PublishToggle.js
+++ b/src/components/PublishToggle.js
@@ -1,0 +1,68 @@
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { Button } from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
+import { globe, lock } from '@wordpress/icons';
+
+export default function PublishToggle() {
+	const { editPost, savePost } = useDispatch( editorStore );
+	const { status, link, isSaving } = useSelect( ( select ) => {
+		const editor = select( editorStore );
+		return {
+			status: editor.getEditedPostAttribute( 'status' ),
+			link: editor.getEditedPostAttribute( 'link' ),
+			isSaving: editor.isSavingPost(),
+		};
+	}, [] );
+
+	const [ copied, setCopied ] = useState( false );
+
+	const isPublic = status === 'publish';
+
+	// Don't show the toggle for draft pages (no title yet).
+	if ( status === 'draft' ) {
+		return null;
+	}
+
+	const toggle = useCallback( async () => {
+		editPost( { status: isPublic ? 'private' : 'publish' } );
+		savePost();
+	}, [ editPost, savePost, isPublic ] );
+
+	const copyLink = useCallback( async () => {
+		if ( link ) {
+			await navigator.clipboard.writeText( link );
+			setCopied( true );
+			setTimeout( () => setCopied( false ), 2000 );
+		}
+	}, [ link ] );
+
+	return (
+		<div className="cortext-publish-toggle">
+			<Button
+				icon={ isPublic ? globe : lock }
+				onClick={ toggle }
+				disabled={ isSaving }
+				variant={ isPublic ? 'primary' : 'secondary' }
+				size="compact"
+			>
+				{ isPublic
+					? __( 'Public', 'cortext' )
+					: __( 'Publish', 'cortext' ) }
+			</Button>
+			{ isPublic && link ? (
+				<Button
+					variant="link"
+					className="cortext-publish-toggle__copy"
+					onClick={ copyLink }
+					size="compact"
+				>
+					{ copied
+						? __( 'Copied!', 'cortext' )
+						: __( 'Copy link', 'cortext' ) }
+				</Button>
+			) : null }
+		</div>
+	);
+}

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -1,0 +1,8 @@
+/**
+ * Frontend entry point for public Cortext pages.
+ *
+ * Currently CSS-only: the import triggers webpack to emit build/frontend.css.
+ * Client-side interactivity (e.g. paginated DataView tables) will land here
+ * when RSM-1475 adds the Collection block's public rendering.
+ */
+import './frontend.scss';

--- a/src/frontend.scss
+++ b/src/frontend.scss
@@ -1,0 +1,31 @@
+/**
+ * Public-facing styles for Cortext pages.
+ *
+ * Enqueued only on singular crtxt_page views. Intentionally minimal —
+ * core block styles come from wp-block-library, enqueued separately.
+ */
+
+.cortext-public-page {
+	margin: 0;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	line-height: 1.6;
+	color: #1e1e1e;
+	background: #fff;
+}
+
+.cortext-public-page__content {
+	max-width: 650px;
+	margin: 0 auto;
+	padding: 2rem 1rem 4rem;
+}
+
+.cortext-public-page__title {
+	font-size: 2.5rem;
+	font-weight: 700;
+	line-height: 1.2;
+	margin: 2rem 0 1.5rem;
+}
+
+.cortext-public-page__body {
+	font-size: 1rem;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -546,6 +546,12 @@ body.cortext-fullscreen {
 	}
 }
 
+.cortext-publish-toggle {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+}
+
 .cortext-data-view {
 	display: flex;
 	flex-direction: column;

--- a/templates/single-crtxt_page.php
+++ b/templates/single-crtxt_page.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Minimal template for public-facing Cortext pages.
+ *
+ * Plugin-owned so it works regardless of the active theme.
+ * `the_content()` triggers `do_blocks()`, rendering any Cortext
+ * blocks (and core blocks) embedded in the page.
+ *
+ * @package Cortext
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+</head>
+<body <?php body_class( 'cortext-public-page' ); ?>>
+<?php wp_body_open(); ?>
+
+<main class="cortext-public-page__content">
+	<?php
+	while ( have_posts() ) :
+		the_post();
+		?>
+		<article id="post-<?php the_ID(); ?>">
+			<h1 class="cortext-public-page__title"><?php the_title(); ?></h1>
+			<div class="cortext-public-page__body">
+				<?php the_content(); ?>
+			</div>
+		</article>
+		<?php
+	endwhile;
+	?>
+</main>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/tests/e2e/specs/public-page.spec.js
+++ b/tests/e2e/specs/public-page.spec.js
@@ -1,0 +1,96 @@
+/**
+ * E2E tests for public page rendering.
+ *
+ * A published crtxt_page should be reachable at /cortext/{slug}/ by an
+ * unauthenticated visitor; a private page should 404.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup.
+	}
+}
+
+test.describe( 'Public page rendering', () => {
+	test( 'published page is accessible to anonymous visitors', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const title = `Public page ${ suffix }`;
+		const bodyText = `Hello from a public Cortext page ${ suffix }`;
+		let createdPage;
+
+		try {
+			createdPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title,
+					status: 'publish',
+					content: `<!-- wp:paragraph -->\n<p>${ bodyText }</p>\n<!-- /wp:paragraph -->`,
+				},
+			} );
+
+			await page.context().clearCookies( { name: /^wordpress_/ } );
+
+			const response = await page.goto(
+				`/cortext/${ createdPage.slug }/`
+			);
+
+			expect( response?.status() ).toBe( 200 );
+			await expect( page.locator( 'h1' ) ).toHaveText( title );
+			await expect(
+				page.locator( 'p' ).getByText( bodyText )
+			).toBeVisible();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				createdPage && `/wp/v2/crtxt_pages/${ createdPage.id }`
+			);
+		}
+	} );
+
+	test( 'private page returns 404 for anonymous visitors', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		let createdPage;
+
+		try {
+			createdPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: `Private page ${ suffix }`,
+					status: 'private',
+				},
+			} );
+
+			await page.context().clearCookies( { name: /^wordpress_/ } );
+
+			const response = await page.goto(
+				`/cortext/${ createdPage.slug }/`
+			);
+
+			expect( response?.status() ).toBe( 404 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				createdPage && `/wp/v2/crtxt_pages/${ createdPage.id }`
+			);
+		}
+	} );
+} );

--- a/tests/php/test-post-type-page.php
+++ b/tests/php/test-post-type-page.php
@@ -47,7 +47,7 @@ final class Test_Post_Type_Page extends BaseTestCase {
 		$this->assertFalse( $object->public );
 		$this->assertTrue( $object->show_ui, 'show_ui stays on so Admin\Screen\'s submenu can link to the core list table as an escape hatch.' );
 		$this->assertFalse( $object->show_in_menu, 'show_in_menu is false because Admin\Screen owns the top-level menu.' );
-		$this->assertFalse( $object->publicly_queryable );
+		$this->assertTrue( $object->publicly_queryable, 'publicly_queryable is true so pages render on the front end.' );
 		$this->assertTrue( $object->exclude_from_search );
 		$this->assertFalse( $object->has_archive );
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,10 @@ const routeLockUnlockShim = path.resolve(
 
 module.exports = {
 	...defaultConfig,
+	entry: {
+		...defaultConfig.entry(),
+		frontend: path.resolve( __dirname, 'src/frontend.js' ),
+	},
 	plugins: [
 		...defaultConfig.plugins.map( ( plugin ) => {
 			if ( plugin instanceof DependencyExtractionWebpackPlugin ) {


### PR DESCRIPTION
**These changes involve rewrite rules. Remember to visit `/wp-admin/options-permalink.php` or deactivate and reactivate the plugin.**


## Summary

Closes #155

- Makes `crtxt_page` publicly queryable at `/cortext/{slug}/` via rewrite rules, with hierarchical URL support (`/cortext/parent/child/`)
- Adds a **Publish** toggle in the editor header that switches pages between `private` (admin-only) and `publish` (public), with a copy-link affordance
- Provides a plugin-owned frontend template (`templates/single-crtxt_page.php`) and lightweight CSS so public pages render independently of the active theme
- WP core handles all access control: `publish` → visible to everyone, `private` → 404 for anonymous, `draft` → 404 for non-authors

DataView block server-side rendering is out of scope (RSM-1475).

Later, for page templates and such, RSM-1589 will be a good starting point.

Closes RSM-1602.

## Test plan

- [ ] Create a `crtxt_page` with text content (paragraphs, headings)
- [ ] Confirm the page is inaccessible at its public URL while in `private` status (404)
- [ ] Use the Publish toggle → confirm the page is reachable at `/cortext/{slug}/`
- [ ] Visit the URL in an incognito browser → confirm content renders correctly
- [ ] Use "Copy link" → confirm the URL is copied to clipboard
- [ ] Toggle back to private → confirm 404 for anonymous visitors
- [ ] Test a hierarchical page (child of another page) → confirm URL resolves
- [ ] Test a `draft` page → confirm the Publish toggle is hidden and URL returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)