### PR TITLE
Enable client-side global search via filterSortAndPaginate

### DIFF
--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -39,6 +39,7 @@ const TITLE_FIELD = {
 		/>
 	),
 	editable: true,
+	enableGlobalSearch: true,
 	// The title column can't be hidden (it's the row identity), but it
 	// reorders and resizes like any other column. `normalizeView` re-adds
 	// the id to `view.fields` if something corrupts the saved state.
@@ -202,18 +203,9 @@ export default function CollectionDataViews( {
 			.filter( ( f ) => f && f.editable );
 	}, [ availableFields, view?.fields ] );
 
-	// Search is already handled server-side, so strip it from the view
-	// before passing to filterSortAndPaginate. Without this, the client
-	// re-filters against enableGlobalSearch (which no fields set), dropping
-	// every row.
 	const { data: dataFiltered, paginationInfo: clientPaginationInfo } =
 		useMemo( () => {
-			const { search, ...viewWithoutSearch } = view;
-			return filterSortAndPaginate(
-				data,
-				viewWithoutSearch,
-				availableFields
-			);
+			return filterSortAndPaginate( data, view, availableFields );
 		}, [ data, view, availableFields ] );
 
 	const requestNext = useCallback(

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -153,6 +153,7 @@ export function mapField( field ) {
 		getValue: ( { item } ) => item?.meta?.[ id ] ?? null,
 		render: buildRender( id, type, label, elements ),
 		editable: EDITABLE_TYPES.has( type ),
+		enableGlobalSearch: [ 'text', 'email', 'url' ].includes( type ),
 	};
 
 	// DataViews v6's FieldType union is

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -50,6 +50,8 @@ export const EDITABLE_TYPES = new Set( [
 	'checkbox',
 ] );
 
+const SEARCHABLE_TYPES = new Set( [ 'text', 'email', 'url' ] );
+
 function buildRender( id, type, label, elements ) {
 	const readOnly = ! EDITABLE_TYPES.has( type );
 	return ( { item } ) => (
@@ -153,7 +155,7 @@ export function mapField( field ) {
 		getValue: ( { item } ) => item?.meta?.[ id ] ?? null,
 		render: buildRender( id, type, label, elements ),
 		editable: EDITABLE_TYPES.has( type ),
-		enableGlobalSearch: [ 'text', 'email', 'url' ].includes( type ),
+		enableGlobalSearch: SEARCHABLE_TYPES.has( type ),
 	};
 
 	// DataViews v6's FieldType union is

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -13,10 +13,6 @@ function buildQueryArgs( collectionId, view ) {
 		per_page: -1,
 	};
 
-	if ( view?.search ) {
-		args.search = view.search;
-	}
-
 	// Ignore filters that the server isn't equipped to honor, otherwise
 	// changes in `view` will result in a new query to be requested from the
 	// server, even though the results will be the same.

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1031,6 +1031,100 @@ test.describe( 'Collection view block', () => {
 		}
 	} );
 
+	test( 'global search filters rows by searchable text fields', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture( requestUtils )
+			);
+
+			// A second entry whose Author value won't match the query.
+			fixture.entry2 = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_${ fixture.slug }`,
+				data: {
+					title: 'Dune',
+					status: 'private',
+					meta: {
+						[ `field-${ fixture.field.id }` ]: 'Frank Herbert',
+					},
+				},
+			} );
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Global search test page',
+					status: 'private',
+					content: createDataViewBlockMarkup( fixture.collection.id, {
+						search: 'Le Guin',
+					} ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+
+			// The matching row should be visible.
+			await expect(
+				canvas.getByText( 'The Left Hand of Darkness' )
+			).toBeVisible();
+			await expect(
+				canvas.getByText( 'Ursula K. Le Guin' )
+			).toBeVisible();
+
+			// The non-matching row should be filtered out.
+			await expect( canvas.getByText( 'Dune' ) ).toBeHidden();
+			await expect(
+				canvas.getByText( 'Frank Herbert' )
+			).toBeHidden();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry2 &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry2.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+
 	test( 'resizes a column via drag and persists the width across reload', async ( {
 		admin,
 		page,


### PR DESCRIPTION
## What

Part of #126

- Perform client-side search across rows' text-based fields
- Stop searching on the server, since server-side support is currently limited to post_title and post_content (too narrow)

## Yes or no?

How does it feel in practice? Is it right for the search action to consider fields and not just titles?
If we keep this, we'll really need decent server-side searching at some point, for scalability.

## How

- Add `enableGlobalSearch: true` to `TITLE_FIELD` and to text/email/url fields in `fieldMapping.js`
- Remove the `search`-stripping workaround in `CollectionDataViews` — `filterSortAndPaginate` now correctly filters rows by search term
- Remove the server-side `search` param from `useCollectionRows` since filtering is handled client-side

## Test plan
- [x] `npm run test:e2e` — all tests pass
- [ ] Type in the DataViews search box — rows filter by title and text field content

🤖 Generated with [Claude Code](https://claude.com/claude-code)