### PR TITLE
Collections: Add field management to the DataView block

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -138,11 +138,11 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 ## 16. DataViews has no per-column menu-item slot `[upstream, soft]`
 
-**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete. To keep a single dropdown per column, we hide DataViews' built-in trigger on custom-field `<th>`s via CSS and portal our own combined trigger in (Sort / Move / Hide *plus* Rename / Duplicate / Delete). Title and system fields keep the built-in trigger. Main's drag-handle click-forward (`DataViewColumnInteractions`) iterates header buttons and skips `display: none` ones via `offsetParent`, so it lands on whichever trigger is visible. Filter is intentionally absent — Cortext doesn't surface column-level filters in the header.
+**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete. To keep a single dropdown per column, `ColumnHeaderActions` portals our own combined trigger into each marker-bearing `<th>` and uses the same MutationObserver pass to detach DataViews' built-in trigger from those cells (Title and system fields keep theirs). Filter is intentionally absent — Cortext doesn't surface column-level filters in the header.
 
-**Where.** `src/components/fields/ColumnHeaderActions.js` (combined dropdown), `src/index.scss` (`.dataviews-view-table th:has(.cortext-column-header-marker) > .dataviews-view-table-header-button { display: none }`), `src/components/DataViewColumnInteractions.js` (visible-button click forward).
+**Where.** `src/components/fields/ColumnHeaderActions.js` (`stripDataViewsTrigger` in the observer pass + the combined-dropdown trigger), `src/components/DataViewColumnInteractions.js` (visible-button click forward).
 
-**Risk.** Re-implementing Sort / Move / Hide ourselves means new DataViews items in those menus won't show up here automatically. If main's drag handle stops calling `.click()` on the header trigger, the column-name click-to-open behavior would need a different forward.
+**Risk.** Re-implementing Sort / Move / Hide ourselves means new DataViews items won't show up here automatically. Detaching DataViews' trigger from the DOM after each render races React's reconciliation (the trigger gets re-rendered and we strip it again on the next observer tick); benign in practice, but a change to DataViews' header structure could surface React warnings or cause a flicker.
 
 **Solution.** A `field.menuItems` (array or render-prop) on DataViews fields, appended to the built-in dropdown. Other consumers (Pattern Manager, Pages, Site Editor) would benefit too. File as a Gutenberg feature request.
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -136,53 +136,53 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 **Solution.** Upstream DataViews could expose table-column APIs that cover `onChangeFields`, `onChangeColumnStyle`, resize handle rendering, per-field min/max widths, double-click autofit, drag overlay/insertion affordances, and stable header/cell slots or refs. If DataViews owned that layer, Cortext could drop the portal/DOM-query adapter, the wrapper min-width overrides, most of the dnd-kit column glue, and the direct DOM mutation used for live resize feedback.
 
-## 16. DataViews has no public per-column menu-item slot `[upstream, soft]`
+## 16. DataViews has no per-column menu-item slot `[upstream, soft]`
 
-**What.** DataViews v6's column header dropdown (Sort / Add filter / Move left / Move right / Hide column) is a closed list — `column-header-menu.js` hardcodes the items and there's no `field.menuItems` (or similar) prop to inject schema actions like Rename / Duplicate / Delete. PR D therefore portals a separate kebab button next to DataViews' built-in column-header trigger and `DataViewColumnInteractions`' resize/reorder handles. Two dropdowns per column is more visual clutter than the Notion-style single combined menu we wanted, but it keeps Cortext out of DataViews' internal dropdown markup.
+**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete. We portal a kebab next to the built-in trigger instead. Two triggers per column is busier than a single combined menu, so the kebab hides until `:hover` / `:focus-within`. It uses WP's `Dropdown` rather than Ariakit's `DropdownMenu` — Ariakit's anchor falls back to viewport `(0, 0)` when the trigger is mounted via `createPortal`.
 
-**Where.** `src/components/fields/ColumnHeaderActions.js`.
+**Where.** `src/components/fields/ColumnHeaderActions.js`, hover-reveal CSS in `src/index.scss`.
 
-**Risk.** If DataViews changes how it positions content inside its header `<th>` (flexbox refactor, slot reordering), the kebab placement may need adjustment. Filter is intentionally omitted today (Cortext doesn't expose column-level filters in the visible header).
+**Risk.** A DataViews refactor of the header `<th>` layout could push the kebab off the right edge. Filter is intentionally absent — Cortext doesn't expose column-level filters in the visible header.
 
-**Solution.** Upstream a public per-column extension surface in DataViews: a `field.menuItems` array (or render-prop) that the built-in column header dropdown appends to its existing items. This would let downstream consumers (Cortext, Pattern Manager, Pages, Site Editor) add domain-specific actions in the existing dropdown rather than next to it. File this as a Gutenberg feature request once the PR D approach is in production.
+**Solution.** A `field.menuItems` (array or render-prop) on DataViews fields, appended to the built-in dropdown. Other consumers (Pattern Manager, Pages, Site Editor) would benefit too. File as a Gutenberg feature request.
 
-## 17. Ghost-column synthetic field is pinned in `view.fields` `[internal]`
+## 17. Ghost `+` column is a synthetic field pinned in `view.fields` `[internal]`
 
-**What.** The `+ add field` ghost column is a synthetic DataViews field (`__add_field`) that has no data and no label. The block always pins it last in `view.fields` for the table layout and excludes it from the user-facing column visibility menu via `enableHiding: false`. If DataViews changes how `enableHiding` is honored, the synthetic could appear as a user-toggleable entry in the visibility menu, which would confuse the column list.
+**What.** The `+ add field` column is a synthetic DataViews field (`__add_field`) — no data, no label, pinned last in `view.fields` for table layout. We rely on `enableHiding: false` to keep it out of the column-visibility menu. If DataViews stops honoring that flag, the synthetic leaks into the menu and confuses the column list.
 
 **Where.** `GHOST_FIELD` and the view-sync effect in `src/components/CollectionDataViews.js`.
 
-**Solution.** If the visibility menu starts surfacing the synthetic, fork the field list in `CollectionDataViews.js` so the visibility menu sees only the data fields while DataViews' table layout still receives the synthetic.
+**Solution.** If `enableHiding` ever stops working, fork the field list in `CollectionDataViews.js` — pass the synthetic to the table layout but hide it from the visibility menu.
 
-## 18. Field schema actions are table-layout only in PR D `[internal]`
+## 18. Field management is table-layout only `[internal]`
 
-**What.** Rename, duplicate, and delete are surfaced via the column header kebab in the table layout. Grid and list layouts have no schema-action affordance and the ghost-column `+` is hidden as well; users in those layouts can still create fields via the toolbar Add field button but can't manage existing fields without switching to table.
+**What.** Rename / Duplicate / Delete only show up in the table-layout column-header kebab. Grid and list layouts have no schema actions and no ghost `+`. Users there can still create fields via the toolbar Add field button, but they have to switch to table to manage existing fields.
 
 **Where.** `ColumnHeaderActions` mounts only when `view.type === 'table'` (`src/components/CollectionDataViews.js`).
 
-**Solution.** A top-level "Manage fields" UI (toolbar modal or a dedicated panel) that lists all custom fields with rename / duplicate / delete actions and works in every layout.
+**Solution.** A toolbar "Manage fields" panel listing every custom field with per-row rename / duplicate / delete, available in every layout.
 
-## 19. Select / multi-select fields are created without inline option editing `[internal]`
+## 19. Select / multi-select fields ship with no options `[internal]`
 
-**What.** The Add field popover follows Notion's click-to-create model: clicking a type creates the field immediately. Select / multi-select fields are created with no pre-defined options, so users have to add option values via wp-admin (or by re-saving the field through the REST API). Notion sidesteps this by auto-discovering options from cell values; Cortext doesn't have that auto-discovery.
+**What.** Add field creates the field immediately when you click a type — there's no second step for type-specific config. For select / multi-select that means the column starts empty; users have to add options via wp-admin or by re-saving through REST.
 
-**Where.** `src/components/fields/AddFieldPopover.js` (no options textarea), `includes/Rest/FieldsController.php` (still accepts an `options` array on `POST /cortext/v1/collections/<id>/fields` — the route is option-aware, only the UI doesn't surface it).
+**Where.** `src/components/fields/AddFieldPopover.js` (no options input). The REST route already accepts an `options` array; the UI just doesn't surface it.
 
-**Solution.** A field-edit dialog accessible from the column header dropdown's Rename/Duplicate/Delete neighborhood, with a small options editor (one-per-line textarea or a Notion-style chip list with colors). Until then, users edit options in wp-admin or via REST.
+**Solution.** A field-edit dialog from the column kebab (next to Rename / Duplicate / Delete) with an options editor — one-per-line textarea, or a chip list with colors. Until then, options live in wp-admin or REST.
 
-## 19. Table layout overrides couple to DataViews internals `[upstream, soft]`
+## 20. Table layout overrides couple to DataViews internals `[upstream, soft]`
 
-**What.** DataViews ships `table-layout: auto; width: 100%` plus per-cell padding rules (`.dataviews-view-table tr td:last-child { padding-right: 48px }`, `.dataviews-view-table__cell-content-wrapper { min-width: 15ch }`). Cortext flips the layout to `table-layout: fixed; width: max-content` with explicit per-cell widths so adding or removing a field doesn't reflow every other column, and matches DataViews' selector specificity to override the last-cell padding so the trailing ghost column stays slim. The result is a content-sized table with horizontal scroll on overflow — closer to Notion's shape — but it depends on DataViews' class names and CSS specificity remaining stable.
+**What.** DataViews ships `table-layout: auto; width: 100%` plus per-cell padding rules. We flip to `table-layout: fixed; width: max-content` with explicit per-cell widths so adding or removing a field doesn't reflow every other column, and match DataViews' selector specificity to override the last-cell padding so the ghost column stays slim. Result: a content-sized table that scrolls horizontally on overflow. Depends on DataViews' class names and selector specificity staying put.
 
 **Where.** `src/index.scss`, around the `.dataviews-view-table` block.
 
-**Solution.** Upstream a `tableLayout` (or similar) prop on DataViews that exposes "auto with redistribution" vs. "fixed with content-sized columns" as a documented choice, plus per-field `width` hints so consumers can pin column widths without touching DataViews CSS.
+**Solution.** A `tableLayout` (or similar) prop on DataViews so consumers can pick between "auto with redistribution" and "fixed with content-sized columns", plus per-field `width` hints so columns can be pinned without overriding DataViews CSS.
 
 ## 21. Field-meta cleanup uses a global delete `[internal]`
 
-**What.** `cleanup_after_field_delete` calls `delete_post_meta_by_key( "field-<id>" )`, which clears that meta key from every post in the database — not just Cortext entry CPTs. The collision risk is theoretical (`<id>` is a globally unique `crtxt_field` post ID, so any postmeta keyed that way belongs to a Cortext entry by construction), but the implementation doesn't enforce the scope. A scoped `DELETE pm FROM wp_postmeta pm INNER JOIN wp_posts p ON p.ID = pm.post_id WHERE pm.meta_key = … AND p.post_type IN (…)` would prove the scope on paper, except the test mock (WorDBless, see #9) can't execute the JOIN, so we'd lose unit coverage of the cleanup path.
+**What.** `cleanup_after_field_delete` calls `delete_post_meta_by_key( "field-<id>" )`, which wipes that key from every post — not just Cortext entry CPTs. The collision risk is theoretical (`<id>` is a globally unique `crtxt_field` post ID, so any postmeta keyed that way belongs to a Cortext entry by construction), but the code doesn't enforce that. A scoped `DELETE pm … INNER JOIN wp_posts p … WHERE p.post_type IN (…)` would prove the scope, but WorDBless (#9) can't run JOINs — we'd lose unit coverage of the cleanup path.
 
 **Where.** `cleanup_after_field_delete` in `includes/PostType/CollectionEntries.php`.
 
-**Solution.** Stand up an integration test environment that runs against a real `wpdb` (e.g., `wp-env` test container with WP_PHPUnit), move the cleanup to a scoped SQL JOIN, and keep the unit suite for the parts that don't need a real database.
+**Solution.** Stand up an integration environment with a real `wpdb` (`wp-env` + WP_PHPUnit), move the cleanup to a scoped JOIN, and keep WorDBless for the parts that don't need a real database.
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -169,3 +169,12 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 **Where.** `src/components/fields/AddFieldPopover.js` (no options textarea), `includes/Rest/FieldsController.php` (still accepts an `options` array on `POST /cortext/v1/collections/<id>/fields` — the route is option-aware, only the UI doesn't surface it).
 
 **Solution.** A field-edit dialog accessible from the column header dropdown's Rename/Duplicate/Delete neighborhood, with a small options editor (one-per-line textarea or a Notion-style chip list with colors). Until then, users edit options in wp-admin or via REST.
+
+## 19. Table layout overrides couple to DataViews internals `[upstream, soft]`
+
+**What.** DataViews ships `table-layout: auto; width: 100%` plus per-cell padding rules (`.dataviews-view-table tr td:last-child { padding-right: 48px }`, `.dataviews-view-table__cell-content-wrapper { min-width: 15ch }`). Cortext flips the layout to `table-layout: fixed; width: max-content` with explicit per-cell widths so adding or removing a field doesn't reflow every other column, and matches DataViews' selector specificity to override the last-cell padding so the trailing ghost column stays slim. The result is a content-sized table with horizontal scroll on overflow — closer to Notion's shape — but it depends on DataViews' class names and CSS specificity remaining stable.
+
+**Where.** `src/index.scss`, around the `.dataviews-view-table` block.
+
+**Solution.** Upstream a `tableLayout` (or similar) prop on DataViews that exposes "auto with redistribution" vs. "fixed with content-sized columns" as a documented choice, plus per-field `width` hints so consumers can pin column widths without touching DataViews CSS.
+

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -135,3 +135,37 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 **Where.** `src/components/DataViewColumnInteractions.js`, `src/components/dataViewColumns.js`, the `DataViewColumnInteractions` mount in `src/components/CollectionDataViews.js`, and the column affordance / table wrapper rules in `src/index.scss`.
 
 **Solution.** Upstream DataViews could expose table-column APIs that cover `onChangeFields`, `onChangeColumnStyle`, resize handle rendering, per-field min/max widths, double-click autofit, drag overlay/insertion affordances, and stable header/cell slots or refs. If DataViews owned that layer, Cortext could drop the portal/DOM-query adapter, the wrapper min-width overrides, most of the dnd-kit column glue, and the direct DOM mutation used for live resize feedback.
+
+## 16. DataViews has no public per-column menu-item slot `[upstream, soft]`
+
+**What.** DataViews v6's column header dropdown (Sort / Add filter / Move left / Move right / Hide column) is a closed list — `column-header-menu.js` hardcodes the items and there's no `field.menuItems` (or similar) prop to inject schema actions like Rename / Duplicate / Delete. PR D therefore portals a separate kebab button next to DataViews' built-in column-header trigger and `DataViewColumnInteractions`' resize/reorder handles. Two dropdowns per column is more visual clutter than the Notion-style single combined menu we wanted, but it keeps Cortext out of DataViews' internal dropdown markup.
+
+**Where.** `src/components/fields/ColumnHeaderActions.js`.
+
+**Risk.** If DataViews changes how it positions content inside its header `<th>` (flexbox refactor, slot reordering), the kebab placement may need adjustment. Filter is intentionally omitted today (Cortext doesn't expose column-level filters in the visible header).
+
+**Solution.** Upstream a public per-column extension surface in DataViews: a `field.menuItems` array (or render-prop) that the built-in column header dropdown appends to its existing items. This would let downstream consumers (Cortext, Pattern Manager, Pages, Site Editor) add domain-specific actions in the existing dropdown rather than next to it. File this as a Gutenberg feature request once the PR D approach is in production.
+
+## 17. Ghost-column synthetic field is pinned in `view.fields` `[internal]`
+
+**What.** The `+ add field` ghost column is a synthetic DataViews field (`__add_field`) that has no data and no label. The block always pins it last in `view.fields` for the table layout and excludes it from the user-facing column visibility menu via `enableHiding: false`. If DataViews changes how `enableHiding` is honored, the synthetic could appear as a user-toggleable entry in the visibility menu, which would confuse the column list.
+
+**Where.** `GHOST_FIELD` and the view-sync effect in `src/components/CollectionDataViews.js`.
+
+**Solution.** If the visibility menu starts surfacing the synthetic, fork the field list in `CollectionDataViews.js` so the visibility menu sees only the data fields while DataViews' table layout still receives the synthetic.
+
+## 18. Field schema actions are table-layout only in PR D `[internal]`
+
+**What.** Rename, duplicate, and delete are surfaced via the column header kebab in the table layout. Grid and list layouts have no schema-action affordance and the ghost-column `+` is hidden as well; users in those layouts can still create fields via the toolbar Add field button but can't manage existing fields without switching to table.
+
+**Where.** `ColumnHeaderActions` mounts only when `view.type === 'table'` (`src/components/CollectionDataViews.js`).
+
+**Solution.** A top-level "Manage fields" UI (toolbar modal or a dedicated panel) that lists all custom fields with rename / duplicate / delete actions and works in every layout.
+
+## 19. Select / multi-select fields are created without inline option editing `[internal]`
+
+**What.** The Add field popover follows Notion's click-to-create model: clicking a type creates the field immediately. Select / multi-select fields are created with no pre-defined options, so users have to add option values via wp-admin (or by re-saving the field through the REST API). Notion sidesteps this by auto-discovering options from cell values; Cortext doesn't have that auto-discovery.
+
+**Where.** `src/components/fields/AddFieldPopover.js` (no options textarea), `includes/Rest/FieldsController.php` (still accepts an `options` array on `POST /cortext/v1/collections/<id>/fields` — the route is option-aware, only the UI doesn't surface it).
+
+**Solution.** A field-edit dialog accessible from the column header dropdown's Rename/Duplicate/Delete neighborhood, with a small options editor (one-per-line textarea or a Notion-style chip list with colors). Until then, users edit options in wp-admin or via REST.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -180,7 +180,7 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 ## 21. Field-meta cleanup uses a global delete `[internal]`
 
-**What.** `cleanup_after_field_delete` calls `delete_post_meta_by_key( "field-<id>" )`, which wipes that key from every post — not just Cortext entry CPTs. The collision risk is theoretical (`<id>` is a globally unique `crtxt_field` post ID, so any postmeta keyed that way belongs to a Cortext entry by construction), but the code doesn't enforce that. A scoped `DELETE pm … INNER JOIN wp_posts p … WHERE p.post_type IN (…)` would prove the scope, but WorDBless (#9) can't run JOINs — we'd lose unit coverage of the cleanup path.
+**What.** `cleanup_after_field_delete` calls `delete_post_meta_by_key( "field-<id>" )`, which wipes that key from every post — not just Cortext entry CPTs. The collision risk is theoretical (`<id>` is a globally unique `crtxt_field` post ID, so any postmeta keyed that way belongs to a Cortext entry by construction), but the code doesn't enforce that. A scoped `DELETE pm … INNER JOIN wp_posts p … WHERE p.post_type IN (…)` would prove the scope, but WorDBless (#9) can't run JOINs and its in-memory `$wpdb->posts` isn't exposed via SQL — `WP_Query`/`get_posts` against dynamic entry CPTs returns empty in the mock, so the per-post fallback also can't be unit-tested here.
 
 **Where.** `cleanup_after_field_delete` in `includes/PostType/CollectionEntries.php`.
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -138,11 +138,11 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 ## 16. DataViews has no per-column menu-item slot `[upstream, soft]`
 
-**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete. To keep a single dropdown per column, `ColumnHeaderActions` portals our own combined trigger into each marker-bearing `<th>` and uses the same MutationObserver pass to detach DataViews' built-in trigger from those cells (Title and system fields keep theirs). Filter is intentionally absent — Cortext doesn't surface column-level filters in the header.
+**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete. To keep a single dropdown per column, we hide DataViews' built-in trigger on custom-field `<th>`s via CSS and portal our own combined trigger in (Sort / Move / Hide *plus* Rename / Duplicate / Delete). Title and system fields keep the built-in trigger. Main's drag-handle click-forward (`DataViewColumnInteractions`) iterates header buttons and skips `display: none` ones via `offsetParent`, so it lands on whichever trigger is visible. Filter is intentionally absent — Cortext doesn't surface column-level filters in the header.
 
-**Where.** `src/components/fields/ColumnHeaderActions.js` (`stripDataViewsTrigger` in the observer pass + the combined-dropdown trigger), `src/components/DataViewColumnInteractions.js` (visible-button click forward).
+**Where.** `src/components/fields/ColumnHeaderActions.js` (combined dropdown), `src/index.scss` (`.dataviews-view-table th:has(.cortext-column-header-marker) > .dataviews-view-table-header-button { display: none }`), `src/components/DataViewColumnInteractions.js` (visible-button click forward).
 
-**Risk.** Re-implementing Sort / Move / Hide ourselves means new DataViews items won't show up here automatically. Detaching DataViews' trigger from the DOM after each render races React's reconciliation (the trigger gets re-rendered and we strip it again on the next observer tick); benign in practice, but a change to DataViews' header structure could surface React warnings or cause a flicker.
+**Risk.** Re-implementing Sort / Move / Hide ourselves means new DataViews items in those menus won't show up here automatically. If main's drag handle stops calling `.click()` on the header trigger, the column-name click-to-open behavior would need a different forward.
 
 **Solution.** A `field.menuItems` (array or render-prop) on DataViews fields, appended to the built-in dropdown. Other consumers (Pattern Manager, Pages, Site Editor) would benefit too. File as a Gutenberg feature request.
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -178,3 +178,11 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 **Solution.** Upstream a `tableLayout` (or similar) prop on DataViews that exposes "auto with redistribution" vs. "fixed with content-sized columns" as a documented choice, plus per-field `width` hints so consumers can pin column widths without touching DataViews CSS.
 
+## 21. Field-meta cleanup uses a global delete `[internal]`
+
+**What.** `cleanup_after_field_delete` calls `delete_post_meta_by_key( "field-<id>" )`, which clears that meta key from every post in the database — not just Cortext entry CPTs. The collision risk is theoretical (`<id>` is a globally unique `crtxt_field` post ID, so any postmeta keyed that way belongs to a Cortext entry by construction), but the implementation doesn't enforce the scope. A scoped `DELETE pm FROM wp_postmeta pm INNER JOIN wp_posts p ON p.ID = pm.post_id WHERE pm.meta_key = … AND p.post_type IN (…)` would prove the scope on paper, except the test mock (WorDBless, see #9) can't execute the JOIN, so we'd lose unit coverage of the cleanup path.
+
+**Where.** `cleanup_after_field_delete` in `includes/PostType/CollectionEntries.php`.
+
+**Solution.** Stand up an integration test environment that runs against a real `wpdb` (e.g., `wp-env` test container with WP_PHPUnit), move the cleanup to a scoped SQL JOIN, and keep the unit suite for the parts that don't need a real database.
+

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -138,11 +138,11 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 ## 16. DataViews has no per-column menu-item slot `[upstream, soft]`
 
-**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete. We portal a kebab next to the built-in trigger instead. Two triggers per column is busier than a single combined menu, so the kebab hides until `:hover` / `:focus-within`. It uses WP's `Dropdown` rather than Ariakit's `DropdownMenu` — Ariakit's anchor falls back to viewport `(0, 0)` when the trigger is mounted via `createPortal`.
+**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete. To keep a single dropdown per column, we hide DataViews' built-in trigger on custom-field `<th>`s via CSS and portal our own combined trigger in (Sort / Move / Hide *plus* Rename / Duplicate / Delete). Title and system fields keep the built-in trigger. Main's drag-handle click-forward (`DataViewColumnInteractions`) iterates header buttons and skips `display: none` ones via `offsetParent`, so it lands on whichever trigger is visible. Filter is intentionally absent — Cortext doesn't surface column-level filters in the header.
 
-**Where.** `src/components/fields/ColumnHeaderActions.js`, hover-reveal CSS in `src/index.scss`.
+**Where.** `src/components/fields/ColumnHeaderActions.js` (combined dropdown), `src/index.scss` (`.dataviews-view-table th:has(.cortext-column-header-marker) > .dataviews-view-table-header-button { display: none }`), `src/components/DataViewColumnInteractions.js` (visible-button click forward).
 
-**Risk.** A DataViews refactor of the header `<th>` layout could push the kebab off the right edge. Filter is intentionally absent — Cortext doesn't expose column-level filters in the visible header.
+**Risk.** Re-implementing Sort / Move / Hide ourselves means new DataViews items in those menus won't show up here automatically. If main's drag handle stops calling `.click()` on the header trigger, the column-name click-to-open behavior would need a different forward.
 
 **Solution.** A `field.menuItems` (array or render-prop) on DataViews fields, appended to the built-in dropdown. Other consumers (Pattern Manager, Pages, Site Editor) would benefit too. File as a Gutenberg feature request.
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -19,6 +19,7 @@ use Cortext\PostType\Field;
 use Cortext\PostType\Page;
 use Cortext\PostType\PageTrashCascade;
 use Cortext\Rest\CollectionsController;
+use Cortext\Rest\FieldsController;
 use Cortext\Rest\PageTrashController;
 use Cortext\Rest\RowsController;
 
@@ -42,6 +43,7 @@ final class Plugin {
 		( new CollectionEntries() )->register();
 		( new RevisionThrottle() )->register();
 		( new CollectionsController() )->register();
+		( new FieldsController() )->register();
 		( new PageTrashController() )->register();
 		( new RowsController() )->register();
 		( new Template() )->register();

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -89,11 +89,15 @@ final class CollectionEntries {
 			return;
 		}
 
-		// Drop the field's `field-<id>` meta on every entry that has it.
-		// The key is naturally scoped: `<id>` is a globally unique post ID,
-		// so collisions with non-Cortext post meta are not a practical
-		// concern. `delete_post_meta_by_key` enumerates every row with that
-		// key across the postmeta table and removes it.
+		// Drop the field's `field-<id>` meta. `delete_post_meta_by_key`
+		// is global (clears the key from every post in the database),
+		// not strictly scoped to Cortext entry CPTs. We rely on the
+		// key being naturally unique: `<id>` is a globally unique post
+		// ID for a `crtxt_field` post, so any postmeta row keyed
+		// `field-<that-id>` belongs to a Cortext entry by construction.
+		// A scoped SQL JOIN would tighten the scope on paper but
+		// WorDBless (the test mock — see tech-debt.md#9) can't simulate
+		// it; tracked as tech-debt.md#21.
 		delete_post_meta_by_key( "field-{$post_id}" );
 
 		// Defensive: remove the field's string ID from any collection's

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -42,6 +42,86 @@ final class CollectionEntries {
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_all' ), 20 );
 		add_action( 'save_post', array( $this, 'record_modified_by' ), 10, 2 );
+		add_action( 'before_delete_post', array( $this, 'cleanup_after_field_delete' ), 10, 2 );
+	}
+
+	/**
+	 * Returns the dynamic entry CPTs currently registered.
+	 *
+	 * Excludes the Cortext utility CPTs (`crtxt_collection`, `crtxt_field`)
+	 * and any post types that don't share the entry CPT prefix.
+	 *
+	 * @return array<int,string>
+	 */
+	public static function get_entry_post_types(): array {
+		$entry_post_types = array();
+		foreach ( get_post_types() as $post_type ) {
+			if (
+				str_starts_with( $post_type, self::CPT_PREFIX ) &&
+				Collection::POST_TYPE !== $post_type &&
+				Field::POST_TYPE !== $post_type
+			) {
+				$entry_post_types[] = $post_type;
+			}
+		}
+		return $entry_post_types;
+	}
+
+	/**
+	 * Removes a field's traces from the database when its post is deleted.
+	 *
+	 * Two cleanups, scoped to Cortext data only:
+	 *
+	 * 1. Drops `field-<id>` postmeta rows from every entry across every
+	 *    Cortext entry CPT in one query. The JOIN against `wp_posts` keeps
+	 *    the delete from touching incidental meta on non-Cortext post types.
+	 * 2. Removes the field's string ID from any collection's `meta.fields`
+	 *    list, preserving the order of the remaining IDs.
+	 *
+	 * Runs on every deletion path (REST, wp-admin, WP-CLI).
+	 *
+	 * @param int          $post_id Post being deleted.
+	 * @param WP_Post|null $post    Post object, or null in pathological calls.
+	 */
+	public function cleanup_after_field_delete( int $post_id, ?WP_Post $post = null ): void {
+		$post_type = $post instanceof WP_Post ? $post->post_type : get_post_type( $post_id );
+		if ( Field::POST_TYPE !== $post_type ) {
+			return;
+		}
+
+		// Drop the field's `field-<id>` meta on every entry that has it.
+		// The key is naturally scoped: `<id>` is a globally unique post ID,
+		// so collisions with non-Cortext post meta are not a practical
+		// concern. `delete_post_meta_by_key` enumerates every row with that
+		// key across the postmeta table and removes it.
+		delete_post_meta_by_key( "field-{$post_id}" );
+
+		// Defensive: remove the field's string ID from any collection's
+		// `meta.fields` list, preserving order of remaining IDs. A real DB
+		// supports the `meta_query` here; the WorDBless test mock does not
+		// (tech-debt.md#9), so this branch runs in production but is
+		// asserted via e2e instead of the PHP unit suite.
+		$field_id_str           = (string) $post_id;
+		$collections_with_field = get_posts(
+			array(
+				'post_type'      => Collection::POST_TYPE,
+				'post_status'    => array( 'draft', 'pending', 'private', 'publish' ),
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- one-time defensive cleanup.
+				'meta_query'     => array(
+					array(
+						'key'     => 'fields',
+						'value'   => $field_id_str,
+						'compare' => '=',
+					),
+				),
+			)
+		);
+
+		foreach ( $collections_with_field as $collection_id ) {
+			delete_post_meta( (int) $collection_id, 'fields', $field_id_str );
+		}
 	}
 
 	/**

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -171,7 +171,15 @@ final class FieldsController {
 		$copy_title = trim( sprintf( __( 'Copy of %s', 'cortext' ), $source->post_title ) );
 
 		$meta = array();
-		foreach ( array( 'type', 'options', 'number_format', 'expression' ) as $key ) {
+		foreach (
+			array(
+				'type',
+				'options',
+				'number_format',
+				'expression',
+				'related_collection_id',
+			) as $key
+		) {
 			$value = get_post_meta( $field_id, $key, true );
 			if ( '' !== $value && null !== $value ) {
 				$meta[ $key ] = (string) $value;

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * REST endpoints for creating and duplicating Cortext fields.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Field;
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class FieldsController {
+
+	private const NAMESPACE = 'cortext/v1';
+
+	private const ALLOWED_TYPES = array(
+		'text',
+		'email',
+		'url',
+		'number',
+		'date',
+		'datetime',
+		'checkbox',
+		'select',
+		'multiselect',
+	);
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/collections/(?P<collection_id>\d+)/fields',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'create' ),
+					'permission_callback' => array( $this, 'can_edit_collection' ),
+					'args'                => array(
+						'collection_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'title'         => array(
+							'type'     => 'string',
+							'required' => true,
+						),
+						'type'          => array(
+							'type'     => 'string',
+							'required' => true,
+							'enum'     => self::ALLOWED_TYPES,
+						),
+						'options'       => array(
+							'type'     => 'array',
+							'required' => false,
+							'items'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'value' => array( 'type' => 'string' ),
+									'label' => array( 'type' => 'string' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/collections/(?P<collection_id>\d+)/fields/(?P<field_id>\d+)/duplicate',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'duplicate' ),
+					'permission_callback' => array( $this, 'can_edit_collection' ),
+					'args'                => array(
+						'collection_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'field_id'      => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function can_edit_collection( WP_REST_Request $request ): bool|WP_Error {
+		$collection_id = (int) $request->get_param( 'collection_id' );
+		$collection    = get_post( $collection_id );
+		if ( ! $collection instanceof WP_Post || Collection::POST_TYPE !== $collection->post_type ) {
+			return new WP_Error(
+				'cortext_collection_not_found',
+				__( 'Collection not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+		return current_user_can( 'edit_post', $collection_id );
+	}
+
+	public function create( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$collection_id = (int) $request->get_param( 'collection_id' );
+
+		$collection_or_error = $this->require_collection( $collection_id );
+		if ( is_wp_error( $collection_or_error ) ) {
+			return $collection_or_error;
+		}
+
+		$title = trim( sanitize_text_field( (string) $request->get_param( 'title' ) ) );
+		if ( '' === $title ) {
+			return new WP_Error(
+				'cortext_field_title_required',
+				__( 'Field name is required.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$type    = (string) $request->get_param( 'type' );
+		$options = $request->get_param( 'options' );
+
+		$meta = array( 'type' => $type );
+		if ( $this->type_supports_options( $type ) && is_array( $options ) ) {
+			$meta['options'] = wp_json_encode( $this->normalize_options( $options ) );
+		}
+
+		return $this->insert_and_attach( $collection_id, $title, $meta );
+	}
+
+	public function duplicate( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$collection_id = (int) $request->get_param( 'collection_id' );
+		$field_id      = (int) $request->get_param( 'field_id' );
+
+		$collection_or_error = $this->require_collection( $collection_id );
+		if ( is_wp_error( $collection_or_error ) ) {
+			return $collection_or_error;
+		}
+
+		$source = get_post( $field_id );
+		if ( ! $source instanceof WP_Post || Field::POST_TYPE !== $source->post_type ) {
+			return new WP_Error(
+				'cortext_field_not_found',
+				__( 'Field not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$existing_ids = $this->collection_field_ids( $collection_id );
+		if ( ! in_array( (string) $field_id, $existing_ids, true ) ) {
+			return new WP_Error(
+				'cortext_field_not_in_collection',
+				__( 'Field does not belong to this collection.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		/* translators: %s: source field title */
+		$copy_title = trim( sprintf( __( 'Copy of %s', 'cortext' ), $source->post_title ) );
+
+		$meta = array();
+		foreach ( array( 'type', 'options', 'number_format', 'expression' ) as $key ) {
+			$value = get_post_meta( $field_id, $key, true );
+			if ( '' !== $value && null !== $value ) {
+				$meta[ $key ] = (string) $value;
+			}
+		}
+
+		return $this->insert_and_attach( $collection_id, $copy_title, $meta, (string) $field_id );
+	}
+
+	/**
+	 * Inserts a new field post and attaches it to the collection.
+	 *
+	 * If the attach step fails the just-created field post is force-deleted so
+	 * callers never observe an orphan field. When `$insert_after_id` is set the
+	 * new field's string ID is spliced into the collection's `meta.fields`
+	 * directly after that ID; otherwise it appends to the end.
+	 *
+	 * @param int                  $collection_id   Collection post ID.
+	 * @param string               $title           Field title.
+	 * @param array<string,string> $meta            Meta keys to write on the new field.
+	 * @param string|null          $insert_after_id String ID to insert after, or null to append.
+	 */
+	private function insert_and_attach(
+		int $collection_id,
+		string $title,
+		array $meta,
+		?string $insert_after_id = null
+	): WP_REST_Response|WP_Error {
+		$field_id = wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => $meta,
+			),
+			true
+		);
+
+		if ( is_wp_error( $field_id ) ) {
+			return $field_id;
+		}
+
+		$attached = $this->attach_field( $collection_id, (int) $field_id, $insert_after_id );
+		if ( ! $attached ) {
+			wp_delete_post( (int) $field_id, true );
+			return new WP_Error(
+				'cortext_field_attach_failed',
+				__( 'Field could not be attached to the collection.', 'cortext' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$collection = get_post( $collection_id );
+		if ( $collection instanceof WP_Post ) {
+			( new CollectionEntries() )->register_for_collection( $collection );
+		}
+
+		$field = get_post( (int) $field_id );
+
+		return new WP_REST_Response(
+			array(
+				'id'    => (int) $field_id,
+				'title' => $field instanceof WP_Post ? $field->post_title : $title,
+				'type'  => isset( $meta['type'] ) ? $meta['type'] : '',
+			),
+			201
+		);
+	}
+
+	private function attach_field( int $collection_id, int $field_id, ?string $insert_after_id ): bool {
+		$field_id_str = (string) $field_id;
+
+		if ( null === $insert_after_id ) {
+			$result = add_post_meta( $collection_id, 'fields', $field_id_str );
+			return false !== $result;
+		}
+
+		$existing  = $this->collection_field_ids( $collection_id );
+		$reordered = array();
+		foreach ( $existing as $id ) {
+			$reordered[] = $id;
+			if ( $id === $insert_after_id ) {
+				$reordered[] = $field_id_str;
+			}
+		}
+
+		// Replace the multi-value meta in one shot to preserve order.
+		delete_post_meta( $collection_id, 'fields' );
+		foreach ( $reordered as $id ) {
+			add_post_meta( $collection_id, 'fields', $id );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the field IDs stored in a collection's `meta.fields`.
+	 *
+	 * @param int $collection_id Collection post ID.
+	 * @return array<int,string> Stringified IDs in display order.
+	 */
+	private function collection_field_ids( int $collection_id ): array {
+		$raw = get_post_meta( $collection_id, 'fields', false );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$ids = array();
+		foreach ( $raw as $id ) {
+			$ids[] = (string) $id;
+		}
+		return $ids;
+	}
+
+	private function require_collection( int $collection_id ): WP_Post|WP_Error {
+		$collection = get_post( $collection_id );
+		if ( ! $collection instanceof WP_Post || Collection::POST_TYPE !== $collection->post_type ) {
+			return new WP_Error(
+				'cortext_collection_not_found',
+				__( 'Collection not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+		return $collection;
+	}
+
+	private function type_supports_options( string $type ): bool {
+		return 'select' === $type || 'multiselect' === $type;
+	}
+
+	/**
+	 * Trims and rejects empty entries; preserves order.
+	 *
+	 * @param array<int,array<string,mixed>> $options Raw option records.
+	 * @return array<int,array{value:string,label:string}>
+	 */
+	private function normalize_options( array $options ): array {
+		$normalized = array();
+		foreach ( $options as $option ) {
+			$value = isset( $option['value'] ) ? trim( (string) $option['value'] ) : '';
+			$label = isset( $option['label'] ) ? trim( (string) $option['label'] ) : '';
+			if ( '' === $value && '' === $label ) {
+				continue;
+			}
+			if ( '' === $value ) {
+				$value = $label;
+			}
+			if ( '' === $label ) {
+				$label = $value;
+			}
+			$normalized[] = array(
+				'value' => $value,
+				'label' => $label,
+			);
+		}
+		return $normalized;
+	}
+}

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -259,17 +259,36 @@ final class FieldsController {
 
 		$existing  = $this->collection_field_ids( $collection_id );
 		$reordered = array();
+		$inserted  = false;
 		foreach ( $existing as $id ) {
 			$reordered[] = $id;
 			if ( $id === $insert_after_id ) {
 				$reordered[] = $field_id_str;
+				$inserted    = true;
 			}
 		}
 
-		// Replace the multi-value meta in one shot to preserve order.
+		// Source ID disappeared between `duplicate()`'s validation and
+		// this re-read (race, or a meta_query filter quirk). Don't write
+		// `$reordered` — that would silently drop the new ID. Caller
+		// force-deletes the orphan field post.
+		if ( ! $inserted ) {
+			return false;
+		}
+
+		// WordPress doesn't expose an atomic multi-value meta update; the
+		// sequence is delete-then-add. If a re-add fails (filter, DB
+		// error), best-effort restore the previous list so the schema
+		// isn't lost.
 		delete_post_meta( $collection_id, 'fields' );
 		foreach ( $reordered as $id ) {
-			add_post_meta( $collection_id, 'fields', $id );
+			if ( false === add_post_meta( $collection_id, 'fields', $id ) ) {
+				delete_post_meta( $collection_id, 'fields' );
+				foreach ( $existing as $rollback_id ) {
+					add_post_meta( $collection_id, 'fields', $rollback_id );
+				}
+				return false;
+			}
 		}
 
 		return true;

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -13,9 +13,10 @@ import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { replace } from '@wordpress/icons';
+import { plus, replace } from '@wordpress/icons';
 
 import CollectionDataViews from '../../components/CollectionDataViews';
+import AddFieldPopover from '../../components/fields/AddFieldPopover';
 import { COLLECTION_QUERY } from '../../collections';
 
 function createDefaultView() {
@@ -166,6 +167,26 @@ function CollectionToolbarControl( { collectionId, onSelect } ) {
 								onSelect( id );
 								onClose();
 							} }
+						/>
+					</div>
+				) }
+			/>
+			<Dropdown
+				contentClassName="cortext-data-view-toolbar-popover"
+				popoverProps={ { placement: 'bottom-start' } }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<ToolbarButton
+						icon={ plus }
+						label={ __( 'Add field', 'cortext' ) }
+						onClick={ onToggle }
+						isPressed={ isOpen }
+					/>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<div className="cortext-data-view-toolbar-popover__content">
+						<AddFieldPopover
+							collectionId={ collectionId }
+							onCreate={ onClose }
 						/>
 					</div>
 				) }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -14,7 +14,11 @@ import { plus } from '@wordpress/icons';
 import DataViewColumnInteractions from './DataViewColumnInteractions';
 import EditableCell, { RowMutationContext } from './EditableCell';
 import ColumnHeaderActions from './fields/ColumnHeaderActions';
-import { TITLE_FIELD_ID, normalizeView } from './dataViewColumns';
+import {
+	GHOST_FIELD_ID,
+	TITLE_FIELD_ID,
+	normalizeView,
+} from './dataViewColumns';
 import useCollectionFields from '../hooks/useCollectionFields';
 import useCollectionRows from '../hooks/useCollectionRows';
 
@@ -56,7 +60,6 @@ const TITLE_FIELD = {
 // empty column that visually echoes Notion's "add column" affordance.
 // Pinned visible (and last) by the view-sync effect when
 // `view.type === 'table'`, dropped from `view.fields` for grid/list.
-export const GHOST_FIELD_ID = '__add_field';
 const GHOST_FIELD = {
 	id: GHOST_FIELD_ID,
 	type: 'text',

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -13,6 +13,7 @@ import { plus } from '@wordpress/icons';
 
 import DataViewColumnInteractions from './DataViewColumnInteractions';
 import EditableCell, { RowMutationContext } from './EditableCell';
+import ColumnHeaderActions from './fields/ColumnHeaderActions';
 import { TITLE_FIELD_ID, normalizeView } from './dataViewColumns';
 import useCollectionFields from '../hooks/useCollectionFields';
 import useCollectionRows from '../hooks/useCollectionRows';
@@ -43,6 +44,31 @@ const TITLE_FIELD = {
 	// reorders and resizes like any other column. `normalizeView` re-adds
 	// the id to `view.fields` if something corrupts the saved state.
 	enableHiding: false,
+};
+
+// Synthetic "ghost column" rendered at the right edge of the table layout.
+// Its `header` carries an aria-hidden marker that `ColumnHeaderActions`
+// portals a `+` button into; the row cells render `null`, leaving an
+// empty column that visually echoes Notion's "add column" affordance.
+// Pinned visible (and last) by the view-sync effect when
+// `view.type === 'table'`, dropped from `view.fields` for grid/list.
+export const GHOST_FIELD_ID = '__add_field';
+const GHOST_FIELD = {
+	id: GHOST_FIELD_ID,
+	type: 'text',
+	label: '',
+	enableSorting: false,
+	enableHiding: false,
+	editable: false,
+	getValue: () => '',
+	render: () => null,
+	header: (
+		<span
+			className="cortext-column-header-marker cortext-column-header-marker--add"
+			data-cortext-add-field-marker="true"
+			aria-hidden="true"
+		/>
+	),
 };
 
 // Pulls a "single equality" prefill out of the active filters: only filters
@@ -157,10 +183,11 @@ export default function CollectionDataViews( {
 		error: rowError,
 		refresh,
 	} = useCollectionRows( collectionId, view );
-	const dataViewFields = useMemo(
-		() => [ TITLE_FIELD, ...fields ],
-		[ fields ]
-	);
+	const isTableLayout = view?.type === 'table';
+	const dataViewFields = useMemo( () => {
+		const base = [ TITLE_FIELD, ...fields ];
+		return isTableLayout ? [ ...base, GHOST_FIELD ] : base;
+	}, [ fields, isTableLayout ] );
 	const tableWrapperRef = useRef( null );
 	// editRequest is the "open this cell for editing" channel: cells that
 	// match its `{ rowId, fieldId }` flip to edit mode and clear it. Used
@@ -330,7 +357,26 @@ export default function CollectionDataViews( {
 			};
 		}
 
-		const normalized = normalizeView( seededView, validIds );
+		let normalized = normalizeView( seededView, validIds );
+
+		// Pin the ghost "+ add field" column last whenever the table
+		// layout is active. In grid/list layouts the synthetic field
+		// is absent from `dataViewFields`, so `normalizeView` dropped
+		// any stale reference already.
+		if ( validIds.has( GHOST_FIELD_ID ) ) {
+			const stripped = ( normalized.fields ?? [] ).filter(
+				( id ) => id !== GHOST_FIELD_ID
+			);
+			const nextFields = [ ...stripped, GHOST_FIELD_ID ];
+			const fieldsChanged =
+				nextFields.length !== ( normalized.fields ?? [] ).length ||
+				nextFields.some(
+					( id, i ) => id !== ( normalized.fields ?? [] )[ i ]
+				);
+			if ( fieldsChanged ) {
+				normalized = { ...normalized, fields: nextFields };
+			}
+		}
 
 		const currentSort = normalized.sort ?? null;
 		const nextSort =
@@ -397,13 +443,16 @@ export default function CollectionDataViews( {
 					isLoading={ isLoading }
 					empty={ empty }
 				/>
-				{ view?.type === 'table' && (
+				{ isTableLayout && (
 					<DataViewColumnInteractions
 						wrapperRef={ tableWrapperRef }
 						view={ view }
 						fields={ dataViewFields }
 						onChangeView={ onChangeView }
 					/>
+				) }
+				{ isTableLayout && (
+					<ColumnHeaderActions collectionId={ collectionId } />
 				) }
 				{ /* tech-debt.md#7: DataViews has no footer slot, so the
 				   New-row affordance and its CSS layout sit outside the

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -27,7 +27,11 @@ const TITLE_FIELD = {
 	header: (
 		<span className="cortext-column-header-label">{ TITLE_LABEL }</span>
 	),
-	getValue: ( { item } ) => item?.title?.rendered ?? item?.title?.raw ?? '',
+	// Prefer `title.raw` over `title.rendered` so sort comparisons use
+	// the unfiltered string (the_title encodes `&` as `&#038;`, which
+	// would otherwise sort under that literal entity). Same reason as
+	// `mapField`'s label fallback in `src/hooks/fieldMapping.js`.
+	getValue: ( { item } ) => item?.title?.raw ?? item?.title?.rendered ?? '',
 	render: ( { item } ) => (
 		<EditableCell
 			item={ item }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -174,7 +174,7 @@ export default function CollectionDataViews( {
 	invalid,
 	error,
 } ) {
-	const { fields, collection, slug, isResolving } =
+	const { fields, collection, slug, isResolving, fieldsResolved } =
 		useCollectionFields( collectionId );
 	const {
 		data,
@@ -336,7 +336,13 @@ export default function CollectionDataViews( {
 	// they sit outside `normalizeView`'s scope. Other view settings
 	// (perPage, search, layout.density) are left alone.
 	useEffect( () => {
-		if ( isResolving ) {
+		// Don't run while we have no data at all *or* while the field
+		// records are mid-refetch — during a refetch `fieldRecords` is
+		// briefly empty for a new include query, and stripping orphan
+		// IDs against that transient state would wipe the user's
+		// `view.fields` (and their persisted view) until the refetch
+		// completes.
+		if ( isResolving || ! fieldsResolved ) {
 			return;
 		}
 		const validIds = new Set( dataViewFields.map( ( f ) => f.id ) );
@@ -400,7 +406,7 @@ export default function CollectionDataViews( {
 				filters: nextFilters,
 			} );
 		}
-	}, [ dataViewFields, isResolving ] );
+	}, [ dataViewFields, isResolving, fieldsResolved ] );
 
 	if ( isResolving ) {
 		return loading;

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -331,6 +331,10 @@ export default function CollectionDataViews( {
 	viewRef.current = view;
 	const onChangeViewRef = useRef( onChangeView );
 	onChangeViewRef.current = onChangeView;
+	// Field IDs known on the previous sync. Drives the auto-show path
+	// for fields the user just created. `null` on first run signals
+	// "saved view, leave it alone."
+	const knownFieldIdsRef = useRef( null );
 
 	// Reconcile saved view state with the live schema whenever the field
 	// set changes: seed defaults on first render, then hand off to
@@ -352,6 +356,7 @@ export default function CollectionDataViews( {
 		const validIds = new Set( dataViewFields.map( ( f ) => f.id ) );
 		const currentView = viewRef.current;
 		const currentFields = currentView?.fields ?? [];
+		const previouslyKnown = knownFieldIdsRef.current;
 
 		let seededView = currentView;
 		if ( currentFields.length === 0 ) {
@@ -368,6 +373,48 @@ export default function CollectionDataViews( {
 		}
 
 		let normalized = normalizeView( seededView, validIds );
+
+		// Splice any editable field that just appeared in the schema
+		// (wasn't present on the previous sync) into its schema position
+		// in `view.fields`. The first render — `previouslyKnown` is
+		// `null` — leaves saved views alone; from then on, the diff
+		// detects fields the user just created via toolbar Add field
+		// or duplicate. Honors user-driven hides because the toggled-off
+		// field IS in `previouslyKnown` and gets skipped here. Inserting
+		// at the schema position (rather than appending) keeps a
+		// duplicated field next to its source instead of jumping to the
+		// end of the visible columns.
+		if ( previouslyKnown && currentFields.length > 0 ) {
+			const next = [ ...( normalized.fields ?? [] ) ];
+			let inserted = false;
+			for (
+				let schemaIdx = 0;
+				schemaIdx < dataViewFields.length;
+				schemaIdx++
+			) {
+				const f = dataViewFields[ schemaIdx ];
+				if (
+					! f.editable ||
+					previouslyKnown.has( f.id ) ||
+					next.includes( f.id )
+				) {
+					continue;
+				}
+				let insertAt = next.length;
+				for ( let i = schemaIdx - 1; i >= 0; i-- ) {
+					const idx = next.indexOf( dataViewFields[ i ].id );
+					if ( idx >= 0 ) {
+						insertAt = idx + 1;
+						break;
+					}
+				}
+				next.splice( insertAt, 0, f.id );
+				inserted = true;
+			}
+			if ( inserted ) {
+				normalized = { ...normalized, fields: next };
+			}
+		}
 
 		// Pin the ghost "+ add field" column last whenever the table
 		// layout is active. In grid/list layouts the synthetic field
@@ -387,6 +434,8 @@ export default function CollectionDataViews( {
 				normalized = { ...normalized, fields: nextFields };
 			}
 		}
+
+		knownFieldIdsRef.current = validIds;
 
 		const currentSort = normalized.sort ?? null;
 		const nextSort =

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -514,7 +514,11 @@ export default function CollectionDataViews( {
 					/>
 				) }
 				{ isTableLayout && (
-					<ColumnHeaderActions collectionId={ collectionId } />
+					<ColumnHeaderActions
+						collectionId={ collectionId }
+						view={ view }
+						onChangeView={ onChangeView }
+					/>
 				) }
 				{ /* tech-debt.md#7: DataViews has no footer slot, so the
 				   New-row affordance and its CSS layout sit outside the

--- a/src/components/DataViewColumnInteractions.js
+++ b/src/components/DataViewColumnInteractions.js
@@ -75,11 +75,16 @@ function findHeaderCells( wrapper, view, fieldsById ) {
 			if ( fieldId === GHOST_FIELD_ID ) {
 				return null;
 			}
+			// Prefer the field's own label over the cell's textContent
+			// for the drag preview. Custom field columns render their
+			// label asynchronously (via `useEntityRecord`), so the cell
+			// can briefly contain only the fallback `field-<id>` text.
+			const fieldLabel = fieldsById.get( fieldId )?.label;
 			return {
 				fieldId,
 				fieldType: fieldTypeFor( fieldId, fieldsById ),
 				index,
-				label: el.textContent?.trim() || fieldId,
+				label: fieldLabel || el.textContent?.trim() || fieldId,
 				el,
 			};
 		} )
@@ -684,6 +689,7 @@ export default function DataViewColumnInteractions( {
 			onDragMove={ onDragMove }
 			onDragEnd={ onDragEnd }
 			onDragCancel={ onDragCancel }
+			autoScroll={ false }
 		>
 			{ cells.map( ( cell ) =>
 				createPortal(

--- a/src/components/DataViewColumnInteractions.js
+++ b/src/components/DataViewColumnInteractions.js
@@ -18,6 +18,7 @@ import {
 } from '@dnd-kit/core';
 
 import {
+	GHOST_FIELD_ID,
 	MAX_COLUMN_WIDTH,
 	TITLE_FIELD_ID,
 	clampWidth,
@@ -66,6 +67,12 @@ function findHeaderCells( wrapper, view, fieldsById ) {
 		.map( ( fieldId, index ) => {
 			const el = cells[ index ];
 			if ( ! el ) {
+				return null;
+			}
+			// Skip the ghost "+ add field" column: empty content means
+			// no width to resize, and reordering the trailing add-field
+			// affordance would be confusing.
+			if ( fieldId === GHOST_FIELD_ID ) {
 				return null;
 			}
 			return {

--- a/src/components/DataViewColumnInteractions.js
+++ b/src/components/DataViewColumnInteractions.js
@@ -394,7 +394,18 @@ function ColumnDragHandle( { cell } ) {
 		( event ) => {
 			event.preventDefault();
 			event.stopPropagation();
-			cell.el.querySelector( HEADER_BUTTON_SELECTOR )?.click();
+			// Forward to the visible header button. On custom field
+			// columns, Cortext hides DataViews' built-in trigger and
+			// portals its own combined dropdown trigger in (same class,
+			// later in DOM order); `offsetParent` rules out the hidden
+			// one. tech-debt.md#16.
+			const buttons = cell.el.querySelectorAll( HEADER_BUTTON_SELECTOR );
+			for ( const btn of buttons ) {
+				if ( btn.offsetParent !== null ) {
+					btn.click();
+					return;
+				}
+			}
 		},
 		[ cell.el ]
 	);

--- a/src/components/dataViewColumns.js
+++ b/src/components/dataViewColumns.js
@@ -7,6 +7,7 @@
  */
 
 export const TITLE_FIELD_ID = 'title';
+export const GHOST_FIELD_ID = '__add_field';
 export const MAX_COLUMN_WIDTH = 640;
 
 // Per-type column-width floors. Calibrated against Notion's behavior: most

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -1,0 +1,165 @@
+import { __ } from '@wordpress/i18n';
+import { Icon, Notice, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import {
+	atSymbol,
+	calendar,
+	check,
+	formatListBullets,
+	globe,
+	tag,
+	typography,
+} from '@wordpress/icons';
+
+import { useCreateField } from '../../hooks/useFieldMutations';
+
+// Inline SVG for the "number" type. `@wordpress/icons` doesn't ship a
+// numeric glyph that reads as "single number" (formatListNumbered looks
+// like an ordered list), so we draw a `#` at the same stroke weight.
+const numberIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+	>
+		<path
+			d="M9.5 5l-1 5H5v1.5h3.2l-.7 3.5H4v1.5h3.2L6.5 19h1.5l.7-3.5h3.5L11.5 19h1.5l.7-3.5h3v-1.5h-2.7l.7-3.5H17V9h-3.2l.7-4h-1.5l-.7 4h-3.5l.7-4h-1.5z"
+			fill="currentColor"
+		/>
+	</svg>
+);
+
+// Inline SVG for "date and time": a calendar with a clock face. Mirrors
+// Notion's separation between Date and Date & time.
+const datetimeIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+	>
+		<path
+			d="M19 4h-2V3a1 1 0 1 0-2 0v1H9V3a1 1 0 1 0-2 0v1H5a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h7.1a5.5 5.5 0 1 1 8.4-7H21V6a2 2 0 0 0-2-2zm0 6H5V6h2v1a1 1 0 1 0 2 0V6h6v1a1 1 0 1 0 2 0V6h2v4zm-2 4v3h-3v1.5h4.5V14H17z"
+			fill="currentColor"
+		/>
+		<circle
+			cx="17"
+			cy="17"
+			r="4.5"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+	</svg>
+);
+
+const FIELD_TYPES = [
+	{ value: 'text', label: __( 'Text', 'cortext' ), icon: typography },
+	{ value: 'number', label: __( 'Number', 'cortext' ), icon: numberIcon },
+	{
+		value: 'select',
+		label: __( 'Select', 'cortext' ),
+		icon: formatListBullets,
+	},
+	{
+		value: 'multiselect',
+		label: __( 'Multi-select', 'cortext' ),
+		icon: tag,
+	},
+	{ value: 'date', label: __( 'Date', 'cortext' ), icon: calendar },
+	{
+		value: 'datetime',
+		label: __( 'Date & time', 'cortext' ),
+		icon: datetimeIcon,
+	},
+	{ value: 'checkbox', label: __( 'Checkbox', 'cortext' ), icon: check },
+	{ value: 'url', label: __( 'URL', 'cortext' ), icon: globe },
+	{ value: 'email', label: __( 'Email', 'cortext' ), icon: atSymbol },
+];
+
+export default function AddFieldPopover( { collectionId, onCreate } ) {
+	const [ title, setTitle ] = useState( '' );
+	const [ submitError, setSubmitError ] = useState( '' );
+
+	const { run, isBusy, error } = useCreateField( collectionId );
+
+	const submit = async ( chosenType ) => {
+		if ( isBusy ) {
+			return;
+		}
+		setSubmitError( '' );
+		// Notion-style fallback: an empty name is allowed; the field
+		// title defaults to the type label ("Text", "Number", …) and
+		// the user can rename later via the column header dropdown.
+		const trimmed = title.trim();
+		const fallback =
+			FIELD_TYPES.find( ( t ) => t.value === chosenType )?.label ||
+			chosenType;
+		try {
+			// Select / multi-select fields are created without
+			// pre-defined options. Options can be edited via wp-admin
+			// today; a future field-edit dialog will bring it inline
+			// (tech-debt.md#18).
+			const created = await run( {
+				title: trimmed || fallback,
+				type: chosenType,
+			} );
+			onCreate?.( created );
+		} catch ( apiError ) {
+			setSubmitError(
+				apiError?.message ||
+					__( 'Field could not be created.', 'cortext' )
+			);
+		}
+	};
+
+	const errorMessage = submitError || error?.message;
+
+	return (
+		<div className="cortext-add-field-popover">
+			{ errorMessage ? (
+				<Notice status="error" isDismissible={ false }>
+					{ errorMessage }
+				</Notice>
+			) : null }
+			<TextControl
+				label={ __( 'Name', 'cortext' ) }
+				placeholder={ __( 'Type property name…', 'cortext' ) }
+				value={ title }
+				onChange={ setTitle }
+				onKeyDown={ ( event ) => {
+					if ( event.key === 'Enter' && ! isBusy ) {
+						event.preventDefault();
+						submit( 'text' );
+					}
+				} }
+				disabled={ isBusy }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			<div className="cortext-add-field-popover__type-section">
+				<span className="cortext-add-field-popover__section-title">
+					{ __( 'Type', 'cortext' ) }
+				</span>
+				<div className="cortext-add-field-popover__type-grid">
+					{ FIELD_TYPES.map( ( option ) => (
+						<button
+							key={ option.value }
+							type="button"
+							className="cortext-add-field-popover__type-button"
+							onClick={ () => submit( option.value ) }
+							disabled={ isBusy }
+						>
+							<Icon
+								icon={ option.icon }
+								className="cortext-add-field-popover__type-icon"
+							/>
+							<span>{ option.label }</span>
+						</button>
+					) ) }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -94,8 +94,7 @@ export default function ColumnHeaderActions( { collectionId } ) {
 					return next;
 				}
 				const same = prev.every(
-					( t, i ) =>
-						t.key === next[ i ].key && t.th === next[ i ].th
+					( t, i ) => t.key === next[ i ].key && t.th === next[ i ].th
 				);
 				return same ? prev : next;
 			} );

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -1,0 +1,266 @@
+/* global MutationObserver */
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Dropdown,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import {
+	createPortal,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { moreVertical, plus } from '@wordpress/icons';
+
+import AddFieldPopover from './AddFieldPopover';
+import RenameFieldInline from './RenameFieldInline';
+import {
+	useDeleteField,
+	useDuplicateField,
+} from '../../hooks/useFieldMutations';
+
+// Projects two kinds of triggers into the DataViews table header:
+//
+// - `[data-cortext-field-marker="<recordId>"]` — kebab menu (Rename /
+//   Duplicate / Delete) for custom fields, sibling to DataViews'
+//   built-in column-header trigger and `DataViewColumnInteractions`'
+//   resize/reorder handles.
+// - `[data-cortext-add-field-marker]` — `+` button on the ghost column
+//   that opens the same `AddFieldPopover` as the toolbar Add field
+//   trigger.
+//
+// Renders an invisible anchor element so the component finds its own
+// position in DOM and walks up to the wrapping `.cortext-data-view`.
+// A MutationObserver re-syncs portals whenever DataViews mutates its
+// header markup (column toggles, sorting, resizing).
+export default function ColumnHeaderActions( { collectionId } ) {
+	const anchorRef = useRef( null );
+	const [ targets, setTargets ] = useState( [] );
+
+	useEffect( () => {
+		const anchor = anchorRef.current;
+		if ( ! anchor ) {
+			return undefined;
+		}
+		const wrapper = anchor.closest( '.cortext-data-view' );
+		if ( ! wrapper ) {
+			return undefined;
+		}
+
+		const sync = () => {
+			const next = [];
+			wrapper
+				.querySelectorAll( '[data-cortext-field-marker]' )
+				.forEach( ( marker ) => {
+					const th = marker.closest( 'th' );
+					if ( ! th ) {
+						return;
+					}
+					const recordId = Number(
+						marker.getAttribute( 'data-cortext-field-marker' )
+					);
+					if ( ! Number.isFinite( recordId ) || recordId <= 0 ) {
+						return;
+					}
+					next.push( {
+						key: `field-${ recordId }`,
+						kind: 'field',
+						recordId,
+						th,
+					} );
+				} );
+			wrapper
+				.querySelectorAll( '[data-cortext-add-field-marker]' )
+				.forEach( ( marker ) => {
+					const th = marker.closest( 'th' );
+					if ( ! th ) {
+						return;
+					}
+					next.push( {
+						key: 'add-field',
+						kind: 'add',
+						th,
+					} );
+				} );
+
+			setTargets( ( prev ) => {
+				if ( prev.length !== next.length ) {
+					return next;
+				}
+				const same = prev.every(
+					( t, i ) =>
+						t.key === next[ i ].key && t.th === next[ i ].th
+				);
+				return same ? prev : next;
+			} );
+		};
+
+		sync();
+		const observer = new MutationObserver( sync );
+		observer.observe( wrapper, { childList: true, subtree: true } );
+		return () => observer.disconnect();
+	}, [] );
+
+	return (
+		<>
+			<span
+				ref={ anchorRef }
+				className="cortext-column-header-actions-anchor"
+				aria-hidden="true"
+			/>
+			{ targets.map( ( target ) => {
+				if ( target.kind === 'field' ) {
+					return createPortal(
+						<FieldActions
+							recordId={ target.recordId }
+							collectionId={ collectionId }
+						/>,
+						target.th,
+						target.key
+					);
+				}
+				return createPortal(
+					<AddFieldTrigger collectionId={ collectionId } />,
+					target.th,
+					target.key
+				);
+			} ) }
+		</>
+	);
+}
+
+function stopBubble( event ) {
+	event.stopPropagation();
+}
+
+function FieldActions( { recordId, collectionId } ) {
+	const [ isRenaming, setIsRenaming ] = useState( false );
+	const [ confirmDelete, setConfirmDelete ] = useState( false );
+	const duplicate = useDuplicateField( collectionId );
+	const remove = useDeleteField( collectionId );
+
+	const onConfirmDelete = useCallback( async () => {
+		try {
+			await remove.run( recordId );
+		} finally {
+			setConfirmDelete( false );
+		}
+	}, [ remove, recordId ] );
+
+	if ( isRenaming ) {
+		return (
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+			<span
+				className="cortext-column-header-actions"
+				onClick={ stopBubble }
+				onPointerDown={ stopBubble }
+			>
+				<RenameFieldInline
+					recordId={ recordId }
+					onDone={ () => setIsRenaming( false ) }
+				/>
+			</span>
+		);
+	}
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<span
+			className="cortext-column-header-actions"
+			onClick={ stopBubble }
+			onPointerDown={ stopBubble }
+		>
+			<DropdownMenu
+				icon={ moreVertical }
+				label={ __( 'Field actions', 'cortext' ) }
+				className="cortext-column-header-actions__trigger"
+				toggleProps={ { size: 'small' } }
+			>
+				{ ( { onClose } ) => (
+					<MenuGroup>
+						<MenuItem
+							onClick={ () => {
+								onClose();
+								setIsRenaming( true );
+							} }
+						>
+							{ __( 'Rename', 'cortext' ) }
+						</MenuItem>
+						<MenuItem
+							onClick={ async () => {
+								onClose();
+								try {
+									await duplicate.run( recordId );
+								} catch {
+									// surfaced via duplicate.error.
+								}
+							} }
+						>
+							{ __( 'Duplicate', 'cortext' ) }
+						</MenuItem>
+						<MenuItem
+							isDestructive
+							onClick={ () => {
+								onClose();
+								setConfirmDelete( true );
+							} }
+						>
+							{ __( 'Delete', 'cortext' ) }
+						</MenuItem>
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+			{ confirmDelete ? (
+				<ConfirmDialog
+					onConfirm={ onConfirmDelete }
+					onCancel={ () => setConfirmDelete( false ) }
+					confirmButtonText={ __( 'Delete', 'cortext' ) }
+				>
+					{ __(
+						'Delete this field? Existing values for this field will be removed from every entry.',
+						'cortext'
+					) }
+				</ConfirmDialog>
+			) : null }
+		</span>
+	);
+}
+
+function AddFieldTrigger( { collectionId } ) {
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<span
+			className="cortext-column-header-actions cortext-column-header-actions--add"
+			onClick={ stopBubble }
+			onPointerDown={ stopBubble }
+		>
+			<Dropdown
+				contentClassName="cortext-data-view-toolbar-popover"
+				popoverProps={ { placement: 'bottom-end' } }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<Button
+						icon={ plus }
+						label={ __( 'Add field', 'cortext' ) }
+						size="small"
+						onClick={ onToggle }
+						isPressed={ isOpen }
+					/>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<div className="cortext-data-view-toolbar-popover__content">
+						<AddFieldPopover
+							collectionId={ collectionId }
+							onCreate={ onClose }
+						/>
+					</div>
+				) }
+			/>
+		</span>
+	);
+}

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -8,14 +8,16 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
+import { useEntityRecord } from '@wordpress/core-data';
 import {
 	createPortal,
 	useCallback,
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { moreVertical, plus } from '@wordpress/icons';
+import { plus } from '@wordpress/icons';
 
 import AddFieldPopover from './AddFieldPopover';
 import RenameFieldInline from './RenameFieldInline';
@@ -23,13 +25,18 @@ import {
 	useDeleteField,
 	useDuplicateField,
 } from '../../hooks/useFieldMutations';
+import { GHOST_FIELD_ID, TITLE_FIELD_ID } from '../dataViewColumns';
 
 // Projects two kinds of triggers into the DataViews table header:
 //
-// - `[data-cortext-field-marker="<recordId>"]` — kebab menu (Rename /
-//   Duplicate / Delete) for custom fields, sibling to DataViews'
-//   built-in column-header trigger and `DataViewColumnInteractions`'
-//   resize/reorder handles.
+// - `[data-cortext-field-marker="<recordId>"]` — combined column-header
+//   dropdown for custom fields. Replaces DataViews' built-in trigger
+//   (hidden via CSS, see `tech-debt.md#16`) with a single menu owning
+//   Sort / Move / Hide *plus* Rename / Duplicate / Delete. The marker
+//   sits inside DataViews' (hidden) trigger and serves only as a portal
+//   anchor; the actual button is rendered as a sibling of the trigger,
+//   inheriting the same class so main's drag handle click-forward
+//   resolves to it.
 // - `[data-cortext-add-field-marker]` — `+` button on the ghost column
 //   that opens the same `AddFieldPopover` as the toolbar Add field
 //   trigger.
@@ -38,7 +45,11 @@ import {
 // position in DOM and walks up to the wrapping `.cortext-data-view`.
 // A MutationObserver re-syncs portals whenever DataViews mutates its
 // header markup (column toggles, sorting, resizing).
-export default function ColumnHeaderActions( { collectionId } ) {
+export default function ColumnHeaderActions( {
+	collectionId,
+	view,
+	onChangeView,
+} ) {
 	const anchorRef = useRef( null );
 	const [ targets, setTargets ] = useState( [] );
 
@@ -118,6 +129,8 @@ export default function ColumnHeaderActions( { collectionId } ) {
 						<FieldActions
 							recordId={ target.recordId }
 							collectionId={ collectionId }
+							view={ view }
+							onChangeView={ onChangeView }
 						/>,
 						target.th,
 						target.key
@@ -137,11 +150,81 @@ function stopBubble( event ) {
 	event.stopPropagation();
 }
 
-function FieldActions( { recordId, collectionId } ) {
+function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 	const [ isRenaming, setIsRenaming ] = useState( false );
 	const [ confirmDelete, setConfirmDelete ] = useState( false );
 	const duplicate = useDuplicateField( collectionId );
 	const remove = useDeleteField( collectionId );
+	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
+
+	const dataViewId = `field-${ recordId }`;
+	const label =
+		record?.title?.raw || record?.title?.rendered || `#${ recordId }`;
+	const visibleFields = useMemo(
+		() => ( Array.isArray( view?.fields ) ? view.fields : [] ),
+		[ view ]
+	);
+	const sortField = view?.sort?.field ?? null;
+	const sortDirection = view?.sort?.direction ?? null;
+	const isSorted = sortField === dataViewId;
+
+	// Title is pinned at index 0 (PR A's normalizeView) and the ghost
+	// column at the end. Move only operates on the data-field region in
+	// between, so a sideways swap can't displace either.
+	const movableFields = useMemo(
+		() =>
+			visibleFields.filter(
+				( id ) => id !== TITLE_FIELD_ID && id !== GHOST_FIELD_ID
+			),
+		[ visibleFields ]
+	);
+	const movableIndex = movableFields.indexOf( dataViewId );
+	const canMoveLeft = movableIndex > 0;
+	const canMoveRight =
+		movableIndex >= 0 && movableIndex < movableFields.length - 1;
+
+	const dispatchSort = useCallback(
+		( direction ) => {
+			onChangeView( {
+				...view,
+				sort: { field: dataViewId, direction },
+			} );
+		},
+		[ onChangeView, view, dataViewId ]
+	);
+
+	const dispatchMove = useCallback(
+		( delta ) => {
+			const order = movableFields.slice();
+			const from = order.indexOf( dataViewId );
+			if ( from < 0 ) {
+				return;
+			}
+			const to = from + delta;
+			if ( to < 0 || to >= order.length ) {
+				return;
+			}
+			order.splice( from, 1 );
+			order.splice( to, 0, dataViewId );
+			// Re-stitch with title first and ghost last so neither can
+			// be displaced by a sideways swap.
+			const ordered = [];
+			if ( visibleFields.includes( TITLE_FIELD_ID ) ) {
+				ordered.push( TITLE_FIELD_ID );
+			}
+			ordered.push( ...order );
+			if ( visibleFields.includes( GHOST_FIELD_ID ) ) {
+				ordered.push( GHOST_FIELD_ID );
+			}
+			onChangeView( { ...view, fields: ordered } );
+		},
+		[ onChangeView, view, dataViewId, movableFields, visibleFields ]
+	);
+
+	const dispatchHide = useCallback( () => {
+		const next = visibleFields.filter( ( id ) => id !== dataViewId );
+		onChangeView( { ...view, fields: next } );
+	}, [ onChangeView, view, dataViewId, visibleFields ] );
 
 	const onConfirmDelete = useCallback( async () => {
 		try {
@@ -176,48 +259,108 @@ function FieldActions( { recordId, collectionId } ) {
 		>
 			<Dropdown
 				contentClassName="cortext-field-actions-popover"
-				popoverProps={ { placement: 'bottom-end' } }
+				popoverProps={ { placement: 'bottom-start' } }
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
-						icon={ moreVertical }
-						size="small"
-						label={ __( 'Field actions', 'cortext' ) }
+						className="dataviews-view-table-header-button cortext-column-header-trigger"
+						variant="tertiary"
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
-					/>
+					>
+						{ label }
+						{ isSorted ? (
+							<span aria-hidden="true">
+								{ sortDirection === 'asc' ? ' ↑' : ' ↓' }
+							</span>
+						) : null }
+					</Button>
 				) }
 				renderContent={ ( { onClose } ) => (
-					<MenuGroup>
-						<MenuItem
-							onClick={ () => {
-								onClose();
-								setIsRenaming( true );
-							} }
-						>
-							{ __( 'Rename', 'cortext' ) }
-						</MenuItem>
-						<MenuItem
-							onClick={ async () => {
-								onClose();
-								try {
-									await duplicate.run( recordId );
-								} catch {
-									// surfaced via duplicate.error.
+					<>
+						<MenuGroup>
+							<MenuItem
+								isSelected={
+									isSorted && sortDirection === 'asc'
 								}
-							} }
-						>
-							{ __( 'Duplicate', 'cortext' ) }
-						</MenuItem>
-						<MenuItem
-							isDestructive
-							onClick={ () => {
-								onClose();
-								setConfirmDelete( true );
-							} }
-						>
-							{ __( 'Delete', 'cortext' ) }
-						</MenuItem>
-					</MenuGroup>
+								onClick={ () => {
+									onClose();
+									dispatchSort( 'asc' );
+								} }
+							>
+								{ __( 'Sort ascending', 'cortext' ) }
+							</MenuItem>
+							<MenuItem
+								isSelected={
+									isSorted && sortDirection === 'desc'
+								}
+								onClick={ () => {
+									onClose();
+									dispatchSort( 'desc' );
+								} }
+							>
+								{ __( 'Sort descending', 'cortext' ) }
+							</MenuItem>
+						</MenuGroup>
+						<MenuGroup>
+							<MenuItem
+								disabled={ ! canMoveLeft }
+								onClick={ () => {
+									onClose();
+									dispatchMove( -1 );
+								} }
+							>
+								{ __( 'Move left', 'cortext' ) }
+							</MenuItem>
+							<MenuItem
+								disabled={ ! canMoveRight }
+								onClick={ () => {
+									onClose();
+									dispatchMove( 1 );
+								} }
+							>
+								{ __( 'Move right', 'cortext' ) }
+							</MenuItem>
+							<MenuItem
+								onClick={ () => {
+									onClose();
+									dispatchHide();
+								} }
+							>
+								{ __( 'Hide column', 'cortext' ) }
+							</MenuItem>
+						</MenuGroup>
+						<MenuGroup>
+							<MenuItem
+								onClick={ () => {
+									onClose();
+									setIsRenaming( true );
+								} }
+							>
+								{ __( 'Rename', 'cortext' ) }
+							</MenuItem>
+							<MenuItem
+								onClick={ async () => {
+									onClose();
+									try {
+										await duplicate.run( recordId );
+									} catch {
+										// surfaced via duplicate.error.
+									}
+								} }
+							>
+								{ __( 'Duplicate', 'cortext' ) }
+							</MenuItem>
+							<MenuItem
+								isDestructive
+								onClick={ () => {
+									onClose();
+									setConfirmDelete( true );
+								} }
+							>
+								{ __( 'Delete', 'cortext' ) }
+							</MenuItem>
+						</MenuGroup>
+					</>
 				) }
 			/>
 			{ confirmDelete ? (

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -63,17 +63,6 @@ export default function ColumnHeaderActions( {
 			return undefined;
 		}
 
-		// Strip DataViews' built-in trigger off any <th> that carries one
-		// of our markers. The combined-dropdown trigger we portal in is
-		// the only column-header button on those cells, so DataViews'
-		// selectors and main's e2e tests count one button per column
-		// either way (tech-debt.md#16).
-		const stripDataViewsTrigger = ( th ) => {
-			th.querySelector(
-				'.dataviews-view-table-header-button:not(.cortext-column-header-trigger)'
-			)?.remove();
-		};
-
 		const sync = () => {
 			const next = [];
 			wrapper
@@ -83,7 +72,6 @@ export default function ColumnHeaderActions( {
 					if ( ! th ) {
 						return;
 					}
-					stripDataViewsTrigger( th );
 					const recordId = Number(
 						marker.getAttribute( 'data-cortext-field-marker' )
 					);
@@ -104,7 +92,6 @@ export default function ColumnHeaderActions( {
 					if ( ! th ) {
 						return;
 					}
-					stripDataViewsTrigger( th );
 					next.push( {
 						key: 'add-field',
 						kind: 'add',

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -146,10 +146,6 @@ export default function ColumnHeaderActions( {
 	);
 }
 
-function stopBubble( event ) {
-	event.stopPropagation();
-}
-
 function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 	const [ isRenaming, setIsRenaming ] = useState( false );
 	const [ confirmDelete, setConfirmDelete ] = useState( false );
@@ -236,12 +232,7 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 
 	if ( isRenaming ) {
 		return (
-			// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-			<span
-				className="cortext-column-header-actions"
-				onClick={ stopBubble }
-				onPointerDown={ stopBubble }
-			>
+			<span className="cortext-column-header-actions">
 				<RenameFieldInline
 					recordId={ recordId }
 					onDone={ () => setIsRenaming( false ) }
@@ -251,12 +242,7 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 	}
 
 	return (
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-		<span
-			className="cortext-column-header-actions"
-			onClick={ stopBubble }
-			onPointerDown={ stopBubble }
-		>
+		<span className="cortext-column-header-actions">
 			<Dropdown
 				contentClassName="cortext-field-actions-popover"
 				popoverProps={ { placement: 'bottom-start' } }
@@ -267,7 +253,9 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
 					>
-						{ label }
+						<span className="cortext-column-header-label">
+							{ label }
+						</span>
 						{ isSorted ? (
 							<span aria-hidden="true">
 								{ sortDirection === 'asc' ? ' ↑' : ' ↓' }
@@ -381,12 +369,7 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 
 function AddFieldTrigger( { collectionId } ) {
 	return (
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-		<span
-			className="cortext-column-header-actions cortext-column-header-actions--add"
-			onClick={ stopBubble }
-			onPointerDown={ stopBubble }
-		>
+		<span className="cortext-column-header-actions cortext-column-header-actions--add">
 			<Dropdown
 				contentClassName="cortext-data-view-toolbar-popover"
 				popoverProps={ { placement: 'bottom-end' } }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -3,7 +3,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	Dropdown,
-	DropdownMenu,
 	MenuGroup,
 	MenuItem,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -175,13 +174,19 @@ function FieldActions( { recordId, collectionId } ) {
 			onClick={ stopBubble }
 			onPointerDown={ stopBubble }
 		>
-			<DropdownMenu
-				icon={ moreVertical }
-				label={ __( 'Field actions', 'cortext' ) }
-				className="cortext-column-header-actions__trigger"
-				toggleProps={ { size: 'small' } }
-			>
-				{ ( { onClose } ) => (
+			<Dropdown
+				contentClassName="cortext-field-actions-popover"
+				popoverProps={ { placement: 'bottom-end' } }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<Button
+						icon={ moreVertical }
+						size="small"
+						label={ __( 'Field actions', 'cortext' ) }
+						onClick={ onToggle }
+						aria-expanded={ isOpen }
+					/>
+				) }
+				renderContent={ ( { onClose } ) => (
 					<MenuGroup>
 						<MenuItem
 							onClick={ () => {
@@ -214,7 +219,7 @@ function FieldActions( { recordId, collectionId } ) {
 						</MenuItem>
 					</MenuGroup>
 				) }
-			</DropdownMenu>
+			/>
 			{ confirmDelete ? (
 				<ConfirmDialog
 					onConfirm={ onConfirmDelete }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -63,6 +63,17 @@ export default function ColumnHeaderActions( {
 			return undefined;
 		}
 
+		// Strip DataViews' built-in trigger off any <th> that carries one
+		// of our markers. The combined-dropdown trigger we portal in is
+		// the only column-header button on those cells, so DataViews'
+		// selectors and main's e2e tests count one button per column
+		// either way (tech-debt.md#16).
+		const stripDataViewsTrigger = ( th ) => {
+			th.querySelector(
+				'.dataviews-view-table-header-button:not(.cortext-column-header-trigger)'
+			)?.remove();
+		};
+
 		const sync = () => {
 			const next = [];
 			wrapper
@@ -72,6 +83,7 @@ export default function ColumnHeaderActions( {
 					if ( ! th ) {
 						return;
 					}
+					stripDataViewsTrigger( th );
 					const recordId = Number(
 						marker.getAttribute( 'data-cortext-field-marker' )
 					);
@@ -92,6 +104,7 @@ export default function ColumnHeaderActions( {
 					if ( ! th ) {
 						return;
 					}
+					stripDataViewsTrigger( th );
 					next.push( {
 						key: 'add-field',
 						kind: 'add',

--- a/src/components/fields/RenameFieldInline.js
+++ b/src/components/fields/RenameFieldInline.js
@@ -1,0 +1,68 @@
+import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+import { useEntityRecord } from '@wordpress/core-data';
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+import { useRenameField } from '../../hooks/useFieldMutations';
+
+// Inline rename affordance. Shown in place of the column header label
+// while the user edits; commits on Enter or blur. Reads the current title
+// from core-data so the input starts with the existing value, and reverts
+// (closes without saving) on Escape.
+export default function RenameFieldInline( { recordId, onDone } ) {
+	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
+	const initialTitle = record?.title?.raw ?? record?.title?.rendered ?? '';
+	const [ value, setValue ] = useState( initialTitle );
+	const inputRef = useRef( null );
+	const { run, isBusy } = useRenameField();
+
+	useEffect( () => {
+		setValue( initialTitle );
+	}, [ initialTitle ] );
+
+	useEffect( () => {
+		const node = inputRef.current?.querySelector( 'input' );
+		if ( node ) {
+			node.focus();
+			node.select();
+		}
+	}, [] );
+
+	const commit = async () => {
+		const trimmed = value.trim();
+		if ( ! trimmed || trimmed === initialTitle ) {
+			onDone?.();
+			return;
+		}
+		try {
+			await run( recordId, trimmed );
+		} catch {
+			// Caller hasn't observed an error path; revert UI state and
+			// let the user retry from the kebab again.
+		}
+		onDone?.();
+	};
+
+	return (
+		<span ref={ inputRef } className="cortext-rename-field-inline">
+			<TextControl
+				value={ value }
+				onChange={ setValue }
+				onKeyDown={ ( event ) => {
+					if ( event.key === 'Enter' ) {
+						event.preventDefault();
+						commit();
+					} else if ( event.key === 'Escape' ) {
+						event.preventDefault();
+						onDone?.();
+					}
+				} }
+				onBlur={ commit }
+				disabled={ isBusy }
+				aria-label={ __( 'Field name', 'cortext' ) }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+		</span>
+	);
+}

--- a/src/hooks/fieldIds.js
+++ b/src/hooks/fieldIds.js
@@ -1,0 +1,44 @@
+// ID converters between the three forms in play across the block:
+//
+// - DataViews row/meta keys: `field-<id>` for custom fields; `title`,
+//   `created_at`, `created_by`, `modified_at`, `modified_by` for the
+//   non-custom columns; `__add_field` for the ghost column.
+// - Field record IDs in REST routes: numeric post IDs.
+// - Collection `meta.fields` storage: stringified post IDs (the meta is
+//   `'type' => 'string', 'single' => false` server-side).
+//
+// `toRecordId` is the gate the management UI calls before offering rename /
+// duplicate / delete — non-custom columns return null and the UI hides the
+// schema action affordance for them.
+
+const FIELD_PREFIX = 'field-';
+
+export function toRecordId( dataViewId ) {
+	if ( typeof dataViewId !== 'string' ) {
+		return null;
+	}
+	if ( ! dataViewId.startsWith( FIELD_PREFIX ) ) {
+		return null;
+	}
+	const tail = dataViewId.slice( FIELD_PREFIX.length );
+	if ( ! /^\d+$/.test( tail ) ) {
+		return null;
+	}
+	return Number( tail );
+}
+
+export function toDataViewId( recordId ) {
+	const id = Number( recordId );
+	if ( ! Number.isFinite( id ) || id <= 0 ) {
+		return null;
+	}
+	return `${ FIELD_PREFIX }${ id }`;
+}
+
+export function toMetaFieldsString( recordId ) {
+	const id = Number( recordId );
+	if ( ! Number.isFinite( id ) || id <= 0 ) {
+		return null;
+	}
+	return String( id );
+}

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -153,13 +153,14 @@ export function mapField( field ) {
 	const base = {
 		id,
 		label,
-		// Header content includes the label and a non-interactive marker
-		// span. `ColumnHeaderActions` queries the DOM for the marker and
-		// portals a sibling action button next to DataViews' built-in
-		// header trigger. The marker itself is aria-hidden and zero-size.
+		// Header content is just an aria-hidden marker.
+		// `ColumnHeaderActions` queries the DOM for it and portals our
+		// combined-dropdown trigger into the owning <th>; DataViews'
+		// built-in trigger is hidden via CSS on marker-bearing columns
+		// (tech-debt.md#16). Skipping the label here avoids leaking
+		// duplicate text into the th's accessible/text content.
 		header: (
 			<HeaderLabel>
-				{ label }
 				<span
 					className="cortext-column-header-marker"
 					data-cortext-field-marker={ field.id }

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -149,7 +149,20 @@ export function mapField( field ) {
 	const base = {
 		id,
 		label,
-		header: <HeaderLabel>{ label }</HeaderLabel>,
+		// Header content includes the label and a non-interactive marker
+		// span. `ColumnHeaderActions` queries the DOM for the marker and
+		// portals a sibling action button next to DataViews' built-in
+		// header trigger. The marker itself is aria-hidden and zero-size.
+		header: (
+			<HeaderLabel>
+				{ label }
+				<span
+					className="cortext-column-header-marker"
+					data-cortext-field-marker={ field.id }
+					aria-hidden="true"
+				/>
+			</HeaderLabel>
+		),
 		getValue: ( { item } ) => item?.meta?.[ id ] ?? null,
 		render: buildRender( id, type, label, elements ),
 		editable: EDITABLE_TYPES.has( type ),

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -143,7 +143,11 @@ export function systemFields() {
 
 export function mapField( field ) {
 	const id = `field-${ field.id }`;
-	const label = field.title?.rendered || field.title?.raw || `#${ field.id }`;
+	// Prefer `title.raw` over `title.rendered`: the latter has the
+	// `the_title` filter applied (wptexturize, entity encoding), which
+	// turns `&` into `&#038;`. We render the label as a JSX text child
+	// (auto-escaped by React), so the entity layer is unwanted noise.
+	const label = field.title?.raw || field.title?.rendered || `#${ field.id }`;
 	const type = field.meta?.type ?? 'text';
 	const elements = elementsFromOptions( field.meta?.options );
 	const base = {

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -23,11 +23,8 @@ export function buildFieldListQuery( fieldIds ) {
 // of `crtxt_field` post IDs in display order. Fetch those records, then
 // map each to a DataViews field. Row meta keys are `field-<post_id>`.
 export default function useCollectionFields( collectionId ) {
-	const { record: collection } = useEntityRecord(
-		'postType',
-		'crtxt_collection',
-		collectionId ?? 0
-	);
+	const { record: collection, isResolving: collectionResolving } =
+		useEntityRecord( 'postType', 'crtxt_collection', collectionId ?? 0 );
 
 	const fieldIds = useMemo( () => {
 		const raw = collection?.meta?.fields;
@@ -62,10 +59,14 @@ export default function useCollectionFields( collectionId ) {
 		return [ ...custom, ...systemFields() ];
 	}, [ fieldRecords ] );
 
-	// `isResolving` only flips true while we have no collection at all —
-	// i.e., the very first render or a fresh collection switch. core-data
-	// keeps cached records visible during refetches, so an invalidation
-	// after a mutation doesn't strand the UI on the loading spinner.
+	// `isResolving` flips true only while we're actively fetching AND
+	// have no record yet. After a 404 (resolution finishes with no
+	// collection) `collectionResolving` flips back to false, so the
+	// consumer can fall through to the invalid-collection notice
+	// instead of spinning forever. During a refetch (after a mutation)
+	// the cached collection stays truthy, so the spinner doesn't
+	// flash even though the resolver briefly enters the resolving
+	// state.
 	//
 	// `fieldsResolved` lets the view-sync wait for authoritative field
 	// data before running. During a refetch (e.g., after creating a
@@ -96,7 +97,8 @@ export default function useCollectionFields( collectionId ) {
 		fields,
 		collection: collection ?? null,
 		slug: collection?.meta?.slug ?? null,
-		isResolving: Boolean( collectionId ) && ! collection,
+		isResolving:
+			Boolean( collectionId ) && ! collection && collectionResolving,
 		fieldsResolved: fieldsResolvedFlag,
 	};
 }

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -78,36 +78,43 @@ export default function useCollectionFields( collectionId ) {
 			? Boolean( collection )
 			: ! fieldsResolving && Boolean( fieldsResolved );
 
-	// Latch the last authoritative `fields` snapshot. When the user
-	// adds or deletes a field, `meta.fields` changes, the
-	// `useEntityRecords` query gets a new `include`, and the records
-	// list briefly returns `null` while that query fetches. Without the
-	// latch, `dataViewFields` would lose every custom column for one or
-	// two render cycles, which DataViews paints as a column collapse
-	// and re-expansion. The ref keeps the previous resolved set visible
-	// until the new resolution lands; `view.fields` only changes once,
-	// atomically, when the new set is ready.
-	const stableFieldsRef = useRef( null );
-	if ( fieldsResolvedFlag ) {
-		stableFieldsRef.current = liveFields;
+	// Latch the last authoritative `fields` snapshot scoped to the
+	// collection that produced it. When the user adds or deletes a
+	// field, `meta.fields` changes, the `useEntityRecords` query gets
+	// a new `include`, and core-data's `hasResolved` flips back to
+	// false until that query settles. Storing the previous fields keeps
+	// `dataViewFields` populated through the transient and lets
+	// `isResolving` stay false (no spinner flash). The collectionId
+	// pairing makes sure a collection switch reverts to the loading
+	// state rather than reusing the previous collection's fields.
+	const stableRef = useRef( { collectionId: null, fields: null } );
+	if ( fieldsResolvedFlag && collectionId ) {
+		stableRef.current = { collectionId, fields: liveFields };
 	}
-	const fields = stableFieldsRef.current ?? liveFields;
+	const hasStableFieldsForCollection =
+		stableRef.current.collectionId === collectionId &&
+		stableRef.current.fields !== null;
+	const fields = hasStableFieldsForCollection
+		? stableRef.current.fields
+		: liveFields;
 
 	return {
 		fields,
 		collection: collection ?? null,
 		slug: collection?.meta?.slug ?? null,
 		// True while either the collection or the field list is still on
-		// its first resolution. Once the collection 404s,
-		// `collectionResolving` flips back to false so the consumer can
-		// fall through to the invalid-collection notice. `fieldsResolved`
-		// is sticky once core-data has resolved at least once, so refetch
-		// transients (e.g., after a mutation) don't flip this back to
-		// true and flash the loading spinner.
+		// its first resolution for this collection. Once we've latched
+		// fields for the current collection (`hasStableFieldsForCollection`),
+		// subsequent refetches (after a mutation that changes the field
+		// list) keep this false so the table doesn't unmount and remount.
+		// The collection 404 path stays handled because
+		// `collectionResolving` flips back to false on resolution failure.
 		isResolving:
 			Boolean( collectionId ) &&
 			( ( ! collection && collectionResolving ) ||
-				( !! collection && fieldIds.length > 0 && ! fieldsResolved ) ),
+				( !! collection &&
+					fieldIds.length > 0 &&
+					! hasStableFieldsForCollection ) ),
 		fieldsResolved: fieldsResolvedFlag,
 	};
 }

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -23,11 +23,11 @@ export function buildFieldListQuery( fieldIds ) {
 // of `crtxt_field` post IDs in display order. Fetch those records, then
 // map each to a DataViews field. Row meta keys are `field-<post_id>`.
 export default function useCollectionFields( collectionId ) {
-	const {
-		record: collection,
-		isResolving: collectionResolving,
-		hasResolved: collectionResolved,
-	} = useEntityRecord( 'postType', 'crtxt_collection', collectionId ?? 0 );
+	const { record: collection } = useEntityRecord(
+		'postType',
+		'crtxt_collection',
+		collectionId ?? 0
+	);
 
 	const fieldIds = useMemo( () => {
 		const raw = collection?.meta?.fields;
@@ -62,15 +62,26 @@ export default function useCollectionFields( collectionId ) {
 		return [ ...custom, ...systemFields() ];
 	}, [ fieldRecords ] );
 
+	// `isResolving` only flips true while we have no collection at all —
+	// i.e., the very first render or a fresh collection switch. core-data
+	// keeps cached records visible during refetches, so an invalidation
+	// after a mutation doesn't strand the UI on the loading spinner.
+	//
+	// `fieldsResolved` lets the view-sync wait for authoritative field
+	// data before running. During a refetch (e.g., after creating a
+	// field) `fieldRecords` briefly returns an empty array; without this
+	// guard the sync would treat all custom fields as "removed" and
+	// strip them from `view.fields`.
+	const fieldsResolvedFlag =
+		fieldIds.length === 0
+			? Boolean( collection )
+			: ! fieldsResolving && Boolean( fieldsResolved );
+
 	return {
 		fields,
 		collection: collection ?? null,
 		slug: collection?.meta?.slug ?? null,
-		isResolving:
-			Boolean( collectionId ) &&
-			( collectionResolving ||
-				! collectionResolved ||
-				( fieldIds.length > 0 &&
-					( fieldsResolving || ! fieldsResolved ) ) ),
+		isResolving: Boolean( collectionId ) && ! collection,
+		fieldsResolved: fieldsResolvedFlag,
 	};
 }

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -1,4 +1,4 @@
-import { useMemo } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 
 import { mapField, systemFields } from './fieldMapping';
@@ -51,7 +51,7 @@ export default function useCollectionFields( collectionId ) {
 		{ enabled: fieldIds.length > 0 }
 	);
 
-	const fields = useMemo( () => {
+	const liveFields = useMemo( () => {
 		const custom = Array.isArray( fieldRecords )
 			? fieldRecords.map( mapField )
 			: [];
@@ -76,6 +76,21 @@ export default function useCollectionFields( collectionId ) {
 		fieldIds.length === 0
 			? Boolean( collection )
 			: ! fieldsResolving && Boolean( fieldsResolved );
+
+	// Latch the last authoritative `fields` snapshot. When the user
+	// adds or deletes a field, `meta.fields` changes, the
+	// `useEntityRecords` query gets a new `include`, and the records
+	// list briefly returns `null` while that query fetches. Without the
+	// latch, `dataViewFields` would lose every custom column for one or
+	// two render cycles, which DataViews paints as a column collapse
+	// and re-expansion. The ref keeps the previous resolved set visible
+	// until the new resolution lands; `view.fields` only changes once,
+	// atomically, when the new set is ready.
+	const stableFieldsRef = useRef( null );
+	if ( fieldsResolvedFlag ) {
+		stableFieldsRef.current = liveFields;
+	}
+	const fields = stableFieldsRef.current ?? liveFields;
 
 	return {
 		fields,

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -3,6 +3,22 @@ import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 
 import { mapField, systemFields } from './fieldMapping';
 
+// Shared field-list query shape. Exported so mutation hooks can invalidate
+// the exact resolver used here without copy-pasting the parameters and
+// drifting out of sync. Does not include `include`, which is per-collection.
+export const FIELD_LIST_QUERY_BASE = {
+	per_page: 100,
+	orderby: 'include',
+	// `crtxt_field` posts are stored as `private`; without an explicit
+	// `status` REST defaults to `publish` and returns zero rows.
+	status: [ 'draft', 'private', 'publish' ],
+	context: 'edit',
+};
+
+export function buildFieldListQuery( fieldIds ) {
+	return { include: fieldIds, ...FIELD_LIST_QUERY_BASE };
+}
+
 // Reads a collection's fields from main's contract: `meta.fields` is an array
 // of `crtxt_field` post IDs in display order. Fetch those records, then
 // map each to a DataViews field. Row meta keys are `field-<post_id>`.
@@ -28,16 +44,7 @@ export default function useCollectionFields( collectionId ) {
 	} = useEntityRecords(
 		'postType',
 		'crtxt_field',
-		{
-			include: fieldIds,
-			per_page: 100,
-			orderby: 'include',
-			// `crtxt_field` posts are stored as `private`; without an
-			// explicit `status` REST defaults to `publish` and returns
-			// zero rows.
-			status: [ 'draft', 'private', 'publish' ],
-			context: 'edit',
-		},
+		buildFieldListQuery( fieldIds ),
 		// Skip the resolver when there are no IDs to look up. Passing
 		// `undefined`/`{}` would fall through to a default empty query,
 		// which fetches every `crtxt_field` in the system.

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -97,8 +97,17 @@ export default function useCollectionFields( collectionId ) {
 		fields,
 		collection: collection ?? null,
 		slug: collection?.meta?.slug ?? null,
+		// True while either the collection or the field list is still on
+		// its first resolution. Once the collection 404s,
+		// `collectionResolving` flips back to false so the consumer can
+		// fall through to the invalid-collection notice. `fieldsResolved`
+		// is sticky once core-data has resolved at least once, so refetch
+		// transients (e.g., after a mutation) don't flip this back to
+		// true and flash the loading spinner.
 		isResolving:
-			Boolean( collectionId ) && ! collection && collectionResolving,
+			Boolean( collectionId ) &&
+			( ( ! collection && collectionResolving ) ||
+				( !! collection && fieldIds.length > 0 && ! fieldsResolved ) ),
 		fieldsResolved: fieldsResolvedFlag,
 	};
 }

--- a/src/hooks/useFieldMutations.js
+++ b/src/hooks/useFieldMutations.js
@@ -25,18 +25,15 @@ function useFieldListInvalidation() {
 	const { invalidateResolution } = useDispatch( 'core' );
 	return useCallback(
 		( collectionId ) => {
+			// Invalidate the collection record only. After it refetches,
+			// `meta.fields` carries the new ID and `useCollectionFields`
+			// passes a different `include` to `useEntityRecords`. That
+			// new query is uncached, so the field list refetches without
+			// us touching the (impossible-to-target) old resolver.
 			invalidateResolution( 'getEntityRecord', [
 				'postType',
 				'crtxt_collection',
 				collectionId,
-			] );
-			// We can't predict the exact `include` shape of every active
-			// `useCollectionFields` resolver, so invalidate the whole
-			// `crtxt_field` records map. Cheap enough — the resolver
-			// re-fetches on next render.
-			invalidateResolution( 'getEntityRecords', [
-				'postType',
-				'crtxt_field',
 			] );
 		},
 		[ invalidateResolution ]

--- a/src/hooks/useFieldMutations.js
+++ b/src/hooks/useFieldMutations.js
@@ -1,0 +1,174 @@
+import { useCallback, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+// Field mutation hooks. Each hook returns `{ run, isBusy, error }`. UI
+// callers always pass numeric record IDs; conversion from DataViews row
+// keys (`field-<id>`) lives in `fieldIds.js` to keep ID handling honest.
+//
+// Create and duplicate go through atomic Cortext routes so the field post
+// and its attachment to the collection succeed or fail together. Rename
+// uses core-data's `saveEntityRecord` so the cached `useEntityRecords`
+// resolver in `useCollectionFields` re-renders without manual list
+// invalidation. Delete uses `deleteEntityRecord`; the server-side
+// `before_delete_post` hook in `CollectionEntries` handles entry-meta
+// cleanup, and the collection record is invalidated so its `meta.fields`
+// refreshes.
+
+function useMutationState() {
+	const [ isBusy, setIsBusy ] = useState( false );
+	const [ error, setError ] = useState( null );
+	return { isBusy, setIsBusy, error, setError };
+}
+
+function useFieldListInvalidation() {
+	const { invalidateResolution } = useDispatch( 'core' );
+	return useCallback(
+		( collectionId ) => {
+			invalidateResolution( 'getEntityRecord', [
+				'postType',
+				'crtxt_collection',
+				collectionId,
+			] );
+			// We can't predict the exact `include` shape of every active
+			// `useCollectionFields` resolver, so invalidate the whole
+			// `crtxt_field` records map. Cheap enough — the resolver
+			// re-fetches on next render.
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				'crtxt_field',
+			] );
+		},
+		[ invalidateResolution ]
+	);
+}
+
+export function useCreateField( collectionId ) {
+	const { isBusy, setIsBusy, error, setError } = useMutationState();
+	const invalidate = useFieldListInvalidation();
+	const run = useCallback(
+		async ( { title, type, options } ) => {
+			setIsBusy( true );
+			setError( null );
+			try {
+				const data = { title, type };
+				if ( options !== undefined ) {
+					data.options = options;
+				}
+				const result = await apiFetch( {
+					path: `/cortext/v1/collections/${ collectionId }/fields`,
+					method: 'POST',
+					data,
+				} );
+				invalidate( collectionId );
+				return result;
+			} catch ( apiError ) {
+				setError( apiError );
+				throw apiError;
+			} finally {
+				setIsBusy( false );
+			}
+		},
+		[ collectionId, invalidate, setIsBusy, setError ]
+	);
+	return { run, isBusy, error };
+}
+
+export function useDuplicateField( collectionId ) {
+	const { isBusy, setIsBusy, error, setError } = useMutationState();
+	const invalidate = useFieldListInvalidation();
+	const run = useCallback(
+		async ( sourceRecordId ) => {
+			setIsBusy( true );
+			setError( null );
+			try {
+				const result = await apiFetch( {
+					path: `/cortext/v1/collections/${ collectionId }/fields/${ sourceRecordId }/duplicate`,
+					method: 'POST',
+				} );
+				invalidate( collectionId );
+				return result;
+			} catch ( apiError ) {
+				setError( apiError );
+				throw apiError;
+			} finally {
+				setIsBusy( false );
+			}
+		},
+		[ collectionId, invalidate, setIsBusy, setError ]
+	);
+	return { run, isBusy, error };
+}
+
+export function useRenameField() {
+	const { saveEntityRecord } = useDispatch( 'core' );
+	const { isBusy, setIsBusy, error, setError } = useMutationState();
+	const run = useCallback(
+		async ( recordId, title ) => {
+			setIsBusy( true );
+			setError( null );
+			try {
+				const saved = await saveEntityRecord(
+					'postType',
+					'crtxt_field',
+					{ id: recordId, title }
+				);
+				if ( ! saved ) {
+					throw new Error( 'cortext_rename_failed' );
+				}
+				return saved;
+			} catch ( apiError ) {
+				setError( apiError );
+				throw apiError;
+			} finally {
+				setIsBusy( false );
+			}
+		},
+		[ saveEntityRecord, setIsBusy, setError ]
+	);
+	return { run, isBusy, error };
+}
+
+export function useDeleteField( collectionId ) {
+	const { deleteEntityRecord, invalidateResolution } = useDispatch( 'core' );
+	const { isBusy, setIsBusy, error, setError } = useMutationState();
+	const run = useCallback(
+		async ( recordId ) => {
+			setIsBusy( true );
+			setError( null );
+			try {
+				const result = await deleteEntityRecord(
+					'postType',
+					'crtxt_field',
+					recordId,
+					{ force: true }
+				);
+				if ( ! result ) {
+					throw new Error( 'cortext_delete_failed' );
+				}
+				// The server `before_delete_post` hook removed the field's
+				// string ID from the collection's `meta.fields`; refetch the
+				// collection so the local view reflects that.
+				invalidateResolution( 'getEntityRecord', [
+					'postType',
+					'crtxt_collection',
+					collectionId,
+				] );
+				return result;
+			} catch ( apiError ) {
+				setError( apiError );
+				throw apiError;
+			} finally {
+				setIsBusy( false );
+			}
+		},
+		[
+			collectionId,
+			deleteEntityRecord,
+			invalidateResolution,
+			setIsBusy,
+			setError,
+		]
+	);
+	return { run, isBusy, error };
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -491,6 +491,16 @@ th:has(.cortext-column-header-marker)
 	display: none;
 }
 
+// `DataViewColumnInteractions` portals a transparent drag handle over
+// each <th> with `z-index: 1`, which intercepts pointer events and
+// keeps `.dataviews-view-table-header-button:hover` from ever firing.
+// Hang the hover state off the <th> instead so the cell as a whole
+// reads as a clickable affordance (and the gray shows through any
+// transparent overlay above it).
+.cortext-data-view .dataviews-view-table thead > tr > th:hover {
+	background-color: $gray-100;
+}
+
 .cortext-column-header-actions {
 	display: inline-flex;
 	align-items: center;
@@ -782,6 +792,7 @@ th:has(.cortext-column-header-marker)
 		// every cell hovers edge-to-edge regardless of content length. The
 		// min/max reset also overrides DataViews's upstream 15ch floor, which
 		// otherwise lets narrow resized columns paint into their neighbors.
+		/* stylelint-disable-next-line no-descending-specificity */
 		tbody .dataviews-view-table__cell-content-wrapper {
 			box-sizing: border-box;
 			width: 100%;
@@ -826,14 +837,18 @@ th:has(.cortext-column-header-marker)
 
 // tech-debt.md#15: The resizer and dnd-kit drag handle are portaled into each
 // `<th>` rendered by `@wordpress/dataviews`, so the th needs a position anchor.
+/* stylelint-disable-next-line no-descending-specificity */
 .cortext-data-view .dataviews-view-table thead > tr > th {
 	position: relative;
-	cursor: grab;
+	cursor: pointer;
 
 	// The library renders the column label as a button that fills the th
-	// and brings its own `cursor: pointer`. Override so the entire header
-	// reads as draggable. The resizer's `cursor: col-resize` (below) wins
-	// at the right edge because the resizer overlays the th.
+	// and brings its own `cursor: pointer`. Inherit the th's pointer so
+	// the entire header (including the drag handle overlay) reads as
+	// clickable — the dropdown is the primary affordance; drag still
+	// works via mousedown on the drag handle. The resizer's
+	// `cursor: col-resize` (below) wins at the right edge.
+	/* stylelint-disable-next-line no-descending-specificity */
 	.dataviews-view-table-header-button {
 		cursor: inherit;
 		max-width: 100%;

--- a/src/index.scss
+++ b/src/index.scss
@@ -501,6 +501,25 @@ th:has(.cortext-column-header-marker)
 	background-color: $gray-100;
 }
 
+// DataViews' :has(...) overrides only narrow the th padding-left on
+// non-first-child header cells (4px in default density, 0 in compact).
+// With `table-layout: auto` the column shrinks to match the th, but
+// our `table-layout: fixed` (above) sets the column to `max(th, td)`
+// of `width + padding`, so a td with full padding-left forces the
+// whole column wider than the th. Mirror the th's padding-left on the
+// tds so column widths follow the header.
+.cortext-data-view
+.dataviews-view-table
+tbody > tr > td:not(:first-child) {
+	padding-left: 4px;
+}
+
+.cortext-data-view
+.dataviews-view-table.has-compact-density
+tbody > tr > td:not(:first-child) {
+	padding-left: 0;
+}
+
 .cortext-column-header-actions {
 	display: inline-flex;
 	align-items: center;

--- a/src/index.scss
+++ b/src/index.scss
@@ -432,16 +432,21 @@ body.cortext-fullscreen {
 // DataViews ships a `table-layout: auto; width: 100%` table. Auto
 // layout sizes each column based on the content of every column, so
 // adding or deleting a field reflows every existing column. Switch
-// to fixed layout with explicit per-cell widths so the column count
-// stops affecting the surviving columns' widths. The table is
-// content-sized (`width: max-content`); the wrapper
-// (.dataviews-wrapper) already has `overflow: auto`, so horizontal
-// scroll engages once the total column width exceeds the container.
-// Any leftover wrapper space sits to the right of the `+` ghost
-// column — same shape as Notion's table.
+// to fixed layout with content-width sizing and explicit per-cell
+// widths, so column count stops affecting the surviving columns'
+// widths and the table grows to its natural content width.
+// `.dataviews-wrapper` already has `overflow: auto`, so horizontal
+// scroll kicks in once columns exceed the wrapper.
 .dataviews-view-table {
 	table-layout: fixed;
 	width: max-content;
+	// Mirror DataViews' inter-row separator under the last row, so the
+	// table has a clean visual end before the "+ New" footer button.
+	// Putting the border on the table (rather than the wrapper or the
+	// footer) keeps it pinned to the table's content width — narrower
+	// than the wrapper when columns fit, scrolling with the rest when
+	// they don't.
+	border-bottom: $border-width solid $gray-200;
 }
 
 .dataviews-view-table th,
@@ -456,16 +461,16 @@ body.cortext-fullscreen {
 	width: 280px;
 }
 
-// The trailing ghost column hosts only the `+ add field` trigger.
-// Keep it slim so the `+` sits right next to the last data column.
-// DataViews forces `min-width: 15ch` on
-// `.dataviews-view-table__cell-content-wrapper` and adds
-// `padding-inline-end: 24px` on the last cell — both override our
-// width unless we collapse them.
-.dataviews-view-table th:last-child,
-.dataviews-view-table td:last-child {
+// Ghost column is just the `+` icon button. DataViews uses
+// `.dataviews-view-table tr td:last-child { padding-right: 48px }`
+// for the last column, plus `min-width: 15ch` on the cell content
+// wrapper. Match DataViews' selector specificity so our overrides
+// win, then size the column to the button's natural width with a
+// tight right padding.
+.dataviews-view-table tr th:last-child,
+.dataviews-view-table tr td:last-child {
 	width: 0;
-	padding-inline-end: $grid-unit-10;
+	padding-right: $grid-unit-10;
 
 	.dataviews-view-table__cell-content-wrapper,
 	.dataviews-view-table__primary-column-content {
@@ -768,6 +773,7 @@ th:has(.cortext-column-header-marker)
 	.dataviews-view-table {
 		table-layout: fixed;
 
+		/* stylelint-disable-next-line no-descending-specificity */
 		tr td {
 			overflow: hidden;
 			padding-block: 0;
@@ -807,7 +813,6 @@ th:has(.cortext-column-header-marker)
 	&__footer {
 		flex: 0 0 auto;
 		padding: $grid-unit-05 $grid-unit-10;
-		border-top: $border-width solid $gray-200;
 	}
 
 	&__new-row.components-button {

--- a/src/index.scss
+++ b/src/index.scss
@@ -478,19 +478,6 @@ body.cortext-fullscreen {
 	}
 }
 
-// Custom field columns and the ghost column carry a marker that
-// `ColumnHeaderActions` portals our trigger into. We hide DataViews'
-// built-in trigger on those <th>s and replace it with a single combined
-// dropdown (Sort / Move / Hide / Rename / Duplicate / Delete) for data
-// columns, or a `+` button for the ghost column. Title and system
-// fields don't have a marker, so their built-in triggers stay visible.
-// `tech-debt.md#16` covers the upstream gap that forces this takeover.
-.dataviews-view-table
-th:has(.cortext-column-header-marker)
-.dataviews-view-table-header-button:not(.cortext-column-header-trigger) {
-	display: none;
-}
-
 // `DataViewColumnInteractions` portals a transparent drag handle over
 // each <th> with `z-index: 1`, which intercepts pointer events and
 // keeps `.dataviews-view-table-header-button:hover` from ever firing.

--- a/src/index.scss
+++ b/src/index.scss
@@ -478,51 +478,22 @@ body.cortext-fullscreen {
 	}
 }
 
-// Cortext kebab (Rename / Duplicate / Delete) and ghost-column `+` are
-// portaled into each <th> next to DataViews' built-in trigger and main's
-// drag/resize handles. Kebab is hover-revealed so columns at rest don't
-// look crowded; ghost-column `+` is sticky-visible since it's the only
-// affordance there. Sits to the left of the 8px-wide resize handle.
-.cortext-column-header-actions {
-	position: absolute;
-	top: 50%;
-	right: 16px;
-	transform: translateY(-50%);
-	z-index: 2;
-	opacity: 0;
-	transition: opacity 120ms ease-out;
-}
-
-// Ghost-column variant: in-flow (drag/resize are gated off the ghost
-// column, so no overlap to worry about), sticky-visible.
-.cortext-column-header-actions--add {
-	position: static;
-	transform: none;
-	opacity: 1;
-	z-index: auto;
-}
-
-// The ghost column's DataViews trigger is empty — its only content is
-// the aria-hidden marker we use as a portal anchor (`querySelectorAll`
-// still resolves the marker through `display: none`). Hiding it here
-// leaves the + button as the sole cell content so it lines up with the
-// data-column labels instead of being pushed to the empty trigger's
-// baseline.
+// Custom field columns and the ghost column carry a marker that
+// `ColumnHeaderActions` portals our trigger into. We hide DataViews'
+// built-in trigger on those <th>s and replace it with a single combined
+// dropdown (Sort / Move / Hide / Rename / Duplicate / Delete) for data
+// columns, or a `+` button for the ghost column. Title and system
+// fields don't have a marker, so their built-in triggers stay visible.
+// `tech-debt.md#16` covers the upstream gap that forces this takeover.
 .dataviews-view-table
-th:has(.cortext-column-header-marker--add)
-.dataviews-view-table-header-button {
+th:has(.cortext-column-header-marker)
+.dataviews-view-table-header-button:not(.cortext-column-header-trigger) {
 	display: none;
 }
 
-.cortext-data-view
-.dataviews-view-table
-thead > tr > th:hover
-.cortext-column-header-actions:not(.cortext-column-header-actions--add),
-.cortext-data-view
-.dataviews-view-table
-thead > tr > th:focus-within
-.cortext-column-header-actions:not(.cortext-column-header-actions--add) {
-	opacity: 1;
+.cortext-column-header-actions {
+	display: inline-flex;
+	align-items: center;
 }
 
 .cortext-rename-field-inline .components-base-control {

--- a/src/index.scss
+++ b/src/index.scss
@@ -430,12 +430,15 @@ body.cortext-fullscreen {
 }
 
 // DataViews ships a `table-layout: auto; width: 100%` table. Auto
-// layout sizes each column based on content of every column, so
-// adding or deleting a field reflows every existing column. Switch to
-// fixed layout with explicit per-cell widths so the column count
-// stops affecting the surviving columns' widths. The wrapper
+// layout sizes each column based on the content of every column, so
+// adding or deleting a field reflows every existing column. Switch
+// to fixed layout with explicit per-cell widths so the column count
+// stops affecting the surviving columns' widths. The table is
+// content-sized (`width: max-content`); the wrapper
 // (.dataviews-wrapper) already has `overflow: auto`, so horizontal
 // scroll engages once the total column width exceeds the container.
+// Any leftover wrapper space sits to the right of the `+` ghost
+// column — same shape as Notion's table.
 .dataviews-view-table {
 	table-layout: fixed;
 	width: max-content;
@@ -453,14 +456,16 @@ body.cortext-fullscreen {
 	width: 280px;
 }
 
-// The trailing ghost column hosts only the `+ add field` trigger;
-// keep it slim so the table doesn't dedicate a full data column to
-// what's effectively a button. DataViews forces `min-width: 15ch`
-// on `.dataviews-view-table__cell-content-wrapper`; override it so
-// the column can actually shrink to the size we asked for.
+// The trailing ghost column hosts only the `+ add field` trigger.
+// Keep it slim so the `+` sits right next to the last data column.
+// DataViews forces `min-width: 15ch` on
+// `.dataviews-view-table__cell-content-wrapper` and adds
+// `padding-inline-end: 24px` on the last cell — both override our
+// width unless we collapse them.
 .dataviews-view-table th:last-child,
 .dataviews-view-table td:last-child {
-	width: 56px;
+	width: 0;
+	padding-inline-end: $grid-unit-10;
 
 	.dataviews-view-table__cell-content-wrapper,
 	.dataviews-view-table__primary-column-content {
@@ -481,24 +486,9 @@ th:has(.cortext-column-header-marker)
 	display: none;
 }
 
-.dataviews-view-table th:has(.cortext-column-header-marker--add) {
-	position: relative;
-}
-
 .cortext-column-header-actions {
 	display: inline-flex;
 	align-items: center;
-}
-
-// On the ghost column the `+` trigger sits over the cell; the built-in
-// DataViews button is empty for the ghost field, so we anchor the
-// portaled trigger to the th rather than letting it lay out inline.
-.cortext-column-header-actions--add {
-	position: absolute;
-	top: 50%;
-	right: $grid-unit-10;
-	transform: translateY(-50%);
-	z-index: 1;
 }
 
 .cortext-field-header-button.components-button {

--- a/src/index.scss
+++ b/src/index.scss
@@ -429,6 +429,45 @@ body.cortext-fullscreen {
 	overflow: hidden;
 }
 
+// DataViews ships a `table-layout: auto; width: 100%` table. Auto
+// layout sizes each column based on content of every column, so
+// adding or deleting a field reflows every existing column. Switch to
+// fixed layout with explicit per-cell widths so the column count
+// stops affecting the surviving columns' widths. The wrapper
+// (.dataviews-wrapper) already has `overflow: auto`, so horizontal
+// scroll engages once the total column width exceeds the container.
+.dataviews-view-table {
+	table-layout: fixed;
+	width: max-content;
+}
+
+.dataviews-view-table th,
+.dataviews-view-table td {
+	width: 200px;
+}
+
+// Title carries the post name and tends to be longer than other
+// fields; give it more breathing room.
+.dataviews-view-table th:first-child,
+.dataviews-view-table td:first-child {
+	width: 280px;
+}
+
+// The trailing ghost column hosts only the `+ add field` trigger;
+// keep it slim so the table doesn't dedicate a full data column to
+// what's effectively a button. DataViews forces `min-width: 15ch`
+// on `.dataviews-view-table__cell-content-wrapper`; override it so
+// the column can actually shrink to the size we asked for.
+.dataviews-view-table th:last-child,
+.dataviews-view-table td:last-child {
+	width: 56px;
+
+	.dataviews-view-table__cell-content-wrapper,
+	.dataviews-view-table__primary-column-content {
+		min-width: 0;
+	}
+}
+
 // On custom-field columns we replace DataViews' built-in header trigger
 // (sort / hide / move) with our own combined dropdown that adds Rename /
 // Duplicate / Delete to the same menu. The built-in trigger is hidden

--- a/src/index.scss
+++ b/src/index.scss
@@ -478,26 +478,51 @@ body.cortext-fullscreen {
 	}
 }
 
-// On custom-field columns we replace DataViews' built-in header trigger
-// (sort / hide / move) with our own combined dropdown that adds Rename /
-// Duplicate / Delete to the same menu. The built-in trigger is hidden
-// via CSS, our portaled trigger takes its place. The `:has()` scope
-// targets <th>s that carry our marker — Title and system fields don't
-// have markers, so their built-in triggers stay visible. See
-// `tech-debt.md#15` and `ColumnHeaderActions.js` for the full story.
+// Cortext kebab (Rename / Duplicate / Delete) and ghost-column `+` are
+// portaled into each <th> next to DataViews' built-in trigger and main's
+// drag/resize handles. Kebab is hover-revealed so columns at rest don't
+// look crowded; ghost-column `+` is sticky-visible since it's the only
+// affordance there. Sits to the left of the 8px-wide resize handle.
+.cortext-column-header-actions {
+	position: absolute;
+	top: 50%;
+	right: 16px;
+	transform: translateY(-50%);
+	z-index: 2;
+	opacity: 0;
+	transition: opacity 120ms ease-out;
+}
+
+// Ghost-column variant: in-flow (drag/resize are gated off the ghost
+// column, so no overlap to worry about), sticky-visible.
+.cortext-column-header-actions--add {
+	position: static;
+	transform: none;
+	opacity: 1;
+	z-index: auto;
+}
+
+// The ghost column's DataViews trigger is empty — its only content is
+// the aria-hidden marker we use as a portal anchor (`querySelectorAll`
+// still resolves the marker through `display: none`). Hiding it here
+// leaves the + button as the sole cell content so it lines up with the
+// data-column labels instead of being pushed to the empty trigger's
+// baseline.
 .dataviews-view-table
-th:has(.cortext-column-header-marker)
+th:has(.cortext-column-header-marker--add)
 .dataviews-view-table-header-button {
 	display: none;
 }
 
-.cortext-column-header-actions {
-	display: inline-flex;
-	align-items: center;
-}
-
-.cortext-field-header-button.components-button {
-	font-weight: inherit;
+.cortext-data-view
+.dataviews-view-table
+thead > tr > th:hover
+.cortext-column-header-actions:not(.cortext-column-header-actions--add),
+.cortext-data-view
+.dataviews-view-table
+thead > tr > th:focus-within
+.cortext-column-header-actions:not(.cortext-column-header-actions--add) {
+	opacity: 1;
 }
 
 .cortext-rename-field-inline .components-base-control {

--- a/src/index.scss
+++ b/src/index.scss
@@ -478,6 +478,19 @@ body.cortext-fullscreen {
 	}
 }
 
+// Custom field columns and the ghost column carry a marker that
+// `ColumnHeaderActions` portals our trigger into. We hide DataViews'
+// built-in trigger on those <th>s and replace it with a single combined
+// dropdown (Sort / Move / Hide / Rename / Duplicate / Delete) for data
+// columns, or a `+` button for the ghost column. Title and system
+// fields don't have a marker, so their built-in triggers stay visible.
+// `tech-debt.md#16` covers the upstream gap that forces this takeover.
+.dataviews-view-table
+th:has(.cortext-column-header-marker)
+.dataviews-view-table-header-button:not(.cortext-column-header-trigger) {
+	display: none;
+}
+
 // `DataViewColumnInteractions` portals a transparent drag handle over
 // each <th> with `z-index: 1`, which intercepts pointer events and
 // keeps `.dataviews-view-table-header-button:hover` from ever firing.

--- a/src/index.scss
+++ b/src/index.scss
@@ -360,6 +360,117 @@ body.cortext-fullscreen {
 	padding: $grid-unit-15;
 }
 
+.cortext-add-field-popover {
+	display: grid;
+	gap: $grid-unit-15;
+	width: min(100%, 320px);
+
+	&__section-title {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		color: $gray-700;
+		display: block;
+		margin-bottom: $grid-unit-05;
+	}
+
+	&__type-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: $grid-unit-05;
+	}
+
+	&__type-button {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+		padding: $grid-unit-10;
+		border: $border-width solid $gray-200;
+		border-radius: 4px;
+		background: transparent;
+		text-align: start;
+		font-size: 13px;
+		color: $gray-900;
+		cursor: pointer;
+		transition: background-color 0.1s ease, border-color 0.1s ease;
+
+		&:disabled {
+			cursor: not-allowed;
+			opacity: 0.5;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline-offset: -1px;
+		}
+
+		&:hover:not(:disabled) {
+			background: $gray-100;
+			border-color: $gray-700;
+		}
+	}
+
+	&__type-icon {
+		flex: 0 0 auto;
+		color: $gray-700;
+	}
+}
+
+// Marker spans live inside DataViews' header trigger button. Zero-size
+// and aria-hidden so they never receive focus or contribute to the
+// column width; the portal layer in `ColumnHeaderActions` finds them by
+// their `data-cortext-*-marker` attribute and projects a sibling button
+// into the owning <th>.
+.cortext-column-header-marker {
+	display: inline-block;
+	width: 0;
+	height: 0;
+	overflow: hidden;
+}
+
+// On custom-field columns we replace DataViews' built-in header trigger
+// (sort / hide / move) with our own combined dropdown that adds Rename /
+// Duplicate / Delete to the same menu. The built-in trigger is hidden
+// via CSS, our portaled trigger takes its place. The `:has()` scope
+// targets <th>s that carry our marker — Title and system fields don't
+// have markers, so their built-in triggers stay visible. See
+// `tech-debt.md#15` and `ColumnHeaderActions.js` for the full story.
+.dataviews-view-table
+th:has(.cortext-column-header-marker)
+.dataviews-view-table-header-button {
+	display: none;
+}
+
+.dataviews-view-table th:has(.cortext-column-header-marker--add) {
+	position: relative;
+}
+
+.cortext-column-header-actions {
+	display: inline-flex;
+	align-items: center;
+}
+
+// On the ghost column the `+` trigger sits over the cell; the built-in
+// DataViews button is empty for the ghost field, so we anchor the
+// portaled trigger to the th rather than letting it lay out inline.
+.cortext-column-header-actions--add {
+	position: absolute;
+	top: 50%;
+	right: $grid-unit-10;
+	transform: translateY(-50%);
+	z-index: 1;
+}
+
+.cortext-field-header-button.components-button {
+	font-weight: inherit;
+}
+
+.cortext-rename-field-inline .components-base-control {
+	margin-bottom: 0;
+	min-width: 140px;
+}
+
 .cortext-collection-chooser {
 	display: grid;
 	gap: $grid-unit-05;

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -845,9 +845,7 @@ test.describe( 'Collection view block', () => {
 				/cortext-chip--neutral/
 			);
 			const statusChipGeometry = await statusChip.evaluate( ( chip ) => {
-				const shell = chip.closest(
-					'.cortext-editable-cell__shell'
-				);
+				const shell = chip.closest( '.cortext-editable-cell__shell' );
 				const chipRect = chip.getBoundingClientRect();
 				const shellRect = shell.getBoundingClientRect();
 
@@ -953,18 +951,15 @@ test.describe( 'Collection view block', () => {
 				data: {
 					title: 'System field page',
 					status: 'private',
-					content: createDataViewBlockMarkup(
-						fixture.collection.id,
-						{
-							fields: [
-								'title',
-								'created_at',
-								'created_by',
-								'modified_at',
-								'modified_by',
-							],
-						}
-					),
+					content: createDataViewBlockMarkup( fixture.collection.id, {
+						fields: [
+							'title',
+							'created_at',
+							'created_by',
+							'modified_at',
+							'modified_by',
+						],
+					} ),
 				},
 			} );
 
@@ -1020,8 +1015,7 @@ test.describe( 'Collection view block', () => {
 			);
 			await deleteIfCreated(
 				requestUtils,
-				fixture.field &&
-					`/wp/v2/crtxt_fields/${ fixture.field.id }`
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
 			);
 			await deleteIfCreated(
 				requestUtils,
@@ -1806,9 +1800,9 @@ test.describe( 'Collection view block', () => {
 				notesTh.evaluate( ( el ) => el.style.transform )
 			).resolves.toBe( notesTransform );
 			const notesCellDragBox = await notesCell.boundingBox();
-			expect( Math.abs( notesCellDragBox.x - notesCellBox.x ) ).toBeLessThan(
-				1
-			);
+			expect(
+				Math.abs( notesCellDragBox.x - notesCellBox.x )
+			).toBeLessThan( 1 );
 			await page.mouse.up();
 
 			await page.evaluate( async () => {
@@ -1867,6 +1861,156 @@ test.describe( 'Collection view block', () => {
 					`/wp/v2/crtxt_fields/${ fieldId }`
 				);
 			}
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+	test( 'creates, renames, duplicates, and deletes fields without leaving the block', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture( requestUtils )
+			);
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Field management page',
+					status: 'private',
+					content: createDataViewBlockMarkup( fixture.collection.id ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			await expect( canvas.getByText( 'Author' ) ).toBeVisible();
+
+			// 1. Toolbar Add field: create a "Notes" text field.
+			await page
+				.getByRole( 'button', { name: 'Add field', exact: true } )
+				.first()
+				.click();
+			const popover = page.locator(
+				'.cortext-data-view-toolbar-popover'
+			);
+			await popover.getByLabel( 'Name' ).fill( 'Notes' );
+			await popover.getByRole( 'button', { name: 'Create' } ).click();
+
+			const notesHeader = canvas.getByRole( 'columnheader', {
+				name: /Notes/,
+			} );
+			await expect( notesHeader ).toBeVisible();
+
+			// 2. Rename "Notes" → "Description" via the column header
+			//    dropdown (combined Sort/Move/Hide + Rename/Duplicate/
+			//    Delete menu — see docs/tech-debt.md#15).
+			await notesHeader.getByRole( 'button', { name: 'Notes' } ).click();
+			await page.getByRole( 'menuitem', { name: 'Rename' } ).click();
+
+			const renameInput = canvas.getByLabel( 'Field name' );
+			await renameInput.fill( 'Description' );
+			await renameInput.press( 'Enter' );
+
+			await expect(
+				canvas.getByRole( 'columnheader', { name: /Description/ } )
+			).toBeVisible();
+			await expect(
+				canvas.getByRole( 'columnheader', { name: /^Notes$/ } )
+			).toHaveCount( 0 );
+
+			// 3. Duplicate "Description" → "Copy of Description".
+			await canvas.getByRole( 'button', { name: 'Description' } ).click();
+			await page.getByRole( 'menuitem', { name: 'Duplicate' } ).click();
+
+			await expect(
+				canvas.getByRole( 'columnheader', {
+					name: /Copy of Description/,
+				} )
+			).toBeVisible();
+
+			// 4. Delete "Copy of Description" via the header dropdown +
+			//    confirm dialog.
+			await canvas
+				.getByRole( 'button', { name: 'Copy of Description' } )
+				.click();
+			await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
+			await page
+				.getByRole( 'button', { name: 'Delete', exact: true } )
+				.click();
+
+			await expect(
+				canvas.getByRole( 'columnheader', {
+					name: /Copy of Description/,
+				} )
+			).toHaveCount( 0 );
+
+			// 5. Ghost column `+` opens the same popover and creates a field.
+			const ghostAdd = canvas
+				.locator( 'th' )
+				.last()
+				.getByRole( 'button', { name: 'Add field' } );
+			await ghostAdd.click();
+			const ghostPopover = page.locator(
+				'.cortext-data-view-toolbar-popover'
+			);
+			await ghostPopover.getByLabel( 'Name' ).fill( 'Tags' );
+			await ghostPopover
+				.getByRole( 'button', { name: 'Create' } )
+				.click();
+
+			await expect(
+				canvas.getByRole( 'columnheader', { name: /Tags/ } )
+			).toBeVisible();
+
+			// 6. Title's column header exposes only DataViews' built-in
+			//    dropdown (sort/hide). It does not surface schema actions
+			//    like Rename — clicking opens DataViews' menu, which has
+			//    no "Rename" item.
+			await canvas.getByRole( 'button', { name: 'Title' } ).click();
+			await expect(
+				page.getByRole( 'menuitem', { name: 'Rename' } )
+			).toHaveCount( 0 );
+		} finally {
+			// Best-effort cleanup. The created/duplicated fields aren't
+			// tracked individually, but they cascade with their
+			// collection's force-delete (and the server cleanup hook
+			// removes their entry meta).
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
 			await deleteIfCreated(
 				requestUtils,
 				fixture.collection &&

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1928,10 +1928,13 @@ test.describe( 'Collection view block', () => {
 			} );
 			await expect( notesHeader ).toBeVisible();
 
-			// 2. Rename "Notes" → "Description" via the column header
-			//    dropdown (combined Sort/Move/Hide + Rename/Duplicate/
-			//    Delete menu — see docs/tech-debt.md#15).
-			await notesHeader.getByRole( 'button', { name: 'Notes' } ).click();
+			// 2. Rename "Notes" → "Description" via the kebab next to
+			//    DataViews' built-in trigger. The kebab is hover-revealed
+			//    (see docs/tech-debt.md#16) so we hover the column first.
+			await notesHeader.hover();
+			await notesHeader
+				.getByRole( 'button', { name: 'Field actions' } )
+				.click();
 			await page.getByRole( 'menuitem', { name: 'Rename' } ).click();
 
 			const renameInput = canvas.getByLabel( 'Field name' );
@@ -1946,7 +1949,13 @@ test.describe( 'Collection view block', () => {
 			).toHaveCount( 0 );
 
 			// 3. Duplicate "Description" → "Copy of Description".
-			await canvas.getByRole( 'button', { name: 'Description' } ).click();
+			const descriptionHeader = canvas.getByRole( 'columnheader', {
+				name: /^Description$/,
+			} );
+			await descriptionHeader.hover();
+			await descriptionHeader
+				.getByRole( 'button', { name: 'Field actions' } )
+				.click();
 			await page.getByRole( 'menuitem', { name: 'Duplicate' } ).click();
 
 			await expect(
@@ -1955,10 +1964,14 @@ test.describe( 'Collection view block', () => {
 				} )
 			).toBeVisible();
 
-			// 4. Delete "Copy of Description" via the header dropdown +
-			//    confirm dialog.
-			await canvas
-				.getByRole( 'button', { name: 'Copy of Description' } )
+			// 4. Delete "Copy of Description" via the kebab + confirm
+			//    dialog.
+			const copyHeader = canvas.getByRole( 'columnheader', {
+				name: /Copy of Description/,
+			} );
+			await copyHeader.hover();
+			await copyHeader
+				.getByRole( 'button', { name: 'Field actions' } )
 				.click();
 			await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
 			await page
@@ -1989,14 +2002,25 @@ test.describe( 'Collection view block', () => {
 				canvas.getByRole( 'columnheader', { name: /Tags/ } )
 			).toBeVisible();
 
-			// 6. Title's column header exposes only DataViews' built-in
-			//    dropdown (sort/hide). It does not surface schema actions
-			//    like Rename — clicking opens DataViews' menu, which has
-			//    no "Rename" item.
-			await canvas.getByRole( 'button', { name: 'Title' } ).click();
+			// 6. Title's <th> has no Cortext kebab — schema actions are
+			//    custom-field only. DataViews' built-in dropdown still
+			//    opens via the column-name button (sort/hide).
+			const titleHeader = canvas.getByRole( 'columnheader', {
+				name: 'Title',
+			} );
 			await expect(
-				page.getByRole( 'menuitem', { name: 'Rename' } )
+				titleHeader.getByRole( 'button', { name: 'Field actions' } )
 			).toHaveCount( 0 );
+
+			// 7. Coexistence: on a custom column, DataViews' built-in
+			//    dropdown still opens for sort/hide alongside our kebab.
+			await canvas
+				.getByRole( 'button', { name: 'Description' } )
+				.click();
+			await expect(
+				page.getByRole( 'menuitem', { name: /Sort ascending/ } )
+			).toBeVisible();
+			await page.keyboard.press( 'Escape' );
 		} finally {
 			// Best-effort cleanup. The created/duplicated fields aren't
 			// tracked individually, but they cascade with their

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1355,7 +1355,7 @@ test.describe( 'Collection view block', () => {
 
 			const canvas = page.frameLocator( '[name="editor-canvas"]' );
 			const button = canvas
-				.locator( '.dataviews-view-table-header-button' )
+				.locator( '.dataviews-view-table-header-button:visible' )
 				.nth( 1 );
 			await button.focus();
 			await expect( button ).toBeFocused();
@@ -1908,6 +1908,22 @@ test.describe( 'Collection view block', () => {
 			const canvas = page.frameLocator( '[name="editor-canvas"]' );
 			await expect( canvas.getByText( 'Author' ) ).toBeVisible();
 
+			// Select the block so its toolbar (with Add field) renders.
+			// Clicking the canvas content tends to land on one of our
+			// interactive controls (column header dropdown, etc.) and
+			// open a popover instead of selecting the block; dispatch
+			// directly through core-data to avoid that.
+			await page.evaluate( () => {
+				const blocks = window.wp.data
+					.select( 'core/block-editor' )
+					.getBlocks();
+				if ( blocks.length ) {
+					window.wp.data
+						.dispatch( 'core/block-editor' )
+						.selectBlock( blocks[ 0 ].clientId );
+				}
+			} );
+
 			// 1. Toolbar Add field: create a "Notes" text field. The
 			//    popover follows Notion's click-to-create model, so
 			//    picking a type submits.
@@ -1928,10 +1944,24 @@ test.describe( 'Collection view block', () => {
 			} );
 			await expect( notesHeader ).toBeVisible();
 
+			// `getByRole('button', { name })` would match both the visible
+			// combined-dropdown trigger (text label) and the transparent
+			// drag-handle overlay (aria-label = field name); filter by
+			// visible text to pick the trigger. The drag handle stacks
+			// above the trigger to capture drag, and forwards click
+			// events via JS — Playwright's strict click would flag the
+			// handle as intercepting, so click via dispatchEvent.
+			const openColumnDropdown = async ( scope, name ) => {
+				const button = scope
+					.getByRole( 'button', { name } )
+					.filter( { hasText: name } );
+				await button.dispatchEvent( 'click' );
+			};
+
 			// 2. Rename "Notes" → "Description" via the column-header
 			//    dropdown (combined Sort/Move/Hide + Rename/Duplicate/
 			//    Delete menu — see docs/tech-debt.md#16).
-			await notesHeader.getByRole( 'button', { name: 'Notes' } ).click();
+			await openColumnDropdown( notesHeader, 'Notes' );
 			await page.getByRole( 'menuitem', { name: 'Rename' } ).click();
 
 			const renameInput = canvas.getByLabel( 'Field name' );
@@ -1946,7 +1976,7 @@ test.describe( 'Collection view block', () => {
 			).toHaveCount( 0 );
 
 			// 3. Duplicate "Description" → "Copy of Description".
-			await canvas.getByRole( 'button', { name: 'Description' } ).click();
+			await openColumnDropdown( canvas, 'Description' );
 			await page.getByRole( 'menuitem', { name: 'Duplicate' } ).click();
 
 			await expect(
@@ -1957,9 +1987,7 @@ test.describe( 'Collection view block', () => {
 
 			// 4. Delete "Copy of Description" via the dropdown + confirm
 			//    dialog.
-			await canvas
-				.getByRole( 'button', { name: 'Copy of Description' } )
-				.click();
+			await openColumnDropdown( canvas, 'Copy of Description' );
 			await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
 			await page
 				.getByRole( 'button', { name: 'Delete', exact: true } )
@@ -1989,19 +2017,14 @@ test.describe( 'Collection view block', () => {
 				canvas.getByRole( 'columnheader', { name: /Tags/ } )
 			).toBeVisible();
 
-			// 6. Title's column header opens DataViews' built-in dropdown
-			//    (sort/hide/move). It does not surface schema actions
-			//    like Rename — the takeover only applies to custom fields.
-			//    Anchor the negative on a positive assertion so a broken
-			//    selector can't silently pass the Rename absence check.
-			await canvas.getByRole( 'button', { name: 'Title' } ).click();
+			// 6. Title's column doesn't get the schema-action takeover —
+			//    its `<th>` keeps DataViews' built-in trigger and has no
+			//    Cortext combined-dropdown trigger.
 			await expect(
-				page.getByRole( 'menuitem', { name: /Sort ascending/ } )
-			).toBeVisible();
-			await expect(
-				page.getByRole( 'menuitem', { name: 'Rename' } )
+				canvas
+					.getByRole( 'columnheader', { name: 'Title' } )
+					.locator( '.cortext-column-header-trigger' )
 			).toHaveCount( 0 );
-			await page.keyboard.press( 'Escape' );
 		} finally {
 			// Best-effort cleanup. The created/duplicated fields aren't
 			// tracked individually, but they cascade with their

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1908,7 +1908,9 @@ test.describe( 'Collection view block', () => {
 			const canvas = page.frameLocator( '[name="editor-canvas"]' );
 			await expect( canvas.getByText( 'Author' ) ).toBeVisible();
 
-			// 1. Toolbar Add field: create a "Notes" text field.
+			// 1. Toolbar Add field: create a "Notes" text field. The
+			//    popover follows Notion's click-to-create model, so
+			//    picking a type submits.
 			await page
 				.getByRole( 'button', { name: 'Add field', exact: true } )
 				.first()
@@ -1917,7 +1919,9 @@ test.describe( 'Collection view block', () => {
 				'.cortext-data-view-toolbar-popover'
 			);
 			await popover.getByLabel( 'Name' ).fill( 'Notes' );
-			await popover.getByRole( 'button', { name: 'Create' } ).click();
+			await popover
+				.getByRole( 'button', { name: 'Text', exact: true } )
+				.click();
 
 			const notesHeader = canvas.getByRole( 'columnheader', {
 				name: /Notes/,
@@ -1978,7 +1982,7 @@ test.describe( 'Collection view block', () => {
 			);
 			await ghostPopover.getByLabel( 'Name' ).fill( 'Tags' );
 			await ghostPopover
-				.getByRole( 'button', { name: 'Create' } )
+				.getByRole( 'button', { name: 'Text', exact: true } )
 				.click();
 
 			await expect(

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1992,10 +1992,16 @@ test.describe( 'Collection view block', () => {
 			// 6. Title's column header opens DataViews' built-in dropdown
 			//    (sort/hide/move). It does not surface schema actions
 			//    like Rename — the takeover only applies to custom fields.
+			//    Anchor the negative on a positive assertion so a broken
+			//    selector can't silently pass the Rename absence check.
 			await canvas.getByRole( 'button', { name: 'Title' } ).click();
+			await expect(
+				page.getByRole( 'menuitem', { name: /Sort ascending/ } )
+			).toBeVisible();
 			await expect(
 				page.getByRole( 'menuitem', { name: 'Rename' } )
 			).toHaveCount( 0 );
+			await page.keyboard.press( 'Escape' );
 		} finally {
 			// Best-effort cleanup. The created/duplicated fields aren't
 			// tracked individually, but they cascade with their

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1928,13 +1928,10 @@ test.describe( 'Collection view block', () => {
 			} );
 			await expect( notesHeader ).toBeVisible();
 
-			// 2. Rename "Notes" → "Description" via the kebab next to
-			//    DataViews' built-in trigger. The kebab is hover-revealed
-			//    (see docs/tech-debt.md#16) so we hover the column first.
-			await notesHeader.hover();
-			await notesHeader
-				.getByRole( 'button', { name: 'Field actions' } )
-				.click();
+			// 2. Rename "Notes" → "Description" via the column-header
+			//    dropdown (combined Sort/Move/Hide + Rename/Duplicate/
+			//    Delete menu — see docs/tech-debt.md#16).
+			await notesHeader.getByRole( 'button', { name: 'Notes' } ).click();
 			await page.getByRole( 'menuitem', { name: 'Rename' } ).click();
 
 			const renameInput = canvas.getByLabel( 'Field name' );
@@ -1949,13 +1946,7 @@ test.describe( 'Collection view block', () => {
 			).toHaveCount( 0 );
 
 			// 3. Duplicate "Description" → "Copy of Description".
-			const descriptionHeader = canvas.getByRole( 'columnheader', {
-				name: /^Description$/,
-			} );
-			await descriptionHeader.hover();
-			await descriptionHeader
-				.getByRole( 'button', { name: 'Field actions' } )
-				.click();
+			await canvas.getByRole( 'button', { name: 'Description' } ).click();
 			await page.getByRole( 'menuitem', { name: 'Duplicate' } ).click();
 
 			await expect(
@@ -1964,14 +1955,10 @@ test.describe( 'Collection view block', () => {
 				} )
 			).toBeVisible();
 
-			// 4. Delete "Copy of Description" via the kebab + confirm
+			// 4. Delete "Copy of Description" via the dropdown + confirm
 			//    dialog.
-			const copyHeader = canvas.getByRole( 'columnheader', {
-				name: /Copy of Description/,
-			} );
-			await copyHeader.hover();
-			await copyHeader
-				.getByRole( 'button', { name: 'Field actions' } )
+			await canvas
+				.getByRole( 'button', { name: 'Copy of Description' } )
 				.click();
 			await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
 			await page
@@ -2002,25 +1989,13 @@ test.describe( 'Collection view block', () => {
 				canvas.getByRole( 'columnheader', { name: /Tags/ } )
 			).toBeVisible();
 
-			// 6. Title's <th> has no Cortext kebab — schema actions are
-			//    custom-field only. DataViews' built-in dropdown still
-			//    opens via the column-name button (sort/hide).
-			const titleHeader = canvas.getByRole( 'columnheader', {
-				name: 'Title',
-			} );
+			// 6. Title's column header opens DataViews' built-in dropdown
+			//    (sort/hide/move). It does not surface schema actions
+			//    like Rename — the takeover only applies to custom fields.
+			await canvas.getByRole( 'button', { name: 'Title' } ).click();
 			await expect(
-				titleHeader.getByRole( 'button', { name: 'Field actions' } )
+				page.getByRole( 'menuitem', { name: 'Rename' } )
 			).toHaveCount( 0 );
-
-			// 7. Coexistence: on a custom column, DataViews' built-in
-			//    dropdown still opens for sort/hide alongside our kebab.
-			await canvas
-				.getByRole( 'button', { name: 'Description' } )
-				.click();
-			await expect(
-				page.getByRole( 'menuitem', { name: /Sort ascending/ } )
-			).toBeVisible();
-			await page.keyboard.press( 'Escape' );
 		} finally {
 			// Best-effort cleanup. The created/duplicated fields aren't
 			// tracked individually, but they cascade with their

--- a/tests/js/hooks/fieldIds.test.js
+++ b/tests/js/hooks/fieldIds.test.js
@@ -1,0 +1,85 @@
+import {
+	toRecordId,
+	toDataViewId,
+	toMetaFieldsString,
+} from '../../../src/hooks/fieldIds';
+
+describe( 'toRecordId', () => {
+	it( 'returns the numeric ID for `field-<id>` keys', () => {
+		expect( toRecordId( 'field-123' ) ).toBe( 123 );
+		expect( toRecordId( 'field-1' ) ).toBe( 1 );
+	} );
+
+	it( 'returns null for system field IDs', () => {
+		expect( toRecordId( 'created_at' ) ).toBeNull();
+		expect( toRecordId( 'created_by' ) ).toBeNull();
+		expect( toRecordId( 'modified_at' ) ).toBeNull();
+		expect( toRecordId( 'modified_by' ) ).toBeNull();
+	} );
+
+	it( 'returns null for the title key', () => {
+		expect( toRecordId( 'title' ) ).toBeNull();
+	} );
+
+	it( 'returns null for the ghost-column synthetic ID', () => {
+		expect( toRecordId( '__add_field' ) ).toBeNull();
+	} );
+
+	it( 'returns null for malformed inputs', () => {
+		expect( toRecordId( 'field-' ) ).toBeNull();
+		expect( toRecordId( 'field-abc' ) ).toBeNull();
+		expect( toRecordId( 'field-12.3' ) ).toBeNull();
+		expect( toRecordId( 'something-else' ) ).toBeNull();
+		expect( toRecordId( null ) ).toBeNull();
+		expect( toRecordId( undefined ) ).toBeNull();
+		expect( toRecordId( 123 ) ).toBeNull();
+	} );
+} );
+
+describe( 'toDataViewId', () => {
+	it( 'returns the `field-<id>` form for positive integers', () => {
+		expect( toDataViewId( 1 ) ).toBe( 'field-1' );
+		expect( toDataViewId( 999 ) ).toBe( 'field-999' );
+	} );
+
+	it( 'accepts numeric strings', () => {
+		expect( toDataViewId( '42' ) ).toBe( 'field-42' );
+	} );
+
+	it( 'returns null for invalid IDs', () => {
+		expect( toDataViewId( 0 ) ).toBeNull();
+		expect( toDataViewId( -1 ) ).toBeNull();
+		expect( toDataViewId( 'abc' ) ).toBeNull();
+		expect( toDataViewId( null ) ).toBeNull();
+		expect( toDataViewId( undefined ) ).toBeNull();
+	} );
+} );
+
+describe( 'toMetaFieldsString', () => {
+	it( 'returns a string copy of the numeric ID', () => {
+		expect( toMetaFieldsString( 1 ) ).toBe( '1' );
+		expect( toMetaFieldsString( 999 ) ).toBe( '999' );
+		expect( toMetaFieldsString( '42' ) ).toBe( '42' );
+	} );
+
+	it( 'returns null for invalid IDs', () => {
+		expect( toMetaFieldsString( 0 ) ).toBeNull();
+		expect( toMetaFieldsString( -1 ) ).toBeNull();
+		expect( toMetaFieldsString( 'abc' ) ).toBeNull();
+		expect( toMetaFieldsString( null ) ).toBeNull();
+	} );
+} );
+
+describe( 'round-trip', () => {
+	it( 'converts numeric ID → DataView ID → numeric ID', () => {
+		const recordId = 123;
+		const dataViewId = toDataViewId( recordId );
+		expect( toRecordId( dataViewId ) ).toBe( recordId );
+	} );
+
+	it( 'converts numeric ID → meta string → REST-compatible numeric', () => {
+		const recordId = 456;
+		const metaString = toMetaFieldsString( recordId );
+		expect( Number( metaString ) ).toBe( recordId );
+	} );
+} );

--- a/tests/js/hooks/fieldMapping.test.js
+++ b/tests/js/hooks/fieldMapping.test.js
@@ -93,6 +93,17 @@ describe( 'mapField', () => {
 			'datetime'
 		);
 	} );
+
+	it( 'prefers title.raw over title.rendered for the column label', () => {
+		// `the_title` filter encodes `&` as `&#038;` on `title.rendered`,
+		// so we use the unfiltered string for the column header text.
+		const mapped = mapField( {
+			id: 5,
+			title: { raw: 'A & B', rendered: 'A &#038; B' },
+			meta: { type: 'text' },
+		} );
+		expect( mapped.label ).toBe( 'A & B' );
+	} );
 } );
 
 describe( 'systemFields', () => {

--- a/tests/js/hooks/useFieldMutations.test.js
+++ b/tests/js/hooks/useFieldMutations.test.js
@@ -65,10 +65,6 @@ describe( 'useCreateField', () => {
 			'getEntityRecord',
 			[ 'postType', 'crtxt_collection', 5 ]
 		);
-		expect( mockDispatch.invalidateResolution ).toHaveBeenCalledWith(
-			'getEntityRecords',
-			[ 'postType', 'crtxt_field' ]
-		);
 	} );
 
 	it( 'forwards options on the request body when present', async () => {
@@ -124,10 +120,6 @@ describe( 'useDuplicateField', () => {
 		expect( mockDispatch.invalidateResolution ).toHaveBeenCalledWith(
 			'getEntityRecord',
 			[ 'postType', 'crtxt_collection', 7 ]
-		);
-		expect( mockDispatch.invalidateResolution ).toHaveBeenCalledWith(
-			'getEntityRecords',
-			[ 'postType', 'crtxt_field' ]
 		);
 	} );
 } );

--- a/tests/js/hooks/useFieldMutations.test.js
+++ b/tests/js/hooks/useFieldMutations.test.js
@@ -1,0 +1,206 @@
+/**
+ * Tests for `src/hooks/useFieldMutations.js`. Mocks `@wordpress/api-fetch`
+ * and the `core` data store so each test asserts the dispatched action
+ * shape and the cache-invalidation calls without going to a real REST
+ * endpoint.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockDispatch = {
+	invalidateResolution: jest.fn(),
+	saveEntityRecord: jest.fn(),
+	deleteEntityRecord: jest.fn(),
+};
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn( () => mockDispatch ),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import {
+	useCreateField,
+	useDuplicateField,
+	useRenameField,
+	useDeleteField,
+} from '../../../src/hooks/useFieldMutations';
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'useCreateField', () => {
+	it( 'POSTs to the atomic create-and-attach route and invalidates resolvers', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			id: 99,
+			title: 'Status',
+			type: 'text',
+		} );
+
+		const { result } = renderHook( () => useCreateField( 5 ) );
+		let returned;
+		await act( async () => {
+			returned = await result.current.run( {
+				title: 'Status',
+				type: 'text',
+			} );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/collections/5/fields',
+			method: 'POST',
+			data: { title: 'Status', type: 'text' },
+		} );
+		expect( returned ).toEqual( {
+			id: 99,
+			title: 'Status',
+			type: 'text',
+		} );
+		expect( mockDispatch.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecord',
+			[ 'postType', 'crtxt_collection', 5 ]
+		);
+		expect( mockDispatch.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			[ 'postType', 'crtxt_field' ]
+		);
+	} );
+
+	it( 'forwards options on the request body when present', async () => {
+		apiFetch.mockResolvedValueOnce( { id: 100 } );
+		const { result } = renderHook( () => useCreateField( 5 ) );
+		await act( async () => {
+			await result.current.run( {
+				title: 'Priority',
+				type: 'select',
+				options: [ { value: 'high', label: 'High' } ],
+			} );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/collections/5/fields',
+			method: 'POST',
+			data: {
+				title: 'Priority',
+				type: 'select',
+				options: [ { value: 'high', label: 'High' } ],
+			},
+		} );
+	} );
+
+	it( 'surfaces errors via `error` and rethrows', async () => {
+		const apiError = new Error( 'boom' );
+		apiFetch.mockRejectedValueOnce( apiError );
+
+		const { result } = renderHook( () => useCreateField( 5 ) );
+		await act( async () => {
+			await expect(
+				result.current.run( { title: 'X', type: 'text' } )
+			).rejects.toThrow( 'boom' );
+		} );
+
+		expect( result.current.error ).toBe( apiError );
+		expect( mockDispatch.invalidateResolution ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'useDuplicateField', () => {
+	it( 'POSTs to the atomic duplicate route and invalidates resolvers', async () => {
+		apiFetch.mockResolvedValueOnce( { id: 50 } );
+		const { result } = renderHook( () => useDuplicateField( 7 ) );
+		await act( async () => {
+			await result.current.run( 42 );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/collections/7/fields/42/duplicate',
+			method: 'POST',
+		} );
+		expect( mockDispatch.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecord',
+			[ 'postType', 'crtxt_collection', 7 ]
+		);
+		expect( mockDispatch.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecords',
+			[ 'postType', 'crtxt_field' ]
+		);
+	} );
+} );
+
+describe( 'useRenameField', () => {
+	it( 'dispatches saveEntityRecord with the new title', async () => {
+		mockDispatch.saveEntityRecord.mockResolvedValueOnce( {
+			id: 42,
+			title: { raw: 'Renamed', rendered: 'Renamed' },
+		} );
+
+		const { result } = renderHook( () => useRenameField() );
+		await act( async () => {
+			await result.current.run( 42, 'Renamed' );
+		} );
+
+		expect( mockDispatch.saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'crtxt_field',
+			{ id: 42, title: 'Renamed' }
+		);
+	} );
+
+	it( 'surfaces a rename failure when saveEntityRecord returns falsy', async () => {
+		mockDispatch.saveEntityRecord.mockResolvedValueOnce( undefined );
+
+		const { result } = renderHook( () => useRenameField() );
+		await act( async () => {
+			await expect(
+				result.current.run( 42, 'X' )
+			).rejects.toThrow( 'cortext_rename_failed' );
+		} );
+
+		expect( result.current.error ).toEqual(
+			new Error( 'cortext_rename_failed' )
+		);
+	} );
+} );
+
+describe( 'useDeleteField', () => {
+	it( 'dispatches deleteEntityRecord with force: true and invalidates the collection', async () => {
+		mockDispatch.deleteEntityRecord.mockResolvedValueOnce( { previous: { id: 42 } } );
+
+		const { result } = renderHook( () => useDeleteField( 5 ) );
+		await act( async () => {
+			await result.current.run( 42 );
+		} );
+
+		expect( mockDispatch.deleteEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'crtxt_field',
+			42,
+			{ force: true }
+		);
+		expect( mockDispatch.invalidateResolution ).toHaveBeenCalledWith(
+			'getEntityRecord',
+			[ 'postType', 'crtxt_collection', 5 ]
+		);
+	} );
+
+	it( 'surfaces a delete failure when deleteEntityRecord returns falsy', async () => {
+		mockDispatch.deleteEntityRecord.mockResolvedValueOnce( undefined );
+
+		const { result } = renderHook( () => useDeleteField( 5 ) );
+		await act( async () => {
+			await expect( result.current.run( 42 ) ).rejects.toThrow(
+				'cortext_delete_failed'
+			);
+		} );
+
+		expect( result.current.error ).toEqual(
+			new Error( 'cortext_delete_failed' )
+		);
+		expect( mockDispatch.invalidateResolution ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/php/test-collection-entries.php
+++ b/tests/php/test-collection-entries.php
@@ -384,4 +384,167 @@ final class Test_Collection_Entries extends BaseTestCase {
 		$this->assertSame( 'string', CollectionEntries::wp_meta_type_for( 'date' ) );
 		$this->assertSame( 'string', CollectionEntries::wp_meta_type_for( 'relation' ) );
 	}
+
+	public function test_get_entry_post_types_excludes_utility_cpts(): void {
+		$entries       = new CollectionEntries();
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Bookmarks',
+				'meta_input'  => array( 'slug' => 'bookmarks' ),
+			)
+		);
+		$entries->register_for_collection( get_post( $collection_id ) );
+
+		$result = CollectionEntries::get_entry_post_types();
+
+		$this->assertContains( 'crtxt_bookmarks', $result );
+		$this->assertNotContains( Collection::POST_TYPE, $result );
+		$this->assertNotContains( Field::POST_TYPE, $result );
+	}
+
+	public function test_field_delete_clears_entry_field_meta(): void {
+		$entries       = new CollectionEntries();
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Posts To Read',
+				'meta_input'  => array( 'slug' => 'reads' ),
+			)
+		);
+		$field_id = wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Status',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+
+		$entries->register_for_collection( get_post( $collection_id ) );
+		$entries->register();
+
+		$entry_a = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_reads',
+				'post_status' => 'publish',
+				'post_title'  => 'Entry A',
+			)
+		);
+		$entry_b = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_reads',
+				'post_status' => 'publish',
+				'post_title'  => 'Entry B',
+			)
+		);
+		update_post_meta( $entry_a, "field-{$field_id}", 'reading' );
+		update_post_meta( $entry_b, "field-{$field_id}", 'done' );
+
+		wp_delete_post( $field_id, true );
+
+		$this->assertSame( '', get_post_meta( $entry_a, "field-{$field_id}", true ) );
+		$this->assertSame( '', get_post_meta( $entry_b, "field-{$field_id}", true ) );
+	}
+
+	public function test_field_delete_keeps_unrelated_field_meta_on_other_entries(): void {
+		$entries       = new CollectionEntries();
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Items',
+				'meta_input'  => array( 'slug' => 'items' ),
+			)
+		);
+		$field_a = wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'A',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		$field_b = wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'B',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_a );
+		add_post_meta( $collection_id, 'fields', (string) $field_b );
+		$entries->register_for_collection( get_post( $collection_id ) );
+		$entries->register();
+
+		$entry_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_items',
+				'post_status' => 'publish',
+				'post_title'  => 'Entry',
+			)
+		);
+		update_post_meta( $entry_id, "field-{$field_a}", 'value-a' );
+		update_post_meta( $entry_id, "field-{$field_b}", 'value-b' );
+
+		wp_delete_post( $field_a, true );
+
+		$this->assertSame( '', get_post_meta( $entry_id, "field-{$field_a}", true ) );
+		$this->assertSame(
+			'value-b',
+			get_post_meta( $entry_id, "field-{$field_b}", true ),
+			'Other field meta on the same entry must be left alone.'
+		);
+	}
+
+	public function test_non_field_delete_skips_entry_meta_cleanup(): void {
+		$entries       = new CollectionEntries();
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Skip Test',
+				'meta_input'  => array( 'slug' => 'skip' ),
+			)
+		);
+		$field_id = wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Stays Attached',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+		$entries->register_for_collection( get_post( $collection_id ) );
+		$entries->register();
+
+		$entry_id = wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_skip',
+				'post_status' => 'publish',
+				'post_title'  => 'Entry',
+			)
+		);
+		update_post_meta( $entry_id, "field-{$field_id}", 'preserved' );
+
+		// Deleting an unrelated post must not run the field cleanup.
+		$unrelated_post_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Decoy',
+			)
+		);
+		wp_delete_post( $unrelated_post_id, true );
+
+		$this->assertSame(
+			'preserved',
+			get_post_meta( $entry_id, "field-{$field_id}", true )
+		);
+	}
 }

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -286,6 +286,38 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		);
 	}
 
+	public function test_duplicate_preserves_related_collection_id(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Tasks', 'tasks-r' );
+		$target_id     = $this->create_collection_with_slug( 'People', 'people-r' );
+
+		// Relation fields aren't creatable through PR D's create route
+		// (its `type` enum doesn't include `relation`), but they exist in
+		// the DB when imported from external sources. Insert directly so
+		// the duplicate route sees a field with `related_collection_id`.
+		$source_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Assignee',
+				'meta_input'  => array(
+					'type'                  => 'relation',
+					'related_collection_id' => $target_id,
+				),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $source_id );
+
+		$copy_id = (int) $this->duplicate_field( $collection_id, $source_id )
+			->get_data()['id'];
+
+		$this->assertSame( 'relation', get_post_meta( $copy_id, 'type', true ) );
+		$this->assertSame(
+			(string) $target_id,
+			(string) get_post_meta( $copy_id, 'related_collection_id', true )
+		);
+	}
+
 	public function test_duplicate_fails_when_source_not_in_collection(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		$first_id  = $this->create_collection_with_slug( 'First', 'first-d' );

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * Tests for Cortext\Rest\FieldsController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Field;
+use Cortext\Rest\FieldsController;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Fields_Controller extends BaseTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->unregister_dynamic_collection_post_types();
+		( new Collection() )->register_post_type();
+		( new Field() )->register_post_type();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new FieldsController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	public function test_creates_field_and_attaches_to_collection(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Tasks', 'tasks' );
+
+		$response = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Status',
+				'type'  => 'text',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$data     = $response->get_data();
+		$field_id = (int) $data['id'];
+
+		$this->assertGreaterThan( 0, $field_id );
+		$this->assertSame( 'Status', get_post( $field_id )->post_title );
+		$this->assertSame( 'text', get_post_meta( $field_id, 'type', true ) );
+		$this->assertSame(
+			array( (string) $field_id ),
+			array_map( 'strval', get_post_meta( $collection_id, 'fields', false ) )
+		);
+	}
+
+	public function test_creates_field_with_select_options_serialized_as_json(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Tags', 'tags' );
+
+		$response = $this->create_field(
+			$collection_id,
+			array(
+				'title'   => 'Priority',
+				'type'    => 'select',
+				'options' => array(
+					array(
+						'value' => 'high',
+						'label' => 'High',
+					),
+					array(
+						'value' => 'low',
+						'label' => 'Low',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$field_id = (int) $response->get_data()['id'];
+		$options  = json_decode( get_post_meta( $field_id, 'options', true ), true );
+
+		$this->assertSame(
+			array(
+				array(
+					'value' => 'high',
+					'label' => 'High',
+				),
+				array(
+					'value' => 'low',
+					'label' => 'Low',
+				),
+			),
+			$options
+		);
+	}
+
+	public function test_create_rejects_invalid_type(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Items', 'items' );
+
+		$response = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Bogus',
+				'type'  => 'unknown_type',
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame(
+			array(),
+			get_posts(
+				array(
+					'post_type'      => Field::POST_TYPE,
+					'post_status'    => 'any',
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				)
+			)
+		);
+	}
+
+	public function test_create_rejects_empty_title(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Empty', 'empty' );
+
+		$response = $this->create_field(
+			$collection_id,
+			array(
+				'title' => ' ',
+				'type'  => 'text',
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_create_rejects_when_collection_missing(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+
+		$response = $this->create_field(
+			999999,
+			array(
+				'title' => 'Orphan',
+				'type'  => 'text',
+			)
+		);
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	public function test_create_requires_edit_capability(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+		$collection_id = $this->create_collection_with_slug( 'Locked', 'locked' );
+
+		$response = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Status',
+				'type'  => 'text',
+			)
+		);
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_create_rolls_back_field_when_attach_fails(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Attach Fails', 'attach' );
+
+		// Force `add_post_meta` for `fields` on this collection to return false.
+		add_filter(
+			'add_post_metadata',
+			function ( $check, $object_id, $meta_key ) use ( $collection_id ) {
+				if ( (int) $object_id === $collection_id && 'fields' === $meta_key ) {
+					return false;
+				}
+				return $check;
+			},
+			10,
+			3
+		);
+
+		$response = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Will Fail',
+				'type'  => 'text',
+			)
+		);
+
+		$this->assertSame( 500, $response->get_status() );
+		$this->assertSame(
+			array(),
+			get_posts(
+				array(
+					'post_type'      => Field::POST_TYPE,
+					'post_status'    => 'any',
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				)
+			),
+			'Orphan field must be force-deleted when attach fails.'
+		);
+	}
+
+	public function test_duplicate_inserts_after_source_with_copy_title(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Schemas', 'schemas' );
+
+		$first_id  = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'A',
+				'type'  => 'text',
+			)
+		)->get_data()['id'];
+		$second_id = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'B',
+				'type'  => 'text',
+			)
+		)->get_data()['id'];
+		$third_id  = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'C',
+				'type'  => 'text',
+			)
+		)->get_data()['id'];
+
+		$response = $this->duplicate_field( $collection_id, (int) $second_id );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$copy_id = (int) $response->get_data()['id'];
+
+		$this->assertSame( 'Copy of B', get_post( $copy_id )->post_title );
+		$this->assertSame(
+			array(
+				(string) $first_id,
+				(string) $second_id,
+				(string) $copy_id,
+				(string) $third_id,
+			),
+			array_map( 'strval', get_post_meta( $collection_id, 'fields', false ) )
+		);
+	}
+
+	public function test_duplicate_clones_meta(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Clone Meta', 'clone' );
+
+		$source_id = $this->create_field(
+			$collection_id,
+			array(
+				'title'   => 'Priority',
+				'type'    => 'select',
+				'options' => array(
+					array(
+						'value' => 'high',
+						'label' => 'High',
+					),
+				),
+			)
+		)->get_data()['id'];
+
+		$copy_id = (int) $this->duplicate_field( $collection_id, (int) $source_id )->get_data()['id'];
+
+		$this->assertSame( 'select', get_post_meta( $copy_id, 'type', true ) );
+		$this->assertSame(
+			get_post_meta( (int) $source_id, 'options', true ),
+			get_post_meta( $copy_id, 'options', true )
+		);
+	}
+
+	public function test_duplicate_fails_when_source_not_in_collection(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$first_id  = $this->create_collection_with_slug( 'First', 'first-d' );
+		$second_id = $this->create_collection_with_slug( 'Second', 'second-d' );
+
+		$source_id = $this->create_field(
+			$first_id,
+			array(
+				'title' => 'In First',
+				'type'  => 'text',
+			)
+		)->get_data()['id'];
+
+		$response = $this->duplicate_field( $second_id, (int) $source_id );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	public function test_duplicate_fails_when_source_field_missing(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Missing Source', 'missing-src' );
+
+		$response = $this->duplicate_field( $collection_id, 999999 );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	public function test_duplicate_requires_edit_capability(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Auth Test', 'auth-d' );
+		$source_id     = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Title',
+				'type'  => 'text',
+			)
+		)->get_data()['id'];
+
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+		$response = $this->duplicate_field( $collection_id, (int) $source_id );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	private function create_field( int $collection_id, array $body ) {
+		$request = new WP_REST_Request(
+			'POST',
+			"/cortext/v1/collections/{$collection_id}/fields"
+		);
+		$request->set_param( 'collection_id', $collection_id );
+		foreach ( $body as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return rest_do_request( $request );
+	}
+
+	private function duplicate_field( int $collection_id, int $field_id ) {
+		$request = new WP_REST_Request(
+			'POST',
+			"/cortext/v1/collections/{$collection_id}/fields/{$field_id}/duplicate"
+		);
+		$request->set_param( 'collection_id', $collection_id );
+		$request->set_param( 'field_id', $field_id );
+		return rest_do_request( $request );
+	}
+
+	private function create_collection_with_slug( string $title, string $slug ): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => array( 'slug' => $slug ),
+			)
+		);
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+
+	private function unregister_dynamic_collection_post_types(): void {
+		foreach ( get_post_types() as $post_type ) {
+			if (
+				str_starts_with( $post_type, CollectionEntries::CPT_PREFIX ) &&
+				! in_array( $post_type, array( Collection::POST_TYPE, Field::POST_TYPE ), true )
+			) {
+				unregister_post_type( $post_type );
+			}
+		}
+	}
+}

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -318,6 +318,102 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		);
 	}
 
+	public function test_duplicate_rolls_back_when_meta_write_fails(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Splice Fails', 'splice-fail' );
+
+		$source_id = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Source',
+				'type'  => 'text',
+			)
+		)->get_data()['id'];
+
+		// Fail the splice's add_post_meta for the new field's ID
+		// (auto-increment post IDs are monotonic, so the copy's ID is
+		// always higher than the source's). Existing IDs in the rollback
+		// path stay <= source_id and write through.
+		add_filter(
+			'add_post_metadata',
+			function ( $check, $object_id, $meta_key, $meta_value ) use ( $collection_id, $source_id ) {
+				if ( (int) $object_id !== $collection_id || 'fields' !== $meta_key ) {
+					return $check;
+				}
+				if ( (int) $meta_value > $source_id ) {
+					return false;
+				}
+				return $check;
+			},
+			10,
+			4
+		);
+
+		$response = $this->duplicate_field( $collection_id, $source_id );
+
+		$this->assertSame( 500, $response->get_status() );
+		$this->assertSame(
+			array( $source_id ),
+			array_map(
+				'intval',
+				get_post_meta( $collection_id, 'fields', false )
+			),
+			'Collection field list must be restored to its pre-duplicate state.'
+		);
+		$source_post = get_post( $source_id );
+		$this->assertInstanceOf(
+			\WP_Post::class,
+			$source_post,
+			'Source field must survive a failed duplicate.'
+		);
+		$this->assertSame( Field::POST_TYPE, $source_post->post_type );
+	}
+
+	public function test_duplicate_rolls_back_when_source_id_disappears_before_attach(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Race', 'race' );
+
+		$source_id = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Source',
+				'type'  => 'text',
+			)
+		)->get_data()['id'];
+
+		// Simulate a race: duplicate()'s validation reads `meta.fields`
+		// and sees the source ID; attach_field re-reads (call #2+) and
+		// the source is gone. attach_field must return false so
+		// insert_and_attach can force-delete the orphan.
+		$reads = 0;
+		add_filter(
+			'get_post_metadata',
+			function ( $value, $object_id, $meta_key ) use ( &$reads, $collection_id ) {
+				if ( (int) $object_id !== $collection_id || 'fields' !== $meta_key ) {
+					return $value;
+				}
+				$reads++;
+				if ( $reads >= 2 ) {
+					return array();
+				}
+				return $value;
+			},
+			10,
+			4
+		);
+
+		$response = $this->duplicate_field( $collection_id, $source_id );
+
+		$this->assertSame( 500, $response->get_status() );
+		$source_post = get_post( $source_id );
+		$this->assertInstanceOf(
+			\WP_Post::class,
+			$source_post,
+			'Source field must survive a failed duplicate.'
+		);
+		$this->assertSame( Field::POST_TYPE, $source_post->post_type );
+	}
+
 	public function test_duplicate_fails_when_source_not_in_collection(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		$first_id  = $this->create_collection_with_slug( 'First', 'first-d' );


### PR DESCRIPTION
## What

Closes #99

Adds field management: create, rename, duplicate, and delete columns without leaving the editor.

## Why

Schema changes used to mean a trip through wp-admin or PHP code. Now it's all in the block: a toolbar `Add field` popover, a `+` button on a ghost column at the right edge of the table, and one dropdown per custom column header that owns sort/move/hide alongside rename/duplicate/delete.

## How

- Two new REST routes (`POST /cortext/v1/collections/<id>/fields` and the duplicate variant) handle create-and-attach in one request, with rollback if the attach step fails. A `before_delete_post` hook cleans up `field-<id>` meta when a field gets deleted from any path (REST, wp-admin, WP-CLI).

- On the client, `useFieldMutations` exposes the four operations, `AddFieldPopover` is the type picker shared by both triggers, and `ColumnHeaderActions` hides DataViews' built-in column header trigger on custom columns and replaces it with our combined dropdown. The `+` ghost column is a synthetic DataViews field whose `header` carries a marker the overlay portals into.

## Testing instructions
Try adding fields with the toolbar `Add field`button and the ghost column `+`.



## Recording
https://github.com/user-attachments/assets/c02a9f2f-e2a0-462b-b1d3-bb68937bc2e9