### PR TITLE
E2E: Suppress and expect specific console errors with withExpectedConsoleError

### DIFF
--- a/tests/e2e/specs/public-page.spec.js
+++ b/tests/e2e/specs/public-page.spec.js
@@ -7,6 +7,8 @@
 
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+const { withExpectedConsoleError } = require( '../utils' );
+
 async function deleteIfCreated( requestUtils, path ) {
 	if ( ! path ) {
 		return;
@@ -69,44 +71,35 @@ test.describe( 'Public page rendering', () => {
 		const suffix = Date.now().toString( 36 ).slice( -4 );
 		let createdPage;
 
-		// Suppress the expected "Failed to load resource: 404" browser
-		// error forwarded by the test harness.
-		//
-		// See: @wordpress/e2e-test-utils-playwright: observeConsoleLogging
-		const originalConsoleError = console.error;
-		const expected404 = [];
-		console.error = ( ...args ) => {
-			if ( /404/.test( args.join( ' ' ) ) ) {
-				expected404.push( args );
-				return;
+		await withExpectedConsoleError(
+			/the server responded with a status of 404/,
+			async () => {
+				try {
+					createdPage = await requestUtils.rest( {
+						method: 'POST',
+						path: '/wp/v2/crtxt_pages',
+						data: {
+							title: `Private page ${ suffix }`,
+							status: 'private',
+						},
+					} );
+
+					await page
+						.context()
+						.clearCookies( { name: /^wordpress_/ } );
+
+					const response = await page.goto(
+						`/cortext/${ createdPage.slug }/`
+					);
+
+					expect( response?.status() ).toBe( 404 );
+				} finally {
+					await deleteIfCreated(
+						requestUtils,
+						createdPage && `/wp/v2/crtxt_pages/${ createdPage.id }`
+					);
+				}
 			}
-			originalConsoleError.call( console, ...args );
-		};
-
-		try {
-			createdPage = await requestUtils.rest( {
-				method: 'POST',
-				path: '/wp/v2/crtxt_pages',
-				data: {
-					title: `Private page ${ suffix }`,
-					status: 'private',
-				},
-			} );
-
-			await page.context().clearCookies( { name: /^wordpress_/ } );
-
-			const response = await page.goto(
-				`/cortext/${ createdPage.slug }/`
-			);
-
-			expect( response?.status() ).toBe( 404 );
-			expect( expected404 ).toHaveLength( 1 );
-		} finally {
-			console.error = originalConsoleError;
-			await deleteIfCreated(
-				requestUtils,
-				createdPage && `/wp/v2/crtxt_pages/${ createdPage.id }`
-			);
-		}
+		);
 	} );
 } );

--- a/tests/e2e/specs/public-page.spec.js
+++ b/tests/e2e/specs/public-page.spec.js
@@ -69,6 +69,20 @@ test.describe( 'Public page rendering', () => {
 		const suffix = Date.now().toString( 36 ).slice( -4 );
 		let createdPage;
 
+		// Suppress the expected "Failed to load resource: 404" browser
+		// error forwarded by the test harness.
+		//
+		// See: @wordpress/e2e-test-utils-playwright: observeConsoleLogging
+		const originalConsoleError = console.error;
+		const expected404 = [];
+		console.error = ( ...args ) => {
+			if ( /404/.test( args.join( ' ' ) ) ) {
+				expected404.push( args );
+				return;
+			}
+			originalConsoleError.call( console, ...args );
+		};
+
 		try {
 			createdPage = await requestUtils.rest( {
 				method: 'POST',
@@ -86,7 +100,9 @@ test.describe( 'Public page rendering', () => {
 			);
 
 			expect( response?.status() ).toBe( 404 );
+			expect( expected404 ).toHaveLength( 1 );
 		} finally {
+			console.error = originalConsoleError;
 			await deleteIfCreated(
 				requestUtils,
 				createdPage && `/wp/v2/crtxt_pages/${ createdPage.id }`

--- a/tests/e2e/specs/shell.spec.js
+++ b/tests/e2e/specs/shell.spec.js
@@ -10,6 +10,8 @@
 
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+const { withExpectedConsoleError } = require( '../utils' );
+
 const SHELL_PATH = '/wp-admin/admin.php?page=cortext';
 
 test.describe( 'Cortext shell', () => {
@@ -53,28 +55,35 @@ test.describe( 'Cortext shell', () => {
 			roles: [ 'subscriber' ],
 		} );
 
-		try {
-			// Keep Playground's `playground_auto_login_already_happened` cookie
-			// intact so the `--login` mu-plugin doesn't silently log us back in
-			// as admin when WP auth cookies are cleared.
-			await page.context().clearCookies( { name: /^wordpress_/ } );
-			await page.request.post( '/wp-login.php', {
-				failOnStatusCode: true,
-				form: {
-					log: 'cortext-subscriber',
-					pwd: 'cortext-sub-password',
-				},
-			} );
+		await withExpectedConsoleError(
+			/the server responded with a status of 403/,
+			async () => {
+				try {
+					// Keep Playground's `playground_auto_login_already_happened` cookie
+					// intact so the `--login` mu-plugin doesn't silently log us back in
+					// as admin when WP auth cookies are cleared.
+					await page
+						.context()
+						.clearCookies( { name: /^wordpress_/ } );
 
-			const response = await page.goto( SHELL_PATH );
+					await page.request.post( '/wp-login.php', {
+						failOnStatusCode: true,
+						form: {
+							log: 'cortext-subscriber',
+							pwd: 'cortext-sub-password',
+						},
+					} );
+					const response = await page.goto( SHELL_PATH );
 
-			expect( response?.status() ).toBe( 403 );
-		} finally {
-			await requestUtils.rest( {
-				method: 'DELETE',
-				path: `/wp/v2/users/${ user.id }`,
-				params: { force: true, reassign: 1 },
-			} );
-		}
+					expect( response?.status() ).toBe( 403 );
+				} finally {
+					await requestUtils.rest( {
+						method: 'DELETE',
+						path: `/wp/v2/users/${ user.id }`,
+						params: { force: true, reassign: 1 },
+					} );
+				}
+			}
+		);
 	} );
 } );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,0 +1,29 @@
+const { expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+// Expect and suppress specific console errors
+//
+// See: @wordpress/e2e-test-utils-playwright: observeConsoleLogging
+async function withExpectedConsoleError( expectedPattern, testFn ) {
+	// eslint-disable-next-line no-console
+	const originalConsoleError = console.error;
+	const messages = [];
+
+	// eslint-disable-next-line no-console
+	console.error = ( ...args ) => {
+		if ( expectedPattern.test( args.join( ' ' ) ) ) {
+			messages.push( args );
+			return;
+		}
+		originalConsoleError.call( console, ...args );
+	};
+
+	try {
+		await testFn();
+		expect( messages ).toHaveLength( 1 );
+	} finally {
+		// eslint-disable-next-line no-console
+		console.error = originalConsoleError;
+	}
+}
+
+module.exports = { withExpectedConsoleError };


### PR DESCRIPTION
- Ideally, all uncaught console messages logged during E2E test runs should trigger a failure
- Catch a specific error message related to a 404 error that we expect in test _Public page rendering_
- Catch a specific error message related to a 403 error that we expect in test _Cortext shell > user without edit_posts gets 403_
- Introduce `tests/e2e/utils.js` with `withExpectedConsoleError`