### PR TITLE
Stop the canvas flash when navigating between pages and collections

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -20,7 +20,7 @@ import {
 import { Button, Disabled, Notice, Spinner } from '@wordpress/components';
 import { cog } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 import useAutosave from '../hooks/useAutosave';
 import {
@@ -40,8 +40,7 @@ const STATUS_LABELS = {
 	error: __( 'Failed to save', 'cortext' ),
 };
 
-function SaveStatus() {
-	const { status } = useAutosave();
+function SaveStatus( { status } ) {
 	const label = STATUS_LABELS[ status ] ?? '';
 
 	return (
@@ -55,7 +54,7 @@ function SaveStatus() {
 	);
 }
 
-function Header() {
+function Header( { saveStatus } ) {
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
 	const isInspectorOpen = useSelect(
@@ -67,7 +66,7 @@ function Header() {
 
 	return (
 		<div className="cortext-canvas__header">
-			<SaveStatus />
+			<SaveStatus status={ saveStatus } />
 			<PublishToggle />
 			<Button
 				icon={ cog }
@@ -174,12 +173,21 @@ function TrashedNotice( { postId } ) {
 	);
 }
 
-function VisualCanvas() {
+function CanvasReadyEffect( { postId, onReady } ) {
+	useEffect( () => {
+		onReady?.( postId );
+	}, [ postId, onReady ] );
+
+	return null;
+}
+
+function VisualCanvas( { postId, onReady } ) {
 	const styles = useSelect(
 		( select ) => select( editorStore ).getEditorSettings().styles,
 		[]
 	);
 	const [ layout ] = useSettings( 'layout' );
+
 	// Mirror the post editor's root-container setup so theme.json
 	// constrained layout (max-width, root padding, post-content gap)
 	// applies. Plain `<BlockList />` defaults to flow with no classes,
@@ -199,30 +207,102 @@ function VisualCanvas() {
 	// render the post centered while the frontend renders flex/grid,
 	// and the user wouldn't notice the divergence until preview.
 	return (
-		<BlockCanvas height="100%" styles={ styles }>
-			<div
-				className="editor-visual-editor__post-title-wrapper is-layout-constrained has-global-padding"
-				contentEditable={ false }
-				style={ { marginTop: '4rem', marginBottom: '2rem' } }
-			>
-				<PostTitle />
-			</div>
-			<BlockList
-				className="wp-block-post-content is-layout-constrained has-global-padding"
-				layout={ { type: 'constrained', ...layout } }
-			/>
-		</BlockCanvas>
+		<div className="cortext-canvas__visual">
+			<BlockCanvas height="100%" styles={ styles }>
+				<div
+					className="editor-visual-editor__post-title-wrapper is-layout-constrained has-global-padding"
+					contentEditable={ false }
+					style={ { marginTop: '4rem', marginBottom: '2rem' } }
+				>
+					<PostTitle />
+				</div>
+				<BlockList
+					className="wp-block-post-content is-layout-constrained has-global-padding"
+					layout={ { type: 'constrained', ...layout } }
+				/>
+				<CanvasReadyEffect postId={ postId } onReady={ onReady } />
+			</BlockCanvas>
+		</div>
 	);
 }
 
-export default function Canvas( { postId } ) {
-	const { record: post, isResolving } = useEntityRecord(
+function CanvasEditor( { post, pendingPost, onSwitchPost, onDisplayedPost } ) {
+	const { status, flushNow, isDirty, isSaving } = useAutosave();
+	const isTrashed = post.status === 'trash';
+
+	useEffect( () => {
+		if ( ! pendingPost || pendingPost.id === post.id ) {
+			return undefined;
+		}
+
+		let cancelled = false;
+
+		async function switchAfterSave() {
+			const didFlush = await flushNow();
+			if ( ! cancelled && didFlush ) {
+				onSwitchPost( pendingPost );
+			}
+		}
+
+		switchAfterSave();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ pendingPost, post.id, flushNow, isDirty, isSaving, onSwitchPost ] );
+
+	return (
+		<>
+			<InterfaceSkeleton
+				className="cortext-canvas"
+				header={ <Header saveStatus={ status } /> }
+				content={
+					<>
+						{ isTrashed && <TrashedNotice postId={ post.id } /> }
+						{ isTrashed ? (
+							<Disabled className="cortext-canvas__locked">
+								<VisualCanvas
+									postId={ post.id }
+									onReady={ onDisplayedPost }
+								/>
+							</Disabled>
+						) : (
+							<VisualCanvas
+								postId={ post.id }
+								onReady={ onDisplayedPost }
+							/>
+						) }
+					</>
+				}
+				sidebar={ <ComplementaryArea.Slot scope={ SCOPE } /> }
+			/>
+			<InspectorSidebar />
+		</>
+	);
+}
+
+export default function Canvas( { postId, onDisplayedPost } ) {
+	const { record: requestedPost } = useEntityRecord(
 		'postType',
 		POST_TYPE,
 		postId
 	);
+	const [ displayedPost, setDisplayedPost ] = useState( null );
+	const renderedPost = displayedPost ?? requestedPost;
 
-	if ( isResolving || ! post ) {
+	useEffect( () => {
+		if ( ! requestedPost ) {
+			return;
+		}
+		setDisplayedPost( ( current ) => {
+			if ( ! current || current.id === requestedPost.id ) {
+				return requestedPost;
+			}
+			return current;
+		} );
+	}, [ requestedPost ] );
+
+	if ( ! renderedPost ) {
 		return (
 			<div className="cortext-canvas__loading">
 				<Spinner />
@@ -230,32 +310,23 @@ export default function Canvas( { postId } ) {
 		);
 	}
 
-	const isTrashed = post.status === 'trash';
+	const pendingPost =
+		requestedPost && requestedPost.id !== renderedPost.id
+			? requestedPost
+			: null;
 
 	return (
 		<EditorProvider
-			post={ post }
+			post={ renderedPost }
 			settings={ window.cortextEditorSettings ?? {} }
 			useSubRegistry={ false }
 		>
-			<InterfaceSkeleton
-				className="cortext-canvas"
-				header={ <Header /> }
-				content={
-					<>
-						{ isTrashed && <TrashedNotice postId={ post.id } /> }
-						{ isTrashed ? (
-							<Disabled className="cortext-canvas__locked">
-								<VisualCanvas />
-							</Disabled>
-						) : (
-							<VisualCanvas />
-						) }
-					</>
-				}
-				sidebar={ <ComplementaryArea.Slot scope={ SCOPE } /> }
+			<CanvasEditor
+				post={ renderedPost }
+				pendingPost={ pendingPost }
+				onSwitchPost={ setDisplayedPost }
+				onDisplayedPost={ onDisplayedPost }
 			/>
-			<InspectorSidebar />
 		</EditorProvider>
 	);
 }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -180,6 +180,7 @@ export default function CollectionDataViews( {
 	empty,
 	invalid,
 	error,
+	onReady,
 } ) {
 	const { fields, collection, slug, isResolving, fieldsResolved } =
 		useCollectionFields( collectionId );
@@ -211,6 +212,7 @@ export default function CollectionDataViews( {
 		data,
 		paginationInfo,
 		isLoading,
+		hasResolved: rowsResolved,
 		error: rowError,
 		refresh,
 	} = useCollectionRows( isResolving ? null : collectionId, reconciledView );
@@ -492,6 +494,12 @@ export default function CollectionDataViews( {
 			} );
 		}
 	}, [ availableFields, isTableLayout, isResolving, fieldsResolved ] );
+
+	useEffect( () => {
+		if ( ! isResolving && rowsResolved ) {
+			onReady?.();
+		}
+	}, [ isResolving, rowsResolved, onReady ] );
 
 	if ( isResolving ) {
 		return loading;

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -83,11 +83,18 @@ export default function useAutosave() {
 			postStatus: ps,
 			savePost: save,
 		} = stateRef.current;
-		if ( d && s && ! saving && ps !== 'trash' ) {
-			maybePromoteStatus();
-			lastSaveAtRef.current = Date.now();
-			save();
+		if ( ! d || ! s || ps === 'trash' ) {
+			return Promise.resolve( true );
 		}
+		if ( saving ) {
+			return Promise.resolve( false );
+		}
+		maybePromoteStatus();
+		lastSaveAtRef.current = Date.now();
+		return Promise.resolve( save() ).then(
+			() => true,
+			() => false
+		);
 	}, [] );
 
 	useEffect( () => {
@@ -147,8 +154,12 @@ export default function useAutosave() {
 				flushNow();
 			}
 		};
-		const onBlur = () => flushNow();
-		const onBeforeUnload = () => flushNow();
+		const onBlur = () => {
+			flushNow();
+		};
+		const onBeforeUnload = () => {
+			flushNow();
+		};
 
 		document.addEventListener( 'visibilitychange', onVisibilityChange );
 		window.addEventListener( 'blur', onBlur );
@@ -165,5 +176,5 @@ export default function useAutosave() {
 		};
 	}, [ flushNow ] );
 
-	return { status, lastSavedAt };
+	return { status, lastSavedAt, flushNow, isDirty, isSaving };
 }

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -18,6 +18,7 @@ export default function useAutosave() {
 		editsReference,
 		postStatus,
 		postTitle,
+		currentPostId,
 	} = useSelect( ( select ) => {
 		const editor = select( editorStore );
 		return {
@@ -30,6 +31,7 @@ export default function useAutosave() {
 				select( coreDataStore ).getReferenceByDistinctEdits(),
 			postStatus: editor.getEditedPostAttribute( 'status' ),
 			postTitle: editor.getEditedPostAttribute( 'title' ),
+			currentPostId: editor.getCurrentPostId(),
 		};
 	}, [] );
 
@@ -147,6 +149,20 @@ export default function useAutosave() {
 			setLastSavedAt( Date.now() );
 		}
 	}, [ isSaving, didSucceed, didFail ] );
+
+	// CanvasEditor stays mounted across post switches so the iframe survives,
+	// which means our local status would otherwise carry a stale "Failed to
+	// save" or "Saved" label into the next post. Skip the initial mount; the
+	// status flags from the editor store are already authoritative there.
+	const lastPostIdRef = useRef( currentPostId );
+	useEffect( () => {
+		if ( lastPostIdRef.current === currentPostId ) {
+			return;
+		}
+		lastPostIdRef.current = currentPostId;
+		setStatus( 'idle' );
+		setLastSavedAt( null );
+	}, [ currentPostId ] );
 
 	useEffect( () => {
 		const onVisibilityChange = () => {

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -43,6 +43,7 @@ export default function useCollectionRows( collectionId, view ) {
 		data: [],
 		paginationInfo: { totalItems: 0, totalPages: 0 },
 		isLoading: false,
+		hasResolved: false,
 		error: null,
 	} );
 	const [ refreshKey, setRefreshKey ] = useState( 0 );
@@ -64,6 +65,7 @@ export default function useCollectionRows( collectionId, view ) {
 				data: [],
 				paginationInfo: { totalItems: 0, totalPages: 0 },
 				isLoading: false,
+				hasResolved: false,
 				error: null,
 			} );
 			return undefined;
@@ -75,7 +77,12 @@ export default function useCollectionRows( collectionId, view ) {
 			buildQueryArgs( collectionId, view )
 		);
 
-		setState( ( prev ) => ( { ...prev, isLoading: true, error: null } ) );
+		setState( ( prev ) => ( {
+			...prev,
+			isLoading: true,
+			hasResolved: false,
+			error: null,
+		} ) );
 
 		apiFetch( { path } )
 			.then( ( body ) => {
@@ -89,6 +96,7 @@ export default function useCollectionRows( collectionId, view ) {
 						totalPages: body.totalPages ?? 1,
 					},
 					isLoading: false,
+					hasResolved: true,
 					error: null,
 				} );
 			} )
@@ -100,6 +108,7 @@ export default function useCollectionRows( collectionId, view ) {
 					data: [],
 					paginationInfo: { totalItems: 0, totalPages: 0 },
 					isLoading: false,
+					hasResolved: true,
 					error,
 				} );
 			} );

--- a/src/index.scss
+++ b/src/index.scss
@@ -286,6 +286,38 @@ body.cortext-fullscreen {
 	}
 }
 
+.cortext-workspace {
+	position: absolute;
+	inset: 0;
+	min-height: 0;
+}
+
+.cortext-workspace__pane {
+	position: absolute;
+	inset: 0;
+	min-height: 0;
+	visibility: hidden;
+	pointer-events: none;
+	z-index: 0;
+}
+
+.cortext-workspace__pane[data-preserve-paint="true"] {
+	visibility: visible;
+}
+
+.cortext-workspace__pane[data-active="true"] {
+	visibility: visible;
+	pointer-events: auto;
+	background: var(--cortext-canvas-frame-surface);
+	z-index: 1;
+}
+
+.cortext-collection-pane {
+	position: relative;
+	height: 100%;
+	min-height: 0;
+}
+
 .cortext-canvas {
 
 	&__header {
@@ -315,8 +347,14 @@ body.cortext-fullscreen {
 	// Gutenberg-internal class; revisit if `@wordpress/interface` ever
 	// exposes a slot for a notice region above the content.
 	.interface-interface-skeleton__content {
+		position: relative;
 		display: flex;
 		flex-direction: column;
+		min-height: 0;
+	}
+
+	&__visual {
+		flex: 1 1 auto;
 		min-height: 0;
 	}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -366,7 +366,11 @@ body.cortext-fullscreen {
 
 	// `<Disabled>` already neutralises pointer events for the trashed
 	// canvas; the muted opacity is the visual cue that editing is locked.
+	// `<Disabled>` itself renders a plain div, so make it a flex column so
+	// the inner `__visual` wrapper still receives a height.
 	&__locked {
+		display: flex;
+		flex-direction: column;
 		flex: 1 1 auto;
 		min-height: 0;
 		opacity: 0.7;

--- a/src/router.js
+++ b/src/router.js
@@ -9,7 +9,6 @@ import { privateApis as routePrivateApis } from '@wordpress/route';
 
 import Sidebar from './components/Sidebar';
 import EntityRoute from './router/EntityRoute';
-import EmptyState from './router/EmptyState';
 import { unlock } from './lock-unlock';
 
 const {
@@ -17,7 +16,6 @@ const {
 	createRootRoute,
 	createRoute,
 	createBrowserHistory,
-	Outlet,
 	RouterProvider,
 	parseHref,
 } = unlock( routePrivateApis );
@@ -27,7 +25,7 @@ function RootLayout() {
 		<div className="cortext-shell">
 			<Sidebar />
 			<main className="cortext-shell__canvas">
-				<Outlet />
+				<EntityRoute />
 			</main>
 		</div>
 	);
@@ -38,13 +36,11 @@ const rootRoute = createRootRoute( { component: RootLayout } );
 const indexRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: '/',
-	component: EmptyState,
 } );
 
 const splatRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: '$',
-	component: EntityRoute,
 } );
 
 const routeTree = rootRoute.addChildren( [ indexRoute, splatRoute ] );

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -102,6 +102,17 @@ function getActiveCollectionId( activePane ) {
 	return match ? Number( match[ 1 ] ) : null;
 }
 
+// Activation flow:
+//   1. URL changes → routeKey recomputes synchronously.
+//   2. committedRouteKey catches up after one render so the new pane mounts
+//      (still inactive) before we hide the previous one.
+//   3. Each pane reports readiness through its own signal: the page canvas
+//      fires onDisplayedPost from inside the iframe portal; collections fire
+//      onReady once their rows resolve.
+//   4. Once a pane is ready we set activePane, swapping it on top.
+// The page pane carries data-preserve-paint so its iframe stays painted when
+// inactive, so navigating page → collection → page reuses the same iframe
+// rather than re-creating (and re-flashing) it.
 export default function EntityRoute() {
 	const params = useParams( { strict: false } );
 	const { prefix, tail } = parseSplatUri( params._splat ?? '' );

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -1,38 +1,17 @@
 import { useParams } from '@tanstack/react-router';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 
 import Canvas from '../components/Canvas';
 import CollectionDataViews from '../components/CollectionDataViews';
+import EmptyState from './EmptyState';
 import {
 	parseIdFromUri,
 	parseSplatUri,
 	useResolveEntity,
 	useResolveCollection,
 } from './useResolveEntity';
-
-function PageRoute( { uri } ) {
-	const { entity, isResolving, notFound } = useResolveEntity( uri );
-
-	if ( isResolving ) {
-		return (
-			<div className="cortext-canvas__loading">
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( notFound || ! entity ) {
-		return (
-			<div className="cortext-canvas__empty">
-				<p>{ __( "That page doesn't exist.", 'cortext' ) }</p>
-			</div>
-		);
-	}
-
-	return <Canvas postId={ entity.id } key={ entity.id } />;
-}
 
 const DEFAULT_VIEW = {
 	type: 'table',
@@ -45,7 +24,7 @@ const DEFAULT_VIEW = {
 	layout: {},
 };
 
-function CollectionView( { collectionId } ) {
+function CollectionView( { collectionId, onReady } ) {
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 
 	return (
@@ -53,54 +32,280 @@ function CollectionView( { collectionId } ) {
 			collectionId={ collectionId }
 			view={ view }
 			onChangeView={ setView }
+			onReady={ onReady }
 			loading={
 				<div className="cortext-canvas__loading">
 					<Spinner />
 				</div>
 			}
 			empty={
-				<p className="cortext-canvas__empty-text">
+				<span className="cortext-canvas__empty-text">
 					{ __( 'No entries yet.', 'cortext' ) }
-				</p>
+				</span>
 			}
 		/>
 	);
 }
 
-function CollectionRoute( { uri } ) {
-	const id = parseIdFromUri( uri );
-	const { entity, isResolving, notFound } = useResolveCollection( id );
-
-	if ( isResolving ) {
-		return (
-			<div className="cortext-canvas__loading">
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( notFound || ! entity ) {
-		return (
-			<div className="cortext-canvas__empty">
-				<p>{ __( "That collection doesn't exist.", 'cortext' ) }</p>
-			</div>
-		);
-	}
-
+function CollectionPane( { collectionId, onReady } ) {
 	return (
-		<div className="cortext-canvas__table">
-			<CollectionView collectionId={ entity.id } key={ entity.id } />
+		<div className="cortext-collection-pane">
+			<div className="cortext-canvas__table">
+				<CollectionView
+					collectionId={ collectionId }
+					onReady={ onReady }
+				/>
+			</div>
 		</div>
 	);
+}
+
+function LoadingPane() {
+	return (
+		<div className="cortext-canvas__loading">
+			<Spinner />
+		</div>
+	);
+}
+
+function NotFoundPane( { type } ) {
+	return (
+		<div className="cortext-canvas__empty">
+			<p>
+				{ type === 'collection'
+					? __( "That collection doesn't exist.", 'cortext' )
+					: __( "That page doesn't exist.", 'cortext' ) }
+			</p>
+		</div>
+	);
+}
+
+function WorkspacePane( { active, preservePaint = false, children } ) {
+	return (
+		<div
+			className="cortext-workspace__pane"
+			data-active={ active ? 'true' : 'false' }
+			data-preserve-paint={ preservePaint ? 'true' : 'false' }
+			aria-hidden={ ! active }
+			{ ...( active ? {} : { inert: '' } ) }
+		>
+			{ children }
+		</div>
+	);
+}
+
+function getActiveCollectionId( activePane ) {
+	const match =
+		typeof activePane === 'string'
+			? activePane.match( /^collection:(\d+)$/ )
+			: null;
+	return match ? Number( match[ 1 ] ) : null;
 }
 
 export default function EntityRoute() {
 	const params = useParams( { strict: false } );
 	const { prefix, tail } = parseSplatUri( params._splat ?? '' );
-
-	if ( prefix === 'collection' ) {
-		return <CollectionRoute uri={ tail } key={ `c-${ tail }` } />;
+	const isCollectionRoute = prefix === 'collection';
+	const isEmptyRoute = ! isCollectionRoute && ! tail;
+	const pageId = isCollectionRoute ? null : parseIdFromUri( tail );
+	const collectionId = isCollectionRoute ? parseIdFromUri( tail ) : null;
+	let routeKey = 'empty';
+	if ( isCollectionRoute ) {
+		routeKey = `collection:${ collectionId ?? 'invalid' }`;
+	} else if ( ! isEmptyRoute ) {
+		routeKey = `page:${ pageId ?? 'invalid' }`;
 	}
+	const [ committedRouteKey, setCommittedRouteKey ] = useState( routeKey );
+	const hasCurrentRouteRendered = committedRouteKey === routeKey;
 
-	return <PageRoute uri={ tail } />;
+	const pageResolution = useResolveEntity( isCollectionRoute ? '' : tail );
+	const collectionResolution = useResolveCollection( collectionId );
+
+	const [ requestedPageId, setRequestedPageId ] = useState( null );
+	const [ displayedPageId, setDisplayedPageId ] = useState( null );
+	const [ collectionIds, setCollectionIds ] = useState( [] );
+	const [ readyCollectionIds, setReadyCollectionIds ] = useState(
+		() => new Set()
+	);
+	const [ activePane, setActivePane ] = useState( null );
+
+	useEffect( () => {
+		setCommittedRouteKey( routeKey );
+	}, [ routeKey ] );
+
+	useEffect( () => {
+		if ( isEmptyRoute && hasCurrentRouteRendered ) {
+			setActivePane( 'empty' );
+		}
+	}, [ isEmptyRoute, hasCurrentRouteRendered ] );
+
+	useEffect( () => {
+		if ( isEmptyRoute || isCollectionRoute || ! hasCurrentRouteRendered ) {
+			return;
+		}
+		const { entity, isResolving, notFound } = pageResolution;
+		if ( entity?.id === pageId ) {
+			setRequestedPageId( entity.id );
+			return;
+		}
+		if ( ! isResolving && notFound ) {
+			setActivePane( 'page:not-found' );
+		}
+	}, [
+		isEmptyRoute,
+		isCollectionRoute,
+		hasCurrentRouteRendered,
+		pageId,
+		pageResolution,
+	] );
+
+	useEffect( () => {
+		if (
+			! isCollectionRoute &&
+			hasCurrentRouteRendered &&
+			requestedPageId === pageId &&
+			requestedPageId &&
+			displayedPageId === requestedPageId
+		) {
+			setActivePane( 'page' );
+		}
+	}, [
+		isCollectionRoute,
+		hasCurrentRouteRendered,
+		pageId,
+		requestedPageId,
+		displayedPageId,
+	] );
+
+	useEffect( () => {
+		if ( ! isCollectionRoute || ! hasCurrentRouteRendered ) {
+			return;
+		}
+		const { entity, isResolving, notFound } = collectionResolution;
+		if ( entity?.id === collectionId ) {
+			setCollectionIds( ( current ) =>
+				current.includes( entity.id )
+					? current
+					: [ ...current, entity.id ]
+			);
+			if ( readyCollectionIds.has( entity.id ) ) {
+				setActivePane( `collection:${ entity.id }` );
+			}
+			return;
+		}
+		if ( ! isResolving && notFound ) {
+			setActivePane( 'collection:not-found' );
+		}
+	}, [
+		isCollectionRoute,
+		hasCurrentRouteRendered,
+		collectionId,
+		collectionResolution,
+		readyCollectionIds,
+	] );
+
+	const handleDisplayedPost = useCallback( ( postId ) => {
+		setDisplayedPageId( postId );
+	}, [] );
+
+	const handleCollectionReady = useCallback(
+		( id ) => {
+			setReadyCollectionIds( ( current ) => {
+				if ( current.has( id ) ) {
+					return current;
+				}
+				const next = new Set( current );
+				next.add( id );
+				return next;
+			} );
+
+			if ( isCollectionRoute && collectionId === id ) {
+				setActivePane( `collection:${ id }` );
+			}
+		},
+		[ isCollectionRoute, collectionId ]
+	);
+
+	useEffect( () => {
+		const keepIds = new Set();
+		const activeCollectionId = getActiveCollectionId( activePane );
+		if ( activeCollectionId ) {
+			keepIds.add( activeCollectionId );
+		}
+		if ( isCollectionRoute && collectionId ) {
+			keepIds.add( collectionId );
+		}
+
+		setCollectionIds( ( current ) => {
+			const next = current.filter( ( id ) => keepIds.has( id ) );
+			return next.length === current.length ? current : next;
+		} );
+		setReadyCollectionIds( ( current ) => {
+			let changed = false;
+			const next = new Set();
+			current.forEach( ( id ) => {
+				if ( keepIds.has( id ) ) {
+					next.add( id );
+				} else {
+					changed = true;
+				}
+			} );
+			return changed ? next : current;
+		} );
+	}, [ activePane, isCollectionRoute, collectionId ] );
+
+	const isInitialPageLoad =
+		! activePane &&
+		! isCollectionRoute &&
+		! pageResolution.notFound &&
+		( pageResolution.isResolving ||
+			Boolean( pageId ) ||
+			( requestedPageId && displayedPageId !== requestedPageId ) );
+	const isInitialCollectionLoad =
+		! activePane &&
+		isCollectionRoute &&
+		! collectionResolution.notFound &&
+		( collectionResolution.isResolving ||
+			( collectionId && ! readyCollectionIds.has( collectionId ) ) );
+	const showLoading = Boolean( isInitialPageLoad || isInitialCollectionLoad );
+	const showEmpty =
+		activePane === 'empty' || ( ! activePane && ! showLoading );
+
+	return (
+		<div className="cortext-workspace">
+			{ requestedPageId && (
+				<WorkspacePane active={ activePane === 'page' } preservePaint>
+					<Canvas
+						postId={ requestedPageId }
+						onDisplayedPost={ handleDisplayedPost }
+					/>
+				</WorkspacePane>
+			) }
+
+			{ collectionIds.map( ( id ) => (
+				<WorkspacePane
+					key={ id }
+					active={ activePane === `collection:${ id }` }
+				>
+					<CollectionPane
+						collectionId={ id }
+						onReady={ () => handleCollectionReady( id ) }
+					/>
+				</WorkspacePane>
+			) ) }
+
+			<WorkspacePane active={ showEmpty }>
+				<EmptyState />
+			</WorkspacePane>
+			<WorkspacePane active={ activePane === 'page:not-found' }>
+				<NotFoundPane type="page" />
+			</WorkspacePane>
+			<WorkspacePane active={ activePane === 'collection:not-found' }>
+				<NotFoundPane type="collection" />
+			</WorkspacePane>
+			<WorkspacePane active={ showLoading }>
+				<LoadingPane />
+			</WorkspacePane>
+		</div>
+	);
 }

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -24,10 +24,12 @@ export function useResolveEntity( uri ) {
 		notFound: false,
 	} );
 
-	// Keyed on `id` rather than `uri` so that canonicalization rewrites
-	// (`/42` → `/about-us-42` for the same record) don't re-fetch and briefly
-	// flip state to `{ entity: null, isResolving: true }`, which would unmount
-	// the editor mid-typing.
+	// Once `id` is real, this collapses to the id so canonicalization rewrites
+	// (`/42` → `/about-us-42`) don't re-fetch. When `id` is null, distinct
+	// unparseable URIs each get their own key so empty → malformed (and
+	// malformed-A → malformed-B) re-run the effect and flip notFound.
+	const fetchKey = id !== null ? `id:${ id }` : `uri:${ uri ?? '' }`;
+
 	useEffect( () => {
 		if ( ! id ) {
 			setState( {
@@ -66,10 +68,9 @@ export function useResolveEntity( uri ) {
 		return () => {
 			cancelled = true;
 		};
-		// `uri` is only read in the no-id branch to distinguish empty from
-		// malformed; we don't want a uri change with the same id to refetch.
+		// `fetchKey` already encodes both id and (when id is null) uri.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ id ] );
+	}, [ fetchKey ] );
 
 	return state;
 }

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -1,0 +1,201 @@
+/**
+ * E2E coverage for route transitions that should not tear down the canvas.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SUFFIX = Date.now().toString( 36 ).slice( -4 );
+const FIRST_PAGE_TITLE = `E2E Lifecycle Page A ${ SUFFIX }`;
+const SECOND_PAGE_TITLE = `E2E Lifecycle Page B ${ SUFFIX }`;
+const COLLECTION_TITLE = `E2E Lifecycle Collection ${ SUFFIX }`;
+const ENTRY_TITLE = `E2E Lifecycle Entry ${ SUFFIX }`;
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch ( _error ) {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+async function waitForEditorPost( page, postId ) {
+	await page.waitForFunction(
+		( expectedPostId ) =>
+			window.wp?.data
+				?.select( 'core/editor' )
+				?.getCurrentPostId?.() === expectedPostId,
+		postId,
+		{ timeout: 15_000 }
+	);
+}
+
+test.describe( 'Navigation lifecycle', () => {
+	test( 'preserves the mounted page canvas and waits for collection rows', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		let releaseRows = () => {};
+
+		try {
+			fixture.firstPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: { title: FIRST_PAGE_TITLE, status: 'private' },
+			} );
+			fixture.secondPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: { title: SECOND_PAGE_TITLE, status: 'private' },
+			} );
+			fixture.slug = `e2elife${ SUFFIX }`;
+			fixture.collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_collections',
+				data: {
+					title: COLLECTION_TITLE,
+					status: 'private',
+					meta: { slug: fixture.slug },
+				},
+			} );
+			fixture.entry = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_${ fixture.slug }`,
+				data: { title: ENTRY_TITLE, status: 'private' },
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.firstPage.id }`
+			);
+			await waitForEditorPost( page, fixture.firstPage.id );
+
+			const canvasBefore = await page
+				.locator( '.cortext-canvas' )
+				.elementHandle();
+			expect( canvasBefore ).not.toBeNull();
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			await sidebar
+				.getByRole( 'button', {
+					name: SECOND_PAGE_TITLE,
+					exact: true,
+				} )
+				.click();
+			await waitForEditorPost( page, fixture.secondPage.id );
+
+			const canvasAfter = await page
+				.locator( '.cortext-canvas' )
+				.elementHandle();
+			expect( canvasAfter ).not.toBeNull();
+			await expect( page.locator( '.cortext-canvas' ) ).toHaveCount( 1 );
+			const keptCanvas = await page.evaluate(
+				( [ before, after ] ) => before === after,
+				[ canvasBefore, canvasAfter ]
+			);
+			expect( keptCanvas ).toBe( true );
+
+			const rowsGate = new Promise( ( resolve ) => {
+				releaseRows = resolve;
+			} );
+			await page.route( '**/wp-json/cortext/v1/rows**', async ( route ) => {
+				if (
+					route
+						.request()
+						.url()
+						.includes( `collection=${ fixture.collection.id }` )
+				) {
+					await rowsGate;
+				}
+				await route.continue();
+			} );
+			const rowsRequest = page.waitForRequest(
+				( request ) =>
+					request.url().includes( '/wp-json/cortext/v1/rows' ) &&
+					request
+						.url()
+						.includes( `collection=${ fixture.collection.id }` )
+			);
+
+			await sidebar
+				.getByRole( 'button', {
+					name: COLLECTION_TITLE,
+					exact: true,
+				} )
+				.click();
+			await rowsRequest;
+
+			await expect(
+				page.locator(
+					'.cortext-workspace__pane[data-active="true"] .cortext-canvas'
+				)
+			).toBeVisible();
+			await expect(
+				page.locator(
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+				)
+			).toHaveCount( 0 );
+
+			releaseRows();
+
+			const activeCollection = page.locator(
+				'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+			);
+			await expect( activeCollection ).toBeVisible();
+			await expect( activeCollection ).toContainText( ENTRY_TITLE );
+
+			const pagePane = page
+				.locator( '.cortext-workspace__pane' )
+				.filter( { has: page.locator( '.cortext-canvas' ) } );
+			await expect( pagePane ).toHaveAttribute( 'data-active', 'false' );
+			await expect( pagePane ).toHaveCSS( 'visibility', 'visible' );
+
+			await sidebar
+				.getByRole( 'button', {
+					name: SECOND_PAGE_TITLE,
+					exact: true,
+				} )
+				.click();
+			await waitForEditorPost( page, fixture.secondPage.id );
+			await expect( pagePane ).toHaveAttribute( 'data-active', 'true' );
+			const canvasAfterCollection = await page
+				.locator( '.cortext-canvas' )
+				.elementHandle();
+			const keptCanvasAfterCollection = await page.evaluate(
+				( [ before, after ] ) => before === after,
+				[ canvasAfter, canvasAfterCollection ]
+			);
+			expect( keptCanvasAfterCollection ).toBe( true );
+		} finally {
+			releaseRows();
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.secondPage &&
+					`/wp/v2/crtxt_pages/${ fixture.secondPage.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.firstPage &&
+					`/wp/v2/crtxt_pages/${ fixture.firstPage.id }`
+			);
+		}
+	} );
+} );

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -31,6 +31,7 @@ const DEFAULT_STATE = {
 	didFail: false,
 	postStatus: 'private',
 	postTitle: '',
+	currentPostId: 1,
 };
 
 let editsReference = {};
@@ -43,6 +44,7 @@ function setStoreState( state ) {
 		isSavingPost: () => merged.isSaving,
 		didPostSaveRequestSucceed: () => merged.didSucceed,
 		didPostSaveRequestFail: () => merged.didFail,
+		getCurrentPostId: () => merged.currentPostId,
 		getEditedPostAttribute: ( name ) => {
 			if ( name === 'status' ) {
 				return merged.postStatus;
@@ -319,6 +321,21 @@ describe( 'useAutosave: status', () => {
 		const { result } = renderHook( () => useAutosave() );
 
 		expect( result.current.status ).toBe( 'error' );
+	} );
+
+	it( 'resets status when the current post id changes', () => {
+		setStoreState( { didFail: true, currentPostId: 1 } );
+
+		const { result, rerender } = renderHook( () => useAutosave() );
+		expect( result.current.status ).toBe( 'error' );
+
+		act( () => {
+			setStoreState( { didFail: false, currentPostId: 2 } );
+			rerender();
+		} );
+
+		expect( result.current.status ).toBe( 'idle' );
+		expect( result.current.lastSavedAt ).toBeNull();
 	} );
 } );
 


### PR DESCRIPTION
## What

Closes #142

Stops the canvas flash when opening pages and switching between pages and collections.

The editor now keeps the main panes mounted and only brings the next one forward once it is ready. That avoids bare iframe flashes, stuck spinners, and unnecessary iframe reloads when moving page -> collection -> page.

This also fixes a few related edge cases: malformed page URLs now show not-found, autosave labels do not carry between pages, and trashed pages get their full-height layout back.

## Testing

1. Open the editor cold and click a page. It should load without a bare iframe flash.
2. Switch page -> collection -> page. The page iframe should be reused.
3. Visit `?p=/page/about-us` and confirm the not-found pane appears.

## Screen recording

**Before**

https://github.com/user-attachments/assets/7b5f7501-61b3-4a56-a404-3f74abe255f7

**After**

https://github.com/user-attachments/assets/93081002-4d7f-4044-b681-4079dbf73c15