### PR TITLE
Add breadcrumbs to the workspace top bar

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -61,8 +61,8 @@ function Segment( { segment } ) {
 	);
 }
 
-export default function Breadcrumbs() {
-	const segments = truncate( useBreadcrumbSegments() );
+export default function Breadcrumbs( { paintedRoute } ) {
+	const segments = truncate( useBreadcrumbSegments( paintedRoute ) );
 
 	if ( segments.length === 0 ) {
 		return null;

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,0 +1,95 @@
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+
+import useBreadcrumbSegments from '../hooks/useBreadcrumbSegments';
+
+// Truncate once the bar would carry more than this many segments. A
+// four-deep page hierarchy fits unchanged; anything beyond collapses the
+// middle into "first / … / parent / current".
+const MAX_SEGMENTS = 4;
+
+// Collapses [root, a, b, c, ..., last] down to [root, …, parent, last] when the
+// chain gets too long. The ellipsis is non-interactive (no popover in this
+// pass) — the issue only asks for overflow protection.
+function truncate( segments ) {
+	if ( segments.length <= MAX_SEGMENTS ) {
+		return segments;
+	}
+	const first = segments[ 0 ];
+	const tail = segments.slice( -2 );
+	return [
+		first,
+		{
+			key: 'ellipsis',
+			label: '…',
+			onClick: null,
+			isCurrent: false,
+			isEllipsis: true,
+		},
+		...tail,
+	];
+}
+
+function Segment( { segment } ) {
+	if ( segment.isEllipsis ) {
+		return (
+			<span className="cortext-breadcrumbs__ellipsis" aria-hidden="true">
+				{ segment.label }
+			</span>
+		);
+	}
+
+	if ( segment.isCurrent || ! segment.onClick ) {
+		return (
+			<span
+				className="cortext-breadcrumbs__segment is-current"
+				aria-current={ segment.isCurrent ? 'page' : undefined }
+			>
+				{ segment.label }
+			</span>
+		);
+	}
+
+	return (
+		<button
+			type="button"
+			className="cortext-breadcrumbs__segment"
+			onClick={ segment.onClick }
+		>
+			{ segment.label }
+		</button>
+	);
+}
+
+export default function Breadcrumbs() {
+	const segments = truncate( useBreadcrumbSegments() );
+
+	if ( segments.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<nav
+			className="cortext-breadcrumbs"
+			aria-label={ __( 'Breadcrumb', 'cortext' ) }
+		>
+			<ol className="cortext-breadcrumbs__list">
+				{ segments.map( ( segment, index ) => (
+					<Fragment key={ segment.key }>
+						{ index > 0 && (
+							<li
+								className="cortext-breadcrumbs__separator"
+								aria-hidden="true"
+							>
+								/
+							</li>
+						) }
+						<li className="cortext-breadcrumbs__item">
+							<Segment segment={ segment } />
+						</li>
+					</Fragment>
+				) ) }
+			</ol>
+		</nav>
+	);
+}

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -29,6 +29,7 @@ import {
 	TRASHED_PAGES_QUERY,
 } from './page-queries';
 import PublishToggle from './PublishToggle';
+import { TopBarActionsFill } from './WorkspaceTopBar';
 
 const SCOPE = 'cortext';
 const INSPECTOR = 'cortext/block-inspector';
@@ -54,7 +55,7 @@ function SaveStatus( { status } ) {
 	);
 }
 
-function Header( { saveStatus } ) {
+function DocumentActions( { saveStatus, isActive } ) {
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
 	const isInspectorOpen = useSelect(
@@ -64,21 +65,31 @@ function Header( { saveStatus } ) {
 		[]
 	);
 
+	// Canvas stays mounted across route changes (preservePaint keeps the
+	// editor iframe warm). Suppress the Fill when this page isn't the active
+	// pane so a backgrounded editor doesn't keep projecting Save/Publish into
+	// the workspace top bar over a collection.
+	if ( ! isActive ) {
+		return null;
+	}
+
 	return (
-		<div className="cortext-canvas__header">
-			<SaveStatus status={ saveStatus } />
-			<PublishToggle />
-			<Button
-				icon={ cog }
-				label={ __( 'Settings', 'cortext' ) }
-				isPressed={ isInspectorOpen }
-				onClick={ () =>
-					isInspectorOpen
-						? disableComplementaryArea( SCOPE )
-						: enableComplementaryArea( SCOPE, INSPECTOR )
-				}
-			/>
-		</div>
+		<TopBarActionsFill>
+			<div className="cortext-document-actions">
+				<SaveStatus status={ saveStatus } />
+				<PublishToggle />
+				<Button
+					icon={ cog }
+					label={ __( 'Settings', 'cortext' ) }
+					isPressed={ isInspectorOpen }
+					onClick={ () =>
+						isInspectorOpen
+							? disableComplementaryArea( SCOPE )
+							: enableComplementaryArea( SCOPE, INSPECTOR )
+					}
+				/>
+			</div>
+		</TopBarActionsFill>
 	);
 }
 
@@ -226,7 +237,13 @@ function VisualCanvas( { postId, onReady } ) {
 	);
 }
 
-function CanvasEditor( { post, pendingPost, onSwitchPost, onDisplayedPost } ) {
+function CanvasEditor( {
+	post,
+	pendingPost,
+	onSwitchPost,
+	onDisplayedPost,
+	isActive,
+} ) {
 	const { status, flushNow, isDirty, isSaving } = useAutosave();
 	const isTrashed = post.status === 'trash';
 
@@ -253,9 +270,9 @@ function CanvasEditor( { post, pendingPost, onSwitchPost, onDisplayedPost } ) {
 
 	return (
 		<>
+			<DocumentActions saveStatus={ status } isActive={ isActive } />
 			<InterfaceSkeleton
 				className="cortext-canvas"
-				header={ <Header saveStatus={ status } /> }
 				content={
 					<>
 						{ isTrashed && <TrashedNotice postId={ post.id } /> }
@@ -281,7 +298,7 @@ function CanvasEditor( { post, pendingPost, onSwitchPost, onDisplayedPost } ) {
 	);
 }
 
-export default function Canvas( { postId, onDisplayedPost } ) {
+export default function Canvas( { postId, onDisplayedPost, isActive } ) {
 	const { record: requestedPost } = useEntityRecord(
 		'postType',
 		POST_TYPE,
@@ -326,6 +343,7 @@ export default function Canvas( { postId, onDisplayedPost } ) {
 				pendingPost={ pendingPost }
 				onSwitchPost={ setDisplayedPost }
 				onDisplayedPost={ onDisplayedPost }
+				isActive={ isActive }
 			/>
 		</EditorProvider>
 	);

--- a/src/components/WorkspaceTopBar.js
+++ b/src/components/WorkspaceTopBar.js
@@ -1,5 +1,7 @@
 import { createSlotFill } from '@wordpress/components';
 
+import Breadcrumbs from './Breadcrumbs';
+
 const SLOT_NAME = 'CortextTopBarActions';
 
 const { Slot, Fill } = createSlotFill( SLOT_NAME );
@@ -13,7 +15,9 @@ export const TopBarActionsFill = Fill;
 export default function WorkspaceTopBar() {
 	return (
 		<div className="cortext-topbar">
-			<div className="cortext-topbar__lead" />
+			<div className="cortext-topbar__lead">
+				<Breadcrumbs />
+			</div>
 			<div className="cortext-topbar__actions">
 				<Slot bubblesVirtually />
 			</div>

--- a/src/components/WorkspaceTopBar.js
+++ b/src/components/WorkspaceTopBar.js
@@ -12,11 +12,11 @@ const { Slot, Fill } = createSlotFill( SLOT_NAME );
 // while sharing chrome with the workspace shell.
 export const TopBarActionsFill = Fill;
 
-export default function WorkspaceTopBar() {
+export default function WorkspaceTopBar( { paintedRoute } ) {
 	return (
 		<div className="cortext-topbar">
 			<div className="cortext-topbar__lead">
-				<Breadcrumbs />
+				<Breadcrumbs paintedRoute={ paintedRoute } />
 			</div>
 			<div className="cortext-topbar__actions">
 				<Slot bubblesVirtually />

--- a/src/components/WorkspaceTopBar.js
+++ b/src/components/WorkspaceTopBar.js
@@ -1,0 +1,22 @@
+import { createSlotFill } from '@wordpress/components';
+
+const SLOT_NAME = 'CortextTopBarActions';
+
+const { Slot, Fill } = createSlotFill( SLOT_NAME );
+
+// Surfaces inside the canvas (currently only the page editor) project their
+// document actions into the right side of the top bar via this Fill, which
+// lets them stay scoped to their own React context (EditorProvider, etc.)
+// while sharing chrome with the workspace shell.
+export const TopBarActionsFill = Fill;
+
+export default function WorkspaceTopBar() {
+	return (
+		<div className="cortext-topbar">
+			<div className="cortext-topbar__lead" />
+			<div className="cortext-topbar__actions">
+				<Slot bubblesVirtually />
+			</div>
+		</div>
+	);
+}

--- a/src/hooks/useBreadcrumbSegments.js
+++ b/src/hooks/useBreadcrumbSegments.js
@@ -1,0 +1,151 @@
+import { __ } from '@wordpress/i18n';
+import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { useCallback, useMemo } from '@wordpress/element';
+
+import {
+	ACTIVE_PAGES_QUERY,
+	POST_TYPE as PAGE_POST_TYPE,
+} from '../components/page-queries';
+import { COLLECTION_QUERY } from '../collections';
+import {
+	computeUri,
+	parseIdFromUri,
+	parseSplatUri,
+} from '../router/useResolveEntity';
+
+const COLLECTION_POST_TYPE = 'crtxt_collection';
+
+function titleOf( entity ) {
+	return (
+		entity?.title?.rendered?.trim() ||
+		entity?.title?.raw?.trim() ||
+		__( '(untitled)', 'cortext' )
+	);
+}
+
+// Returns the breadcrumb segments for the active route. Page routes contribute
+// the natural ancestor chain; collection routes are flat (just the collection
+// itself). Empty / not-found / loading routes return an empty list. There is
+// no synthetic "workspace root" segment because there's no workspace home to
+// navigate to — `/` only renders the empty state.
+export default function useBreadcrumbSegments() {
+	const params = useParams( { strict: false } );
+	const navigate = useNavigate();
+	const { prefix, tail } = parseSplatUri( params._splat ?? '' );
+	const isCollection = prefix === 'collection';
+	const id = parseIdFromUri( tail );
+	const pageId = ! isCollection && id ? id : null;
+	const collectionId = isCollection && id ? id : null;
+
+	// Pulled from the same store the Sidebar populates, so no extra fetch.
+	const { records: pages } = useEntityRecords(
+		'postType',
+		PAGE_POST_TYPE,
+		ACTIVE_PAGES_QUERY
+	);
+	const { records: collections } = useEntityRecords(
+		'postType',
+		COLLECTION_POST_TYPE,
+		COLLECTION_QUERY
+	);
+
+	// Falls back to the single-record fetch when the list hasn't resolved yet
+	// (or doesn't contain the active id, e.g. a freshly-created page).
+	const { record: currentPage } = useEntityRecord(
+		'postType',
+		PAGE_POST_TYPE,
+		pageId ?? 0
+	);
+	const { record: currentCollection } = useEntityRecord(
+		'postType',
+		COLLECTION_POST_TYPE,
+		collectionId ?? 0
+	);
+
+	const goToPage = useCallback(
+		( page ) => {
+			navigate( {
+				to: '/$',
+				params: { _splat: computeUri( page, 'page' ) },
+			} );
+		},
+		[ navigate ]
+	);
+
+	return useMemo( () => {
+		if ( pageId ) {
+			const pagesById = new Map(
+				( pages ?? [] ).map( ( p ) => [ p.id, p ] )
+			);
+			// `currentPage` may resolve before the active-pages list, or be
+			// the only source for a freshly-created page that's not yet in
+			// the cached query. Treat it as authoritative when it matches.
+			const head =
+				pagesById.get( pageId ) ??
+				( currentPage?.id === pageId ? currentPage : null );
+			if ( ! head ) {
+				// Not yet resolved (loading) or 404. Suppress the breadcrumb
+				// rather than render "(untitled)" for a record that may not
+				// exist.
+				return [];
+			}
+			if ( ! pagesById.has( pageId ) ) {
+				pagesById.set( head.id, head );
+			}
+
+			const chain = [];
+			let cursor = head;
+			const seen = new Set();
+			while ( cursor && ! seen.has( cursor.id ) ) {
+				seen.add( cursor.id );
+				chain.unshift( cursor );
+				cursor = cursor.parent
+					? pagesById.get( cursor.parent ) ?? null
+					: null;
+			}
+
+			return chain.map( ( page, index ) => {
+				const isCurrent = index === chain.length - 1;
+				return {
+					key: `page:${ page.id }`,
+					label: titleOf( page ),
+					onClick: isCurrent ? null : () => goToPage( page ),
+					isCurrent,
+				};
+			} );
+		}
+
+		if ( collectionId ) {
+			const fromList = ( collections ?? [] ).find(
+				( c ) => c.id === collectionId
+			);
+			const collection =
+				fromList ??
+				( currentCollection?.id === collectionId
+					? currentCollection
+					: null );
+			if ( ! collection ) {
+				return [];
+			}
+			return [
+				{
+					key: `collection:${ collection.id }`,
+					label: titleOf( collection ),
+					onClick: null,
+					isCurrent: true,
+				},
+			];
+		}
+
+		return [];
+	}, [
+		pageId,
+		collectionId,
+		pages,
+		collections,
+		currentPage,
+		currentCollection,
+		goToPage,
+	] );
+}

--- a/src/hooks/useBreadcrumbSegments.js
+++ b/src/hooks/useBreadcrumbSegments.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
-import { useNavigate, useParams } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useMemo } from '@wordpress/element';
 
 import {
@@ -8,11 +8,7 @@ import {
 	POST_TYPE as PAGE_POST_TYPE,
 } from '../components/page-queries';
 import { COLLECTION_QUERY } from '../collections';
-import {
-	computeUri,
-	parseIdFromUri,
-	parseSplatUri,
-} from '../router/useResolveEntity';
+import { computeUri } from '../router/useResolveEntity';
 
 const COLLECTION_POST_TYPE = 'crtxt_collection';
 
@@ -24,19 +20,17 @@ function titleOf( entity ) {
 	);
 }
 
-// Returns the breadcrumb segments for the active route. Page routes contribute
-// the natural ancestor chain; collection routes are flat (just the collection
-// itself). Empty / not-found / loading routes return an empty list. There is
-// no synthetic "workspace root" segment because there's no workspace home to
-// navigate to — `/` only renders the empty state.
-export default function useBreadcrumbSegments() {
-	const params = useParams( { strict: false } );
+// Returns the breadcrumb segments for the currently painted surface. Driven by
+// `paintedRoute` (from EntityRoute) rather than the URL so the breadcrumb
+// updates in lockstep with the document-actions Fill — both sides of the top
+// bar describe the same entity even mid-navigation. Page routes contribute the
+// natural ancestor chain; collection routes are flat. Empty / not-found /
+// unresolved routes return no segments.
+export default function useBreadcrumbSegments( paintedRoute ) {
 	const navigate = useNavigate();
-	const { prefix, tail } = parseSplatUri( params._splat ?? '' );
-	const isCollection = prefix === 'collection';
-	const id = parseIdFromUri( tail );
-	const pageId = ! isCollection && id ? id : null;
-	const collectionId = isCollection && id ? id : null;
+	const kind = paintedRoute?.kind ?? 'unresolved';
+	const pageId = kind === 'page' ? paintedRoute.id : null;
+	const collectionId = kind === 'collection' ? paintedRoute.id : null;
 
 	// Pulled from the same store the Sidebar populates, so no extra fetch.
 	const { records: pages } = useEntityRecords(
@@ -85,9 +79,6 @@ export default function useBreadcrumbSegments() {
 				pagesById.get( pageId ) ??
 				( currentPage?.id === pageId ? currentPage : null );
 			if ( ! head ) {
-				// Not yet resolved (loading) or 404. Suppress the breadcrumb
-				// rather than render "(untitled)" for a record that may not
-				// exist.
 				return [];
 			}
 			if ( ! pagesById.has( pageId ) ) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -353,6 +353,65 @@ body.cortext-fullscreen {
 	gap: $grid-unit-10;
 }
 
+.cortext-breadcrumbs {
+	min-width: 0;
+	flex: 1 1 auto;
+
+	&__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		min-width: 0;
+		flex-wrap: nowrap;
+	}
+
+	&__item {
+		min-width: 0;
+		display: flex;
+		align-items: center;
+	}
+
+	&__separator {
+		color: var(--cortext-text-muted);
+		flex: 0 0 auto;
+		user-select: none;
+	}
+
+	&__ellipsis {
+		color: var(--cortext-text-muted);
+		flex: 0 0 auto;
+	}
+
+	&__segment {
+		appearance: none;
+		background: transparent;
+		border: 0;
+		padding: 0 $grid-unit-05;
+		font: inherit;
+		color: var(--cortext-text-muted);
+		cursor: pointer;
+		border-radius: var(--cortext-shell-radius);
+		max-width: 24ch;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		&:hover:not(.is-current),
+		&:focus:not(.is-current) {
+			color: var(--cortext-text);
+			background: var(--cortext-button-hover-surface);
+		}
+
+		&.is-current {
+			color: var(--cortext-text);
+			cursor: default;
+		}
+	}
+}
+
 .cortext-canvas {
 
 	&__loading,

--- a/src/index.scss
+++ b/src/index.scss
@@ -271,6 +271,9 @@ body.cortext-fullscreen {
 .cortext-shell__canvas {
 	position: relative;
 	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
 	// The shell column that frames the iframe. Follows the shell theme via
 	// --cortext-canvas-frame-surface. The iframe interior is painted by the active
 	// block theme, not by this token.
@@ -287,8 +290,8 @@ body.cortext-fullscreen {
 }
 
 .cortext-workspace {
-	position: absolute;
-	inset: 0;
+	position: relative;
+	flex: 1 1 auto;
 	min-height: 0;
 }
 
@@ -318,18 +321,39 @@ body.cortext-fullscreen {
 	min-height: 0;
 }
 
-.cortext-canvas {
+.cortext-topbar {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+	padding: $grid-unit-10 $grid-unit-20;
+	background: var(--cortext-shell-surface);
+	color: var(--cortext-text);
+	border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
+	min-height: 0;
 
-	&__header {
+	&__lead {
+		flex: 1 1 auto;
+		min-width: 0;
+		display: flex;
+		align-items: center;
+	}
+
+	&__actions {
+		flex: 0 0 auto;
 		display: flex;
 		align-items: center;
 		gap: $grid-unit-10;
-		padding: $grid-unit-10 $grid-unit-20;
-		flex: 1;
-		background: var(--cortext-shell-surface);
-		color: var(--cortext-text);
-		border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	}
+}
+
+.cortext-document-actions {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+}
+
+.cortext-canvas {
 
 	&__loading,
 	&__empty {
@@ -1046,7 +1070,7 @@ thead > tr > th {
 // that Cortext owns. The editor iframe, inspector, and block toolbars keep
 // Gutenberg's own component styling.
 .cortext-sidebar,
-.cortext-canvas__header {
+.cortext-topbar {
 
 	.components-button {
 		border-radius: var(--cortext-shell-radius);

--- a/src/router.js
+++ b/src/router.js
@@ -9,7 +9,6 @@ import { privateApis as routePrivateApis } from '@wordpress/route';
 import { SlotFillProvider } from '@wordpress/components';
 
 import Sidebar from './components/Sidebar';
-import WorkspaceTopBar from './components/WorkspaceTopBar';
 import EntityRoute from './router/EntityRoute';
 import { unlock } from './lock-unlock';
 
@@ -28,7 +27,6 @@ function RootLayout() {
 			<div className="cortext-shell">
 				<Sidebar />
 				<main className="cortext-shell__canvas">
-					<WorkspaceTopBar />
 					<EntityRoute />
 				</main>
 			</div>

--- a/src/router.js
+++ b/src/router.js
@@ -6,8 +6,10 @@
 // router emits those hrefs on navigation and parses them back on load.
 
 import { privateApis as routePrivateApis } from '@wordpress/route';
+import { SlotFillProvider } from '@wordpress/components';
 
 import Sidebar from './components/Sidebar';
+import WorkspaceTopBar from './components/WorkspaceTopBar';
 import EntityRoute from './router/EntityRoute';
 import { unlock } from './lock-unlock';
 
@@ -22,12 +24,15 @@ const {
 
 function RootLayout() {
 	return (
-		<div className="cortext-shell">
-			<Sidebar />
-			<main className="cortext-shell__canvas">
-				<EntityRoute />
-			</main>
-		</div>
+		<SlotFillProvider>
+			<div className="cortext-shell">
+				<Sidebar />
+				<main className="cortext-shell__canvas">
+					<WorkspaceTopBar />
+					<EntityRoute />
+				</main>
+			</div>
+		</SlotFillProvider>
 	);
 }
 

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -11,6 +11,7 @@ import {
 
 import Canvas from '../components/Canvas';
 import CollectionDataViews from '../components/CollectionDataViews';
+import WorkspaceTopBar from '../components/WorkspaceTopBar';
 import EmptyState from './EmptyState';
 import { useResolveEntity, useResolveCollection } from './useResolveEntity';
 import { init, parseTarget, reducer } from './entityRouteReducer';
@@ -169,42 +170,69 @@ export default function EntityRoute() {
 		dispatch( { type: 'COLLECTION_READY', id } );
 	}, [] );
 
+	// Drives the breadcrumb from the same paint state the document-actions
+	// Fill uses, so both sides of the top bar update together. Reading the
+	// URL directly would race ahead of the still-active pane during the
+	// in-between window of a route change.
+	let paintedRoute = { kind: 'unresolved' };
+	if ( active.kind === 'page' ) {
+		paintedRoute = { kind: 'page', id: mountedPageId };
+	} else if ( active.kind === 'collection' ) {
+		paintedRoute = { kind: 'collection', id: active.id };
+	} else if (
+		active.kind === 'empty' ||
+		active.kind === 'page-not-found' ||
+		active.kind === 'collection-not-found'
+	) {
+		paintedRoute = { kind: active.kind };
+	}
+
 	return (
-		<div className="cortext-workspace">
-			{ mountedPageId !== null && (
-				<WorkspacePane active={ active.kind === 'page' } preservePaint>
-					<Canvas
-						postId={ mountedPageId }
-						onDisplayedPost={ handlePageDisplayed }
-						isActive={ active.kind === 'page' }
-					/>
-				</WorkspacePane>
-			) }
+		<>
+			<WorkspaceTopBar paintedRoute={ paintedRoute } />
+			<div className="cortext-workspace">
+				{ mountedPageId !== null && (
+					<WorkspacePane
+						active={ active.kind === 'page' }
+						preservePaint
+					>
+						<Canvas
+							postId={ mountedPageId }
+							onDisplayedPost={ handlePageDisplayed }
+							isActive={ active.kind === 'page' }
+						/>
+					</WorkspacePane>
+				) }
 
-			{ mountedCollectionIds.map( ( id ) => (
+				{ mountedCollectionIds.map( ( id ) => (
+					<WorkspacePane
+						key={ id }
+						active={
+							active.kind === 'collection' && active.id === id
+						}
+					>
+						<CollectionPane
+							collectionId={ id }
+							onReady={ handleCollectionReady }
+						/>
+					</WorkspacePane>
+				) ) }
+
+				<WorkspacePane active={ active.kind === 'empty' }>
+					<EmptyState />
+				</WorkspacePane>
+				<WorkspacePane active={ active.kind === 'page-not-found' }>
+					<NotFoundPane type="page" />
+				</WorkspacePane>
 				<WorkspacePane
-					key={ id }
-					active={ active.kind === 'collection' && active.id === id }
+					active={ active.kind === 'collection-not-found' }
 				>
-					<CollectionPane
-						collectionId={ id }
-						onReady={ handleCollectionReady }
-					/>
+					<NotFoundPane type="collection" />
 				</WorkspacePane>
-			) ) }
-
-			<WorkspacePane active={ active.kind === 'empty' }>
-				<EmptyState />
-			</WorkspacePane>
-			<WorkspacePane active={ active.kind === 'page-not-found' }>
-				<NotFoundPane type="page" />
-			</WorkspacePane>
-			<WorkspacePane active={ active.kind === 'collection-not-found' }>
-				<NotFoundPane type="collection" />
-			</WorkspacePane>
-			<WorkspacePane active={ active.kind === 'loading' }>
-				<LoadingPane />
-			</WorkspacePane>
-		</div>
+				<WorkspacePane active={ active.kind === 'loading' }>
+					<LoadingPane />
+				</WorkspacePane>
+			</div>
+		</>
 	);
 }

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -176,6 +176,7 @@ export default function EntityRoute() {
 					<Canvas
 						postId={ mountedPageId }
 						onDisplayedPost={ handlePageDisplayed }
+						isActive={ active.kind === 'page' }
 					/>
 				</WorkspacePane>
 			) }


### PR DESCRIPTION
## What

Closes #96

Adds breadcrumbs to the workspace top bar.

Pages show their parent chain. Collections show the collection name. Long page paths collapse to `first / ... / parent / current`, and empty/not-found routes do not render a breadcrumb.

The page editor actions now live in the shared top bar through Slot/Fill, so a backgrounded page editor does not leave Save/Publish/Settings over a collection.

## Testing

1. Open a deep page. The breadcrumb shows the chain; ancestors are clickable and the current page is not.
2. Click an ancestor and confirm the URL and canvas update.
3. Open a collection and confirm the breadcrumb shows the collection name.
4. Visit `/page/bogus-99999` or `/` and confirm no breadcrumb shows.