### PR TITLE
View transitions: Add cross-fade effect between editor surfaces

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -23,6 +23,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
 import useAutosave from '../hooks/useAutosave';
+import { withViewTransition } from '../hooks/viewTransition';
 import {
 	ACTIVE_PAGES_QUERY,
 	POST_TYPE,
@@ -257,7 +258,10 @@ function CanvasEditor( {
 		async function switchAfterSave() {
 			const didFlush = await flushNow();
 			if ( ! cancelled && didFlush ) {
-				onSwitchPost( pendingPost );
+				// Page-to-page swaps don't change EntityRoute's `active`, so
+				// the surface-level cross-fade can't see them. Trigger one
+				// here instead.
+				withViewTransition( () => onSwitchPost( pendingPost ) );
 			}
 		}
 

--- a/src/hooks/viewTransition.js
+++ b/src/hooks/viewTransition.js
@@ -1,0 +1,27 @@
+import { flushSync } from '@wordpress/element';
+
+function prefersReducedMotion() {
+	return (
+		typeof window !== 'undefined' &&
+		!! window.matchMedia &&
+		window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches
+	);
+}
+
+// Wrap a state update so the browser snapshots the canvas before and
+// after, then cross-fades between them. Without View Transitions support
+// or with reduced motion on, just runs the updater directly.
+export function withViewTransition( updater ) {
+	const supported =
+		typeof document !== 'undefined' &&
+		typeof document.startViewTransition === 'function';
+
+	if ( ! supported || prefersReducedMotion() ) {
+		updater();
+		return;
+	}
+
+	document.startViewTransition( () => {
+		flushSync( updater );
+	} );
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -268,6 +268,12 @@ body.cortext-fullscreen {
 	}
 }
 
+// Skip the default root snapshot so the sidebar and top bar stay live
+// during the swap. Only the canvas opts in below.
+:root {
+	view-transition-name: none;
+}
+
 .cortext-shell__canvas {
 	position: relative;
 	overflow: hidden;
@@ -278,6 +284,8 @@ body.cortext-fullscreen {
 	// --cortext-canvas-frame-surface. The iframe interior is painted by the active
 	// block theme, not by this token.
 	background: var(--cortext-canvas-frame-surface);
+	// Named so the cross-fade is scoped to this column.
+	view-transition-name: cortext-canvas;
 
 	// InterfaceSkeleton defaults to `position: fixed` at >= 782px, which would
 	// escape our grid and overlap the page-list sidebar. Scope it to fill just
@@ -286,6 +294,15 @@ body.cortext-fullscreen {
 		position: absolute !important;
 		inset: 0;
 		min-height: 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	::view-transition-group(cortext-canvas),
+	::view-transition-old(cortext-canvas),
+	::view-transition-new(cortext-canvas) {
+		animation: none !important;
 	}
 }
 

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -6,12 +6,14 @@ import {
 	useEffect,
 	useMemo,
 	useReducer,
+	useRef,
 	useState,
 } from '@wordpress/element';
 
 import Canvas from '../components/Canvas';
 import CollectionDataViews from '../components/CollectionDataViews';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
+import { withViewTransition } from '../hooks/viewTransition';
 import EmptyState from './EmptyState';
 import { useResolveEntity, useResolveCollection } from './useResolveEntity';
 import { init, parseTarget, reducer } from './entityRouteReducer';
@@ -102,9 +104,28 @@ export default function EntityRoute() {
 	const splat = params._splat ?? '';
 	const target = useMemo( () => parseTarget( splat ), [ splat ] );
 
-	const [ state, dispatch ] = useReducer( reducer, target, init );
+	const [ state, rawDispatch ] = useReducer( reducer, target, init );
 	const { active, mountedPageId, displayedPageId, mountedCollectionIds } =
 		state;
+
+	// Run the reducer ahead of time so we only wrap the dispatch when
+	// `active` actually flips. Otherwise every PAGE_RESOLVED or
+	// COLLECTION_RESOLVED would pin the canvas for the cross-fade
+	// duration even though nothing visible changed.
+	const stateRef = useRef( state );
+	stateRef.current = state;
+	const dispatch = useCallback( ( action ) => {
+		const before = stateRef.current;
+		const after = reducer( before, action );
+		const visualChanged =
+			before.active.kind !== after.active.kind ||
+			( before.active.id ?? null ) !== ( after.active.id ?? null );
+		if ( ! visualChanged ) {
+			rawDispatch( action );
+			return;
+		}
+		withViewTransition( () => rawDispatch( action ) );
+	}, [] );
 
 	const pageResolution = useResolveEntity(
 		target.kind === 'page' ? target.tail : ''
@@ -115,7 +136,7 @@ export default function EntityRoute() {
 
 	useEffect( () => {
 		dispatch( { type: 'TARGET_CHANGED', target } );
-	}, [ target ] );
+	}, [ target, dispatch ] );
 
 	useEffect( () => {
 		if ( target.kind !== 'page' || target.id === null ) {
@@ -139,7 +160,7 @@ export default function EntityRoute() {
 		if ( ! isResolving && notFound ) {
 			dispatch( { type: 'PAGE_NOT_FOUND' } );
 		}
-	}, [ target, pageResolution ] );
+	}, [ target, pageResolution, dispatch ] );
 
 	useEffect( () => {
 		if ( target.kind !== 'collection' || target.id === null ) {
@@ -161,15 +182,21 @@ export default function EntityRoute() {
 		if ( ! isResolving && notFound ) {
 			dispatch( { type: 'COLLECTION_NOT_FOUND' } );
 		}
-	}, [ target, collectionResolution ] );
+	}, [ target, collectionResolution, dispatch ] );
 
-	const handlePageDisplayed = useCallback( ( id ) => {
-		dispatch( { type: 'PAGE_DISPLAYED', id } );
-	}, [] );
+	const handlePageDisplayed = useCallback(
+		( id ) => {
+			dispatch( { type: 'PAGE_DISPLAYED', id } );
+		},
+		[ dispatch ]
+	);
 
-	const handleCollectionReady = useCallback( ( id ) => {
-		dispatch( { type: 'COLLECTION_READY', id } );
-	}, [] );
+	const handleCollectionReady = useCallback(
+		( id ) => {
+			dispatch( { type: 'COLLECTION_READY', id } );
+		},
+		[ dispatch ]
+	);
 
 	// Drives the breadcrumb from the same paint state the document-actions
 	// Fill uses, so both sides of the top bar update together. Use


### PR DESCRIPTION
## What

Closes #143

Adds a cross-fade when the canvas switches between editor surfaces.

It uses the View Transitions API when the browser supports it and keeps the existing instant swap everywhere else. Route-level transitions cover collections and page/collection changes; page-to-page changes run inside the canvas, where the page content actually changes.

## Testing

1. In Chrome/Edge or Safari, switch between collections, pages, and page/collection routes. The canvas should cross-fade while the sidebar stays still.
2. In a browser without View Transitions support, the swap should stay instant.

## Screen recording

https://github.com/user-attachments/assets/2a8daf91-f649-4501-ba40-3602bc4a9b98