### PR TITLE
Breadcrumb polishing

### DIFF
--- a/src/hooks/useBreadcrumbSegments.js
+++ b/src/hooks/useBreadcrumbSegments.js
@@ -12,10 +12,14 @@ import { computeUri } from '../router/useResolveEntity';
 
 const COLLECTION_POST_TYPE = 'crtxt_collection';
 
+// Prefer `title.raw` over `title.rendered`: WordPress runs rendered titles
+// through its formatting pipeline, so `&` becomes `&#038;` etc. React would
+// then show the literal entity text in the bar (we don't use
+// `dangerouslySetInnerHTML`). Both fields are available under edit context.
 function titleOf( entity ) {
 	return (
-		entity?.title?.rendered?.trim() ||
 		entity?.title?.raw?.trim() ||
+		entity?.title?.rendered?.trim() ||
 		__( '(untitled)', 'cortext' )
 	);
 }

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -103,7 +103,8 @@ export default function EntityRoute() {
 	const target = useMemo( () => parseTarget( splat ), [ splat ] );
 
 	const [ state, dispatch ] = useReducer( reducer, target, init );
-	const { active, mountedPageId, mountedCollectionIds } = state;
+	const { active, mountedPageId, displayedPageId, mountedCollectionIds } =
+		state;
 
 	const pageResolution = useResolveEntity(
 		target.kind === 'page' ? target.tail : ''
@@ -171,12 +172,15 @@ export default function EntityRoute() {
 	}, [] );
 
 	// Drives the breadcrumb from the same paint state the document-actions
-	// Fill uses, so both sides of the top bar update together. Reading the
-	// URL directly would race ahead of the still-active pane during the
-	// in-between window of a route change.
+	// Fill uses, so both sides of the top bar update together. Use
+	// `displayedPageId` rather than `mountedPageId` for the page case: when
+	// navigating page A → B, mountedPageId flips to B as soon as B resolves,
+	// but Canvas keeps painting A until autosave flushes and `setDisplayedPost`
+	// catches up. Reading the mounted id would let the breadcrumb jump to B
+	// while A is still on screen.
 	let paintedRoute = { kind: 'unresolved' };
-	if ( active.kind === 'page' ) {
-		paintedRoute = { kind: 'page', id: mountedPageId };
+	if ( active.kind === 'page' && displayedPageId !== null ) {
+		paintedRoute = { kind: 'page', id: displayedPageId };
 	} else if ( active.kind === 'collection' ) {
 		paintedRoute = { kind: 'collection', id: active.id };
 	} else if (


### PR DESCRIPTION
## What

Part of #96

Two breadcrumb fixes from #53.

- Breadcrumb waits for the canvas to finish switching pages instead of jumping ahead.
- Page titles use the raw title, so `A & B` no longer shows as `A &#038; B`.

## Testing

1. Rename a page to `A & B` and confirm the breadcrumb renders it correctly.
2. Type unsaved text in a page, then switch pages from the sidebar.
3. Confirm the breadcrumb changes only when the editor switches to the new page.