### PR TITLE
Add format options for number and date fields

### DIFF
--- a/includes/PostType/Field.php
+++ b/includes/PostType/Field.php
@@ -57,6 +57,7 @@ final class Field {
 			'type',
 			'options',
 			'number_format',
+			'date_format',
 			'expression',
 		);
 

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -176,6 +176,7 @@ final class FieldsController {
 				'type',
 				'options',
 				'number_format',
+				'date_format',
 				'expression',
 				'related_collection_id',
 			) as $key

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -100,18 +100,24 @@ function clampDecimals( decimals ) {
 
 // Formats a number value per a stored `number_format` config. Returns
 // `String(value)` for non-numeric values so editing partial input ("3.")
-// or stale string values doesn't blow up the cell.
+// or stale string values doesn't blow up the cell. Only forces a fixed
+// decimal count when the user explicitly picks one — otherwise we let
+// Intl decide, so a field with no saved format still shows `1.25` as
+// `1.25` rather than truncating it to `1`.
 export function formatNumberValue( value, format ) {
 	const num = typeof value === 'number' ? value : Number( value );
 	if ( ! Number.isFinite( num ) ) {
 		return String( value );
 	}
 	const style = format?.style ?? 'plain';
-	const decimals = clampDecimals( format?.decimals );
-	const fractionOpts = {
-		minimumFractionDigits: decimals,
-		maximumFractionDigits: decimals,
-	};
+	const hasDecimals =
+		format?.decimals !== undefined && format?.decimals !== null;
+	const fractionOpts = hasDecimals
+		? {
+				minimumFractionDigits: clampDecimals( format.decimals ),
+				maximumFractionDigits: clampDecimals( format.decimals ),
+		  }
+		: {};
 	const locale = siteLocale();
 	try {
 		if ( style === 'percent' ) {

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -11,6 +11,7 @@ import {
 	__experimentalNumberControl as NumberControl,
 	TextControl,
 } from '@wordpress/components';
+import { getSettings } from '@wordpress/date';
 import {
 	createContext,
 	useContext,
@@ -23,6 +24,19 @@ import { Icon, check } from '@wordpress/icons';
 
 import MultiselectEdit from './MultiselectEdit';
 import Chip from './fields/Chip';
+
+// Resolves the WordPress site locale into a BCP 47 tag for Intl. WP
+// stores locales as `en_US` / `de_DE`; Intl expects `en-US` / `de-DE`.
+// All cell-level number and date formatting routes through this so a
+// single site renders identically for every viewer (matching how WP
+// formats dates server-side via `dateI18n`).
+function siteLocale() {
+	const wpLocale = getSettings()?.l10n?.locale;
+	if ( ! wpLocale ) {
+		return undefined;
+	}
+	return wpLocale.replace( '_', '-' );
+}
 
 // tech-debt.md#1: DataViews v6 has no inline cell editing in any layout,
 // so we mount this component from `field.render` (a display renderer in
@@ -45,24 +59,6 @@ export const RowMutationContext = createContext( {
 const TEXT_INPUT_TYPES = new Set( [ 'text', 'email', 'url', 'number' ] );
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 const DATE_PREFIX_PATTERN = /^(\d{4}-\d{2}-\d{2})(?:T|$)/;
-
-function formatDateOnlyDisplay( value ) {
-	const match = DATE_ONLY_PATTERN.exec( String( value ) );
-	if ( ! match ) {
-		return null;
-	}
-
-	const [ , year, month, day ] = match;
-	const date = new Date( Number( year ), Number( month ) - 1, Number( day ) );
-	if (
-		date.getFullYear() !== Number( year ) ||
-		date.getMonth() !== Number( month ) - 1 ||
-		date.getDate() !== Number( day )
-	) {
-		return null;
-	}
-	return date.toLocaleDateString();
-}
 
 export function dateOnlyValue( value ) {
 	if ( value === null || value === undefined || value === '' ) {
@@ -93,11 +89,113 @@ function FieldError( { message } ) {
 // rendered as text so we never produce a broken link.
 const URL_PATTERN = /^https?:\/\//i;
 
+// Clamp decimals to a sane range; Intl.NumberFormat throws above 100.
+function clampDecimals( decimals ) {
+	const d = Number( decimals );
+	if ( ! Number.isFinite( d ) ) {
+		return 0;
+	}
+	return Math.min( 6, Math.max( 0, Math.trunc( d ) ) );
+}
+
+// Formats a number value per a stored `number_format` config. Returns
+// `String(value)` for non-numeric values so editing partial input ("3.")
+// or stale string values doesn't blow up the cell.
+export function formatNumberValue( value, format ) {
+	const num = typeof value === 'number' ? value : Number( value );
+	if ( ! Number.isFinite( num ) ) {
+		return String( value );
+	}
+	const style = format?.style ?? 'plain';
+	const decimals = clampDecimals( format?.decimals );
+	const fractionOpts = {
+		minimumFractionDigits: decimals,
+		maximumFractionDigits: decimals,
+	};
+	const locale = siteLocale();
+	try {
+		if ( style === 'percent' ) {
+			return new Intl.NumberFormat( locale, {
+				style: 'percent',
+				...fractionOpts,
+			} ).format( num );
+		}
+		if ( style === 'currency' ) {
+			return new Intl.NumberFormat( locale, {
+				style: 'currency',
+				currency: format?.currency || 'USD',
+				...fractionOpts,
+			} ).format( num );
+		}
+		return new Intl.NumberFormat( locale, {
+			useGrouping: style === 'comma',
+			...fractionOpts,
+		} ).format( num );
+	} catch {
+		return String( num );
+	}
+}
+
+// Formats a date / datetime value per a stored `date_format` config.
+// Returns `String(value)` for unparseable input so the cell still shows
+// something rather than going blank on bad data.
+export function formatDateValue( value, type, format ) {
+	const style = format?.style ?? 'locale';
+	const showTime = format?.time ?? type === 'datetime';
+	const hour12 = format?.hour12 ?? true;
+	let locale;
+	if ( style === 'us' ) {
+		locale = 'en-US';
+	} else if ( style === 'eu' ) {
+		locale = 'en-GB';
+	} else {
+		locale = siteLocale();
+	}
+
+	// Date-only input (YYYY-MM-DD) builds a local-midnight Date so the
+	// calendar day is preserved across time zones. The default `Date`
+	// parser would treat it as UTC and shift the day west of GMT.
+	if ( type === 'date' ) {
+		const match = DATE_ONLY_PATTERN.exec( String( value ) );
+		if ( match ) {
+			const [ , y, m, d ] = match;
+			const date = new Date( Number( y ), Number( m ) - 1, Number( d ) );
+			return new Intl.DateTimeFormat( locale, {
+				year: 'numeric',
+				month: '2-digit',
+				day: '2-digit',
+			} ).format( date );
+		}
+	}
+
+	const date = new Date( value );
+	if ( Number.isNaN( date.getTime() ) ) {
+		return String( value );
+	}
+
+	const options = {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	};
+	if ( showTime ) {
+		options.hour = '2-digit';
+		options.minute = '2-digit';
+		options.hour12 = hour12;
+	}
+	return new Intl.DateTimeFormat( locale, options ).format( date );
+}
+
 // Returns either '' (empty cell) or a renderable value (string or JSX).
 // `display === ''` is the consumer's empty-cell signal — see CellShell's
 // `isEmpty` prop. Non-empty values may be JSX (anchor for url, icon for
 // checkbox, chip(s) for select / multiselect).
-export function formatDisplay( value, type, elements ) {
+//
+// Third arg is a bag of optional rendering hints: `elements` for select
+// chips, `format` for number / date config. Both are field-level and
+// constant across rows, so callers pass them once via the render prop.
+export function formatDisplay( value, type, options = {} ) {
+	const { elements, format } = options;
 	if ( value === null || value === undefined || value === '' ) {
 		return '';
 	}
@@ -170,19 +268,11 @@ export function formatDisplay( value, type, elements ) {
 	}
 
 	if ( type === 'date' || type === 'datetime' ) {
-		if ( type === 'date' ) {
-			const dateOnlyDisplay = formatDateOnlyDisplay( value );
-			if ( dateOnlyDisplay ) {
-				return dateOnlyDisplay;
-			}
-		}
-		const date = new Date( value );
-		if ( Number.isNaN( date.getTime() ) ) {
-			return String( value );
-		}
-		return type === 'date'
-			? date.toLocaleDateString()
-			: date.toLocaleString();
+		return formatDateValue( value, type, format );
+	}
+
+	if ( type === 'number' ) {
+		return formatNumberValue( value, format );
 	}
 
 	return String( value );
@@ -390,7 +480,7 @@ function SelectEditor( { value, elements, onCommit, onCancel, onTab, label } ) {
 	);
 }
 
-function DateEditor( { value, type, onCommit, onCancel, label } ) {
+function DateEditor( { value, type, format, onCommit, onCancel, label } ) {
 	return (
 		<Dropdown
 			defaultOpen
@@ -403,7 +493,7 @@ function DateEditor( { value, type, onCommit, onCancel, label } ) {
 					aria-expanded={ isOpen }
 				>
 					{ value
-						? formatDisplay( value, type )
+						? formatDisplay( value, type, { format } )
 						: __( 'Pick a date…', 'cortext' ) }
 				</Button>
 			) }
@@ -419,7 +509,7 @@ function DateEditor( { value, type, onCommit, onCancel, label } ) {
 								onClose();
 							}
 						} }
-						is12Hour
+						is12Hour={ format?.hour12 ?? true }
 						aria-label={ label }
 					/>
 				</div>
@@ -433,6 +523,7 @@ export default function EditableCell( {
 	fieldId,
 	fieldType,
 	elements,
+	format,
 	label,
 	getValue,
 	readOnly = false,
@@ -448,7 +539,7 @@ export default function EditableCell( {
 	const value = getValue
 		? getValue( { item } )
 		: item?.meta?.[ fieldId ] ?? null;
-	const display = formatDisplay( value, fieldType, elements );
+	const display = formatDisplay( value, fieldType, { elements, format } );
 
 	// Open this cell when the parent targets it via editRequest (new-row
 	// title auto-open, Tab navigation, etc.), then clear the request so
@@ -588,6 +679,7 @@ export default function EditableCell( {
 				<DateEditor
 					value={ value }
 					type={ fieldType }
+					format={ format }
 					onCommit={ commit }
 					onCancel={ closeEditor }
 					label={ label }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	Dropdown,
+	Icon,
 	MenuGroup,
 	MenuItem,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -17,15 +18,18 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { plus } from '@wordpress/icons';
+import { chevronRight, plus } from '@wordpress/icons';
 
 import AddFieldPopover from './AddFieldPopover';
+import FieldFormatPopover from './FieldFormatPopover';
 import RenameFieldInline from './RenameFieldInline';
 import {
 	useDeleteField,
 	useDuplicateField,
 } from '../../hooks/useFieldMutations';
 import { GHOST_FIELD_ID, TITLE_FIELD_ID } from '../dataViewColumns';
+
+const FORMATTABLE_TYPES = new Set( [ 'number', 'date', 'datetime' ] );
 
 // Projects two kinds of triggers into the DataViews table header:
 //
@@ -148,10 +152,38 @@ export default function ColumnHeaderActions( {
 
 function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 	const [ isRenaming, setIsRenaming ] = useState( false );
+	const [ isFormatting, setIsFormatting ] = useState( false );
 	const [ confirmDelete, setConfirmDelete ] = useState( false );
+	const formatItemRef = useRef( null );
+	const closeTimerRef = useRef( null );
 	const duplicate = useDuplicateField( collectionId );
 	const remove = useDeleteField( collectionId );
 	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
+	const fieldType = record?.meta?.type;
+	const canFormat = FORMATTABLE_TYPES.has( fieldType );
+
+	// Format submenu uses a hover-with-grace pattern: the panel stays
+	// visible while the cursor is over either the trigger row or the
+	// panel itself. The grace timer absorbs the dead pixels between them
+	// so the user doesn't lose the panel by overshooting on the way over.
+	const cancelClose = useCallback( () => {
+		if ( closeTimerRef.current ) {
+			clearTimeout( closeTimerRef.current );
+			closeTimerRef.current = null;
+		}
+	}, [] );
+	const scheduleClose = useCallback( () => {
+		cancelClose();
+		closeTimerRef.current = setTimeout( () => {
+			setIsFormatting( false );
+			closeTimerRef.current = null;
+		}, 180 );
+	}, [ cancelClose ] );
+	const openFormat = useCallback( () => {
+		cancelClose();
+		setIsFormatting( true );
+	}, [ cancelClose ] );
+	useEffect( () => () => cancelClose(), [ cancelClose ] );
 
 	const dataViewId = `field-${ recordId }`;
 	const label =
@@ -246,6 +278,10 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 			<Dropdown
 				contentClassName="cortext-field-actions-popover"
 				popoverProps={ { placement: 'bottom-start' } }
+				onClose={ () => {
+					cancelClose();
+					setIsFormatting( false );
+				} }
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
 						className="dataviews-view-table-header-button cortext-column-header-trigger"
@@ -265,6 +301,38 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 				) }
 				renderContent={ ( { onClose } ) => (
 					<>
+						{ /* Property-config group: edit how the column
+						     itself is defined. Mirrors Notion's first
+						     section (Edit property / Change type). */ }
+						<MenuGroup>
+							<MenuItem
+								onClick={ () => {
+									onClose();
+									setIsRenaming( true );
+								} }
+							>
+								{ __( 'Rename', 'cortext' ) }
+							</MenuItem>
+							{ canFormat ? (
+								<MenuItem
+									ref={ formatItemRef }
+									className="cortext-column-header-actions__submenu-item"
+									onClick={ openFormat }
+									onMouseEnter={ openFormat }
+									onMouseLeave={ scheduleClose }
+									suffix={
+										<Icon
+											icon={ chevronRight }
+											size={ 18 }
+										/>
+									}
+								>
+									{ __( 'Edit field', 'cortext' ) }
+								</MenuItem>
+							) : null }
+						</MenuGroup>
+						{ /* View group: sort, hide. Notion bundles
+						     filter/sort/group/hide together. */ }
 						<MenuGroup>
 							<MenuItem
 								isSelected={
@@ -288,7 +356,18 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 							>
 								{ __( 'Sort descending', 'cortext' ) }
 							</MenuItem>
+							<MenuItem
+								onClick={ () => {
+									onClose();
+									dispatchHide();
+								} }
+							>
+								{ __( 'Hide column', 'cortext' ) }
+							</MenuItem>
 						</MenuGroup>
+						{ /* Column-lifecycle group: move, duplicate,
+						     delete. Notion's "Insert left/right /
+						     Duplicate / Delete property" cluster. */ }
 						<MenuGroup>
 							<MenuItem
 								disabled={ ! canMoveLeft }
@@ -307,24 +386,6 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 								} }
 							>
 								{ __( 'Move right', 'cortext' ) }
-							</MenuItem>
-							<MenuItem
-								onClick={ () => {
-									onClose();
-									dispatchHide();
-								} }
-							>
-								{ __( 'Hide column', 'cortext' ) }
-							</MenuItem>
-						</MenuGroup>
-						<MenuGroup>
-							<MenuItem
-								onClick={ () => {
-									onClose();
-									setIsRenaming( true );
-								} }
-							>
-								{ __( 'Rename', 'cortext' ) }
 							</MenuItem>
 							<MenuItem
 								onClick={ async () => {
@@ -348,6 +409,15 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 								{ __( 'Delete', 'cortext' ) }
 							</MenuItem>
 						</MenuGroup>
+						{ isFormatting && canFormat ? (
+							<FieldFormatPopover
+								recordId={ recordId }
+								anchor={ formatItemRef.current }
+								onClose={ () => setIsFormatting( false ) }
+								onMouseEnter={ openFormat }
+								onMouseLeave={ scheduleClose }
+							/>
+						) : null }
 					</>
 				) }
 			/>

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -1,0 +1,394 @@
+import { __ } from '@wordpress/i18n';
+import { Icon, Popover } from '@wordpress/components';
+import { useEntityRecord } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { forwardRef, useMemo, useRef, useState } from '@wordpress/element';
+import { check, chevronRight } from '@wordpress/icons';
+
+import { parseFormat } from '../../hooks/fieldMapping';
+
+// Number "format" rows flatten the storage shape (style + currency) into
+// a single flat list so the menu mirrors Notion. Each entry carries the
+// `style` (and `currency` for the four currency rows) it projects onto
+// the persisted `number_format` JSON.
+const NUMBER_FORMATS = [
+	{ id: 'plain', label: __( 'Number', 'cortext' ), style: 'plain' },
+	{
+		id: 'comma',
+		label: __( 'Number with commas', 'cortext' ),
+		style: 'comma',
+	},
+	{ id: 'percent', label: __( 'Percent', 'cortext' ), style: 'percent' },
+	{
+		id: 'usd',
+		label: __( 'US Dollar (USD)', 'cortext' ),
+		style: 'currency',
+		currency: 'USD',
+	},
+	{
+		id: 'eur',
+		label: __( 'Euro (EUR)', 'cortext' ),
+		style: 'currency',
+		currency: 'EUR',
+	},
+	{
+		id: 'gbp',
+		label: __( 'Pound (GBP)', 'cortext' ),
+		style: 'currency',
+		currency: 'GBP',
+	},
+	{
+		id: 'jpy',
+		label: __( 'Yen (JPY)', 'cortext' ),
+		style: 'currency',
+		currency: 'JPY',
+	},
+];
+
+const DECIMAL_OPTIONS = [ 0, 1, 2, 3, 4, 5, 6 ];
+
+const DATE_FORMATS = [
+	{ id: 'locale', label: __( 'Locale default', 'cortext' ) },
+	{ id: 'us', label: __( 'US (MM/DD/YYYY)', 'cortext' ) },
+	{ id: 'eu', label: __( 'EU (DD/MM/YYYY)', 'cortext' ) },
+];
+
+const TIME_OPTIONS = [
+	{ id: 'off', label: __( 'Off', 'cortext' ), time: false },
+	{
+		id: '12',
+		label: __( '12-hour', 'cortext' ),
+		time: true,
+		hour12: true,
+	},
+	{
+		id: '24',
+		label: __( '24-hour', 'cortext' ),
+		time: true,
+		hour12: false,
+	},
+];
+
+function findNumberFormat( config ) {
+	if ( ! config?.style || config.style === 'plain' ) {
+		return NUMBER_FORMATS[ 0 ];
+	}
+	if ( config.style === 'currency' ) {
+		const match = NUMBER_FORMATS.find(
+			( f ) => f.style === 'currency' && f.currency === config.currency
+		);
+		return match ?? NUMBER_FORMATS[ 3 ];
+	}
+	return (
+		NUMBER_FORMATS.find( ( f ) => f.style === config.style ) ??
+		NUMBER_FORMATS[ 0 ]
+	);
+}
+
+function findTimeOption( config ) {
+	if ( ! config?.time ) {
+		return TIME_OPTIONS[ 0 ];
+	}
+	return config.hour12 === false ? TIME_OPTIONS[ 2 ] : TIME_OPTIONS[ 1 ];
+}
+
+// One submenu row. The label sits left, the current value in the middle
+// (muted), and a chevron on the right hints at the third-level flyout.
+// `isOpen` toggles the focus ring so users can tell which row spawned
+// the visible flyout.
+const SubmenuRow = forwardRef( function SubmenuRow(
+	{ label, value, onClick, isOpen },
+	ref
+) {
+	return (
+		<button
+			ref={ ref }
+			type="button"
+			className={
+				'cortext-format-submenu__row' + ( isOpen ? ' is-open' : '' )
+			}
+			onClick={ onClick }
+			aria-haspopup="menu"
+			aria-expanded={ isOpen }
+		>
+			<span className="cortext-format-submenu__row-label">{ label }</span>
+			<span className="cortext-format-submenu__row-value">{ value }</span>
+			<Icon
+				icon={ chevronRight }
+				className="cortext-format-submenu__row-chevron"
+			/>
+		</button>
+	);
+} );
+
+function ChoiceList( { items, isSelected, onPick } ) {
+	return (
+		<ul className="cortext-format-submenu__list" role="menu">
+			{ items.map( ( item ) => {
+				const selected = isSelected( item );
+				return (
+					<li key={ item.id ?? item.value } role="none">
+						<button
+							type="button"
+							role="menuitemradio"
+							aria-checked={ selected }
+							className={
+								'cortext-format-submenu__list-item' +
+								( selected ? ' is-selected' : '' )
+							}
+							onClick={ () => onPick( item ) }
+						>
+							<span className="cortext-format-submenu__list-check">
+								{ selected ? <Icon icon={ check } /> : null }
+							</span>
+							<span>{ item.label }</span>
+						</button>
+					</li>
+				);
+			} ) }
+		</ul>
+	);
+}
+
+function NumberFormBody( { config, onChange } ) {
+	const [ openRow, setOpenRow ] = useState( null );
+	const formatRowRef = useRef( null );
+	const decimalsRowRef = useRef( null );
+	const current = findNumberFormat( config );
+	const decimals = config?.decimals ?? 0;
+
+	const pickFormat = ( item ) => {
+		const next = { style: item.style, decimals };
+		if ( item.style === 'currency' ) {
+			next.currency = item.currency;
+		}
+		onChange( next );
+		setOpenRow( null );
+	};
+
+	const pickDecimals = ( n ) => {
+		onChange( { ...( config ?? { style: 'plain' } ), decimals: n } );
+		setOpenRow( null );
+	};
+
+	return (
+		<>
+			<SubmenuRow
+				ref={ formatRowRef }
+				label={ __( 'Number format', 'cortext' ) }
+				value={ current.label }
+				isOpen={ openRow === 'format' }
+				onClick={ () =>
+					setOpenRow( openRow === 'format' ? null : 'format' )
+				}
+			/>
+			<SubmenuRow
+				ref={ decimalsRowRef }
+				label={ __( 'Decimal places', 'cortext' ) }
+				value={ String( decimals ) }
+				isOpen={ openRow === 'decimals' }
+				onClick={ () =>
+					setOpenRow( openRow === 'decimals' ? null : 'decimals' )
+				}
+			/>
+			{ openRow === 'format' ? (
+				<Popover
+					anchor={ formatRowRef.current }
+					placement="right-start"
+					offset={ 8 }
+					onClose={ () => setOpenRow( null ) }
+					className="cortext-format-submenu__flyout"
+				>
+					<ChoiceList
+						items={ NUMBER_FORMATS }
+						isSelected={ ( item ) => item.id === current.id }
+						onPick={ pickFormat }
+					/>
+				</Popover>
+			) : null }
+			{ openRow === 'decimals' ? (
+				<Popover
+					anchor={ decimalsRowRef.current }
+					placement="right-start"
+					offset={ 8 }
+					onClose={ () => setOpenRow( null ) }
+					className="cortext-format-submenu__flyout"
+				>
+					<ChoiceList
+						items={ DECIMAL_OPTIONS.map( ( n ) => ( {
+							id: `d${ n }`,
+							label: String( n ),
+							value: n,
+						} ) ) }
+						isSelected={ ( item ) => item.value === decimals }
+						onPick={ ( item ) => pickDecimals( item.value ) }
+					/>
+				</Popover>
+			) : null }
+		</>
+	);
+}
+
+function DateFormBody( { type, config, onChange } ) {
+	const [ openRow, setOpenRow ] = useState( null );
+	const formatRowRef = useRef( null );
+	const timeRowRef = useRef( null );
+
+	const styleId = config?.style ?? 'locale';
+	const currentDateFormat =
+		DATE_FORMATS.find( ( f ) => f.id === styleId ) ?? DATE_FORMATS[ 0 ];
+	const currentTime = findTimeOption( config );
+
+	const pickFormat = ( item ) => {
+		onChange( {
+			style: item.id,
+			time: config?.time ?? type === 'datetime',
+			hour12: config?.hour12 ?? true,
+		} );
+		setOpenRow( null );
+	};
+
+	const pickTime = ( item ) => {
+		onChange( {
+			style: config?.style ?? 'locale',
+			time: item.time,
+			hour12: item.time ? item.hour12 : config?.hour12 ?? true,
+		} );
+		setOpenRow( null );
+	};
+
+	return (
+		<>
+			<SubmenuRow
+				ref={ formatRowRef }
+				label={ __( 'Date format', 'cortext' ) }
+				value={ currentDateFormat.label }
+				isOpen={ openRow === 'format' }
+				onClick={ () =>
+					setOpenRow( openRow === 'format' ? null : 'format' )
+				}
+			/>
+			<SubmenuRow
+				ref={ timeRowRef }
+				label={ __( 'Time', 'cortext' ) }
+				value={ currentTime.label }
+				isOpen={ openRow === 'time' }
+				onClick={ () =>
+					setOpenRow( openRow === 'time' ? null : 'time' )
+				}
+			/>
+			{ openRow === 'format' ? (
+				<Popover
+					anchor={ formatRowRef.current }
+					placement="right-start"
+					offset={ 8 }
+					onClose={ () => setOpenRow( null ) }
+					className="cortext-format-submenu__flyout"
+				>
+					<ChoiceList
+						items={ DATE_FORMATS }
+						isSelected={ ( item ) =>
+							item.id === currentDateFormat.id
+						}
+						onPick={ pickFormat }
+					/>
+				</Popover>
+			) : null }
+			{ openRow === 'time' ? (
+				<Popover
+					anchor={ timeRowRef.current }
+					placement="right-start"
+					offset={ 8 }
+					onClose={ () => setOpenRow( null ) }
+					className="cortext-format-submenu__flyout"
+				>
+					<ChoiceList
+						items={ TIME_OPTIONS }
+						isSelected={ ( item ) => item.id === currentTime.id }
+						onPick={ pickTime }
+					/>
+				</Popover>
+			) : null }
+		</>
+	);
+}
+
+// Renders Notion-style cascading format menu. Anchored to the Format
+// menu item so it sits beside the column dropdown. Auto-saves on every
+// selection. Hover handlers keep the panel open while the cursor is
+// somewhere over the column dropdown's Format row or this panel; the
+// parent owns the grace timer (`scheduleClose`) that absorbs the dead
+// pixels between them. `focusOnMount={ false }` keeps focus inside the
+// parent dropdown so it doesn't auto-close when the panel mounts.
+export default function FieldFormatPopover( {
+	recordId,
+	anchor,
+	onClose,
+	onMouseEnter,
+	onMouseLeave,
+} ) {
+	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
+
+	const type = record?.meta?.type ?? 'text';
+	const isNumber = type === 'number';
+	const isDate = type === 'date' || type === 'datetime';
+
+	const initial = useMemo(
+		() =>
+			parseFormat(
+				isNumber
+					? record?.meta?.number_format
+					: record?.meta?.date_format
+			),
+		[ isNumber, record ]
+	);
+
+	const persist = async ( next ) => {
+		if ( ! record ) {
+			return;
+		}
+		const key = isNumber ? 'number_format' : 'date_format';
+		editEntityRecord( 'postType', 'crtxt_field', recordId, {
+			meta: { [ key ]: next ? JSON.stringify( next ) : '' },
+		} );
+		await saveEditedEntityRecord( 'postType', 'crtxt_field', recordId );
+	};
+
+	if ( ! record || ( ! isNumber && ! isDate ) ) {
+		return null;
+	}
+
+	return (
+		<Popover
+			anchor={ anchor }
+			placement="right-start"
+			offset={ 8 }
+			onClose={ onClose }
+			focusOnMount={ false }
+			className="cortext-format-submenu"
+		>
+			<div
+				className="cortext-format-submenu__panel"
+				onMouseEnter={ onMouseEnter }
+				onMouseLeave={ onMouseLeave }
+			>
+				{ isNumber ? (
+					<NumberFormBody config={ initial } onChange={ persist } />
+				) : (
+					<DateFormBody
+						type={ type }
+						config={ initial }
+						onChange={ persist }
+					/>
+				) }
+				<p className="cortext-format-submenu__note">
+					{ __(
+						'Changes apply to all views showing this field.',
+						'cortext'
+					) }
+				</p>
+			</div>
+		</Popover>
+	);
+}

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -45,7 +45,19 @@ const NUMBER_FORMATS = [
 	},
 ];
 
-const DECIMAL_OPTIONS = [ 0, 1, 2, 3, 4, 5, 6 ];
+// `value: null` is the "let Intl decide" state; we store no `decimals`
+// key on the field meta in that case, so existing data keeps its
+// natural precision (e.g. 1.25 stays 1.25 rather than rounding).
+const DECIMAL_OPTIONS = [
+	{ id: 'default', label: __( 'Default', 'cortext' ), value: null },
+	{ id: 'd0', label: '0', value: 0 },
+	{ id: 'd1', label: '1', value: 1 },
+	{ id: 'd2', label: '2', value: 2 },
+	{ id: 'd3', label: '3', value: 3 },
+	{ id: 'd4', label: '4', value: 4 },
+	{ id: 'd5', label: '5', value: 5 },
+	{ id: 'd6', label: '6', value: 6 },
+];
 
 const DATE_FORMATS = [
 	{ id: 'locale', label: __( 'Locale default', 'cortext' ) },
@@ -155,10 +167,14 @@ function NumberFormBody( { config, onChange } ) {
 	const formatRowRef = useRef( null );
 	const decimalsRowRef = useRef( null );
 	const current = findNumberFormat( config );
-	const decimals = config?.decimals ?? 0;
+	const decimals = config?.decimals ?? null;
+	const hasDecimals = decimals !== null;
 
 	const pickFormat = ( item ) => {
-		const next = { style: item.style, decimals };
+		const next = { style: item.style };
+		if ( hasDecimals ) {
+			next.decimals = decimals;
+		}
 		if ( item.style === 'currency' ) {
 			next.currency = item.currency;
 		}
@@ -166,8 +182,14 @@ function NumberFormBody( { config, onChange } ) {
 		setOpenRow( null );
 	};
 
-	const pickDecimals = ( n ) => {
-		onChange( { ...( config ?? { style: 'plain' } ), decimals: n } );
+	const pickDecimals = ( value ) => {
+		const next = { ...( config ?? { style: 'plain' } ) };
+		if ( value === null ) {
+			delete next.decimals;
+		} else {
+			next.decimals = value;
+		}
+		onChange( next );
 		setOpenRow( null );
 	};
 
@@ -185,7 +207,11 @@ function NumberFormBody( { config, onChange } ) {
 			<SubmenuRow
 				ref={ decimalsRowRef }
 				label={ __( 'Decimal places', 'cortext' ) }
-				value={ String( decimals ) }
+				value={
+					hasDecimals
+						? String( decimals )
+						: __( 'Default', 'cortext' )
+				}
 				isOpen={ openRow === 'decimals' }
 				onClick={ () =>
 					setOpenRow( openRow === 'decimals' ? null : 'decimals' )
@@ -215,11 +241,7 @@ function NumberFormBody( { config, onChange } ) {
 					className="cortext-format-submenu__flyout"
 				>
 					<ChoiceList
-						items={ DECIMAL_OPTIONS.map( ( n ) => ( {
-							id: `d${ n }`,
-							label: String( n ),
-							value: n,
-						} ) ) }
+						items={ DECIMAL_OPTIONS }
 						isSelected={ ( item ) => item.value === decimals }
 						onPick={ ( item ) => pickDecimals( item.value ) }
 					/>

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -97,11 +97,16 @@ function findNumberFormat( config ) {
 	);
 }
 
-function findTimeOption( config ) {
-	if ( ! config?.time ) {
+// Mirrors `formatDateValue`'s defaults so the row label matches what
+// the column actually renders: datetime fields show time on by default,
+// date fields never do, and 12-hour is the default clock.
+function findTimeOption( config, type ) {
+	const time = config?.time ?? type === 'datetime';
+	if ( ! time ) {
 		return TIME_OPTIONS[ 0 ];
 	}
-	return config.hour12 === false ? TIME_OPTIONS[ 2 ] : TIME_OPTIONS[ 1 ];
+	const hour12 = config?.hour12 ?? true;
+	return hour12 === false ? TIME_OPTIONS[ 2 ] : TIME_OPTIONS[ 1 ];
 }
 
 // One submenu row. The label sits left, the current value in the middle
@@ -264,7 +269,7 @@ function DateFormBody( { type, config, onChange } ) {
 	const styleId = config?.style ?? 'locale';
 	const currentDateFormat =
 		DATE_FORMATS.find( ( f ) => f.id === styleId ) ?? DATE_FORMATS[ 0 ];
-	const currentTime = findTimeOption( config );
+	const currentTime = findTimeOption( config, type );
 
 	const pickFormat = ( item ) => {
 		onChange( {

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -255,6 +255,11 @@ function DateFormBody( { type, config, onChange } ) {
 	const [ openRow, setOpenRow ] = useState( null );
 	const formatRowRef = useRef( null );
 	const timeRowRef = useRef( null );
+	// `date` fields store dates without a time component, the inline
+	// editor strips time on commit, and the renderer ignores time
+	// options for date-only values. Hide the Time row entirely so we
+	// don't expose a control that has nothing to act on.
+	const supportsTime = type === 'datetime';
 
 	const styleId = config?.style ?? 'locale';
 	const currentDateFormat =
@@ -264,7 +269,7 @@ function DateFormBody( { type, config, onChange } ) {
 	const pickFormat = ( item ) => {
 		onChange( {
 			style: item.id,
-			time: config?.time ?? type === 'datetime',
+			time: supportsTime ? config?.time ?? true : false,
 			hour12: config?.hour12 ?? true,
 		} );
 		setOpenRow( null );
@@ -290,15 +295,17 @@ function DateFormBody( { type, config, onChange } ) {
 					setOpenRow( openRow === 'format' ? null : 'format' )
 				}
 			/>
-			<SubmenuRow
-				ref={ timeRowRef }
-				label={ __( 'Time', 'cortext' ) }
-				value={ currentTime.label }
-				isOpen={ openRow === 'time' }
-				onClick={ () =>
-					setOpenRow( openRow === 'time' ? null : 'time' )
-				}
-			/>
+			{ supportsTime ? (
+				<SubmenuRow
+					ref={ timeRowRef }
+					label={ __( 'Time', 'cortext' ) }
+					value={ currentTime.label }
+					isOpen={ openRow === 'time' }
+					onClick={ () =>
+						setOpenRow( openRow === 'time' ? null : 'time' )
+					}
+				/>
+			) : null }
 			{ openRow === 'format' ? (
 				<Popover
 					anchor={ formatRowRef.current }
@@ -316,7 +323,7 @@ function DateFormBody( { type, config, onChange } ) {
 					/>
 				</Popover>
 			) : null }
-			{ openRow === 'time' ? (
+			{ supportsTime && openRow === 'time' ? (
 				<Popover
 					anchor={ timeRowRef.current }
 					placement="right-start"

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -35,6 +35,26 @@ export function elementsFromOptions( raw ) {
 	} );
 }
 
+// Parses stored format meta (number_format / date_format) into a plain
+// object. Same forgiving contract as `elementsFromOptions`: malformed
+// JSON, non-objects, and empty values all return `undefined` so callers
+// fall through to type-level defaults.
+export function parseFormat( raw ) {
+	if ( ! raw ) {
+		return undefined;
+	}
+	let parsed;
+	try {
+		parsed = typeof raw === 'string' ? JSON.parse( raw ) : raw;
+	} catch {
+		return undefined;
+	}
+	if ( ! parsed || typeof parsed !== 'object' || Array.isArray( parsed ) ) {
+		return undefined;
+	}
+	return parsed;
+}
+
 // Cortext field types that this client knows how to edit inline. Anything
 // outside this set (formula, rollup, relation, …) renders read-only — see
 // `EditableCell`'s `readOnly` branch.
@@ -52,7 +72,7 @@ export const EDITABLE_TYPES = new Set( [
 
 const SEARCHABLE_TYPES = new Set( [ 'text', 'email', 'url' ] );
 
-function buildRender( id, type, label, elements ) {
+function buildRender( id, type, label, elements, format ) {
 	const readOnly = ! EDITABLE_TYPES.has( type );
 	return ( { item } ) => (
 		<EditableCell
@@ -60,6 +80,7 @@ function buildRender( id, type, label, elements ) {
 			fieldId={ id }
 			fieldType={ type }
 			elements={ elements }
+			format={ format }
 			label={ label }
 			readOnly={ readOnly }
 		/>
@@ -152,6 +173,12 @@ export function mapField( field ) {
 	const label = field.title?.raw || field.title?.rendered || `#${ field.id }`;
 	const type = field.meta?.type ?? 'text';
 	const elements = elementsFromOptions( field.meta?.options );
+	let format;
+	if ( type === 'number' ) {
+		format = parseFormat( field.meta?.number_format );
+	} else if ( type === 'date' || type === 'datetime' ) {
+		format = parseFormat( field.meta?.date_format );
+	}
 	const base = {
 		id,
 		label,
@@ -171,7 +198,7 @@ export function mapField( field ) {
 			</HeaderLabel>
 		),
 		getValue: ( { item } ) => item?.meta?.[ id ] ?? null,
-		render: buildRender( id, type, label, elements ),
+		render: buildRender( id, type, label, elements, format ),
 		editable: EDITABLE_TYPES.has( type ),
 		enableGlobalSearch: SEARCHABLE_TYPES.has( type ),
 	};

--- a/src/index.scss
+++ b/src/index.scss
@@ -479,6 +479,128 @@ body.cortext-fullscreen {
 	}
 }
 
+// Notion-style format submenu. The outer popover sits beside the column
+// dropdown; each row is a button that anchors a third-level flyout for
+// picking a value. The visual is intentionally tight (240px panel) so it
+// reads as a continuation of the parent menu rather than a modal.
+.cortext-format-submenu {
+	&__panel {
+		min-width: 240px;
+		padding: $grid-unit-05;
+	}
+
+	&__row {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+		width: 100%;
+		padding: $grid-unit-10 $grid-unit-15;
+		border: 0;
+		border-radius: 4px;
+		background: transparent;
+		text-align: start;
+		font-size: 13px;
+		color: $gray-900;
+		cursor: pointer;
+
+		&:hover,
+		&.is-open {
+			background: $gray-100;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline-offset: -1px;
+		}
+	}
+
+	&__row-label {
+		flex: 1 1 auto;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__row-value {
+		flex: 0 0 auto;
+		color: $gray-700;
+		font-size: 12px;
+	}
+
+	&__row-chevron {
+		flex: 0 0 auto;
+		color: $gray-700;
+	}
+
+	&__note {
+		margin: $grid-unit-10 $grid-unit-15 $grid-unit-05;
+		padding: 0;
+		font-size: 11px;
+		color: $gray-700;
+	}
+
+	&__flyout {
+		.components-popover__content {
+			min-width: 200px;
+			padding: $grid-unit-05;
+		}
+	}
+
+	&__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		max-height: 320px;
+		overflow-y: auto;
+	}
+
+	&__list-item {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		width: 100%;
+		padding: $grid-unit-05 $grid-unit-10;
+		border: 0;
+		border-radius: 4px;
+		background: transparent;
+		text-align: start;
+		font-size: 13px;
+		color: $gray-900;
+		cursor: pointer;
+
+		&:hover {
+			background: $gray-100;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline-offset: -1px;
+		}
+
+		&.is-selected {
+			color: var(--wp-admin-theme-color, $gray-900);
+		}
+	}
+
+	&__list-check {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		flex: 0 0 auto;
+	}
+}
+
+// Format MenuItem dresses up like a submenu trigger: chevron on the
+// right, no "ellipsis" suffix that suggests a modal.
+.cortext-column-header-actions__submenu-item {
+	.components-menu-item__item {
+		flex: 1 1 auto;
+	}
+}
+
 // Marker spans live inside DataViews' header trigger button. Zero-size
 // and aria-hidden so they never receive focus or contribute to the
 // column width; the portal layer in `ColumnHeaderActions` finds them by

--- a/src/index.scss
+++ b/src/index.scss
@@ -484,6 +484,7 @@ body.cortext-fullscreen {
 // picking a value. The visual is intentionally tight (240px panel) so it
 // reads as a continuation of the parent menu rather than a modal.
 .cortext-format-submenu {
+
 	&__panel {
 		min-width: 240px;
 		padding: $grid-unit-05;
@@ -541,6 +542,7 @@ body.cortext-fullscreen {
 	}
 
 	&__flyout {
+
 		.components-popover__content {
 			min-width: 200px;
 			padding: $grid-unit-05;
@@ -596,6 +598,7 @@ body.cortext-fullscreen {
 // Format MenuItem dresses up like a submenu trigger: chevron on the
 // right, no "ellipsis" suffix that suggests a modal.
 .cortext-column-header-actions__submenu-item {
+
 	.components-menu-item__item {
 		flex: 1 1 auto;
 	}

--- a/tests/js/components/EditableCell.test.js
+++ b/tests/js/components/EditableCell.test.js
@@ -2,11 +2,13 @@ import { render, screen } from '@testing-library/react';
 
 import {
 	dateOnlyValue,
+	formatDateValue,
 	formatDisplay,
+	formatNumberValue,
 } from '../../../src/components/EditableCell';
 
-function renderDisplay( value, type, elements ) {
-	return render( <>{ formatDisplay( value, type, elements ) }</> );
+function renderDisplay( value, type, options ) {
+	return render( <>{ formatDisplay( value, type, options ) }</> );
 }
 
 describe( 'formatDisplay', () => {
@@ -20,9 +22,106 @@ describe( 'formatDisplay', () => {
 	} );
 
 	describe( 'date / datetime', () => {
-		it( 'formats date-only values as local calendar dates', () => {
-			expect( formatDisplay( '2026-04-16', 'date' ) ).toBe(
-				new Date( 2026, 3, 16 ).toLocaleDateString()
+		it( 'formats date-only values per the chosen locale', () => {
+			expect(
+				formatDisplay( '2026-04-16', 'date', {
+					format: { style: 'us' },
+				} )
+			).toBe( '04/16/2026' );
+			expect(
+				formatDisplay( '2026-04-16', 'date', {
+					format: { style: 'eu' },
+				} )
+			).toBe( '16/04/2026' );
+		} );
+
+		it( 'omits time when the format toggles it off', () => {
+			const out = formatDisplay( '2026-03-15T14:30:00', 'datetime', {
+				format: { style: 'us', time: false },
+			} );
+			expect( out ).toBe( '03/15/2026' );
+		} );
+
+		it( 'honors the 24-hour clock toggle', () => {
+			const out = formatDisplay( '2026-03-15T14:30:00', 'datetime', {
+				format: { style: 'us', time: true, hour12: false },
+			} );
+			expect( out ).toContain( '14:30' );
+		} );
+	} );
+
+	describe( 'number', () => {
+		it( 'falls through to plain string when no format is given', () => {
+			expect( formatDisplay( 1234, 'number' ) ).toBe( '1234' );
+		} );
+
+		it( 'groups thousands when style is comma', () => {
+			expect(
+				formatDisplay( 1234567, 'number', {
+					format: { style: 'comma' },
+				} )
+			).toBe( '1,234,567' );
+		} );
+
+		it( 'renders percent style by multiplying by 100', () => {
+			expect(
+				formatDisplay( 0.5, 'number', {
+					format: { style: 'percent', decimals: 0 },
+				} )
+			).toBe( '50%' );
+		} );
+
+		it( 'applies decimal places', () => {
+			expect(
+				formatDisplay( 1.2, 'number', {
+					format: { style: 'plain', decimals: 3 },
+				} )
+			).toBe( '1.200' );
+		} );
+
+		it( 'renders currency with the chosen ISO code', () => {
+			const out = formatNumberValue( 9.95, {
+				style: 'currency',
+				currency: 'EUR',
+				decimals: 2,
+			} );
+			expect( out ).toMatch( /9[.,]95/ );
+			expect( out ).toMatch( /€|EUR/ );
+		} );
+
+		it( 'falls back to String for non-numeric input', () => {
+			expect( formatNumberValue( 'n/a', { style: 'comma' } ) ).toBe(
+				'n/a'
+			);
+		} );
+
+		it( 'follows the WordPress site locale for separators', () => {
+			// `@wordpress/date` defaults the locale to 'en' under jest, so
+			// the comma case still produces `1,234,567`. If the wiring
+			// ever drops back to `undefined`, this still passes in en-US
+			// runtimes; the explicit getSettings() check is what catches
+			// the regression.
+			const { getSettings } = require( '@wordpress/date' );
+			expect( getSettings().l10n.locale ).toBe( 'en' );
+			expect(
+				formatNumberValue( 1234567, { style: 'comma' } )
+			).toBe( '1,234,567' );
+		} );
+	} );
+
+	describe( 'formatDateValue helper', () => {
+		it( 'parses datetime strings and renders without time when toggled off', () => {
+			expect(
+				formatDateValue( '2026-03-15T14:30:00', 'datetime', {
+					style: 'eu',
+					time: false,
+				} )
+			).toBe( '15/03/2026' );
+		} );
+
+		it( 'returns String(value) for unparseable input', () => {
+			expect( formatDateValue( 'nope', 'datetime', null ) ).toBe(
+				'nope'
 			);
 		} );
 	} );
@@ -65,7 +164,7 @@ describe( 'formatDisplay', () => {
 			const elements = [
 				{ value: 'open', label: 'Open', color: '#ffe2dd' },
 			];
-			renderDisplay( 'open', 'select', elements );
+			renderDisplay( 'open', 'select', { elements } );
 			const chip = screen.getByText( 'Open' );
 			expect( chip ).toHaveClass( 'cortext-chip' );
 			expect( chip ).not.toHaveClass( 'cortext-chip--neutral' );
@@ -73,11 +172,11 @@ describe( 'formatDisplay', () => {
 		} );
 
 		it( 'sets a contrasting foreground for hex colors', () => {
-			renderDisplay(
-				'open',
-				'select',
-				[ { value: 'open', label: 'Open', color: '#000000' } ]
-			);
+			renderDisplay( 'open', 'select', {
+				elements: [
+					{ value: 'open', label: 'Open', color: '#000000' },
+				],
+			} );
 			expect( screen.getByText( 'Open' ).style.color ).toBe(
 				'rgb(255, 255, 255)'
 			);
@@ -85,15 +184,17 @@ describe( 'formatDisplay', () => {
 
 		it( 'falls back to a neutral chip when the option has no color', () => {
 			const elements = [ { value: 'open', label: 'Open' } ];
-			renderDisplay( 'open', 'select', elements );
+			renderDisplay( 'open', 'select', { elements } );
 			expect( screen.getByText( 'Open' ) ).toHaveClass(
 				'cortext-chip--neutral'
 			);
 		} );
 
 		it( 'renders a chip labeled with the raw value when not in elements', () => {
-			renderDisplay( 'orphan', 'select', [] );
-			expect( screen.getByText( 'orphan' ) ).toHaveClass( 'cortext-chip' );
+			renderDisplay( 'orphan', 'select', { elements: [] } );
+			expect( screen.getByText( 'orphan' ) ).toHaveClass(
+				'cortext-chip'
+			);
 		} );
 	} );
 
@@ -103,7 +204,7 @@ describe( 'formatDisplay', () => {
 				{ value: 'a', label: 'A', color: '#ffe2dd' },
 				{ value: 'b', label: 'B', color: '#ddebf1' },
 			];
-			renderDisplay( [ 'a', 'b' ], 'multiselect', elements );
+			renderDisplay( [ 'a', 'b' ], 'multiselect', { elements } );
 			expect( screen.getByText( 'A' ) ).toHaveClass( 'cortext-chip' );
 			expect( screen.getByText( 'B' ) ).toHaveClass( 'cortext-chip' );
 			expect( screen.getByText( 'A' ).style.backgroundColor ).not.toBe(
@@ -112,7 +213,9 @@ describe( 'formatDisplay', () => {
 		} );
 
 		it( 'returns the empty string for an empty array', () => {
-			expect( formatDisplay( [], 'multiselect', [] ) ).toBe( '' );
+			expect( formatDisplay( [], 'multiselect', { elements: [] } ) ).toBe(
+				''
+			);
 		} );
 	} );
 } );

--- a/tests/js/components/EditableCell.test.js
+++ b/tests/js/components/EditableCell.test.js
@@ -95,6 +95,32 @@ describe( 'formatDisplay', () => {
 			);
 		} );
 
+		it( 'preserves natural precision when no decimals are configured', () => {
+			// Existing fields and freshly-saved formats both omit
+			// `decimals`. The renderer must not force-truncate them — Intl
+			// keeps up to 3 fraction digits by default for plain output,
+			// which matches what users expect from "no format set".
+			expect( formatDisplay( 1.25, 'number' ) ).toBe( '1.25' );
+			expect(
+				formatDisplay( 1.25, 'number', {
+					format: { style: 'plain' },
+				} )
+			).toBe( '1.25' );
+			expect(
+				formatDisplay( 1234.5, 'number', {
+					format: { style: 'comma' },
+				} )
+			).toBe( '1,234.5' );
+		} );
+
+		it( 'rounds to the explicit decimals when 0 is picked', () => {
+			expect(
+				formatDisplay( 1.25, 'number', {
+					format: { style: 'plain', decimals: 0 },
+				} )
+			).toBe( '1' );
+		} );
+
 		it( 'follows the WordPress site locale for separators', () => {
 			// `@wordpress/date` defaults the locale to 'en' under jest, so
 			// the comma case still produces `1,234,567`. If the wiring

--- a/tests/js/hooks/fieldMapping.test.js
+++ b/tests/js/hooks/fieldMapping.test.js
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import {
 	elementsFromOptions,
 	mapField,
+	parseFormat,
 	systemFields,
 } from '../../../src/hooks/fieldMapping';
 
@@ -38,9 +39,7 @@ describe( 'elementsFromOptions', () => {
 			elementsFromOptions( [
 				{ value: 'open', label: 'Open', color: '#ffe2dd' },
 			] )
-		).toEqual( [
-			{ value: 'open', label: 'Open', color: '#ffe2dd' },
-		] );
+		).toEqual( [ { value: 'open', label: 'Open', color: '#ffe2dd' } ] );
 	} );
 
 	it( 'accepts a JSON string as input', () => {
@@ -54,6 +53,36 @@ describe( 'elementsFromOptions', () => {
 	} );
 } );
 
+describe( 'parseFormat', () => {
+	it( 'returns undefined for falsy input', () => {
+		expect( parseFormat( null ) ).toBeUndefined();
+		expect( parseFormat( '' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for malformed JSON', () => {
+		expect( parseFormat( '{not json' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for non-objects', () => {
+		expect( parseFormat( '"hello"' ) ).toBeUndefined();
+		expect( parseFormat( '[1,2]' ) ).toBeUndefined();
+	} );
+
+	it( 'parses a JSON object', () => {
+		expect( parseFormat( '{"style":"comma","decimals":2}' ) ).toEqual( {
+			style: 'comma',
+			decimals: 2,
+		} );
+	} );
+
+	it( 'accepts an already-parsed object', () => {
+		expect( parseFormat( { style: 'us', time: false } ) ).toEqual( {
+			style: 'us',
+			time: false,
+		} );
+	} );
+} );
+
 describe( 'mapField', () => {
 	const baseField = ( overrides ) => ( {
 		id: 5,
@@ -62,7 +91,9 @@ describe( 'mapField', () => {
 	} );
 
 	it( "maps Cortext's number to DataViews 'text' so decimals sort correctly", () => {
-		expect( mapField( baseField( { type: 'number' } ) ).type ).toBe( 'text' );
+		expect( mapField( baseField( { type: 'number' } ) ).type ).toBe(
+			'text'
+		);
 	} );
 
 	it( "maps checkbox to DataViews 'boolean'", () => {
@@ -78,7 +109,9 @@ describe( 'mapField', () => {
 	} );
 
 	it( "maps email to DataViews 'email'", () => {
-		expect( mapField( baseField( { type: 'email' } ) ).type ).toBe( 'email' );
+		expect( mapField( baseField( { type: 'email' } ) ).type ).toBe(
+			'email'
+		);
 	} );
 
 	it( "maps url to DataViews 'text' (DataViews has no 'url' type)", () => {
@@ -151,8 +184,12 @@ describe( 'systemFields', () => {
 		expect( byId( 'modified_at' ).getValue( { item } ) ).toBe(
 			'2026-04-30T10:00:00+00:00'
 		);
-		expect( byId( 'created_by' ).getValue( { item } ) ).toBe( 'Ada Lovelace' );
-		expect( byId( 'modified_by' ).getValue( { item } ) ).toBe( 'Grace Hopper' );
+		expect( byId( 'created_by' ).getValue( { item } ) ).toBe(
+			'Ada Lovelace'
+		);
+		expect( byId( 'modified_by' ).getValue( { item } ) ).toBe(
+			'Grace Hopper'
+		);
 	} );
 
 	it( 'returns null when the row is missing the value', () => {
@@ -183,8 +220,6 @@ describe( 'systemFields', () => {
 		// We don't assert the exact format (locale-dependent), only that
 		// something formatted comes out and the empty branch isn't hit.
 		expect( container.textContent.length ).toBeGreaterThan( 0 );
-		expect( container.textContent ).not.toBe(
-			'2026-04-30T09:48:54+00:00'
-		);
+		expect( container.textContent ).not.toBe( '2026-04-30T09:48:54+00:00' );
 	} );
 } );

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -286,6 +286,54 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		);
 	}
 
+	public function test_duplicate_clones_format_meta(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Format Meta', 'format-meta' );
+
+		$number_format = wp_json_encode(
+			array(
+				'style'    => 'currency',
+				'decimals' => 2,
+				'currency' => 'EUR',
+			)
+		);
+		$date_format   = wp_json_encode(
+			array(
+				'style'  => 'us',
+				'time'   => true,
+				'hour12' => false,
+			)
+		);
+
+		// Format meta is written via core-data after creation, so insert
+		// the source field directly with the meta in place.
+		$source_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Price',
+				'meta_input'  => array(
+					'type'          => 'number',
+					'number_format' => $number_format,
+					'date_format'   => $date_format,
+				),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $source_id );
+
+		$copy_id = (int) $this->duplicate_field( $collection_id, $source_id )
+			->get_data()['id'];
+
+		$this->assertSame(
+			$number_format,
+			get_post_meta( $copy_id, 'number_format', true )
+		);
+		$this->assertSame(
+			$date_format,
+			get_post_meta( $copy_id, 'date_format', true )
+		);
+	}
+
 	public function test_duplicate_preserves_related_collection_id(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		$collection_id = $this->create_collection_with_slug( 'Tasks', 'tasks-r' );


### PR DESCRIPTION
## What

Closes #123

Adds formatting options for number and date fields.

Number fields can render as plain numbers, percentages, or currency, with a chosen decimal count. Date fields can choose the date layout and whether to show time.

The setting lives on the field, so the whole column updates together, survives reloads, and copies when the field is duplicated. Values render with `Intl` using the WordPress site locale.

## Testing

1. Add a Number field and try each format and decimal option.
2. Add a Date & time field and try each date/time option.
3. Reload and confirm the formatting sticks.
4. Duplicate a formatted field and confirm the copy keeps the same settings.
5. Run `npm test` and `composer test`.

## Screenshot

<img width="1671" height="583" alt="image" src="https://github.com/user-attachments/assets/5f0a80a8-ff6a-4326-87d2-3f7b4aee162d" />