### PR TITLE
Sidebar & toolbar refresh

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -204,3 +204,19 @@ Double-click autofit is the trickiest piece. With no measurement hook upstream, 
 
 **Solution.** Add a `height` (or "rows visible") attribute to the block with an inspector control, fall back to the variable when unset, and let the variable stay as a theme-overridable default. Computing the default from `density × perPage` is a smaller win; once the per-block control exists, the default rarely matters.
 
+## 24. Workspace notices filtered by id prefix `[upstream, soft]`
+
+**What.** Gutenberg's editor store fires off its own "Page updated" snackbar on every successful save. Autosave runs constantly here, so that toast would never stop popping up. Our workaround is a custom `SnackbarList` that only shows notices whose id starts with `cortext-`; everything else gets dropped on the floor, including any third-party plugin notice or a future first-party one we'd actually want to surface.
+
+**Where.** `CortextSnackbars` in `src/components/Canvas.js`, paired with the `id: 'cortext-autosave-error'` we set on the autosave error notice in `src/hooks/useAutosave.js`.
+
+**Solution.** Upstream could expose a way to suppress the editor's default save notice, or scope notices per surface so we don't have to share a global stream. Until then, anything Cortext wants visible has to opt in with a `cortext-` id.
+
+## 25. dnd-kit doesn't observe `inert` `[upstream, soft]`
+
+**What.** Collapsed branches of the page tree stay mounted so the expand/collapse animation can run. The wrapper gets `inert` so focus, screen readers, and click events skip the subtree, but dnd-kit doesn't pay attention to that. It walks its registered droppables in JavaScript, asks each one for its bounding rect, and treats them as live drop targets whether anything visible is there or not. Without intervention, a drag can land on a row you can't see. The workaround is to thread an `isHidden` prop down through `PageRow` and pass `disabled: isHidden` to every `useDroppable`. Anything else that wants this animation pattern has to do the same drilling.
+
+**Where.** The `isHidden` prop chain through `src/components/PageRow.js`, plus the wrapper's `inert` attribute in the same file.
+
+**Solution.** dnd-kit honoring `inert` (or computed `pointer-events: none`) on an ancestor would let us drop the prop-drilling. Until then, any tree-shaped surface that uses a CSS-clipped collapse animation has to thread `disabled` through its rows itself.
+

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -186,3 +186,11 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 **Solution.** Stand up an integration environment with a real `wpdb` (`wp-env` + WP_PHPUnit), move the cleanup to a scoped JOIN, and keep WorDBless for the parts that don't need a real database.
 
+## 22. Canvas toolbar is page-only `[internal]`
+
+**What.** The top toolbar (Publish, Settings) lives inside `Canvas.js`, rendered as the `header` slot of `<InterfaceSkeleton>`. Collections take a different path (`EntityRoute` -> `CollectionPane`, a plain `<div>` with no `InterfaceSkeleton`) and show no toolbar at all. Now that the toolbar is styled to match the sidebar header height, the inconsistency is visible: pages show a polished top strip; collections jump straight from the sidebar header into content.
+
+**Where.** `Header` component in `src/components/Canvas.js`, mounted via `InterfaceSkeleton`'s `header` prop. `CollectionPane` in `src/router/EntityRoute.js` has no equivalent.
+
+**Solution.** Lift the toolbar into the workspace shell (probably into `EntityRoute.js`) and expose a slot via `@wordpress/components` SlotFill so each pane contributes its own actions. Pages keep contributing Publish + Settings; collections grow their own actions (view switcher, "New entry") in a follow-up. Until then, collections just don't have the strip.
+

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -220,3 +220,11 @@ Double-click autofit is the trickiest piece. With no measurement hook upstream, 
 
 **Solution.** dnd-kit honoring `inert` (or computed `pointer-events: none`) on an ancestor would let us drop the prop-drilling. Until then, any tree-shaped surface that uses a CSS-clipped collapse animation has to thread `disabled` through its rows itself.
 
+## 26. Sidebar rename input pinned via WP component internals `[upstream]`
+
+**What.** The page-row rename uses `<TextControl size="compact" __next40pxDefaultSize>`, which should produce a 32px input matching the 32px row. It doesn't, on its own: the wrapping `BaseControl > field > InputControl > container` chain still contributes vertical space, so opening rename used to bump the row a few pixels. The fix pins `height` / `min-height` / `max-height` to `$grid-unit-40` and zeroes `padding-block` on every layer in that chain (`.components-base-control`, `.components-base-control__field`, `.components-input-control`, `.components-input-control__container`, `.components-input-control__input`). It works, but it couples Cortext to WP component-internal class names. If WP refactors `TextControl` (renames a class, drops a wrapper, restructures the DOM), the input loses its height pin and the row starts bumping again, silently.
+
+**Where.** The `&__rename` block in `src/index.scss`. The e2e test `keeps the rename input inside the page row height` in `tests/e2e/specs/sidebar-layout.spec.js` is the tripwire: it asserts the input never overflows the row's bounding rect, so a WP-internals refactor would surface there before reaching production.
+
+**Solution.** Either WP exposes a "fit-the-row" size for `TextControl` (or a CSS variable hook for input height), or we replace the rename `TextControl` with a plain `<input>` styled to match the row. The plain input is the more reliable path: drops the WP-internals coupling, but adds a small amount of styling and accessibility plumbing we currently get for free. Worth doing the day this test fails on a WP bump.
+

--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -87,8 +87,9 @@ final class Screen {
 			self::SCRIPT_HANDLE,
 			'window.cortextSettings = ' . wp_json_encode(
 				array(
-					'adminUrl' => admin_url(),
-					'menuSlug' => self::MENU_SLUG,
+					'adminUrl'        => admin_url(),
+					'menuSlug'        => self::MENU_SLUG,
+					'userDisplayName' => wp_get_current_user()->display_name,
 				)
 			) . ';',
 			'before'

--- a/includes/Theming/Preferences.php
+++ b/includes/Theming/Preferences.php
@@ -2,15 +2,13 @@
 /**
  * Shell preferences bootstrap.
  *
- * Emits a tiny pre-mount script that reads the user's color-scheme
- * preference from `localStorage`, resolves `auto` against the system
- * `prefers-color-scheme` media query, and stamps the result on
- * `#cortext-root` as `data-theme`. Running before React mounts removes
- * the flash between the root element rendering and the React hook
- * applying the attribute.
+ * Emits a pre-mount script that reads the user's shell preferences
+ * (color scheme, sidebar collapse + width) from localStorage and stamps
+ * the resolved values onto `#cortext-root`, so the first paint matches
+ * the user's preference without a flash before the React hooks mount.
  *
- * The same value is exposed as `window.cortextBootstrap.colorScheme` so
- * `useColorScheme()` can seed its initial state without re-reading
+ * Values are also exposed as `window.cortextBootstrap` so the hooks
+ * (`useColorScheme`, `useSidebarLayout`) can seed without re-reading
  * storage.
  *
  * @package Cortext
@@ -41,11 +39,30 @@ final class Preferences {
 	if ( pref === 'auto' ) {
 		resolved = window.matchMedia && window.matchMedia( '(prefers-color-scheme: dark)' ).matches ? 'dark' : 'light';
 	}
+
+	// Clamp to the same range as useSidebarLayout so a saved width never
+	// paints out of range.
+	var sidebarCollapsed = false;
+	var sidebarWidth = 280;
+	try {
+		sidebarCollapsed = window.localStorage.getItem( 'cortext.sidebarCollapsed' ) === 'true';
+		var rawWidth = parseInt( window.localStorage.getItem( 'cortext.sidebarWidth' ), 10 );
+		if ( rawWidth >= 220 && rawWidth <= 480 ) {
+			sidebarWidth = rawWidth;
+		}
+	} catch ( e ) {}
+
 	var root = document.getElementById( 'cortext-root' );
 	if ( root ) {
 		root.setAttribute( 'data-theme', resolved );
+		root.setAttribute( 'data-sidebar-collapsed', sidebarCollapsed ? 'true' : 'false' );
+		root.style.setProperty( '--cortext-sidebar-width', sidebarWidth + 'px' );
 	}
-	window.cortextBootstrap = { colorScheme: pref };
+
+	window.cortextBootstrap = {
+		colorScheme: pref,
+		sidebar: { collapsed: sidebarCollapsed, width: sidebarWidth },
+	};
 })();
 JS;
 	}

--- a/includes/Theming/Preferences.php
+++ b/includes/Theming/Preferences.php
@@ -46,9 +46,16 @@ final class Preferences {
 	var sidebarWidth = 280;
 	try {
 		sidebarCollapsed = window.localStorage.getItem( 'cortext.sidebarCollapsed' ) === 'true';
-		var rawWidth = parseInt( window.localStorage.getItem( 'cortext.sidebarWidth' ), 10 );
-		if ( rawWidth >= 220 && rawWidth <= 480 ) {
-			sidebarWidth = rawWidth;
+		var storedWidth = window.localStorage.getItem( 'cortext.sidebarWidth' );
+		var rawWidth = storedWidth === null ? NaN : Number( storedWidth );
+		if ( isFinite( rawWidth ) ) {
+			if ( rawWidth < 220 ) {
+				sidebarWidth = 220;
+			} else if ( rawWidth > 480 ) {
+				sidebarWidth = 480;
+			} else {
+				sidebarWidth = Math.round( rawWidth );
+			}
 		}
 	} catch ( e ) {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"@wordpress/i18n": "^6.17.0",
 				"@wordpress/icons": "^12.2.0",
 				"@wordpress/interface": "^9.0.0",
+				"@wordpress/notices": "^5.44.0",
 				"@wordpress/private-apis": "^1.44.0",
 				"@wordpress/route": "^0.10.0",
 				"@wordpress/url": "^4.44.0"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"@wordpress/i18n": "^6.17.0",
 		"@wordpress/icons": "^12.2.0",
 		"@wordpress/interface": "^9.0.0",
+		"@wordpress/notices": "^5.44.0",
 		"@wordpress/private-apis": "^1.44.0",
 		"@wordpress/route": "^0.10.0",
 		"@wordpress/url": "^4.44.0"

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -3,6 +3,7 @@ import { useEntityRecord } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	EditorProvider,
+	EditorSnackbars,
 	PostTitle,
 	store as editorStore,
 } from '@wordpress/editor';
@@ -236,6 +237,7 @@ function CanvasEditor( { post, pendingPost, onSwitchPost, onDisplayedPost } ) {
 			<InterfaceSkeleton
 				className="cortext-canvas"
 				header={ <Header /> }
+				notices={ <EditorSnackbars /> }
 				content={
 					<>
 						{ isTrashed && <TrashedNotice postId={ post.id } /> }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -66,18 +66,22 @@ function Header( { saveStatus } ) {
 
 	return (
 		<div className="cortext-canvas__header">
-			<SaveStatus status={ saveStatus } />
-			<PublishToggle />
-			<Button
-				icon={ cog }
-				label={ __( 'Settings', 'cortext' ) }
-				isPressed={ isInspectorOpen }
-				onClick={ () =>
-					isInspectorOpen
-						? disableComplementaryArea( SCOPE )
-						: enableComplementaryArea( SCOPE, INSPECTOR )
-				}
-			/>
+			<div className="cortext-canvas__header-left">
+				<SaveStatus status={ saveStatus } />
+			</div>
+			<div className="cortext-canvas__header-right">
+				<PublishToggle />
+				<Button
+					icon={ cog }
+					label={ __( 'Settings', 'cortext' ) }
+					isPressed={ isInspectorOpen }
+					onClick={ () =>
+						isInspectorOpen
+							? disableComplementaryArea( SCOPE )
+							: enableComplementaryArea( SCOPE, INSPECTOR )
+					}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -33,28 +33,7 @@ import PublishToggle from './PublishToggle';
 const SCOPE = 'cortext';
 const INSPECTOR = 'cortext/block-inspector';
 
-const STATUS_LABELS = {
-	idle: '',
-	saving: __( 'Saving…', 'cortext' ),
-	saved: __( 'Saved', 'cortext' ),
-	error: __( 'Failed to save', 'cortext' ),
-};
-
-function SaveStatus( { status } ) {
-	const label = STATUS_LABELS[ status ] ?? '';
-
-	return (
-		<div
-			className={ `cortext-canvas__status cortext-canvas__status--${ status }` }
-			role="status"
-			aria-live="polite"
-		>
-			{ label }
-		</div>
-	);
-}
-
-function Header( { saveStatus } ) {
+function Header() {
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
 	const isInspectorOpen = useSelect(
@@ -66,9 +45,6 @@ function Header( { saveStatus } ) {
 
 	return (
 		<div className="cortext-canvas__header">
-			<div className="cortext-canvas__header-left">
-				<SaveStatus status={ saveStatus } />
-			</div>
 			<div className="cortext-canvas__header-right">
 				<PublishToggle />
 				<Button
@@ -231,7 +207,7 @@ function VisualCanvas( { postId, onReady } ) {
 }
 
 function CanvasEditor( { post, pendingPost, onSwitchPost, onDisplayedPost } ) {
-	const { status, flushNow, isDirty, isSaving } = useAutosave();
+	const { flushNow, isDirty, isSaving } = useAutosave();
 	const isTrashed = post.status === 'trash';
 
 	useEffect( () => {
@@ -259,7 +235,7 @@ function CanvasEditor( { post, pendingPost, onSwitchPost, onDisplayedPost } ) {
 		<>
 			<InterfaceSkeleton
 				className="cortext-canvas"
-				header={ <Header saveStatus={ status } /> }
+				header={ <Header /> }
 				content={
 					<>
 						{ isTrashed && <TrashedNotice postId={ post.id } /> }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -3,7 +3,6 @@ import { useEntityRecord } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	EditorProvider,
-	EditorSnackbars,
 	PostTitle,
 	store as editorStore,
 } from '@wordpress/editor';
@@ -18,7 +17,14 @@ import {
 	ComplementaryArea,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import { Button, Disabled, Notice, Spinner } from '@wordpress/components';
+import {
+	Button,
+	Disabled,
+	Notice,
+	SnackbarList,
+	Spinner,
+} from '@wordpress/components';
+import { store as noticesStore } from '@wordpress/notices';
 import { cog } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
@@ -35,6 +41,28 @@ import { TopBarActionsFill } from './WorkspaceTopBar';
 
 const SCOPE = 'cortext';
 const INSPECTOR = 'cortext/block-inspector';
+
+// Renders only Cortext-owned snackbars (the autosave failure toast). The
+// editor store also dispatches its own "Post updated" success notice on every
+// save; in an autosave-silent UI those would fire constantly, so we filter to
+// notices we tagged ourselves.
+function CortextSnackbars() {
+	const notices = useSelect(
+		( select ) =>
+			select( noticesStore )
+				.getNotices()
+				.filter(
+					( n ) =>
+						n.type === 'snackbar' &&
+						typeof n.id === 'string' &&
+						n.id.startsWith( 'cortext-' )
+				),
+		[]
+	);
+	const { removeNotice } = useDispatch( noticesStore );
+
+	return <SnackbarList notices={ notices } onRemove={ removeNotice } />;
+}
 
 function DocumentActions( { isActive } ) {
 	const { enableComplementaryArea, disableComplementaryArea } =
@@ -254,7 +282,7 @@ function CanvasEditor( {
 	return (
 		<>
 			<DocumentActions isActive={ isActive } />
-			<EditorSnackbars />
+			<CortextSnackbars />
 			<InterfaceSkeleton
 				className="cortext-canvas"
 				content={

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -88,6 +88,7 @@ function DocumentActions( { isActive } ) {
 				<PublishToggle />
 				<Button
 					icon={ cog }
+					size="compact"
 					label={ __( 'Settings', 'cortext' ) }
 					isPressed={ isInspectorOpen }
 					onClick={ () =>

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -33,6 +33,11 @@ export default function PageRow( {
 	onDelete,
 	autoRenameId, // page id that should immediately enter rename mode
 	onAutoRenameConsumed,
+	// True when an ancestor is collapsed: this row and its subtree are
+	// visually clipped but stay mounted for the expand/collapse animation.
+	// Drop targets must be off so dnd-kit's pointerWithin doesn't hit
+	// invisible descendants and route a drop to the wrong row.
+	isHidden = false,
 } ) {
 	const { page, children } = node;
 	const hasChildren = children.length > 0;
@@ -84,14 +89,17 @@ export default function PageRow( {
 	const dropBefore = useDroppable( {
 		id: `before:${ page.id }`,
 		data: { zone: 'before', pageId: page.id },
+		disabled: isHidden,
 	} );
 	const dropInside = useDroppable( {
 		id: `inside:${ page.id }`,
 		data: { zone: 'inside', pageId: page.id },
+		disabled: isHidden,
 	} );
 	const dropAfter = useDroppable( {
 		id: `after:${ page.id }`,
 		data: { zone: 'after', pageId: page.id },
+		disabled: isHidden,
 	} );
 
 	const isDropTarget = activeDrop && activeDrop.targetId === page.id;
@@ -303,6 +311,7 @@ export default function PageRow( {
 								onDelete={ onDelete }
 								autoRenameId={ autoRenameId }
 								onAutoRenameConsumed={ onAutoRenameConsumed }
+								isHidden={ isHidden || ! isExpanded }
 							/>
 						) ) }
 					</ul>

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -183,6 +183,7 @@ export default function PageRow( {
 							<TextControl
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
+								size="compact"
 								value={ draftTitle }
 								onChange={ setDraftTitle }
 								onBlur={ commitRename }
@@ -202,6 +203,7 @@ export default function PageRow( {
 					) : (
 						<Button
 							className="cortext-sidebar__title"
+							size="compact"
 							onClick={ () => onSelect( page.id ) }
 							isPressed={ isSelected }
 						>

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -7,7 +7,7 @@ import {
 	MenuItem,
 	TextControl,
 } from '@wordpress/components';
-import { chevronDown, chevronRight } from '@wordpress/icons';
+import { chevronRight } from '@wordpress/icons';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 
 const GRID_UNIT = 20; // matches $grid-unit-20 in index.scss
@@ -143,8 +143,11 @@ export default function PageRow( {
 				>
 					{ hasChildren ? (
 						<Button
-							className="cortext-sidebar__chevron"
-							icon={ isExpanded ? chevronDown : chevronRight }
+							className={
+								'cortext-sidebar__chevron' +
+								( isExpanded ? ' is-expanded' : '' )
+							}
+							icon={ chevronRight }
 							size="small"
 							label={
 								isExpanded
@@ -274,28 +277,36 @@ export default function PageRow( {
 				</div>
 			</div>
 
-			{ hasChildren && isExpanded && (
-				<ul className="cortext-sidebar__children">
-					{ children.map( ( child ) => (
-						<PageRow
-							key={ child.page.id }
-							node={ child }
-							depth={ depth + 1 }
-							selectedId={ selectedId }
-							expandedIds={ expandedIds }
-							draggedId={ draggedId }
-							activeDrop={ activeDrop }
-							onSelect={ onSelect }
-							onToggleExpand={ onToggleExpand }
-							onCreateChild={ onCreateChild }
-							onRename={ onRename }
-							onDuplicate={ onDuplicate }
-							onDelete={ onDelete }
-							autoRenameId={ autoRenameId }
-							onAutoRenameConsumed={ onAutoRenameConsumed }
-						/>
-					) ) }
-				</ul>
+			{ hasChildren && (
+				<div
+					className={
+						'cortext-sidebar__children-wrapper' +
+						( isExpanded ? ' is-expanded' : '' )
+					}
+					aria-hidden={ ! isExpanded }
+				>
+					<ul className="cortext-sidebar__children">
+						{ children.map( ( child ) => (
+							<PageRow
+								key={ child.page.id }
+								node={ child }
+								depth={ depth + 1 }
+								selectedId={ selectedId }
+								expandedIds={ expandedIds }
+								draggedId={ draggedId }
+								activeDrop={ activeDrop }
+								onSelect={ onSelect }
+								onToggleExpand={ onToggleExpand }
+								onCreateChild={ onCreateChild }
+								onRename={ onRename }
+								onDuplicate={ onDuplicate }
+								onDelete={ onDelete }
+								autoRenameId={ autoRenameId }
+								onAutoRenameConsumed={ onAutoRenameConsumed }
+							/>
+						) ) }
+					</ul>
+				</div>
 			) }
 		</li>
 	);

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -2,12 +2,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import {
 	Button,
-	DropdownMenu,
+	Dropdown,
 	MenuGroup,
 	MenuItem,
 	TextControl,
 } from '@wordpress/components';
-import { chevronRight } from '@wordpress/icons';
+import { chevronRight, moreVertical, plus } from '@wordpress/icons';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 
 const GRID_UNIT = 20; // matches $grid-unit-20 in index.scss
@@ -209,30 +209,44 @@ export default function PageRow( {
 						</Button>
 					) }
 
-					<DropdownMenu
-						className="cortext-sidebar__menu"
-						icon="ellipsis"
+					<Button
+						className="cortext-sidebar__add-child"
+						icon={ plus }
+						size="small"
 						label={ sprintf(
-							/* translators: %s: page title */
-							__( 'Actions for %s', 'cortext' ),
+							/* translators: %s: parent page title */
+							__( 'Add a page inside %s', 'cortext' ),
 							title
 						) }
-						popoverProps={ { placement: 'bottom-end' } }
-						toggleProps={ {
-							onPointerDown: ( e ) => e.stopPropagation(),
+						onClick={ ( e ) => {
+							e.stopPropagation();
+							onCreateChild( page.id );
 						} }
-					>
-						{ ( { onClose } ) => (
+						onPointerDown={ ( e ) => e.stopPropagation() }
+					/>
+
+					<Dropdown
+						popoverProps={ { placement: 'bottom-end' } }
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<Button
+								className={
+									'cortext-sidebar__menu' +
+									( isOpen ? ' is-opened' : '' )
+								}
+								icon={ moreVertical }
+								size="small"
+								label={ sprintf(
+									/* translators: %s: page title */
+									__( 'Actions for %s', 'cortext' ),
+									title
+								) }
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+								onPointerDown={ ( e ) => e.stopPropagation() }
+							/>
+						) }
+						renderContent={ ( { onClose } ) => (
 							<MenuGroup>
-								<MenuItem
-									icon="plus"
-									onClick={ () => {
-										onCreateChild( page.id );
-										onClose();
-									} }
-								>
-									{ __( 'Add child page', 'cortext' ) }
-								</MenuItem>
 								<MenuItem
 									icon="edit"
 									onClick={ () => {
@@ -263,7 +277,7 @@ export default function PageRow( {
 								</MenuItem>
 							</MenuGroup>
 						) }
-					</DropdownMenu>
+					/>
 
 					{ /* Drop zones overlay the row. pointer-events are off
 					     so they don't block clicks when idle. */ }

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -283,7 +283,7 @@ export default function PageRow( {
 						'cortext-sidebar__children-wrapper' +
 						( isExpanded ? ' is-expanded' : '' )
 					}
-					aria-hidden={ ! isExpanded }
+					{ ...( isExpanded ? {} : { inert: '' } ) }
 				>
 					<ul className="cortext-sidebar__children">
 						{ children.map( ( child ) => (

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -7,6 +7,7 @@ import {
 	MenuItem,
 	TextControl,
 } from '@wordpress/components';
+import { chevronDown, chevronRight } from '@wordpress/icons';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 
 const GRID_UNIT = 20; // matches $grid-unit-20 in index.scss
@@ -143,11 +144,8 @@ export default function PageRow( {
 					{ hasChildren ? (
 						<Button
 							className="cortext-sidebar__chevron"
-							icon={
-								isExpanded
-									? 'arrow-down-alt2'
-									: 'arrow-right-alt2'
-							}
+							icon={ isExpanded ? chevronDown : chevronRight }
+							size="small"
 							label={
 								isExpanded
 									? __( 'Collapse', 'cortext' )

--- a/src/components/PublishToggle.js
+++ b/src/components/PublishToggle.js
@@ -44,7 +44,7 @@ export default function PublishToggle() {
 				icon={ isPublic ? globe : lock }
 				onClick={ toggle }
 				disabled={ isSaving }
-				variant={ isPublic ? 'primary' : 'secondary' }
+				variant="tertiary"
 				size="compact"
 			>
 				{ isPublic

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -615,7 +615,7 @@ export default function Sidebar( {
 					href={ adminUrl }
 					icon={
 						<span className="cortext-sidebar__back-icon">
-							<Icon icon={ chevronLeft } size={ 18 } />
+							<Icon icon={ chevronLeft } size={ 24 } />
 							<Icon icon={ wordpress } size={ 20 } />
 						</span>
 					}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -61,6 +61,7 @@ import SidebarTrash from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
 import {
 	buildTree,
+	collectAncestorIds,
 	computeDropTarget,
 	isDescendantOf,
 	nextChildOrder,
@@ -191,6 +192,27 @@ export default function Sidebar( {
 	const [ autoRenameId, setAutoRenameId ] = useState( null );
 
 	const autoExpandTimerRef = useRef( null );
+
+	useEffect( () => {
+		if ( selectedId === null ) {
+			return;
+		}
+		const ancestorIds = collectAncestorIds( selectedId, pages );
+		if ( ancestorIds.length === 0 ) {
+			return;
+		}
+		setExpandedIds( ( prev ) => {
+			let changed = false;
+			const next = new Set( prev );
+			ancestorIds.forEach( ( id ) => {
+				if ( ! next.has( id ) ) {
+					next.add( id );
+					changed = true;
+				}
+			} );
+			return changed ? next : prev;
+		} );
+	}, [ selectedId, pages ] );
 
 	const getEntityRecord = useSelect(
 		( select ) => select( 'core' ).getEntityRecord,

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -602,6 +602,7 @@ export default function Sidebar( {
 									<div className="cortext-sidebar__row">
 										<Button
 											className="cortext-sidebar__title"
+											size="compact"
 											variant="tertiary"
 											onClick={ () =>
 												navigate( {

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -10,7 +10,40 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { Button, Icon, Spinner } from '@wordpress/components';
-import { chevronLeft, chevronRight, plus, wordpress } from '@wordpress/icons';
+import { chevronLeft, plus, wordpress } from '@wordpress/icons';
+
+// Notion-style sidebar toggle: panel outline with a vertical accent on
+// the left side. Same icon for both states; the aria-label tells the
+// user what the toggle will do.
+const sidebarToggleIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<rect
+			x="4"
+			y="5"
+			width="16"
+			height="14"
+			rx="2"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			fill="none"
+		/>
+		<line
+			x1="9"
+			y1="5"
+			x2="9"
+			y2="19"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+	</svg>
+);
 import {
 	DndContext,
 	DragOverlay,
@@ -439,7 +472,7 @@ export default function Sidebar( {
 				) }
 				<Button
 					className="cortext-sidebar__collapse-toggle"
-					icon={ collapsed ? chevronRight : chevronLeft }
+					icon={ sidebarToggleIcon }
 					label={
 						collapsed
 							? __( 'Expand sidebar', 'cortext' )

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -614,10 +614,14 @@ export default function Sidebar( {
 					label={ __( 'Back to WordPress', 'cortext' ) }
 					href={ adminUrl }
 					icon={
-						<span className="cortext-sidebar__back-icon">
-							<Icon icon={ chevronLeft } size={ 24 } />
-							<Icon icon={ wordpress } size={ 20 } />
-						</span>
+						collapsed ? (
+							<Icon icon={ wordpress } size={ 24 } />
+						) : (
+							<span className="cortext-sidebar__back-icon">
+								<Icon icon={ chevronLeft } size={ 24 } />
+								<Icon icon={ wordpress } size={ 20 } />
+							</span>
+						)
 					}
 				/>
 				<ThemeToggle />

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,6 +9,7 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { Button, Spinner } from '@wordpress/components';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 import {
 	DndContext,
 	DragOverlay,
@@ -21,6 +22,7 @@ import {
 import { useNavigate, useParams } from '@tanstack/react-router';
 
 import PageRow from './PageRow';
+import SidebarResizeHandle from './SidebarResizeHandle';
 import SidebarTrash from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
 import {
@@ -55,7 +57,12 @@ function parseDropId( id ) {
 	return { zone, targetId: pageId };
 }
 
-export default function Sidebar() {
+export default function Sidebar( {
+	collapsed = false,
+	width,
+	onToggleCollapsed,
+	onWidthChange,
+} ) {
 	// TODO(scale): per_page: 100 is the REST collection endpoint's hard ceiling.
 	// Workspaces are expected to exceed 100 pages — pages past the cap won't
 	// appear in the tree. Followup needs a lazy-loaded tree (load children on
@@ -391,123 +398,162 @@ export default function Sidebar() {
 		: null;
 
 	return (
-		<aside className="cortext-sidebar">
+		<aside
+			id="cortext-sidebar"
+			className="cortext-sidebar"
+			data-collapsed={ collapsed ? 'true' : 'false' }
+		>
 			<div className="cortext-sidebar__header">
+				{ collapsed ? (
+					<Button
+						icon="plus"
+						label={ __( 'New page', 'cortext' ) }
+						onClick={ createRootPage }
+					/>
+				) : (
+					<Button
+						className="cortext-sidebar__new-page"
+						variant="primary"
+						onClick={ createRootPage }
+					>
+						{ __( 'New page', 'cortext' ) }
+					</Button>
+				) }
+				<Button
+					className="cortext-sidebar__collapse-toggle"
+					icon={ collapsed ? chevronRight : chevronLeft }
+					label={
+						collapsed
+							? __( 'Expand sidebar', 'cortext' )
+							: __( 'Collapse sidebar', 'cortext' )
+					}
+					onClick={ onToggleCollapsed }
+				/>
+			</div>
+			{ ! collapsed && (
+				<div className="cortext-sidebar__content">
+					<h2 className="cortext-sidebar__section-title">
+						{ __( 'Pages', 'cortext' ) }
+					</h2>
+					{ isResolving && pages.length === 0 && (
+						<div className="cortext-sidebar__loading">
+							<Spinner />
+						</div>
+					) }
+					{ ! isResolving && pages.length === 0 && (
+						<p className="cortext-sidebar__empty">
+							{ __( 'No pages yet.', 'cortext' ) }
+						</p>
+					) }
+
+					<DndContext
+						sensors={ sensors }
+						collisionDetection={ pointerWithin }
+						onDragStart={ handleDragStart }
+						onDragOver={ handleDragOver }
+						onDragEnd={ handleDragEnd }
+						onDragCancel={ handleDragCancel }
+					>
+						<ul className="cortext-sidebar__list">
+							{ tree.map( ( node ) => (
+								<PageRow
+									key={ node.page.id }
+									node={ node }
+									depth={ 0 }
+									selectedId={ selectedId }
+									expandedIds={ expandedIds }
+									draggedId={ draggedId }
+									activeDrop={ activeDrop }
+									onSelect={ onSelect }
+									onToggleExpand={ toggleExpand }
+									onCreateChild={ createChildPage }
+									onRename={ renamePage }
+									onDuplicate={ duplicatePage }
+									onDelete={ trashPage }
+									autoRenameId={ autoRenameId }
+									onAutoRenameConsumed={ () =>
+										setAutoRenameId( null )
+									}
+								/>
+							) ) }
+						</ul>
+
+						<DragOverlay>
+							{ draggedPage ? (
+								<div className="cortext-sidebar__drag-preview">
+									{ draggedPage.title?.rendered?.trim() ||
+										__( '(untitled)', 'cortext' ) }
+								</div>
+							) : null }
+						</DragOverlay>
+					</DndContext>
+
+					<h2 className="cortext-sidebar__section-title">
+						{ __( 'Collections', 'cortext' ) }
+					</h2>
+					{ isResolvingCollections && ! collections?.length && (
+						<div className="cortext-sidebar__loading">
+							<Spinner />
+						</div>
+					) }
+					{ ! isResolvingCollections && ! collections?.length && (
+						<p className="cortext-sidebar__empty">
+							{ __( 'No collections yet.', 'cortext' ) }
+						</p>
+					) }
+					{ collections?.length > 0 && (
+						<ul className="cortext-sidebar__list">
+							{ collections.map( ( collection ) => (
+								<li
+									key={ collection.id }
+									className="cortext-sidebar__node"
+								>
+									<div className="cortext-sidebar__row">
+										<Button
+											className="cortext-sidebar__title"
+											variant="tertiary"
+											onClick={ () =>
+												navigate( {
+													to: '/$',
+													params: {
+														_splat: computeUri(
+															collection,
+															'collection'
+														),
+													},
+												} )
+											}
+										>
+											{ collection.title.rendered }
+										</Button>
+									</div>
+								</li>
+							) ) }
+						</ul>
+					) }
+
+					<SidebarTrash
+						activePages={ pages }
+						selectedId={ selectedId }
+						onSelect={ onSelect }
+					/>
+				</div>
+			) }
+			<div className="cortext-sidebar__footer">
 				<Button
 					icon="arrow-left-alt2"
 					label={ __( 'Back to WordPress', 'cortext' ) }
 					href={ adminUrl }
 				/>
-				<Button variant="primary" onClick={ createRootPage }>
-					{ __( 'New page', 'cortext' ) }
-				</Button>
 				<ThemeToggle />
 			</div>
-			<h2 className="cortext-sidebar__section-title">
-				{ __( 'Pages', 'cortext' ) }
-			</h2>
-			{ isResolving && pages.length === 0 && (
-				<div className="cortext-sidebar__loading">
-					<Spinner />
-				</div>
+			{ ! collapsed && (
+				<SidebarResizeHandle
+					width={ width }
+					onChange={ onWidthChange }
+					onToggleCollapsed={ onToggleCollapsed }
+				/>
 			) }
-			{ ! isResolving && pages.length === 0 && (
-				<p className="cortext-sidebar__empty">
-					{ __( 'No pages yet.', 'cortext' ) }
-				</p>
-			) }
-
-			<DndContext
-				sensors={ sensors }
-				collisionDetection={ pointerWithin }
-				onDragStart={ handleDragStart }
-				onDragOver={ handleDragOver }
-				onDragEnd={ handleDragEnd }
-				onDragCancel={ handleDragCancel }
-			>
-				<ul className="cortext-sidebar__list">
-					{ tree.map( ( node ) => (
-						<PageRow
-							key={ node.page.id }
-							node={ node }
-							depth={ 0 }
-							selectedId={ selectedId }
-							expandedIds={ expandedIds }
-							draggedId={ draggedId }
-							activeDrop={ activeDrop }
-							onSelect={ onSelect }
-							onToggleExpand={ toggleExpand }
-							onCreateChild={ createChildPage }
-							onRename={ renamePage }
-							onDuplicate={ duplicatePage }
-							onDelete={ trashPage }
-							autoRenameId={ autoRenameId }
-							onAutoRenameConsumed={ () =>
-								setAutoRenameId( null )
-							}
-						/>
-					) ) }
-				</ul>
-
-				<DragOverlay>
-					{ draggedPage ? (
-						<div className="cortext-sidebar__drag-preview">
-							{ draggedPage.title?.rendered?.trim() ||
-								__( '(untitled)', 'cortext' ) }
-						</div>
-					) : null }
-				</DragOverlay>
-			</DndContext>
-
-			<h2 className="cortext-sidebar__section-title">
-				{ __( 'Collections', 'cortext' ) }
-			</h2>
-			{ isResolvingCollections && ! collections?.length && (
-				<div className="cortext-sidebar__loading">
-					<Spinner />
-				</div>
-			) }
-			{ ! isResolvingCollections && ! collections?.length && (
-				<p className="cortext-sidebar__empty">
-					{ __( 'No collections yet.', 'cortext' ) }
-				</p>
-			) }
-			{ collections?.length > 0 && (
-				<ul className="cortext-sidebar__list">
-					{ collections.map( ( collection ) => (
-						<li
-							key={ collection.id }
-							className="cortext-sidebar__node"
-						>
-							<div className="cortext-sidebar__row">
-								<Button
-									className="cortext-sidebar__title"
-									variant="tertiary"
-									onClick={ () =>
-										navigate( {
-											to: '/$',
-											params: {
-												_splat: computeUri(
-													collection,
-													'collection'
-												),
-											},
-										} )
-									}
-								>
-									{ collection.title.rendered }
-								</Button>
-							</div>
-						</li>
-					) ) }
-				</ul>
-			) }
-
-			<SidebarTrash
-				activePages={ pages }
-				selectedId={ selectedId }
-				onSelect={ onSelect }
-			/>
 		</aside>
 	);
 }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -10,7 +10,7 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { Button, Icon, Spinner } from '@wordpress/components';
-import { chevronLeft, plus, wordpress } from '@wordpress/icons';
+import { plus, wordpress } from '@wordpress/icons';
 
 // Notion-style sidebar toggle: panel outline with a vertical accent on
 // the left side. Same icon for both states; the aria-label tells the
@@ -611,18 +611,9 @@ export default function Sidebar( {
 			<div className="cortext-sidebar__footer">
 				<Button
 					className="cortext-sidebar__back"
-					label={ __( 'Back to WordPress', 'cortext' ) }
+					label={ __( 'Go to WordPress', 'cortext' ) }
 					href={ adminUrl }
-					icon={
-						collapsed ? (
-							<Icon icon={ wordpress } size={ 24 } />
-						) : (
-							<span className="cortext-sidebar__back-icon">
-								<Icon icon={ chevronLeft } size={ 24 } />
-								<Icon icon={ wordpress } size={ 20 } />
-							</span>
-						)
-					}
+					icon={ <Icon icon={ wordpress } size={ 24 } /> }
 				/>
 				<ThemeToggle />
 			</div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,4 +1,5 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -8,8 +9,8 @@ import {
 	useCallback,
 	useEffect,
 } from '@wordpress/element';
-import { Button, Spinner } from '@wordpress/components';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { Button, Icon, Spinner } from '@wordpress/components';
+import { chevronLeft, chevronRight, plus, wordpress } from '@wordpress/icons';
 import {
 	DndContext,
 	DragOverlay,
@@ -86,6 +87,14 @@ export default function Sidebar( {
 	const params = useParams( { strict: false } );
 	const activeUri = params._splat ?? '';
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
+	const userName = window.cortextSettings?.userDisplayName ?? '';
+	const brandLabel = userName
+		? sprintf(
+				/* translators: %s: user display name */
+				__( "%s's Cortext", 'cortext' ),
+				userName
+		  )
+		: __( 'Cortext', 'cortext' );
 
 	const { prefix: activePrefix, tail: activeTail } = useMemo(
 		() => parseSplatUri( activeUri ),
@@ -196,6 +205,25 @@ export default function Sidebar( {
 			setAutoRenameId( created.id );
 		}
 	}, [ saveEntityRecord, onSelect ] );
+
+	const createRootCollection = useCallback( async () => {
+		const created = await apiFetch( {
+			path: '/cortext/v1/collections',
+			method: 'POST',
+			data: { title: __( 'Untitled', 'cortext' ) },
+		} );
+		invalidateResolution( 'getEntityRecords', [
+			'postType',
+			'crtxt_collection',
+			COLLECTION_QUERY,
+		] );
+		if ( created?.id ) {
+			navigate( {
+				to: '/$',
+				params: { _splat: computeUri( created, 'collection' ) },
+			} );
+		}
+	}, [ invalidateResolution, navigate ] );
 
 	const createChildPage = useCallback(
 		async ( parentId ) => {
@@ -404,20 +432,10 @@ export default function Sidebar( {
 			data-collapsed={ collapsed ? 'true' : 'false' }
 		>
 			<div className="cortext-sidebar__header">
-				{ collapsed ? (
-					<Button
-						icon="plus"
-						label={ __( 'New page', 'cortext' ) }
-						onClick={ createRootPage }
-					/>
-				) : (
-					<Button
-						className="cortext-sidebar__new-page"
-						variant="primary"
-						onClick={ createRootPage }
-					>
-						{ __( 'New page', 'cortext' ) }
-					</Button>
+				{ ! collapsed && (
+					<span className="cortext-sidebar__brand">
+						{ brandLabel }
+					</span>
 				) }
 				<Button
 					className="cortext-sidebar__collapse-toggle"
@@ -432,9 +450,18 @@ export default function Sidebar( {
 			</div>
 			{ ! collapsed && (
 				<div className="cortext-sidebar__content">
-					<h2 className="cortext-sidebar__section-title">
-						{ __( 'Pages', 'cortext' ) }
-					</h2>
+					<div className="cortext-sidebar__section-header">
+						<h2 className="cortext-sidebar__section-title">
+							{ __( 'Pages', 'cortext' ) }
+						</h2>
+						<Button
+							className="cortext-sidebar__section-action"
+							icon={ plus }
+							size="small"
+							label={ __( 'New page', 'cortext' ) }
+							onClick={ createRootPage }
+						/>
+					</div>
 					{ isResolving && pages.length === 0 && (
 						<div className="cortext-sidebar__loading">
 							<Spinner />
@@ -488,9 +515,18 @@ export default function Sidebar( {
 						</DragOverlay>
 					</DndContext>
 
-					<h2 className="cortext-sidebar__section-title">
-						{ __( 'Collections', 'cortext' ) }
-					</h2>
+					<div className="cortext-sidebar__section-header">
+						<h2 className="cortext-sidebar__section-title">
+							{ __( 'Collections', 'cortext' ) }
+						</h2>
+						<Button
+							className="cortext-sidebar__section-action"
+							icon={ plus }
+							size="small"
+							label={ __( 'New collection', 'cortext' ) }
+							onClick={ createRootCollection }
+						/>
+					</div>
 					{ isResolvingCollections && ! collections?.length && (
 						<div className="cortext-sidebar__loading">
 							<Spinner />
@@ -541,9 +577,15 @@ export default function Sidebar( {
 			) }
 			<div className="cortext-sidebar__footer">
 				<Button
-					icon="arrow-left-alt2"
+					className="cortext-sidebar__back"
 					label={ __( 'Back to WordPress', 'cortext' ) }
 					href={ adminUrl }
+					icon={
+						<span className="cortext-sidebar__back-icon">
+							<Icon icon={ chevronLeft } size={ 18 } />
+							<Icon icon={ wordpress } size={ 20 } />
+						</span>
+					}
 				/>
 				<ThemeToggle />
 			</div>

--- a/src/components/SidebarResizeHandle.js
+++ b/src/components/SidebarResizeHandle.js
@@ -9,9 +9,9 @@ import {
 } from '../hooks/useSidebarLayout';
 
 // Pointer drag writes the CSS var on the root every move (no React
-// re-render per frame) and commits to state on pointerup. Keyboard
-// parity: the handle is focusable, with arrows/Home/End to resize and
-// Enter to toggle collapse.
+// re-render per frame) and commits to state on pointerup. Pointer cancel
+// reverts to the starting width. Keyboard parity: the handle is focusable,
+// with arrows/Home/End to resize and Enter to toggle collapse.
 export default function SidebarResizeHandle( {
 	width,
 	onChange,
@@ -63,20 +63,33 @@ export default function SidebarResizeHandle( {
 		[ writeRoot ]
 	);
 
-	const endResize = useCallback(
+	const cleanupResize = useCallback( ( event ) => {
+		if ( event.currentTarget.hasPointerCapture( event.pointerId ) ) {
+			event.currentTarget.releasePointerCapture( event.pointerId );
+		}
+		setIsResizing( false );
+		document.body.classList.remove( 'cortext-sidebar-resizing' );
+		const root = document.getElementById( 'cortext-root' );
+		if ( root ) {
+			root.removeAttribute( 'data-sidebar-resizing' );
+		}
+	}, [] );
+
+	const commitResize = useCallback(
 		( event ) => {
-			if ( event.currentTarget.hasPointerCapture( event.pointerId ) ) {
-				event.currentTarget.releasePointerCapture( event.pointerId );
-			}
-			setIsResizing( false );
-			document.body.classList.remove( 'cortext-sidebar-resizing' );
-			const root = document.getElementById( 'cortext-root' );
-			if ( root ) {
-				root.removeAttribute( 'data-sidebar-resizing' );
-			}
+			cleanupResize( event );
 			onChange( liveWidthRef.current );
 		},
-		[ onChange ]
+		[ cleanupResize, onChange ]
+	);
+
+	const cancelResize = useCallback(
+		( event ) => {
+			cleanupResize( event );
+			liveWidthRef.current = startWidthRef.current;
+			writeRoot( startWidthRef.current );
+		},
+		[ cleanupResize, writeRoot ]
 	);
 
 	const onKeyDown = useCallback(
@@ -127,8 +140,8 @@ export default function SidebarResizeHandle( {
 			aria-valuemax={ SIDEBAR_WIDTH_MAX }
 			onPointerDown={ onPointerDown }
 			onPointerMove={ onPointerMove }
-			onPointerUp={ endResize }
-			onPointerCancel={ endResize }
+			onPointerUp={ commitResize }
+			onPointerCancel={ cancelResize }
 			onKeyDown={ onKeyDown }
 		/>
 	);

--- a/src/components/SidebarResizeHandle.js
+++ b/src/components/SidebarResizeHandle.js
@@ -1,0 +1,135 @@
+import { __ } from '@wordpress/i18n';
+import { useCallback, useRef, useState } from '@wordpress/element';
+
+import {
+	clampWidth,
+	SIDEBAR_RESIZE_STEP,
+	SIDEBAR_WIDTH_MIN,
+	SIDEBAR_WIDTH_MAX,
+} from '../hooks/useSidebarLayout';
+
+// Pointer drag writes the CSS var on the root every move (no React
+// re-render per frame) and commits to state on pointerup. Keyboard
+// parity: the handle is focusable, with arrows/Home/End to resize and
+// Enter to toggle collapse.
+export default function SidebarResizeHandle( {
+	width,
+	onChange,
+	onToggleCollapsed,
+} ) {
+	const [ isResizing, setIsResizing ] = useState( false );
+	const startXRef = useRef( 0 );
+	const startWidthRef = useRef( width );
+	const liveWidthRef = useRef( width );
+
+	const writeRoot = useCallback( ( next ) => {
+		const root = document.getElementById( 'cortext-root' );
+		if ( root ) {
+			root.style.setProperty( '--cortext-sidebar-width', `${ next }px` );
+		}
+	}, [] );
+
+	const onPointerDown = useCallback(
+		( event ) => {
+			if ( event.button !== 0 ) {
+				return;
+			}
+			event.preventDefault();
+			event.currentTarget.setPointerCapture( event.pointerId );
+			startXRef.current = event.clientX;
+			startWidthRef.current = width;
+			liveWidthRef.current = width;
+			setIsResizing( true );
+			document.body.classList.add( 'cortext-sidebar-resizing' );
+			const root = document.getElementById( 'cortext-root' );
+			if ( root ) {
+				root.setAttribute( 'data-sidebar-resizing', 'true' );
+			}
+		},
+		[ width ]
+	);
+
+	const onPointerMove = useCallback(
+		( event ) => {
+			if ( ! event.currentTarget.hasPointerCapture( event.pointerId ) ) {
+				return;
+			}
+			const next = clampWidth(
+				startWidthRef.current + ( event.clientX - startXRef.current )
+			);
+			liveWidthRef.current = next;
+			writeRoot( next );
+		},
+		[ writeRoot ]
+	);
+
+	const endResize = useCallback(
+		( event ) => {
+			if ( event.currentTarget.hasPointerCapture( event.pointerId ) ) {
+				event.currentTarget.releasePointerCapture( event.pointerId );
+			}
+			setIsResizing( false );
+			document.body.classList.remove( 'cortext-sidebar-resizing' );
+			const root = document.getElementById( 'cortext-root' );
+			if ( root ) {
+				root.removeAttribute( 'data-sidebar-resizing' );
+			}
+			onChange( liveWidthRef.current );
+		},
+		[ onChange ]
+	);
+
+	const onKeyDown = useCallback(
+		( event ) => {
+			let next = null;
+			switch ( event.key ) {
+				case 'ArrowLeft':
+					next = clampWidth( width - SIDEBAR_RESIZE_STEP );
+					break;
+				case 'ArrowRight':
+					next = clampWidth( width + SIDEBAR_RESIZE_STEP );
+					break;
+				case 'Home':
+					next = SIDEBAR_WIDTH_MIN;
+					break;
+				case 'End':
+					next = SIDEBAR_WIDTH_MAX;
+					break;
+				case 'Enter':
+				case ' ':
+					event.preventDefault();
+					onToggleCollapsed();
+					return;
+				default:
+					return;
+			}
+			event.preventDefault();
+			writeRoot( next );
+			onChange( next );
+		},
+		[ width, onChange, onToggleCollapsed, writeRoot ]
+	);
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+		<div
+			className={
+				'cortext-sidebar__resize-handle' +
+				( isResizing ? ' is-resizing' : '' )
+			}
+			role="separator"
+			tabIndex={ 0 }
+			aria-orientation="vertical"
+			aria-controls="cortext-sidebar"
+			aria-label={ __( 'Resize sidebar', 'cortext' ) }
+			aria-valuenow={ width }
+			aria-valuemin={ SIDEBAR_WIDTH_MIN }
+			aria-valuemax={ SIDEBAR_WIDTH_MAX }
+			onPointerDown={ onPointerDown }
+			onPointerMove={ onPointerMove }
+			onPointerUp={ endResize }
+			onPointerCancel={ endResize }
+			onKeyDown={ onKeyDown }
+		/>
+	);
+}

--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -31,7 +31,7 @@ export default function ThemeToggle() {
 
 	return (
 		<Dropdown
-			popoverProps={ { placement: 'bottom-end' } }
+			popoverProps={ { placement: 'top-end' } }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					className="cortext-sidebar__theme-toggle"

--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { DropdownMenu } from '@wordpress/components';
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { desktop, Icon } from '@wordpress/icons';
 
 import useColorScheme from '../hooks/useColorScheme';
@@ -29,32 +29,52 @@ export default function ThemeToggle() {
 
 	const triggerIcon = resolved === 'dark' ? moonIcon : sunIcon;
 
-	const controls = [
-		{
-			title: __( 'Light', 'cortext' ),
-			icon: sunIcon,
-			isActive: preference === 'light',
-			onClick: () => setPreference( 'light' ),
-		},
-		{
-			title: __( 'Dark', 'cortext' ),
-			icon: moonIcon,
-			isActive: preference === 'dark',
-			onClick: () => setPreference( 'dark' ),
-		},
-		{
-			title: __( 'Match system', 'cortext' ),
-			icon: <Icon icon={ desktop } />,
-			isActive: preference === 'auto',
-			onClick: () => setPreference( 'auto' ),
-		},
-	];
-
 	return (
-		<DropdownMenu
-			icon={ triggerIcon }
-			label={ __( 'Color scheme', 'cortext' ) }
-			controls={ controls }
+		<Dropdown
+			popoverProps={ { placement: 'bottom-end' } }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					className="cortext-sidebar__theme-toggle"
+					icon={ triggerIcon }
+					label={ __( 'Color scheme', 'cortext' ) }
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+				/>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<MenuGroup>
+					<MenuItem
+						icon={ sunIcon }
+						isSelected={ preference === 'light' }
+						onClick={ () => {
+							setPreference( 'light' );
+							onClose();
+						} }
+					>
+						{ __( 'Light', 'cortext' ) }
+					</MenuItem>
+					<MenuItem
+						icon={ moonIcon }
+						isSelected={ preference === 'dark' }
+						onClick={ () => {
+							setPreference( 'dark' );
+							onClose();
+						} }
+					>
+						{ __( 'Dark', 'cortext' ) }
+					</MenuItem>
+					<MenuItem
+						icon={ <Icon icon={ desktop } /> }
+						isSelected={ preference === 'auto' }
+						onClick={ () => {
+							setPreference( 'auto' );
+							onClose();
+						} }
+					>
+						{ __( 'Match system', 'cortext' ) }
+					</MenuItem>
+				</MenuGroup>
+			) }
 		/>
 	);
 }

--- a/src/components/pages-tree.js
+++ b/src/components/pages-tree.js
@@ -74,6 +74,32 @@ export function collectDescendants( rootId, pages ) {
 }
 
 /**
+ * Collect ancestor page IDs for a page, nearest parent first.
+ * Used to expand the sidebar path for the active page after a reload.
+ *
+ * @param {number} pageId Active page ID.
+ * @param {Array}  pages  Flat page list.
+ * @return {number[]} Ancestor IDs, nearest parent first.
+ */
+export function collectAncestorIds( pageId, pages ) {
+	const byId = new Map( pages.map( ( p ) => [ p.id, p ] ) );
+	const out = [];
+	const seen = new Set( [ pageId ] );
+	let current = byId.get( pageId );
+
+	while ( current?.parent && byId.has( current.parent ) ) {
+		if ( seen.has( current.parent ) ) {
+			break;
+		}
+		out.push( current.parent );
+		seen.add( current.parent );
+		current = byId.get( current.parent );
+	}
+
+	return out;
+}
+
+/**
  * True iff `descendantId` is anywhere in the ancestor chain of `ancestorId`.
  * Used to reject drops that would create a cycle.
  *

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -2,12 +2,15 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { __ } from '@wordpress/i18n';
 
 const DEBOUNCE_MS = 800;
 const MIN_SAVE_INTERVAL_MS = 2000;
 
 export default function useAutosave() {
 	const { savePost, editPost } = useDispatch( editorStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const {
 		isDirty,
@@ -144,11 +147,17 @@ export default function useAutosave() {
 			setStatus( 'saving' );
 		} else if ( didFail ) {
 			setStatus( 'error' );
+			// The toolbar no longer carries a save status, so a failed
+			// autosave needs its own way of reaching the user. Snackbar
+			// is dismissable and stays out of the way when things work.
+			createErrorNotice( __( 'Failed to save changes.', 'cortext' ), {
+				type: 'snackbar',
+			} );
 		} else if ( didSucceed ) {
 			setStatus( 'saved' );
 			setLastSavedAt( Date.now() );
 		}
-	}, [ isSaving, didSucceed, didFail ] );
+	}, [ isSaving, didSucceed, didFail, createErrorNotice ] );
 
 	// CanvasEditor stays mounted across post switches so the iframe survives,
 	// which means our local status would otherwise carry a stale "Failed to

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -7,10 +7,11 @@ import { __ } from '@wordpress/i18n';
 
 const DEBOUNCE_MS = 800;
 const MIN_SAVE_INTERVAL_MS = 2000;
+const AUTOSAVE_ERROR_NOTICE_ID = 'cortext-autosave-error';
 
 export default function useAutosave() {
 	const { savePost, editPost } = useDispatch( editorStore );
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
 
 	const {
 		isDirty,
@@ -151,14 +152,15 @@ export default function useAutosave() {
 			// autosave needs its own way of reaching the user. Snackbar
 			// is dismissable and stays out of the way when things work.
 			createErrorNotice( __( 'Failed to save changes.', 'cortext' ), {
-				id: 'cortext-autosave-error',
+				id: AUTOSAVE_ERROR_NOTICE_ID,
 				type: 'snackbar',
 			} );
 		} else if ( didSucceed ) {
 			setStatus( 'saved' );
 			setLastSavedAt( Date.now() );
+			removeNotice( AUTOSAVE_ERROR_NOTICE_ID );
 		}
-	}, [ isSaving, didSucceed, didFail, createErrorNotice ] );
+	}, [ isSaving, didSucceed, didFail, createErrorNotice, removeNotice ] );
 
 	// CanvasEditor stays mounted across post switches so the iframe survives,
 	// which means our local status would otherwise carry a stale "Failed to

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -151,6 +151,7 @@ export default function useAutosave() {
 			// autosave needs its own way of reaching the user. Snackbar
 			// is dismissable and stays out of the way when things work.
 			createErrorNotice( __( 'Failed to save changes.', 'cortext' ), {
+				id: 'cortext-autosave-error',
 				type: 'snackbar',
 			} );
 		} else if ( didSucceed ) {

--- a/src/hooks/useSidebarLayout.js
+++ b/src/hooks/useSidebarLayout.js
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from '@wordpress/element';
+
+const COLLAPSED_KEY = 'cortext.sidebarCollapsed';
+const WIDTH_KEY = 'cortext.sidebarWidth';
+
+export const SIDEBAR_WIDTH_DEFAULT = 280;
+export const SIDEBAR_WIDTH_MIN = 220;
+export const SIDEBAR_WIDTH_MAX = 480;
+export const SIDEBAR_RESIZE_STEP = 16;
+
+export function clampWidth( value ) {
+	const n = Number( value );
+	if ( ! Number.isFinite( n ) ) {
+		return SIDEBAR_WIDTH_DEFAULT;
+	}
+	if ( n < SIDEBAR_WIDTH_MIN ) {
+		return SIDEBAR_WIDTH_MIN;
+	}
+	if ( n > SIDEBAR_WIDTH_MAX ) {
+		return SIDEBAR_WIDTH_MAX;
+	}
+	return Math.round( n );
+}
+
+function getRoot() {
+	return typeof document === 'undefined'
+		? null
+		: document.getElementById( 'cortext-root' );
+}
+
+function applyToRoot( { collapsed, width } ) {
+	const root = getRoot();
+	if ( ! root ) {
+		return;
+	}
+	root.setAttribute( 'data-sidebar-collapsed', collapsed ? 'true' : 'false' );
+	root.style.setProperty( '--cortext-sidebar-width', `${ width }px` );
+}
+
+// Owns the collapsed flag + expanded width. Theming\Preferences stamps
+// both values onto `#cortext-root` pre-mount so there's no width flash;
+// this hook takes over once React is up. localStorage for now, same as
+// useColorScheme.
+export default function useSidebarLayout() {
+	const [ collapsed, setCollapsedState ] = useState( () => {
+		const seeded = window.cortextBootstrap?.sidebar?.collapsed;
+		return seeded === true;
+	} );
+	const [ width, setWidthState ] = useState( () => {
+		const seeded = window.cortextBootstrap?.sidebar?.width;
+		return clampWidth( seeded ?? SIDEBAR_WIDTH_DEFAULT );
+	} );
+
+	useEffect( () => {
+		applyToRoot( { collapsed, width } );
+	}, [ collapsed, width ] );
+
+	const setCollapsed = useCallback( ( value ) => {
+		const next = Boolean( value );
+		setCollapsedState( next );
+		try {
+			window.localStorage.setItem(
+				COLLAPSED_KEY,
+				next ? 'true' : 'false'
+			);
+		} catch {
+			// Storage denied (private mode, quota); choice still applies
+			// for this session.
+		}
+	}, [] );
+
+	const toggleCollapsed = useCallback( () => {
+		setCollapsedState( ( prev ) => {
+			const next = ! prev;
+			try {
+				window.localStorage.setItem(
+					COLLAPSED_KEY,
+					next ? 'true' : 'false'
+				);
+			} catch {}
+			return next;
+		} );
+	}, [] );
+
+	const setWidth = useCallback( ( value ) => {
+		const next = clampWidth( value );
+		setWidthState( next );
+		try {
+			window.localStorage.setItem( WIDTH_KEY, String( next ) );
+		} catch {}
+	}, [] );
+
+	return {
+		collapsed,
+		width,
+		setCollapsed,
+		toggleCollapsed,
+		setWidth,
+	};
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -139,16 +139,23 @@ body.cortext-fullscreen {
 		}
 	}
 
-	// Sits inline with the section title; reveal on hover/focus, the same
-	// way `__menu` works on page rows.
+	// Touch/no-hover devices need visible actions because hover reveal is
+	// unavailable. Desktop fine pointers hide them below until hover/focus.
 	&__section-action.components-button {
-		opacity: 0;
+		opacity: 1;
 		transition: opacity 0.12s ease;
 	}
 
-	&__section-header:hover &__section-action,
-	&__section-header:focus-within &__section-action {
-		opacity: 1;
+	@media (hover: hover) and (pointer: fine) {
+
+		&__section-action.components-button {
+			opacity: 0;
+		}
+
+		&__section-header:hover &__section-action,
+		&__section-header:focus-within &__section-action {
+			opacity: 1;
+		}
 	}
 
 	&__content {
@@ -348,16 +355,24 @@ body.cortext-fullscreen {
 	&__menu,
 	&__add-child {
 		flex: 0 0 auto;
-		opacity: 0;
+		opacity: 1;
 		transition: opacity 0.12s ease;
 	}
 
-	&__row:hover &__menu,
-	&__row:focus-within &__menu,
-	&__menu.is-opened,
-	&__row:hover &__add-child,
-	&__row:focus-within &__add-child {
-		opacity: 1;
+	@media (hover: hover) and (pointer: fine) {
+
+		&__menu,
+		&__add-child {
+			opacity: 0;
+		}
+
+		&__row:hover &__menu,
+		&__row:focus-within &__menu,
+		&__menu.is-opened,
+		&__row:hover &__add-child,
+		&__row:focus-within &__add-child {
+			opacity: 1;
+		}
 	}
 
 	// Overlay droppable strips. Pointer-events off so they don't swallow

--- a/src/index.scss
+++ b/src/index.scss
@@ -217,10 +217,39 @@ body.cortext-fullscreen {
 	&__chevron {
 		flex: 0 0 auto;
 
+		// One icon, rotated 90 degrees to mark expansion. Animating a
+		// rotation reads cleaner than swapping right/down icons on click.
+		svg {
+			transition: transform 160ms ease;
+		}
+
+		&.is-expanded svg {
+			transform: rotate(90deg);
+		}
+
 		&--placeholder {
 			display: inline-block;
 			width: $grid-unit-30;
 			height: $grid-unit-30;
+		}
+	}
+
+	// `grid-template-rows: 0fr → 1fr` animates from collapsed to natural
+	// height without measuring. The inner ul needs `min-height: 0` and
+	// `overflow: hidden` so the grid track can clip below the content's
+	// intrinsic height.
+	&__children-wrapper {
+		display: grid;
+		grid-template-rows: 0fr;
+		transition: grid-template-rows 160ms ease;
+
+		> .cortext-sidebar__children {
+			min-height: 0;
+			overflow: hidden;
+		}
+
+		&.is-expanded {
+			grid-template-rows: 1fr;
 		}
 	}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -151,13 +151,6 @@ body.cortext-fullscreen {
 		opacity: 1;
 	}
 
-	// `< W` back affordance. Inline-flex so the chevron and W sit side by
-	// side inside the WP `Button` icon slot.
-	&__back-icon {
-		display: inline-flex;
-		align-items: center;
-	}
-
 	&__content {
 		flex: 1 1 auto;
 		min-height: 0;
@@ -175,6 +168,15 @@ body.cortext-fullscreen {
 		gap: $grid-unit-10;
 		padding: $grid-unit-10 $grid-unit-15;
 		border-top: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
+	}
+
+	&__back.components-button,
+	&__theme-toggle.components-button {
+		width: $grid-unit-40;
+		min-width: $grid-unit-40;
+		height: $grid-unit-40;
+		padding: 0;
+		justify-content: center;
 	}
 
 	/* stylelint-disable-next-line no-descending-specificity */
@@ -522,9 +524,7 @@ body.cortext-fullscreen {
 			margin-left: 0;
 		}
 
-		.cortext-sidebar__collapse-toggle.components-button,
-		.cortext-sidebar__back.components-button,
-		.cortext-sidebar__theme-toggle.components-button {
+		.cortext-sidebar__collapse-toggle.components-button {
 			width: $grid-unit-40;
 			min-width: $grid-unit-40;
 			height: $grid-unit-40;

--- a/src/index.scss
+++ b/src/index.scss
@@ -500,16 +500,15 @@ body.cortext-sidebar-resizing {
 	&__header {
 		display: flex;
 		align-items: stretch;
-		justify-content: space-between;
+		justify-content: flex-end;
 		padding-inline: $grid-unit-15;
-		height: 36px;
+		height: var(--cortext-topbar-height);
 		flex: 0 0 auto;
 		background: var(--cortext-shell-surface);
 		color: var(--cortext-text);
 		border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	}
 
-	&__header-left,
 	&__header-right {
 		display: flex;
 		align-items: stretch;
@@ -521,18 +520,6 @@ body.cortext-sidebar-resizing {
 		height: 100%;
 		min-height: 0;
 		border-radius: 0;
-	}
-
-	// Save status: muted text that fades in/out as the autosave hook
-	// flips between idle / saving / saved / error.
-	&__status {
-		font-size: 12px;
-		color: var(--cortext-text-muted);
-		min-width: 7ch;
-	}
-
-	&__status--error {
-		color: #cc1818;
 	}
 
 	&__loading,

--- a/src/index.scss
+++ b/src/index.scss
@@ -641,19 +641,6 @@ body.cortext-sidebar-resizing {
 
 .cortext-canvas {
 
-	&__header-right {
-		display: flex;
-		align-items: stretch;
-	}
-
-	// Buttons span the full toolbar height; remove their default radius
-	// so they read as edge-to-edge segments rather than floating chips.
-	&__header .components-button {
-		height: 100%;
-		min-height: 0;
-		border-radius: 0;
-	}
-
 	&__loading,
 	&__empty {
 		display: flex;

--- a/src/index.scss
+++ b/src/index.scss
@@ -567,7 +567,7 @@ body.cortext-sidebar-resizing {
 	gap: $grid-unit-10;
 	height: var(--cortext-topbar-height);
 	padding-inline: $grid-unit-20;
-	background: var(--cortext-shell-surface);
+	background: var(--cortext-sidebar-surface);
 	color: var(--cortext-text);
 	border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	min-height: 0;

--- a/src/index.scss
+++ b/src/index.scss
@@ -500,7 +500,7 @@ body.cortext-sidebar-resizing {
 		align-items: center;
 		justify-content: space-between;
 		gap: $grid-unit-10;
-		padding: $grid-unit-10 $grid-unit-20;
+		padding: $grid-unit-05 $grid-unit-20;
 		flex: 1;
 		background: var(--cortext-shell-surface);
 		color: var(--cortext-text);

--- a/src/index.scss
+++ b/src/index.scss
@@ -214,6 +214,9 @@ body.cortext-fullscreen {
 		display: flex;
 		align-items: center;
 		gap: $grid-unit-05;
+		// Pin to the compact-size height of the title button and rename
+		// input so swapping between them doesn't bump the row.
+		height: $grid-unit-40;
 		border-radius: var(--cortext-shell-radius);
 		cursor: grab;
 		user-select: none;

--- a/src/index.scss
+++ b/src/index.scss
@@ -315,6 +315,32 @@ body.cortext-fullscreen {
 	&__rename {
 		flex: 1 1 auto;
 		min-width: 0;
+		height: $grid-unit-40;
+
+		// TextControl mounts BaseControl > field > InputBase > container >
+		// input, and each level can carry default padding/margin that
+		// grows the row past its compact min-height. Pin every wrapper
+		// to the same height so the row stays put when entering rename
+		// mode.
+		.components-base-control,
+		.components-base-control__field,
+		.components-input-control,
+		.components-input-control__container {
+			box-sizing: border-box;
+			margin: 0;
+			height: $grid-unit-40;
+			min-height: $grid-unit-40;
+			max-height: $grid-unit-40;
+		}
+
+		.components-input-control__input,
+		input {
+			box-sizing: border-box;
+			height: $grid-unit-40;
+			min-height: $grid-unit-40;
+			max-height: $grid-unit-40;
+			padding-block: 0;
+		}
 	}
 
 	&__menu,

--- a/src/index.scss
+++ b/src/index.scss
@@ -238,6 +238,10 @@ body.cortext-fullscreen {
 			background: var(--cortext-sidebar-item-hover-surface);
 		}
 
+		&:focus-within:not(.is-selected) {
+			background: var(--cortext-sidebar-item-hover-surface);
+		}
+
 		&.is-selected {
 			background: var(--cortext-sidebar-item-selected-surface);
 		}
@@ -1512,6 +1516,14 @@ thead > tr > th {
 			background: var(--cortext-button-hover-surface);
 			color: var(--cortext-button-text);
 		}
+	}
+
+	// Keep hover/focus from painting only the inner title/action button, which
+	// makes the row look split into separate cells. The row itself handles
+	// the focus background.
+	.cortext-sidebar__row .components-button:not(.is-primary):hover:not(:disabled),
+	.cortext-sidebar__row .components-button:not(.is-primary):focus:not(:disabled) {
+		background: transparent;
 	}
 
 	.components-button.is-primary {

--- a/src/index.scss
+++ b/src/index.scss
@@ -102,7 +102,7 @@ body.cortext-fullscreen {
 		align-items: center;
 		gap: $grid-unit-10;
 		height: var(--cortext-topbar-height);
-		padding-inline: $grid-unit-15;
+		padding-inline: $grid-unit-20;
 		border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	}
 
@@ -111,6 +111,7 @@ body.cortext-fullscreen {
 		min-width: 0;
 		font-weight: 600;
 		font-size: 13px;
+		line-height: 20px;
 		color: var(--cortext-text);
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -118,6 +119,7 @@ body.cortext-fullscreen {
 	}
 
 	&__collapse-toggle {
+		align-self: center;
 		margin-left: auto;
 	}
 
@@ -566,12 +568,15 @@ body.cortext-sidebar-resizing {
 		min-width: 0;
 		display: flex;
 		align-items: center;
+		height: 20px;
+		line-height: 20px;
 	}
 
 	&__actions {
 		flex: 0 0 auto;
 		display: flex;
 		align-items: center;
+		align-self: center;
 		gap: $grid-unit-10;
 	}
 }
@@ -585,41 +590,63 @@ body.cortext-sidebar-resizing {
 .cortext-breadcrumbs {
 	min-width: 0;
 	flex: 1 1 auto;
+	display: flex;
+	align-items: center;
+	height: 20px;
+	line-height: 20px;
 
 	&__list {
 		list-style: none;
 		margin: 0;
 		padding: 0;
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: $grid-unit-05;
+		height: 20px;
+		line-height: inherit;
 		min-width: 0;
 		flex-wrap: nowrap;
 	}
 
 	&__item {
+		list-style: none;
 		min-width: 0;
 		display: flex;
 		align-items: center;
+		height: 20px;
+		line-height: inherit;
 	}
 
 	&__separator {
+		list-style: none;
+		display: inline-flex;
+		align-items: center;
+		height: 20px;
 		color: var(--cortext-text-muted);
 		flex: 0 0 auto;
+		line-height: inherit;
 		user-select: none;
 	}
 
 	&__ellipsis {
+		display: inline-flex;
+		align-items: center;
+		height: 20px;
 		color: var(--cortext-text-muted);
 		flex: 0 0 auto;
+		line-height: inherit;
 	}
 
 	&__segment {
 		appearance: none;
+		display: inline-flex;
+		align-items: center;
+		height: 20px;
 		background: transparent;
 		border: 0;
 		padding: 0 $grid-unit-05;
 		font: inherit;
+		line-height: inherit;
 		color: var(--cortext-text-muted);
 		cursor: pointer;
 		border-radius: var(--cortext-shell-radius);

--- a/src/index.scss
+++ b/src/index.scss
@@ -218,6 +218,14 @@ body.cortext-fullscreen {
 		cursor: grab;
 		user-select: none;
 
+		// Hover paints the whole row, not just the inner title button, so
+		// the chevron and kebab areas feel like part of what you're hovering.
+		// `:not(.is-selected)` keeps the active row on its selected
+		// background even while the cursor sits on it.
+		&:hover:not(.is-selected) {
+			background: var(--cortext-sidebar-item-hover-surface);
+		}
+
 		&.is-selected {
 			background: var(--cortext-sidebar-item-selected-surface);
 		}
@@ -355,6 +363,7 @@ body.cortext-fullscreen {
 		white-space: nowrap;
 	}
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	&__trash-row .cortext-sidebar__row {
 		padding: $grid-unit-05;
 		align-items: flex-start;

--- a/src/index.scss
+++ b/src/index.scss
@@ -70,13 +70,54 @@ body.cortext-fullscreen {
 		padding: $grid-unit-15;
 	}
 
-	&__new-page.components-button {
+	&__brand {
 		flex: 1 1 auto;
-		justify-content: center;
+		min-width: 0;
+		font-weight: 600;
+		font-size: 13px;
+		color: var(--cortext-text);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	&__collapse-toggle {
 		margin-left: auto;
+	}
+
+	&__section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: $grid-unit-05;
+		margin: $grid-unit-15 0 $grid-unit-05 0;
+		padding: 0 $grid-unit-05;
+
+		// Title margin/padding moves to the row.
+		/* stylelint-disable-next-line no-descending-specificity */
+		.cortext-sidebar__section-title {
+			margin: 0;
+			padding: 0;
+		}
+	}
+
+	// Sits inline with the section title; reveal on hover/focus, the same
+	// way `__menu` works on page rows.
+	&__section-action.components-button {
+		opacity: 0;
+		transition: opacity 0.12s ease;
+	}
+
+	&__section-header:hover &__section-action,
+	&__section-header:focus-within &__section-action {
+		opacity: 1;
+	}
+
+	// `< W` back affordance. Inline-flex so the chevron and W sit side by
+	// side inside the WP `Button` icon slot.
+	&__back-icon {
+		display: inline-flex;
+		align-items: center;
 	}
 
 	&__content {
@@ -98,6 +139,7 @@ body.cortext-fullscreen {
 		border-top: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	}
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	&__section-title {
 		font-size: 11px;
 		font-weight: 600;

--- a/src/index.scss
+++ b/src/index.scss
@@ -101,7 +101,8 @@ body.cortext-fullscreen {
 		display: flex;
 		align-items: center;
 		gap: $grid-unit-10;
-		padding: $grid-unit-10 $grid-unit-15;
+		height: var(--cortext-topbar-height);
+		padding-inline: $grid-unit-15;
 		border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	}
 
@@ -553,7 +554,8 @@ body.cortext-sidebar-resizing {
 	display: flex;
 	align-items: center;
 	gap: $grid-unit-10;
-	padding: $grid-unit-10 $grid-unit-20;
+	height: var(--cortext-topbar-height);
+	padding-inline: $grid-unit-20;
 	background: var(--cortext-shell-surface);
 	color: var(--cortext-text);
 	border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);

--- a/src/index.scss
+++ b/src/index.scss
@@ -37,21 +37,65 @@ body.cortext-fullscreen {
 
 .cortext-shell {
 	display: grid;
-	grid-template-columns: 280px 1fr;
+	grid-template-columns: var(--cortext-sidebar-width) 1fr;
 	height: 100vh;
+	transition: grid-template-columns 160ms ease;
+}
+
+// Skip the transition while the drag/keyboard nudge is live so the grid
+// tracks the input frame for frame.
+.cortext-root[data-sidebar-resizing="true"] .cortext-shell {
+	transition: none;
+}
+
+// Collapsed: pin to rail width but keep the saved expanded width on the
+// root, so toggling back restores it.
+.cortext-root[data-sidebar-collapsed="true"] .cortext-shell {
+	grid-template-columns: var(--cortext-sidebar-width-rail) 1fr;
 }
 
 .cortext-sidebar {
+	position: relative;
+	display: flex;
+	flex-direction: column;
 	background: var(--cortext-sidebar-surface);
 	border-right: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
-	overflow-y: auto;
-	padding: $grid-unit-15;
+	overflow: hidden;
 
 	&__header {
+		flex: 0 0 auto;
 		display: flex;
 		align-items: center;
 		gap: $grid-unit-10;
-		margin-bottom: $grid-unit-15;
+		padding: $grid-unit-15;
+	}
+
+	&__new-page.components-button {
+		flex: 1 1 auto;
+		justify-content: center;
+	}
+
+	&__collapse-toggle {
+		margin-left: auto;
+	}
+
+	&__content {
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow-y: auto;
+		padding: 0 $grid-unit-15 $grid-unit-15;
+	}
+
+	&__footer {
+		flex: 0 0 auto;
+		// Keeps the footer at the bottom in collapsed mode, where the
+		// content region isn't rendered.
+		margin-top: auto;
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+		padding: $grid-unit-10 $grid-unit-15;
+		border-top: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	}
 
 	&__section-title {
@@ -266,6 +310,66 @@ body.cortext-fullscreen {
 		font-size: 11px;
 		color: #cc1818;
 	}
+
+	// Modeled on `.cortext-column-resizer` so both resizers feel the same.
+	&__resize-handle {
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: 8px;
+		height: 100%;
+		cursor: col-resize;
+		background: transparent;
+		border: 0;
+		padding: 0;
+		z-index: 2;
+		touch-action: none;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			right: 0;
+			width: 3px;
+			height: 100%;
+			background: var(--cortext-accent);
+			opacity: 0;
+			transition: opacity 100ms ease;
+		}
+
+		&:hover::after,
+		&:focus-visible::after,
+		&.is-resizing::after {
+			opacity: 1;
+		}
+
+		&:focus-visible {
+			outline: none;
+		}
+	}
+
+	// Sections aren't rendered when collapsed (see Sidebar.js); just stack
+	// the chrome.
+	&[data-collapsed="true"] {
+
+		.cortext-sidebar__header,
+		.cortext-sidebar__footer {
+			flex-direction: column;
+			align-items: stretch;
+			gap: $grid-unit-05;
+			padding: $grid-unit-05;
+		}
+
+		.cortext-sidebar__collapse-toggle {
+			margin-left: 0;
+		}
+	}
+}
+
+// Lock the global cursor and disable selection while a resize drag is live.
+body.cortext-sidebar-resizing {
+	cursor: col-resize;
+	user-select: none;
 }
 
 .cortext-shell__canvas {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1423,8 +1423,21 @@ thead > tr > th {
 
 	.components-button {
 		border-radius: var(--cortext-shell-radius);
+
+		// WP components paints a 1.5px accent ring on `:focus:not(:active)`,
+		// which fires on click as well as keyboard nav. Inside chrome that
+		// already has hover/pressed/selected backgrounds, that ring reads
+		// as a stray line at the edge of each button (visible alongside
+		// the chevron / title / kebab in a hovered tree row). Drop it for
+		// click; keep `:focus-visible` so keyboard nav still has a focus
+		// indicator.
+		&:focus:not(:focus-visible) {
+			box-shadow: none;
+			outline: none;
+		}
 	}
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	.components-button:not(.is-primary) {
 		background: var(--cortext-button-surface);
 		color: var(--cortext-button-text);

--- a/src/index.scss
+++ b/src/index.scss
@@ -498,12 +498,32 @@ body.cortext-sidebar-resizing {
 	&__header {
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
 		gap: $grid-unit-10;
 		padding: $grid-unit-10 $grid-unit-20;
 		flex: 1;
 		background: var(--cortext-shell-surface);
 		color: var(--cortext-text);
 		border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
+	}
+
+	&__header-left,
+	&__header-right {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+	}
+
+	// Save status: muted text that fades in/out as the autosave hook
+	// flips between idle / saving / saved / error.
+	&__status {
+		font-size: 12px;
+		color: var(--cortext-text-muted);
+		min-width: 7ch;
+	}
+
+	&__status--error {
+		color: #cc1818;
 	}
 
 	&__loading,

--- a/src/index.scss
+++ b/src/index.scss
@@ -505,13 +505,31 @@ body.cortext-fullscreen {
 		.cortext-sidebar__header,
 		.cortext-sidebar__footer {
 			flex-direction: column;
-			align-items: stretch;
+			align-items: center;
+			justify-content: center;
 			gap: $grid-unit-05;
-			padding: $grid-unit-05;
+		}
+
+		.cortext-sidebar__header {
+			padding: 0;
+		}
+
+		.cortext-sidebar__footer {
+			padding: $grid-unit-05 0;
 		}
 
 		.cortext-sidebar__collapse-toggle {
 			margin-left: 0;
+		}
+
+		.cortext-sidebar__collapse-toggle.components-button,
+		.cortext-sidebar__back.components-button,
+		.cortext-sidebar__theme-toggle.components-button {
+			width: $grid-unit-40;
+			min-width: $grid-unit-40;
+			height: $grid-unit-40;
+			padding: 0;
+			justify-content: center;
 		}
 	}
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -314,7 +314,8 @@ body.cortext-fullscreen {
 		min-width: 0;
 	}
 
-	&__menu {
+	&__menu,
+	&__add-child {
 		flex: 0 0 auto;
 		opacity: 0;
 		transition: opacity 0.12s ease;
@@ -322,7 +323,9 @@ body.cortext-fullscreen {
 
 	&__row:hover &__menu,
 	&__row:focus-within &__menu,
-	&__menu.is-opened {
+	&__menu.is-opened,
+	&__row:hover &__add-child,
+	&__row:focus-within &__add-child {
 		opacity: 1;
 	}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -497,11 +497,11 @@ body.cortext-sidebar-resizing {
 
 	&__header {
 		display: flex;
-		align-items: center;
+		align-items: stretch;
 		justify-content: space-between;
-		gap: $grid-unit-10;
-		padding: $grid-unit-05 $grid-unit-20;
-		flex: 1;
+		padding-inline: $grid-unit-15;
+		height: 36px;
+		flex: 0 0 auto;
 		background: var(--cortext-shell-surface);
 		color: var(--cortext-text);
 		border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
@@ -510,8 +510,15 @@ body.cortext-sidebar-resizing {
 	&__header-left,
 	&__header-right {
 		display: flex;
-		align-items: center;
-		gap: $grid-unit-10;
+		align-items: stretch;
+	}
+
+	// Buttons span the full toolbar height; remove their default radius
+	// so they read as edge-to-edge segments rather than floating chips.
+	&__header .components-button {
+		height: 100%;
+		min-height: 0;
+		border-radius: 0;
 	}
 
 	// Save status: muted text that fades in/out as the autosave hook

--- a/src/index.scss
+++ b/src/index.scss
@@ -67,7 +67,9 @@ body.cortext-fullscreen {
 		display: flex;
 		align-items: center;
 		gap: $grid-unit-10;
-		padding: $grid-unit-15;
+		height: var(--cortext-topbar-height);
+		padding-inline: $grid-unit-15;
+		border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	}
 
 	&__brand {

--- a/src/router.js
+++ b/src/router.js
@@ -5,10 +5,12 @@
 // URLs are canonical: `/wp-admin/admin.php?page=cortext&p=/<app-path>`. The
 // router emits those hrefs on navigation and parses them back on load.
 
+import { useEffect } from '@wordpress/element';
 import { privateApis as routePrivateApis } from '@wordpress/route';
 
 import Sidebar from './components/Sidebar';
 import EntityRoute from './router/EntityRoute';
+import useSidebarLayout from './hooks/useSidebarLayout';
 import { unlock } from './lock-unlock';
 
 const {
@@ -20,10 +22,48 @@ const {
 	parseHref,
 } = unlock( routePrivateApis );
 
+// Cmd/Ctrl+\ to toggle the sidebar. Cmd+B would clash with rich-text bold
+// inside the editor iframe.
+function isEditableTarget( target ) {
+	if ( ! target ) {
+		return false;
+	}
+	if ( target.tagName === 'IFRAME' ) {
+		return true;
+	}
+	const tag = target.tagName;
+	if ( tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' ) {
+		return true;
+	}
+	return target.isContentEditable === true;
+}
+
 function RootLayout() {
+	const { collapsed, width, toggleCollapsed, setWidth } = useSidebarLayout();
+
+	useEffect( () => {
+		const onKeyDown = ( event ) => {
+			if ( event.key !== '\\' || ! ( event.metaKey || event.ctrlKey ) ) {
+				return;
+			}
+			if ( isEditableTarget( event.target ) ) {
+				return;
+			}
+			event.preventDefault();
+			toggleCollapsed();
+		};
+		window.addEventListener( 'keydown', onKeyDown );
+		return () => window.removeEventListener( 'keydown', onKeyDown );
+	}, [ toggleCollapsed ] );
+
 	return (
 		<div className="cortext-shell">
-			<Sidebar />
+			<Sidebar
+				collapsed={ collapsed }
+				width={ width }
+				onToggleCollapsed={ toggleCollapsed }
+				onWidthChange={ setWidth }
+			/>
 			<main className="cortext-shell__canvas">
 				<EntityRoute />
 			</main>

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -65,6 +65,11 @@
 	--cortext-sidebar-width-min: 220px;
 	--cortext-sidebar-width-max: 480px;
 
+	// Sidebar header and canvas top bar both use this so the two columns
+	// share the same top edge and the bar doesn't change size between
+	// pages and collections.
+	--cortext-topbar-height: 48px;
+
 	&[data-theme="dark"] {
 		--cortext-shell-surface: #2a2a2a;
 		--cortext-sidebar-surface: #2a2a2a;

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -26,9 +26,14 @@
 
 	// Shell surfaces
 	--cortext-shell-surface: #{colors.$white};
-	--cortext-sidebar-surface: #{colors.$white};
-	--cortext-sidebar-item-hover-surface: #{colors.$gray-100};
-	--cortext-sidebar-item-selected-surface: #{colors.$gray-100};
+	// Warm off-white for the sidebar (and topbar, which inherits this) so
+	// it reads as chrome rather than canvas. Hover and selected step a few
+	// values darker so the active page doesn't blur into a hover preview.
+	// The values aren't from the WP palette (which has no warm tones);
+	// they're picked to match a Notion-style chrome.
+	--cortext-sidebar-surface: #f7f6f3;
+	--cortext-sidebar-item-hover-surface: #ebeae6;
+	--cortext-sidebar-item-selected-surface: #e3e1dc;
 	--cortext-canvas-frame-surface: #{colors.$white};
 	--cortext-chrome-border: #{colors.$gray-200};
 	--cortext-text: #{colors.$gray-900};

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -43,6 +43,13 @@
 	--cortext-shell-radius: #{variables.$radius-small};
 	--cortext-shell-border-width: #{variables.$border-width};
 
+	// Sidebar widths. Min/max also live in useSidebarLayout and in
+	// Theming\Preferences; keep the three in sync.
+	--cortext-sidebar-width: 280px;
+	--cortext-sidebar-width-rail: 56px;
+	--cortext-sidebar-width-min: 220px;
+	--cortext-sidebar-width-max: 480px;
+
 	&[data-theme="dark"] {
 		--cortext-shell-surface: #2a2a2a;
 		--cortext-sidebar-surface: #2a2a2a;

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -50,6 +50,10 @@
 	--cortext-sidebar-width-min: 220px;
 	--cortext-sidebar-width-max: 480px;
 
+	// Both the sidebar header and the canvas toolbar use this so the
+	// two columns line up at the top.
+	--cortext-topbar-height: 36px;
+
 	&[data-theme="dark"] {
 		--cortext-shell-surface: #2a2a2a;
 		--cortext-sidebar-surface: #2a2a2a;

--- a/tests/e2e/specs/sidebar-layout.spec.js
+++ b/tests/e2e/specs/sidebar-layout.spec.js
@@ -125,6 +125,56 @@ async function readRenameRowGeometry( page ) {
 	} );
 }
 
+async function readFooterIconGeometry( page ) {
+	return page.evaluate( () => {
+		const back = document.querySelector( '.cortext-sidebar__back' );
+		const theme = document.querySelector(
+			'.cortext-sidebar__theme-toggle'
+		);
+		if ( ! back || ! theme ) {
+			return null;
+		}
+
+		const box = ( element ) => {
+			const rect = element.getBoundingClientRect();
+			return {
+				width: rect.width,
+				height: rect.height,
+				xCenter: rect.left + rect.width / 2,
+				yCenter: rect.top + rect.height / 2,
+			};
+		};
+
+		return {
+			back: box( back ),
+			theme: box( theme ),
+		};
+	} );
+}
+
+async function readThemePopoverPlacement( page ) {
+	return page.evaluate( () => {
+		const trigger = document.querySelector(
+			'.cortext-sidebar__theme-toggle'
+		);
+		const popover = Array.from(
+			document.querySelectorAll( '.components-popover' )
+		).find( ( element ) => element.textContent.includes( 'Match system' ) );
+		if ( ! trigger || ! popover ) {
+			return null;
+		}
+
+		const triggerBox = trigger.getBoundingClientRect();
+		const popoverBox = popover.getBoundingClientRect();
+
+		return {
+			triggerTop: triggerBox.top,
+			popoverBottom: popoverBox.bottom,
+			gap: triggerBox.top - popoverBox.bottom,
+		};
+	} );
+}
+
 async function clearSidebarPrefs( page ) {
 	await page.evaluate( () => {
 		try {
@@ -154,6 +204,7 @@ test.describe( 'Sidebar layout controls', () => {
 		await expect
 			.poll( () => readSidebarWidth( page ) )
 			.toBeLessThanOrEqual( RAIL_WIDTH + 2 );
+		const collapsedFooter = await readFooterIconGeometry( page );
 		await expect( page.locator( '#cortext-root' ) ).toHaveAttribute(
 			'data-sidebar-collapsed',
 			'true'
@@ -177,6 +228,36 @@ test.describe( 'Sidebar layout controls', () => {
 		expect( railAlignment.headerHeightDelta ).toBeLessThanOrEqual( 1 );
 		expect( railAlignment.toggleHeaderDelta ).toBeLessThanOrEqual( 1 );
 		expect( railAlignment.footerIconDelta ).toBeLessThanOrEqual( 1 );
+
+		await page.getByRole( 'button', { name: 'Expand sidebar' } ).click();
+		const expandingFooter = await readFooterIconGeometry( page );
+
+		expect( collapsedFooter ).not.toBeNull();
+		expect( expandingFooter ).not.toBeNull();
+		expect( expandingFooter.back.width ).toBe( collapsedFooter.back.width );
+		expect( expandingFooter.theme.width ).toBe(
+			collapsedFooter.theme.width
+		);
+		expect( expandingFooter.back.height ).toBe(
+			collapsedFooter.back.height
+		);
+		expect( expandingFooter.theme.height ).toBe(
+			collapsedFooter.theme.height
+		);
+
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeGreaterThan( 200 );
+
+		await page.getByRole( 'button', { name: 'Color scheme' } ).click();
+		await expect(
+			page.getByRole( 'menuitem', { name: 'Match system' } )
+		).toBeVisible();
+		const themePlacement = await readThemePopoverPlacement( page );
+		expect( themePlacement ).not.toBeNull();
+		expect( themePlacement.popoverBottom ).toBeLessThanOrEqual(
+			themePlacement.triggerTop + 1
+		);
 	} );
 
 	test( 'aligns the brand and current breadcrumb text vertically', async ( {

--- a/tests/e2e/specs/sidebar-layout.spec.js
+++ b/tests/e2e/specs/sidebar-layout.spec.js
@@ -20,7 +20,7 @@ async function deleteIfCreated( requestUtils, path ) {
 			path,
 			params: { force: true },
 		} );
-	} catch ( _error ) {
+	} catch {
 		// Best-effort cleanup; the record may already be gone.
 	}
 }
@@ -28,7 +28,9 @@ async function deleteIfCreated( requestUtils, path ) {
 async function readSidebarWidth( page ) {
 	return page.evaluate( () => {
 		const sidebar = document.getElementById( 'cortext-sidebar' );
-		return sidebar ? Math.round( sidebar.getBoundingClientRect().width ) : 0;
+		return sidebar
+			? Math.round( sidebar.getBoundingClientRect().width )
+			: 0;
 	} );
 }
 
@@ -49,12 +51,76 @@ async function readChromeLabelAlignment( page ) {
 
 		const headerCenter = headerBox.top + headerBox.height / 2;
 		const brandCenter = brandBox.top + brandBox.height / 2;
-		const breadcrumbCenter =
-			breadcrumbBox.top + breadcrumbBox.height / 2;
+		const breadcrumbCenter = breadcrumbBox.top + breadcrumbBox.height / 2;
 
 		return {
 			labelDelta: Math.abs( brandCenter - breadcrumbCenter ),
 			headerDelta: Math.abs( brandCenter - headerCenter ),
+		};
+	} );
+}
+
+async function readCollapsedRailAlignment( page ) {
+	return page.evaluate( () => {
+		const header = document.querySelector( '.cortext-sidebar__header' );
+		const topbar = document.querySelector( '.cortext-topbar' );
+		const toggle = document.querySelector(
+			'.cortext-sidebar__collapse-toggle'
+		);
+		const back = document.querySelector( '.cortext-sidebar__back' );
+		const theme = document.querySelector(
+			'.cortext-sidebar__theme-toggle'
+		);
+		if ( ! header || ! topbar || ! toggle || ! back || ! theme ) {
+			return null;
+		}
+
+		const box = ( element ) => {
+			const rect = element.getBoundingClientRect();
+			return {
+				left: rect.left,
+				top: rect.top,
+				width: rect.width,
+				height: rect.height,
+				xCenter: rect.left + rect.width / 2,
+				yCenter: rect.top + rect.height / 2,
+			};
+		};
+
+		const headerBox = box( header );
+		const topbarBox = box( topbar );
+		const toggleBox = box( toggle );
+		const backBox = box( back );
+		const themeBox = box( theme );
+
+		return {
+			headerHeightDelta: Math.abs( headerBox.height - topbarBox.height ),
+			toggleHeaderDelta: Math.abs(
+				toggleBox.yCenter - headerBox.yCenter
+			),
+			footerIconDelta: Math.abs( backBox.xCenter - themeBox.xCenter ),
+		};
+	} );
+}
+
+async function readRenameRowGeometry( page ) {
+	return page.evaluate( () => {
+		const input = document.querySelector(
+			'.cortext-sidebar__rename input'
+		);
+		const row = input?.closest( '.cortext-sidebar__row' );
+		if ( ! input || ! row ) {
+			return null;
+		}
+
+		const inputBox = input.getBoundingClientRect();
+		const rowBox = row.getBoundingClientRect();
+
+		return {
+			inputHeight: inputBox.height,
+			rowHeight: rowBox.height,
+			overflowTop: rowBox.top - inputBox.top,
+			overflowBottom: inputBox.bottom - rowBox.bottom,
 		};
 	} );
 }
@@ -64,7 +130,7 @@ async function clearSidebarPrefs( page ) {
 		try {
 			window.localStorage.removeItem( 'cortext.sidebarCollapsed' );
 			window.localStorage.removeItem( 'cortext.sidebarWidth' );
-		} catch ( _e ) {}
+		} catch {}
 	} );
 }
 
@@ -88,21 +154,29 @@ test.describe( 'Sidebar layout controls', () => {
 		await expect
 			.poll( () => readSidebarWidth( page ) )
 			.toBeLessThanOrEqual( RAIL_WIDTH + 2 );
-		await expect(
-			page.locator( '#cortext-root' )
-		).toHaveAttribute( 'data-sidebar-collapsed', 'true' );
+		await expect( page.locator( '#cortext-root' ) ).toHaveAttribute(
+			'data-sidebar-collapsed',
+			'true'
+		);
 
 		await page.reload();
 
 		await expect
 			.poll( () => readSidebarWidth( page ) )
 			.toBeLessThanOrEqual( RAIL_WIDTH + 2 );
-		await expect(
-			page.locator( '#cortext-root' )
-		).toHaveAttribute( 'data-sidebar-collapsed', 'true' );
+		await expect( page.locator( '#cortext-root' ) ).toHaveAttribute(
+			'data-sidebar-collapsed',
+			'true'
+		);
 		await expect(
 			page.getByRole( 'button', { name: 'Expand sidebar' } )
 		).toBeVisible();
+
+		const railAlignment = await readCollapsedRailAlignment( page );
+		expect( railAlignment ).not.toBeNull();
+		expect( railAlignment.headerHeightDelta ).toBeLessThanOrEqual( 1 );
+		expect( railAlignment.toggleHeaderDelta ).toBeLessThanOrEqual( 1 );
+		expect( railAlignment.footerIconDelta ).toBeLessThanOrEqual( 1 );
 	} );
 
 	test( 'aligns the brand and current breadcrumb text vertically', async ( {
@@ -194,7 +268,9 @@ test.describe( 'Sidebar layout controls', () => {
 			.toBeGreaterThan( 200 );
 	} );
 
-	test( 'arrow keys nudge width on the focused handle', async ( { page } ) => {
+	test( 'arrow keys nudge width on the focused handle', async ( {
+		page,
+	} ) => {
 		const handle = page.locator( '.cortext-sidebar__resize-handle' );
 		await handle.focus();
 
@@ -206,13 +282,65 @@ test.describe( 'Sidebar layout controls', () => {
 			.toBeGreaterThan( startWidth );
 
 		await page.keyboard.press( 'End' );
-		await expect.poll( () => readSidebarWidth( page ) ).toBeGreaterThan(
-			startWidth + 100
-		);
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeGreaterThan( startWidth + 100 );
 
 		await page.keyboard.press( 'Home' );
-		await expect.poll( () => readSidebarWidth( page ) ).toBeLessThan(
-			startWidth + 1
-		);
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeLessThan( startWidth + 1 );
+	} );
+
+	test( 'keeps the rename input inside the page row height', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const title = `E2E Rename Geometry ${ suffix }`;
+		const fixture = {};
+
+		try {
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: { title, status: 'private' },
+			} );
+
+			await admin.visitAdminPage(
+				SHELL_PATH,
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			await sidebar
+				.getByRole( 'button', { name: title, exact: true } )
+				.hover();
+			await sidebar
+				.getByRole( 'button', {
+					name: `Actions for ${ title }`,
+					exact: true,
+				} )
+				.click();
+			await page.getByRole( 'menuitem', { name: 'Rename' } ).click();
+
+			await expect(
+				page.locator( '.cortext-sidebar__rename input' )
+			).toBeVisible();
+
+			const geometry = await readRenameRowGeometry( page );
+			expect( geometry ).not.toBeNull();
+			expect( geometry.inputHeight ).toBeLessThanOrEqual(
+				geometry.rowHeight
+			);
+			expect( geometry.overflowTop ).toBeLessThanOrEqual( 0 );
+			expect( geometry.overflowBottom ).toBeLessThanOrEqual( 0 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page ? `/wp/v2/crtxt_pages/${ fixture.page.id }` : null
+			);
+		}
 	} );
 } );

--- a/tests/e2e/specs/sidebar-layout.spec.js
+++ b/tests/e2e/specs/sidebar-layout.spec.js
@@ -1,0 +1,134 @@
+/**
+ * Sidebar collapse + resize controls. Covers the toggle, the drag, the
+ * keyboard shortcut, and reload persistence (the PHP bootstrap path).
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SHELL_PATH = 'admin.php';
+const SHELL_QUERY = 'page=cortext';
+
+const RAIL_WIDTH = 56;
+
+async function readSidebarWidth( page ) {
+	return page.evaluate( () => {
+		const sidebar = document.getElementById( 'cortext-sidebar' );
+		return sidebar ? Math.round( sidebar.getBoundingClientRect().width ) : 0;
+	} );
+}
+
+async function clearSidebarPrefs( page ) {
+	await page.evaluate( () => {
+		try {
+			window.localStorage.removeItem( 'cortext.sidebarCollapsed' );
+			window.localStorage.removeItem( 'cortext.sidebarWidth' );
+		} catch ( _e ) {}
+	} );
+}
+
+test.describe( 'Sidebar layout controls', () => {
+	test.beforeEach( async ( { admin, page } ) => {
+		await admin.visitAdminPage( SHELL_PATH, SHELL_QUERY );
+		await expect( page.locator( '#cortext-sidebar' ) ).toBeVisible();
+		await clearSidebarPrefs( page );
+		await page.reload();
+		await expect( page.locator( '#cortext-sidebar' ) ).toBeVisible();
+	} );
+
+	test( 'collapse toggle pins to rail width and persists across reload', async ( {
+		page,
+	} ) => {
+		const expandedWidth = await readSidebarWidth( page );
+		expect( expandedWidth ).toBeGreaterThan( 200 );
+
+		await page.getByRole( 'button', { name: 'Collapse sidebar' } ).click();
+
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeLessThanOrEqual( RAIL_WIDTH + 2 );
+		await expect(
+			page.locator( '#cortext-root' )
+		).toHaveAttribute( 'data-sidebar-collapsed', 'true' );
+
+		await page.reload();
+
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeLessThanOrEqual( RAIL_WIDTH + 2 );
+		await expect(
+			page.locator( '#cortext-root' )
+		).toHaveAttribute( 'data-sidebar-collapsed', 'true' );
+		await expect(
+			page.getByRole( 'button', { name: 'Expand sidebar' } )
+		).toBeVisible();
+	} );
+
+	test( 'resize handle drags to a new width and persists', async ( {
+		page,
+	} ) => {
+		const handle = page.locator( '.cortext-sidebar__resize-handle' );
+		await expect( handle ).toBeVisible();
+
+		const handleBox = await handle.boundingBox();
+		const startX = handleBox.x + handleBox.width / 2;
+		const startY = handleBox.y + handleBox.height / 2;
+		const targetX = startX + 80;
+
+		await page.mouse.move( startX, startY );
+		await page.mouse.down();
+		await page.mouse.move( targetX, startY, { steps: 10 } );
+		await page.mouse.up();
+
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeGreaterThan( 320 );
+
+		const beforeReload = await readSidebarWidth( page );
+		await page.reload();
+
+		const afterReload = await readSidebarWidth( page );
+		expect( Math.abs( afterReload - beforeReload ) ).toBeLessThanOrEqual(
+			2
+		);
+	} );
+
+	test( 'Cmd/Ctrl+\\ toggles collapse', async ( { page } ) => {
+		const modifier =
+			process.platform === 'darwin' ? 'Meta+\\' : 'Control+\\';
+
+		await page.locator( '#cortext-root' ).click();
+		await page.keyboard.press( modifier );
+
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeLessThanOrEqual( RAIL_WIDTH + 2 );
+
+		await page.keyboard.press( modifier );
+
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeGreaterThan( 200 );
+	} );
+
+	test( 'arrow keys nudge width on the focused handle', async ( { page } ) => {
+		const handle = page.locator( '.cortext-sidebar__resize-handle' );
+		await handle.focus();
+
+		const startWidth = await readSidebarWidth( page );
+
+		await page.keyboard.press( 'ArrowRight' );
+		await expect
+			.poll( () => readSidebarWidth( page ) )
+			.toBeGreaterThan( startWidth );
+
+		await page.keyboard.press( 'End' );
+		await expect.poll( () => readSidebarWidth( page ) ).toBeGreaterThan(
+			startWidth + 100
+		);
+
+		await page.keyboard.press( 'Home' );
+		await expect.poll( () => readSidebarWidth( page ) ).toBeLessThan(
+			startWidth + 1
+		);
+	} );
+} );

--- a/tests/e2e/specs/sidebar-layout.spec.js
+++ b/tests/e2e/specs/sidebar-layout.spec.js
@@ -10,10 +10,52 @@ const SHELL_QUERY = 'page=cortext';
 
 const RAIL_WIDTH = 56;
 
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch ( _error ) {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
 async function readSidebarWidth( page ) {
 	return page.evaluate( () => {
 		const sidebar = document.getElementById( 'cortext-sidebar' );
 		return sidebar ? Math.round( sidebar.getBoundingClientRect().width ) : 0;
+	} );
+}
+
+async function readChromeLabelAlignment( page ) {
+	return page.evaluate( () => {
+		const header = document.querySelector( '.cortext-sidebar__header' );
+		const brand = document.querySelector( '.cortext-sidebar__brand' );
+		const breadcrumb = document.querySelector(
+			'.cortext-breadcrumbs__segment.is-current'
+		);
+		if ( ! header || ! brand || ! breadcrumb ) {
+			return null;
+		}
+
+		const headerBox = header.getBoundingClientRect();
+		const brandBox = brand.getBoundingClientRect();
+		const breadcrumbBox = breadcrumb.getBoundingClientRect();
+
+		const headerCenter = headerBox.top + headerBox.height / 2;
+		const brandCenter = brandBox.top + brandBox.height / 2;
+		const breadcrumbCenter =
+			breadcrumbBox.top + breadcrumbBox.height / 2;
+
+		return {
+			labelDelta: Math.abs( brandCenter - breadcrumbCenter ),
+			headerDelta: Math.abs( brandCenter - headerCenter ),
+		};
 	} );
 }
 
@@ -61,6 +103,48 @@ test.describe( 'Sidebar layout controls', () => {
 		await expect(
 			page.getByRole( 'button', { name: 'Expand sidebar' } )
 		).toBeVisible();
+	} );
+
+	test( 'aligns the brand and current breadcrumb text vertically', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const fixture = {};
+
+		try {
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: `E2E Chrome Alignment ${ suffix }`,
+					status: 'private',
+				},
+			} );
+
+			await admin.visitAdminPage(
+				SHELL_PATH,
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			await expect(
+				page.locator( '.cortext-sidebar__brand' )
+			).toBeVisible();
+			await expect(
+				page.locator( '.cortext-breadcrumbs__segment.is-current' )
+			).toHaveText( `E2E Chrome Alignment ${ suffix }` );
+
+			const alignment = await readChromeLabelAlignment( page );
+			expect( alignment ).not.toBeNull();
+			expect( alignment.labelDelta ).toBeLessThanOrEqual( 2 );
+			expect( alignment.headerDelta ).toBeLessThanOrEqual( 2 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page ? `/wp/v2/crtxt_pages/${ fixture.page.id }` : null
+			);
+		}
 	} );
 
 	test( 'resize handle drags to a new width and persists', async ( {

--- a/tests/js/pages-tree.test.js
+++ b/tests/js/pages-tree.test.js
@@ -6,6 +6,7 @@
 
 import {
 	buildTree,
+	collectAncestorIds,
 	collectDescendants,
 	isDescendantOf,
 	computeDropTarget,
@@ -64,6 +65,28 @@ describe( 'collectDescendants', () => {
 	it( 'returns empty for a leaf', () => {
 		const pages = [ makePage( 1 ), makePage( 2, 1 ) ];
 		expect( collectDescendants( 2, pages ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'collectAncestorIds', () => {
+	it( 'collects ancestors nearest parent first', () => {
+		const pages = [
+			makePage( 1 ),
+			makePage( 2, 1 ),
+			makePage( 3, 2 ),
+		];
+
+		expect( collectAncestorIds( 3, pages ) ).toEqual( [ 2, 1 ] );
+	} );
+
+	it( 'returns empty for a root page', () => {
+		expect( collectAncestorIds( 1, [ makePage( 1 ) ] ) ).toEqual( [] );
+	} );
+
+	it( 'stops when an ancestor is missing', () => {
+		const pages = [ makePage( 2, 1 ), makePage( 3, 2 ) ];
+
+		expect( collectAncestorIds( 3, pages ) ).toEqual( [ 2 ] );
 	} );
 } );
 

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -20,6 +20,10 @@ jest.mock( '@wordpress/core-data', () => ( {
 	store: { name: 'core' },
 } ) );
 
+jest.mock( '@wordpress/notices', () => ( {
+	store: { name: 'core/notices' },
+} ) );
+
 import { useSelect, useDispatch } from '@wordpress/data';
 import useAutosave from '../../src/hooks/useAutosave';
 
@@ -82,6 +86,7 @@ beforeEach( () => {
 	useDispatch.mockReturnValue( {
 		savePost: jest.fn(),
 		editPost: jest.fn(),
+		createErrorNotice: jest.fn(),
 	} );
 } );
 
@@ -321,6 +326,23 @@ describe( 'useAutosave: status', () => {
 		const { result } = renderHook( () => useAutosave() );
 
 		expect( result.current.status ).toBe( 'error' );
+	} );
+
+	it( 'surfaces a snackbar notice when a save fails', () => {
+		const createErrorNotice = jest.fn();
+		useDispatch.mockReturnValue( {
+			savePost: jest.fn(),
+			editPost: jest.fn(),
+			createErrorNotice,
+		} );
+		setStoreState( { didFail: true } );
+
+		renderHook( () => useAutosave() );
+
+		expect( createErrorNotice ).toHaveBeenCalledWith(
+			expect.any( String ),
+			{ type: 'snackbar' }
+		);
 	} );
 
 	it( 'resets status when the current post id changes', () => {

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -87,6 +87,7 @@ beforeEach( () => {
 		savePost: jest.fn(),
 		editPost: jest.fn(),
 		createErrorNotice: jest.fn(),
+		removeNotice: jest.fn(),
 	} );
 } );
 
@@ -334,6 +335,7 @@ describe( 'useAutosave: status', () => {
 			savePost: jest.fn(),
 			editPost: jest.fn(),
 			createErrorNotice,
+			removeNotice: jest.fn(),
 		} );
 		setStoreState( { didFail: true } );
 
@@ -345,6 +347,28 @@ describe( 'useAutosave: status', () => {
 				type: 'snackbar',
 				id: 'cortext-autosave-error',
 			} )
+		);
+	} );
+
+	it( 'removes the autosave error notice after a successful save', () => {
+		const removeNotice = jest.fn();
+		useDispatch.mockReturnValue( {
+			savePost: jest.fn(),
+			editPost: jest.fn(),
+			createErrorNotice: jest.fn(),
+			removeNotice,
+		} );
+		setStoreState( { didFail: true } );
+
+		const { rerender } = renderHook( () => useAutosave() );
+
+		act( () => {
+			setStoreState( { didFail: false, didSucceed: true } );
+			rerender();
+		} );
+
+		expect( removeNotice ).toHaveBeenCalledWith(
+			'cortext-autosave-error'
 		);
 	} );
 

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -341,7 +341,10 @@ describe( 'useAutosave: status', () => {
 
 		expect( createErrorNotice ).toHaveBeenCalledWith(
 			expect.any( String ),
-			{ type: 'snackbar' }
+			expect.objectContaining( {
+				type: 'snackbar',
+				id: 'cortext-autosave-error',
+			} )
 		);
 	} );
 

--- a/tests/js/useSidebarLayout.test.js
+++ b/tests/js/useSidebarLayout.test.js
@@ -1,0 +1,185 @@
+/**
+ * Tests for `useSidebarLayout`: seeding from `window.cortextBootstrap`,
+ * width clamping, localStorage persistence, and root-element stamping.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import useSidebarLayout, {
+	clampWidth,
+	SIDEBAR_WIDTH_DEFAULT,
+	SIDEBAR_WIDTH_MAX,
+	SIDEBAR_WIDTH_MIN,
+} from '../../src/hooks/useSidebarLayout';
+
+function createRoot() {
+	const root = document.createElement( 'div' );
+	root.id = 'cortext-root';
+	document.body.appendChild( root );
+	return root;
+}
+
+beforeEach( () => {
+	window.localStorage.clear();
+	delete window.cortextBootstrap;
+	document.body.innerHTML = '';
+} );
+
+describe( 'clampWidth', () => {
+	it( 'returns the default when given a non-finite value', () => {
+		expect( clampWidth( undefined ) ).toBe( SIDEBAR_WIDTH_DEFAULT );
+		expect( clampWidth( NaN ) ).toBe( SIDEBAR_WIDTH_DEFAULT );
+	} );
+
+	it( 'clamps below the minimum', () => {
+		expect( clampWidth( 100 ) ).toBe( SIDEBAR_WIDTH_MIN );
+	} );
+
+	it( 'clamps above the maximum', () => {
+		expect( clampWidth( 9999 ) ).toBe( SIDEBAR_WIDTH_MAX );
+	} );
+
+	it( 'rounds in-range values', () => {
+		expect( clampWidth( 300.7 ) ).toBe( 301 );
+	} );
+} );
+
+describe( 'useSidebarLayout: seeding', () => {
+	it( 'seeds collapsed=false and width=default when no bootstrap value', () => {
+		createRoot();
+
+		const { result } = renderHook( () => useSidebarLayout() );
+
+		expect( result.current.collapsed ).toBe( false );
+		expect( result.current.width ).toBe( SIDEBAR_WIDTH_DEFAULT );
+	} );
+
+	it( 'seeds from window.cortextBootstrap.sidebar', () => {
+		createRoot();
+		window.cortextBootstrap = {
+			sidebar: { collapsed: true, width: 320 },
+		};
+
+		const { result } = renderHook( () => useSidebarLayout() );
+
+		expect( result.current.collapsed ).toBe( true );
+		expect( result.current.width ).toBe( 320 );
+	} );
+
+	it( 'clamps an out-of-range bootstrap width', () => {
+		createRoot();
+		window.cortextBootstrap = {
+			sidebar: { collapsed: false, width: 9999 },
+		};
+
+		const { result } = renderHook( () => useSidebarLayout() );
+
+		expect( result.current.width ).toBe( SIDEBAR_WIDTH_MAX );
+	} );
+} );
+
+describe( 'useSidebarLayout: root stamping', () => {
+	it( 'writes data-sidebar-collapsed and the CSS var on mount', () => {
+		const root = createRoot();
+		window.cortextBootstrap = {
+			sidebar: { collapsed: true, width: 300 },
+		};
+
+		renderHook( () => useSidebarLayout() );
+
+		expect( root.getAttribute( 'data-sidebar-collapsed' ) ).toBe( 'true' );
+		expect( root.style.getPropertyValue( '--cortext-sidebar-width' ) ).toBe(
+			'300px'
+		);
+	} );
+
+	it( 'updates root attributes when state changes', () => {
+		const root = createRoot();
+
+		const { result } = renderHook( () => useSidebarLayout() );
+
+		act( () => {
+			result.current.setCollapsed( true );
+		} );
+		expect( root.getAttribute( 'data-sidebar-collapsed' ) ).toBe( 'true' );
+
+		act( () => {
+			result.current.setWidth( 360 );
+		} );
+		expect( root.style.getPropertyValue( '--cortext-sidebar-width' ) ).toBe(
+			'360px'
+		);
+	} );
+} );
+
+describe( 'useSidebarLayout: persistence', () => {
+	it( 'persists collapsed to localStorage', () => {
+		createRoot();
+
+		const { result } = renderHook( () => useSidebarLayout() );
+
+		act( () => {
+			result.current.setCollapsed( true );
+		} );
+
+		expect( window.localStorage.getItem( 'cortext.sidebarCollapsed' ) ).toBe(
+			'true'
+		);
+	} );
+
+	it( 'toggleCollapsed flips and persists', () => {
+		createRoot();
+
+		const { result } = renderHook( () => useSidebarLayout() );
+
+		act( () => {
+			result.current.toggleCollapsed();
+		} );
+		expect( result.current.collapsed ).toBe( true );
+		expect( window.localStorage.getItem( 'cortext.sidebarCollapsed' ) ).toBe(
+			'true'
+		);
+
+		act( () => {
+			result.current.toggleCollapsed();
+		} );
+		expect( result.current.collapsed ).toBe( false );
+		expect( window.localStorage.getItem( 'cortext.sidebarCollapsed' ) ).toBe(
+			'false'
+		);
+	} );
+
+	it( 'persists clamped width to localStorage', () => {
+		createRoot();
+
+		const { result } = renderHook( () => useSidebarLayout() );
+
+		act( () => {
+			result.current.setWidth( 9999 );
+		} );
+
+		expect( result.current.width ).toBe( SIDEBAR_WIDTH_MAX );
+		expect( window.localStorage.getItem( 'cortext.sidebarWidth' ) ).toBe(
+			String( SIDEBAR_WIDTH_MAX )
+		);
+	} );
+
+	it( 'survives a localStorage write failure', () => {
+		createRoot();
+		const original = window.localStorage.setItem;
+		window.localStorage.setItem = () => {
+			throw new Error( 'quota' );
+		};
+
+		const { result } = renderHook( () => useSidebarLayout() );
+
+		expect( () =>
+			act( () => {
+				result.current.setWidth( 320 );
+			} )
+		).not.toThrow();
+		expect( result.current.width ).toBe( 320 );
+
+		window.localStorage.setItem = original;
+	} );
+} );


### PR DESCRIPTION
## What

Closes #140

Adds a collapsible, resizable sidebar and cleans up the sidebar/top-bar chrome.

## Why

The sidebar was fixed-width, reset on reload, and did not leave enough room for smaller screens. The sidebar header also did not line up with the new top bar.

## Changes

- Sidebar can collapse to an icon rail, resize between 220px and 480px, and remember width/collapse state across reloads.
- Resize handle supports pointer drag and keyboard controls.
- Page and collection rows use compact sizing; rename keeps the row height stable.
- Page actions are easier to reach: section `+` buttons, child-page `+`, and row menus are visible on touch devices and hover-revealed on desktop.
- Reloading a nested page expands its ancestor chain so the active page is visible.
- Collapsed subtrees are hidden from drag/drop targeting.
- Sidebar and top bar now share height, background, and button sizing.
- Autosave notices are quieter: successful saves do not show "Page updated," and stale error snackbars are cleared after a later successful save.

## Testing

1. Toggle the sidebar collapse button and `Cmd/Ctrl+\`; reload and confirm the state persists.
2. Drag the resize handle, then test arrow keys, `Home`, `End`, and `Enter`.
3. Create pages and collections from the sidebar.
4. Add, rename, duplicate, trash, expand, and collapse page rows.
5. Open a nested child page, reload, and confirm its parent chain reopens.
6. Drag near a collapsed parent and confirm hidden children are not valid drop targets.
7. Check hover, click, and keyboard focus states for rows and chrome buttons.
8. Block a save request and confirm only the failed-save snackbar appears.

## Captures

| Before | After |
| - | - |
| <img width="1277" height="854" alt="image" src="https://github.com/user-attachments/assets/1e2b60b0-64ff-4e50-95b2-43de31fab249" /> | <img width="1280" height="851" alt="image" src="https://github.com/user-attachments/assets/f4a134bd-350b-43c5-a11a-21ac3361fb50" /> |

https://github.com/user-attachments/assets/1b8e6035-0e63-4aff-9439-b5931ab8d447