### PR TITLE
Polish/rebuild the column header dropdown to match core DataViews

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -228,3 +228,34 @@ Double-click autofit is the trickiest piece. With no measurement hook upstream, 
 
 **Solution.** Either WP exposes a "fit-the-row" size for `TextControl` (or a CSS variable hook for input height), or we replace the rename `TextControl` with a plain `<input>` styled to match the row. The plain input is the more reliable path: drops the WP-internals coupling, but adds a small amount of styling and accessibility plumbing we currently get for free. Worth doing the day this test fails on a WP bump.
 
+## 27. `Menu` outside-click only watches one document `[upstream]`
+
+**What.** WP's `Menu` (privateApis, Ariakit underneath) only sees clicks on the document the popover renders in. The `cortext/data-view` block renders inside Gutenberg's editor iframe, so clicks on the editor sidebar or top toolbar never reach Ariakit and the column dropdown stays open until the user clicks back into the canvas. We add a `mousedown` listener on `window.parent.document` while the menu is open and short-circuit when there isn't a parent (the Cortext admin isn't in an iframe).
+
+**Where.** The `useEffect` block in `FieldActions` in `src/components/fields/ColumnHeaderActions.js`.
+
+**Solution.** Either Ariakit grows a way to register extra documents for outside-click detection, or WP's wrapper does it for us. We drop the listener once that ships.
+
+## 28. `Menu.Item` has no destructive variant `[upstream]`
+
+**What.** The legacy `MenuItem` from `@wordpress/components` accepted `isDestructive` and rendered the row in red. The new privateApis `Menu.Item` dropped that prop without a replacement (verified in `node_modules/@wordpress/components/build-types/menu/types.d.ts` against `ItemProps`). For the Delete column action we paint the red ourselves with a className and one CSS rule, scoped to inactive rows so the focus/hover highlight overrides it.
+
+**Where.** The Delete `Menu.Item` in `src/components/fields/ColumnHeaderActions.js` and `.cortext-column-header-actions__destructive-item` in `src/index.scss`.
+
+**Solution.** Add `isDestructive` (or a `variant: 'destructive'`) to `Menu.Item` upstream. One-line change here once it ships.
+
+## 29. `Menu.Popover` doesn't portal by default `[upstream]`
+
+**What.** Without `portal` set, `Menu.Popover` renders inline at its mount point. Our column trigger lives inside a `<th>` whose `text-transform: uppercase` cascades into the menu items and turns every label into ALL CAPS. We pass `portal` explicitly. Most popovers in the system portal by default; this one doesn't.
+
+**Where.** The `<Menu.Popover portal …>` in `src/components/fields/ColumnHeaderActions.js`.
+
+**Solution.** Flip the default upstream. Trivial PR.
+
+## 30. `Menu` submenus only accept menu primitives `[upstream]`
+
+**What.** `Menu.SubmenuTriggerItem` opens a nested `Menu.Popover`, but the popover's children have to be `Menu.Item` / `Menu.Group` / `Menu.Separator`. Our "Edit field" submenu has tile previews (Number / Bar / Ring), labelled rows with right-anchored values, and three more popovers for format, color, and time choices. None of that fits the menu-primitive contract, so the format panel stays as a sibling popover, we run the hover-with-grace bridge ourselves, and the parent menu's `hideOnInteractOutside` filter ignores clicks landing in `.cortext-format-submenu` or `.cortext-format-submenu__flyout`.
+
+**Where.** `openFormat` / `scheduleClose` and `hideMenuOnInteractOutside` in `src/components/fields/ColumnHeaderActions.js`. `FieldFormatPopover` and its flyouts in `src/components/fields/FieldFormatPopover.js`.
+
+**Solution.** An arbitrary-content submenu variant in WP's `Menu` (or upstream Ariakit) would let the format panel mount as a real submenu, with outside-click and focus management owned by the library. Until then the manual bridge stays.

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -408,6 +408,7 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 							name="cortext-column-sort"
 							value="asc"
 							checked={ isSorted && sortDirection === 'asc' }
+							hideOnClick
 							onChange={ () => dispatchSort( 'asc' ) }
 						>
 							<Menu.ItemLabel>
@@ -418,6 +419,7 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 							name="cortext-column-sort"
 							value="desc"
 							checked={ isSorted && sortDirection === 'desc' }
+							hideOnClick
 							onChange={ () => dispatchSort( 'desc' ) }
 						>
 							<Menu.ItemLabel>

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -165,6 +165,7 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 	const [ isRenaming, setIsRenaming ] = useState( false );
 	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
 	const [ isFormatting, setIsFormatting ] = useState( false );
+	const [ shouldFocusFormat, setShouldFocusFormat ] = useState( false );
 	const [ confirmDelete, setConfirmDelete ] = useState( false );
 	const formatItemRef = useRef( null );
 	const closeTimerRef = useRef( null );
@@ -188,20 +189,55 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 		cancelClose();
 		closeTimerRef.current = setTimeout( () => {
 			setIsFormatting( false );
+			setShouldFocusFormat( false );
 			closeTimerRef.current = null;
 		}, 180 );
 	}, [ cancelClose ] );
-	const openFormat = useCallback( () => {
-		cancelClose();
-		setIsFormatting( true );
-	}, [ cancelClose ] );
+	const openFormat = useCallback(
+		( focus = false ) => {
+			cancelClose();
+			setShouldFocusFormat( focus );
+			setIsFormatting( true );
+		},
+		[ cancelClose ]
+	);
 	useEffect( () => () => cancelClose(), [ cancelClose ] );
 
 	const closeMenu = useCallback( () => {
 		cancelClose();
 		setIsFormatting( false );
+		setShouldFocusFormat( false );
 		setIsMenuOpen( false );
 	}, [ cancelClose ] );
+
+	const closeFormat = useCallback( () => {
+		cancelClose();
+		setIsFormatting( false );
+		setShouldFocusFormat( false );
+	}, [ cancelClose ] );
+
+	const closeFormatAndFocusTrigger = useCallback( () => {
+		closeFormat();
+		window.requestAnimationFrame( () => {
+			formatItemRef.current?.focus();
+		} );
+	}, [ closeFormat ] );
+
+	const openFormatFromKeyboard = useCallback(
+		( event ) => {
+			if (
+				! [ 'ArrowRight', 'Enter', ' ', 'Spacebar' ].includes(
+					event.key
+				)
+			) {
+				return;
+			}
+			event.preventDefault();
+			event.stopPropagation();
+			openFormat( true );
+		},
+		[ openFormat ]
+	);
 
 	const onMenuOpenChange = useCallback(
 		( nextOpen ) => {
@@ -394,8 +430,9 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 								suffix={
 									<Icon icon={ chevronRight } size={ 18 } />
 								}
-								onClick={ openFormat }
-								onMouseEnter={ openFormat }
+								onClick={ () => openFormat() }
+								onKeyDown={ openFormatFromKeyboard }
+								onMouseEnter={ () => openFormat() }
 								onMouseLeave={ scheduleClose }
 							>
 								<Menu.ItemLabel>
@@ -492,8 +529,10 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 				<FieldFormatPopover
 					recordId={ recordId }
 					anchor={ formatItemRef.current }
-					onClose={ () => setIsFormatting( false ) }
-					onMouseEnter={ openFormat }
+					focusOnMount={ shouldFocusFormat ? 'firstElement' : false }
+					onClose={ closeFormat }
+					onCloseWithFocus={ closeFormatAndFocusTrigger }
+					onMouseEnter={ () => openFormat() }
 					onMouseLeave={ scheduleClose }
 				/>
 			) : null }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -249,11 +249,15 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 		if ( ! parentDoc || parentDoc === document ) {
 			return undefined;
 		}
-		const onParentMouseDown = () => closeMenu();
+		const onParentMouseDown = ( event ) => {
+			if ( hideMenuOnInteractOutside( event ) ) {
+				closeMenu();
+			}
+		};
 		parentDoc.addEventListener( 'mousedown', onParentMouseDown );
 		return () =>
 			parentDoc.removeEventListener( 'mousedown', onParentMouseDown );
-	}, [ isMenuOpen, closeMenu ] );
+	}, [ isMenuOpen, closeMenu, hideMenuOnInteractOutside ] );
 
 	const dataViewId = `field-${ recordId }`;
 	const label =

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -229,6 +229,32 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 		return true;
 	}, [] );
 
+	// When this component renders inside an iframe (e.g. the Gutenberg
+	// canvas), Ariakit's outside-click listener only fires for events in
+	// the iframe document. Clicks on the editor chrome (sidebar, header)
+	// happen on the parent document, so without an extra listener there
+	// the menu stays open until the user clicks back into the canvas.
+	useEffect( () => {
+		if ( ! isMenuOpen ) {
+			return undefined;
+		}
+		let parentDoc;
+		try {
+			if ( window.parent && window.parent !== window ) {
+				parentDoc = window.parent.document;
+			}
+		} catch {
+			parentDoc = undefined;
+		}
+		if ( ! parentDoc || parentDoc === document ) {
+			return undefined;
+		}
+		const onParentMouseDown = () => closeMenu();
+		parentDoc.addEventListener( 'mousedown', onParentMouseDown );
+		return () =>
+			parentDoc.removeEventListener( 'mousedown', onParentMouseDown );
+	}, [ isMenuOpen, closeMenu ] );
+
 	const dataViewId = `field-${ recordId }`;
 	const label =
 		record?.title?.raw || record?.title?.rendered || `#${ recordId }`;

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -4,11 +4,11 @@ import {
 	Button,
 	Dropdown,
 	Icon,
-	MenuGroup,
-	MenuItem,
+	privateApis as componentsPrivateApis,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
+import { unlock } from '../../lock-unlock';
 import { useEntityRecord } from '@wordpress/core-data';
 import {
 	createPortal,
@@ -18,7 +18,16 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { chevronRight, plus } from '@wordpress/icons';
+import {
+	arrowLeft,
+	arrowRight,
+	chevronRight,
+	copy,
+	pencil,
+	plus,
+	trash,
+	unseen,
+} from '@wordpress/icons';
 
 import AddFieldPopover from './AddFieldPopover';
 import FieldFormatPopover from './FieldFormatPopover';
@@ -28,6 +37,8 @@ import {
 	useDuplicateField,
 } from '../../hooks/useFieldMutations';
 import { GHOST_FIELD_ID, TITLE_FIELD_ID } from '../dataViewColumns';
+
+const { Menu } = unlock( componentsPrivateApis );
 
 const FORMATTABLE_TYPES = new Set( [ 'number', 'date', 'datetime' ] );
 
@@ -152,6 +163,7 @@ export default function ColumnHeaderActions( {
 
 function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 	const [ isRenaming, setIsRenaming ] = useState( false );
+	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
 	const [ isFormatting, setIsFormatting ] = useState( false );
 	const [ confirmDelete, setConfirmDelete ] = useState( false );
 	const formatItemRef = useRef( null );
@@ -184,6 +196,38 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 		setIsFormatting( true );
 	}, [ cancelClose ] );
 	useEffect( () => () => cancelClose(), [ cancelClose ] );
+
+	const closeMenu = useCallback( () => {
+		cancelClose();
+		setIsFormatting( false );
+		setIsMenuOpen( false );
+	}, [ cancelClose ] );
+
+	const onMenuOpenChange = useCallback(
+		( nextOpen ) => {
+			if ( nextOpen ) {
+				setIsMenuOpen( true );
+			} else {
+				closeMenu();
+			}
+		},
+		[ closeMenu ]
+	);
+
+	// Keep Ariakit from auto-hiding the menu when the user interacts
+	// with the format popover or one of its third-level flyouts.
+	const hideMenuOnInteractOutside = useCallback( ( event ) => {
+		const target = event.target;
+		if ( target && typeof target.closest === 'function' ) {
+			if (
+				target.closest( '.cortext-format-submenu' ) ||
+				target.closest( '.cortext-format-submenu__flyout' )
+			) {
+				return false;
+			}
+		}
+		return true;
+	}, [] );
 
 	const dataViewId = `field-${ recordId }`;
 	const label =
@@ -275,152 +319,151 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 
 	return (
 		<span className="cortext-column-header-actions">
-			<Dropdown
-				contentClassName="cortext-field-actions-popover"
-				popoverProps={ { placement: 'bottom-start' } }
-				onClose={ () => {
-					cancelClose();
-					setIsFormatting( false );
-				} }
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Button
-						className="dataviews-view-table-header-button cortext-column-header-trigger"
-						variant="tertiary"
-						onClick={ onToggle }
-						aria-expanded={ isOpen }
-					>
-						<span className="cortext-column-header-label">
-							{ label }
+			<Menu open={ isMenuOpen } onOpenChange={ onMenuOpenChange }>
+				<Menu.TriggerButton
+					render={
+						<Button
+							className="dataviews-view-table-header-button cortext-column-header-trigger"
+							variant="tertiary"
+						/>
+					}
+				>
+					<span className="cortext-column-header-label">
+						{ label }
+					</span>
+					{ isSorted ? (
+						<span aria-hidden="true">
+							{ sortDirection === 'asc' ? ' ↑' : ' ↓' }
 						</span>
-						{ isSorted ? (
-							<span aria-hidden="true">
-								{ sortDirection === 'asc' ? ' ↑' : ' ↓' }
-							</span>
-						) : null }
-					</Button>
-				) }
-				renderContent={ ( { onClose } ) => (
-					<>
-						{ /* Property-config group: edit how the column
-						     itself is defined. Mirrors Notion's first
-						     section (Edit property / Change type). */ }
-						<MenuGroup>
-							<MenuItem
-								onClick={ () => {
-									onClose();
-									setIsRenaming( true );
-								} }
-							>
+					) : null }
+				</Menu.TriggerButton>
+				<Menu.Popover
+					className="cortext-field-actions-popover"
+					modal={ false }
+					portal
+					hideOnInteractOutside={ hideMenuOnInteractOutside }
+					style={ { minWidth: '240px' } }
+				>
+					{ /* Property-config group: edit how the column
+					     itself is defined. Mirrors Notion's first
+					     section (Edit property / Change type). */ }
+					<Menu.Group>
+						<Menu.Item
+							prefix={ <Icon icon={ pencil } /> }
+							onClick={ () => setIsRenaming( true ) }
+						>
+							<Menu.ItemLabel>
 								{ __( 'Rename', 'cortext' ) }
-							</MenuItem>
-							{ canFormat ? (
-								<MenuItem
-									ref={ formatItemRef }
-									className="cortext-column-header-actions__submenu-item"
-									onClick={ openFormat }
-									onMouseEnter={ openFormat }
-									onMouseLeave={ scheduleClose }
-									suffix={
-										<Icon
-											icon={ chevronRight }
-											size={ 18 }
-										/>
-									}
-								>
-									{ __( 'Edit field', 'cortext' ) }
-								</MenuItem>
-							) : null }
-						</MenuGroup>
-						{ /* View group: sort, hide. Notion bundles
-						     filter/sort/group/hide together. */ }
-						<MenuGroup>
-							<MenuItem
-								isSelected={
-									isSorted && sortDirection === 'asc'
+							</Menu.ItemLabel>
+						</Menu.Item>
+						{ canFormat ? (
+							<Menu.Item
+								ref={ formatItemRef }
+								className="cortext-column-header-actions__submenu-item"
+								hideOnClick={ false }
+								suffix={
+									<Icon icon={ chevronRight } size={ 18 } />
 								}
-								onClick={ () => {
-									onClose();
-									dispatchSort( 'asc' );
-								} }
-							>
-								{ __( 'Sort ascending', 'cortext' ) }
-							</MenuItem>
-							<MenuItem
-								isSelected={
-									isSorted && sortDirection === 'desc'
-								}
-								onClick={ () => {
-									onClose();
-									dispatchSort( 'desc' );
-								} }
-							>
-								{ __( 'Sort descending', 'cortext' ) }
-							</MenuItem>
-							<MenuItem
-								onClick={ () => {
-									onClose();
-									dispatchHide();
-								} }
-							>
-								{ __( 'Hide column', 'cortext' ) }
-							</MenuItem>
-						</MenuGroup>
-						{ /* Column-lifecycle group: move, duplicate,
-						     delete. Notion's "Insert left/right /
-						     Duplicate / Delete property" cluster. */ }
-						<MenuGroup>
-							<MenuItem
-								disabled={ ! canMoveLeft }
-								onClick={ () => {
-									onClose();
-									dispatchMove( -1 );
-								} }
-							>
-								{ __( 'Move left', 'cortext' ) }
-							</MenuItem>
-							<MenuItem
-								disabled={ ! canMoveRight }
-								onClick={ () => {
-									onClose();
-									dispatchMove( 1 );
-								} }
-							>
-								{ __( 'Move right', 'cortext' ) }
-							</MenuItem>
-							<MenuItem
-								onClick={ async () => {
-									onClose();
-									try {
-										await duplicate.run( recordId );
-									} catch {
-										// surfaced via duplicate.error.
-									}
-								} }
-							>
-								{ __( 'Duplicate', 'cortext' ) }
-							</MenuItem>
-							<MenuItem
-								isDestructive
-								onClick={ () => {
-									onClose();
-									setConfirmDelete( true );
-								} }
-							>
-								{ __( 'Delete', 'cortext' ) }
-							</MenuItem>
-						</MenuGroup>
-						{ isFormatting && canFormat ? (
-							<FieldFormatPopover
-								recordId={ recordId }
-								anchor={ formatItemRef.current }
-								onClose={ () => setIsFormatting( false ) }
+								onClick={ openFormat }
 								onMouseEnter={ openFormat }
 								onMouseLeave={ scheduleClose }
-							/>
+							>
+								<Menu.ItemLabel>
+									{ __( 'Edit field', 'cortext' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
 						) : null }
-					</>
-				) }
-			/>
+					</Menu.Group>
+					<Menu.Separator />
+					{ /* View group: sort, hide. Notion bundles
+					     filter/sort/group/hide together. */ }
+					<Menu.Group>
+						<Menu.RadioItem
+							name="cortext-column-sort"
+							value="asc"
+							checked={ isSorted && sortDirection === 'asc' }
+							onChange={ () => dispatchSort( 'asc' ) }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Sort ascending', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.RadioItem>
+						<Menu.RadioItem
+							name="cortext-column-sort"
+							value="desc"
+							checked={ isSorted && sortDirection === 'desc' }
+							onChange={ () => dispatchSort( 'desc' ) }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Sort descending', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.RadioItem>
+						<Menu.Item
+							prefix={ <Icon icon={ unseen } /> }
+							onClick={ dispatchHide }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Hide column', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+					</Menu.Group>
+					<Menu.Separator />
+					{ /* Column-lifecycle group: move, duplicate,
+					     delete. Notion's "Insert left/right /
+					     Duplicate / Delete property" cluster. */ }
+					<Menu.Group>
+						<Menu.Item
+							prefix={ <Icon icon={ arrowLeft } /> }
+							disabled={ ! canMoveLeft }
+							onClick={ () => dispatchMove( -1 ) }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Move left', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Item
+							prefix={ <Icon icon={ arrowRight } /> }
+							disabled={ ! canMoveRight }
+							onClick={ () => dispatchMove( 1 ) }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Move right', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Item
+							prefix={ <Icon icon={ copy } /> }
+							onClick={ async () => {
+								try {
+									await duplicate.run( recordId );
+								} catch {
+									// surfaced via duplicate.error.
+								}
+							} }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Duplicate', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Item
+							prefix={ <Icon icon={ trash } /> }
+							onClick={ () => setConfirmDelete( true ) }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Delete', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+					</Menu.Group>
+				</Menu.Popover>
+			</Menu>
+			{ isFormatting && canFormat ? (
+				<FieldFormatPopover
+					recordId={ recordId }
+					anchor={ formatItemRef.current }
+					onClose={ () => setIsFormatting( false ) }
+					onMouseEnter={ openFormat }
+					onMouseLeave={ scheduleClose }
+				/>
+			) : null }
 			{ confirmDelete ? (
 				<ConfirmDialog
 					onConfirm={ onConfirmDelete }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -473,6 +473,7 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 							</Menu.ItemLabel>
 						</Menu.Item>
 						<Menu.Item
+							className="cortext-column-header-actions__destructive-item"
 							prefix={ <Icon icon={ trash } /> }
 							onClick={ () => setConfirmDelete( true ) }
 						>

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -611,12 +611,14 @@ function DateFormBody( { type, config, onChange } ) {
 // selection. Hover handlers keep the panel open while the cursor is
 // somewhere over the column dropdown's Format row or this panel; the
 // parent owns the grace timer (`scheduleClose`) that absorbs the dead
-// pixels between them. `focusOnMount={ false }` keeps focus inside the
-// parent dropdown so it doesn't auto-close when the panel mounts.
+// pixels between them. Keyboard-opened panels can opt into focusOnMount so
+// tabbing enters the panel instead of moving to the next table column.
 export default function FieldFormatPopover( {
 	recordId,
 	anchor,
+	focusOnMount = false,
 	onClose,
+	onCloseWithFocus,
 	onMouseEnter,
 	onMouseLeave,
 } ) {
@@ -652,14 +654,24 @@ export default function FieldFormatPopover( {
 		return null;
 	}
 
+	const onPopoverKeyDown = ( event ) => {
+		if ( event.key !== 'Escape' && event.key !== 'ArrowLeft' ) {
+			return;
+		}
+		event.preventDefault();
+		event.stopPropagation();
+		onCloseWithFocus();
+	};
+
 	return (
 		<Popover
 			anchor={ anchor }
 			placement="right-start"
 			offset={ 8 }
 			onClose={ onClose }
-			focusOnMount={ false }
+			focusOnMount={ focusOnMount }
 			className="cortext-format-submenu"
+			onKeyDown={ onPopoverKeyDown }
 		>
 			<div
 				className="cortext-format-submenu__panel"

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -14,6 +14,79 @@ import { check, chevronRight } from '@wordpress/icons';
 import { parseFormat } from '../../hooks/fieldMapping';
 import { FORMAT_COLORS, findFormatColor } from './formatColors';
 
+const FOCUSABLE_CONTROL_SELECTOR = [
+	'button:not(:disabled)',
+	'input:not(:disabled):not([type="hidden"])',
+	'select:not(:disabled)',
+	'textarea:not(:disabled)',
+	'[tabindex]:not([tabindex="-1"])',
+].join( ',' );
+
+function getFocusableControls( container ) {
+	return Array.from(
+		container?.querySelectorAll( FOCUSABLE_CONTROL_SELECTOR ) ?? []
+	).filter(
+		( element ) =>
+			! element.closest( '[hidden], [aria-hidden="true"]' ) &&
+			element.getAttribute( 'aria-disabled' ) !== 'true'
+	);
+}
+
+function shouldLetElementHandleArrowKeys( element ) {
+	if ( ! element ) {
+		return false;
+	}
+	if ( element.isContentEditable ) {
+		return true;
+	}
+	const tagName = element.tagName;
+	if ( tagName === 'TEXTAREA' || tagName === 'SELECT' ) {
+		return true;
+	}
+	if ( tagName !== 'INPUT' ) {
+		return false;
+	}
+	return ! [ 'button', 'checkbox', 'radio', 'reset', 'submit' ].includes(
+		element.type
+	);
+}
+
+function focusRelativeControl( container, activeElement, direction ) {
+	const controls = getFocusableControls( container );
+	if ( ! controls.length ) {
+		return false;
+	}
+	const currentIndex = controls.includes( activeElement )
+		? controls.indexOf( activeElement )
+		: -1;
+	let nextIndex;
+	if ( currentIndex === -1 ) {
+		nextIndex = direction > 0 ? 0 : controls.length - 1;
+	} else {
+		nextIndex =
+			( currentIndex + direction + controls.length ) % controls.length;
+	}
+	controls[ nextIndex ]?.focus();
+	return true;
+}
+
+function focusEdgeControl( container, edge ) {
+	const controls = getFocusableControls( container );
+	if ( ! controls.length ) {
+		return false;
+	}
+	const next =
+		edge === 'last' ? controls[ controls.length - 1 ] : controls[ 0 ];
+	next?.focus();
+	return true;
+}
+
+function focusRefOnNextFrame( ref ) {
+	window.requestAnimationFrame( () => {
+		ref.current?.focus();
+	} );
+}
+
 // Number "format" rows flatten the storage shape (style + currency) into
 // a single flat list so the menu mirrors Notion. Each entry carries the
 // `style` (and `currency` for the four currency rows) it projects onto
@@ -121,9 +194,18 @@ function findTimeOption( config, type ) {
 // `isOpen` toggles the focus ring so users can tell which row spawned
 // the visible flyout.
 const SubmenuRow = forwardRef( function SubmenuRow(
-	{ label, value, onClick, isOpen },
+	{ label, value, onClick, onOpen, isOpen },
 	ref
 ) {
+	const onKeyDown = ( event ) => {
+		if ( event.key !== 'ArrowRight' ) {
+			return;
+		}
+		event.preventDefault();
+		event.stopPropagation();
+		onOpen();
+	};
+
 	return (
 		<button
 			ref={ ref }
@@ -132,6 +214,7 @@ const SubmenuRow = forwardRef( function SubmenuRow(
 				'cortext-format-submenu__row' + ( isOpen ? ' is-open' : '' )
 			}
 			onClick={ onClick }
+			onKeyDown={ onKeyDown }
 			aria-haspopup="menu"
 			aria-expanded={ isOpen }
 		>
@@ -145,9 +228,51 @@ const SubmenuRow = forwardRef( function SubmenuRow(
 	);
 } );
 
-function ChoiceList( { items, isSelected, onPick } ) {
+function ChoiceList( {
+	items,
+	isSelected,
+	onPick,
+	onClose,
+	returnFocusRef,
+	renderBeforeLabel,
+} ) {
+	const closeAndReturnFocus = () => {
+		onClose();
+		focusRefOnNextFrame( returnFocusRef );
+	};
+	const onKeyDown = ( event ) => {
+		if ( event.key === 'Escape' || event.key === 'ArrowLeft' ) {
+			event.preventDefault();
+			event.stopPropagation();
+			closeAndReturnFocus();
+			return;
+		}
+		if ( event.key === 'ArrowDown' || event.key === 'ArrowUp' ) {
+			event.preventDefault();
+			event.stopPropagation();
+			focusRelativeControl(
+				event.currentTarget,
+				event.currentTarget.ownerDocument.activeElement,
+				event.key === 'ArrowDown' ? 1 : -1
+			);
+			return;
+		}
+		if ( event.key === 'Home' || event.key === 'End' ) {
+			event.preventDefault();
+			event.stopPropagation();
+			focusEdgeControl(
+				event.currentTarget,
+				event.key === 'End' ? 'last' : 'first'
+			);
+		}
+	};
+
 	return (
-		<ul className="cortext-format-submenu__list" role="menu">
+		<ul
+			className="cortext-format-submenu__list"
+			role="menu"
+			onKeyDown={ onKeyDown }
+		>
 			{ items.map( ( item ) => {
 				const selected = isSelected( item );
 				return (
@@ -162,9 +287,15 @@ function ChoiceList( { items, isSelected, onPick } ) {
 							}
 							onClick={ () => onPick( item ) }
 						>
-							<span className="cortext-format-submenu__list-check">
-								{ selected ? <Icon icon={ check } /> : null }
-							</span>
+							{ renderBeforeLabel ? (
+								renderBeforeLabel( item, selected )
+							) : (
+								<span className="cortext-format-submenu__list-check">
+									{ selected ? (
+										<Icon icon={ check } />
+									) : null }
+								</span>
+							) }
 							<span>{ item.label }</span>
 						</button>
 					</li>
@@ -279,34 +410,24 @@ function ColorSwatch( { id } ) {
 	);
 }
 
-function ColorList( { value, onPick } ) {
+function ColorList( { value, onPick, onClose, returnFocusRef } ) {
 	const current = value ?? 'default';
 	return (
-		<ul className="cortext-format-submenu__list" role="menu">
-			{ FORMAT_COLORS.map( ( color ) => {
-				const selected = color.id === current;
-				return (
-					<li key={ color.id } role="none">
-						<button
-							type="button"
-							role="menuitemradio"
-							aria-checked={ selected }
-							className={
-								'cortext-format-submenu__list-item' +
-								( selected ? ' is-selected' : '' )
-							}
-							onClick={ () => onPick( color.id ) }
-						>
-							<span className="cortext-format-submenu__list-check">
-								{ selected ? <Icon icon={ check } /> : null }
-							</span>
-							<ColorSwatch id={ color.id } />
-							<span>{ color.label }</span>
-						</button>
-					</li>
-				);
-			} ) }
-		</ul>
+		<ChoiceList
+			items={ FORMAT_COLORS }
+			isSelected={ ( color ) => color.id === current }
+			onPick={ ( color ) => onPick( color.id ) }
+			onClose={ onClose }
+			returnFocusRef={ returnFocusRef }
+			renderBeforeLabel={ ( color, selected ) => (
+				<>
+					<span className="cortext-format-submenu__list-check">
+						{ selected ? <Icon icon={ check } /> : null }
+					</span>
+					<ColorSwatch id={ color.id } />
+				</>
+			) }
+		/>
 	);
 }
 
@@ -425,6 +546,7 @@ function NumberFormBody( { config, onChange } ) {
 				onClick={ () =>
 					setOpenRow( openRow === 'format' ? null : 'format' )
 				}
+				onOpen={ () => setOpenRow( 'format' ) }
 			/>
 			<SubmenuRow
 				ref={ decimalsRowRef }
@@ -438,6 +560,7 @@ function NumberFormBody( { config, onChange } ) {
 				onClick={ () =>
 					setOpenRow( openRow === 'decimals' ? null : 'decimals' )
 				}
+				onOpen={ () => setOpenRow( 'decimals' ) }
 			/>
 			<ShowAsTiles value={ display } onChange={ pickDisplay } />
 			{ isVisual ? (
@@ -455,6 +578,7 @@ function NumberFormBody( { config, onChange } ) {
 						onClick={ () =>
 							setOpenRow( openRow === 'color' ? null : 'color' )
 						}
+						onOpen={ () => setOpenRow( 'color' ) }
 					/>
 					{ showDivideBy ? (
 						<SubmenuInputRow
@@ -482,6 +606,8 @@ function NumberFormBody( { config, onChange } ) {
 						items={ NUMBER_FORMATS }
 						isSelected={ ( item ) => item.id === current.id }
 						onPick={ pickFormat }
+						onClose={ () => setOpenRow( null ) }
+						returnFocusRef={ formatRowRef }
 					/>
 				</Popover>
 			) : null }
@@ -497,6 +623,8 @@ function NumberFormBody( { config, onChange } ) {
 						items={ DECIMAL_OPTIONS }
 						isSelected={ ( item ) => item.value === decimals }
 						onPick={ ( item ) => pickDecimals( item.value ) }
+						onClose={ () => setOpenRow( null ) }
+						returnFocusRef={ decimalsRowRef }
 					/>
 				</Popover>
 			) : null }
@@ -508,7 +636,12 @@ function NumberFormBody( { config, onChange } ) {
 					onClose={ () => setOpenRow( null ) }
 					className="cortext-format-submenu__flyout"
 				>
-					<ColorList value={ colorId } onPick={ pickColor } />
+					<ColorList
+						value={ colorId }
+						onPick={ pickColor }
+						onClose={ () => setOpenRow( null ) }
+						returnFocusRef={ colorRowRef }
+					/>
 				</Popover>
 			) : null }
 		</>
@@ -558,6 +691,7 @@ function DateFormBody( { type, config, onChange } ) {
 				onClick={ () =>
 					setOpenRow( openRow === 'format' ? null : 'format' )
 				}
+				onOpen={ () => setOpenRow( 'format' ) }
 			/>
 			{ supportsTime ? (
 				<SubmenuRow
@@ -568,6 +702,7 @@ function DateFormBody( { type, config, onChange } ) {
 					onClick={ () =>
 						setOpenRow( openRow === 'time' ? null : 'time' )
 					}
+					onOpen={ () => setOpenRow( 'time' ) }
 				/>
 			) : null }
 			{ openRow === 'format' ? (
@@ -584,6 +719,8 @@ function DateFormBody( { type, config, onChange } ) {
 							item.id === currentDateFormat.id
 						}
 						onPick={ pickFormat }
+						onClose={ () => setOpenRow( null ) }
+						returnFocusRef={ formatRowRef }
 					/>
 				</Popover>
 			) : null }
@@ -599,6 +736,8 @@ function DateFormBody( { type, config, onChange } ) {
 						items={ TIME_OPTIONS }
 						isSelected={ ( item ) => item.id === currentTime.id }
 						onPick={ pickTime }
+						onClose={ () => setOpenRow( null ) }
+						returnFocusRef={ timeRowRef }
 					/>
 				</Popover>
 			) : null }
@@ -655,7 +794,49 @@ export default function FieldFormatPopover( {
 	}
 
 	const onPopoverKeyDown = ( event ) => {
-		if ( event.key !== 'Escape' && event.key !== 'ArrowLeft' ) {
+		const activeElement = event.currentTarget.ownerDocument.activeElement;
+		if (
+			( event.key === 'ArrowDown' || event.key === 'ArrowUp' ) &&
+			! shouldLetElementHandleArrowKeys( activeElement )
+		) {
+			const panel = event.currentTarget.querySelector(
+				'.cortext-format-submenu__panel'
+			);
+			if (
+				focusRelativeControl(
+					panel,
+					activeElement,
+					event.key === 'ArrowDown' ? 1 : -1
+				)
+			) {
+				event.preventDefault();
+				event.stopPropagation();
+			}
+			return;
+		}
+		if (
+			( event.key === 'Home' || event.key === 'End' ) &&
+			! shouldLetElementHandleArrowKeys( activeElement )
+		) {
+			const panel = event.currentTarget.querySelector(
+				'.cortext-format-submenu__panel'
+			);
+			if (
+				focusEdgeControl(
+					panel,
+					event.key === 'End' ? 'last' : 'first'
+				)
+			) {
+				event.preventDefault();
+				event.stopPropagation();
+			}
+			return;
+		}
+		if (
+			event.key !== 'Escape' &&
+			( event.key !== 'ArrowLeft' ||
+				shouldLetElementHandleArrowKeys( activeElement ) )
+		) {
 			return;
 		}
 		event.preventDefault();

--- a/src/index.scss
+++ b/src/index.scss
@@ -1147,6 +1147,15 @@ body.cortext-sidebar-resizing {
 	}
 }
 
+// Replaces the `isDestructive` red text we used to get from MenuItem.
+// The new Menu.Item from privateApis has no destructive variant, so
+// the visual signal for "Delete" has to be applied here. Ariakit
+// flips the row to the theme color when active, which keeps the
+// active-state contrast intact.
+.cortext-column-header-actions__destructive-item:not([data-active-item="true"]) {
+	color: var(--wp-components-color-destructive, #cc1818);
+}
+
 // Marker spans live inside DataViews' header trigger button. Zero-size
 // and aria-hidden so they never receive focus or contribute to the
 // column width; the portal layer in `ColumnHeaderActions` finds them by

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -893,6 +893,145 @@ test.describe( 'Collection view block', () => {
 			);
 		}
 	} );
+
+	test( 'opens the field format panel from the column menu with keyboard', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			const suffix = Date.now().toString( 36 ).slice( -4 );
+			const slug = `e2eformat${ suffix }`;
+			fixture.slug = slug;
+
+			fixture.collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_collections',
+				data: {
+					title: `Format keyboard ${ suffix }`,
+					status: 'private',
+					meta: { slug },
+				},
+			} );
+
+			fixture.field = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_fields',
+				data: {
+					title: 'Score',
+					status: 'private',
+					meta: { type: 'number' },
+				},
+			} );
+
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_collections/${ fixture.collection.id }`,
+				data: {
+					meta: { fields: [ String( fixture.field.id ) ] },
+				},
+			} );
+
+			fixture.entry = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_${ slug }`,
+				data: {
+					title: 'Keyboard row',
+					status: 'private',
+					meta: {
+						[ `field-${ fixture.field.id }` ]: 12.5,
+					},
+				},
+			} );
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Format keyboard page',
+					status: 'private',
+					content: createDataViewBlockMarkup( fixture.collection.id, {
+						fields: [ 'title', `field-${ fixture.field.id }` ],
+					} ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			const scoreHeader = canvas.getByRole( 'columnheader', {
+				name: /Score/,
+			} );
+			const scoreButton = scoreHeader
+				.getByRole( 'button', { name: 'Score' } )
+				.filter( { hasText: 'Score' } );
+
+			await expect( scoreButton ).toBeVisible();
+			await scoreButton.focus();
+			await scoreButton.press( 'Enter' );
+
+			const renameItem = canvas.getByRole( 'menuitem', {
+				name: 'Rename',
+			} );
+			const editFieldItem = canvas.getByRole( 'menuitem', {
+				name: 'Edit field',
+			} );
+			await expect( renameItem ).toBeFocused();
+
+			await page.keyboard.press( 'ArrowDown' );
+			await expect( editFieldItem ).toBeFocused();
+
+			await page.keyboard.press( 'ArrowRight' );
+			const formatPanel = page.locator( '.cortext-format-submenu' );
+			const numberFormatRow = formatPanel.getByRole( 'button', {
+				name: /Number format/,
+			} );
+			await expect( numberFormatRow ).toBeFocused();
+
+			await page.keyboard.press( 'Tab' );
+			await expect(
+				formatPanel.getByRole( 'button', { name: /Decimal places/ } )
+			).toBeFocused();
+
+			await page.keyboard.press( 'ArrowLeft' );
+			await expect( formatPanel ).toHaveCount( 0 );
+			await expect( editFieldItem ).toBeFocused();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+
 	test( 'renders system field columns as read-only when visible', async ( {
 		admin,
 		page,
@@ -1089,9 +1228,7 @@ test.describe( 'Collection view block', () => {
 
 			// The non-matching row should be filtered out.
 			await expect( canvas.getByText( 'Dune' ) ).toBeHidden();
-			await expect(
-				canvas.getByText( 'Frank Herbert' )
-			).toBeHidden();
+			await expect( canvas.getByText( 'Frank Herbert' ) ).toBeHidden();
 		} finally {
 			await deleteIfCreated(
 				requestUtils,

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -2051,12 +2051,14 @@ test.describe( 'Collection view block', () => {
 					.filter( { hasText: name } );
 				await button.dispatchEvent( 'click' );
 			};
+			const columnMenuItem = ( name ) =>
+				canvas.getByRole( 'menuitem', { name } );
 
 			// 2. Rename "Notes" → "Description" via the column-header
 			//    dropdown (combined Sort/Move/Hide + Rename/Duplicate/
 			//    Delete menu — see docs/tech-debt.md#16).
 			await openColumnDropdown( notesHeader, 'Notes' );
-			await page.getByRole( 'menuitem', { name: 'Rename' } ).click();
+			await columnMenuItem( 'Rename' ).click();
 
 			const renameInput = canvas.getByLabel( 'Field name' );
 			await renameInput.fill( 'Description' );
@@ -2071,7 +2073,7 @@ test.describe( 'Collection view block', () => {
 
 			// 3. Duplicate "Description" → "Copy of Description".
 			await openColumnDropdown( canvas, 'Description' );
-			await page.getByRole( 'menuitem', { name: 'Duplicate' } ).click();
+			await columnMenuItem( 'Duplicate' ).click();
 
 			await expect(
 				canvas.getByRole( 'columnheader', {
@@ -2082,7 +2084,7 @@ test.describe( 'Collection view block', () => {
 			// 4. Delete "Copy of Description" via the dropdown + confirm
 			//    dialog.
 			await openColumnDropdown( canvas, 'Copy of Description' );
-			await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
+			await columnMenuItem( 'Delete' ).click();
 			await page
 				.getByRole( 'button', { name: 'Delete', exact: true } )
 				.click();

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -894,7 +894,7 @@ test.describe( 'Collection view block', () => {
 		}
 	} );
 
-	test( 'opens the field format panel from the column menu with keyboard', async ( {
+	test( 'navigates the field format panel from the column menu with keyboard', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -1002,10 +1002,42 @@ test.describe( 'Collection view block', () => {
 			} );
 			await expect( numberFormatRow ).toBeFocused();
 
-			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'ArrowRight' );
+			const numberFormatFlyout = page.locator(
+				'.cortext-format-submenu__flyout'
+			);
+			const plainNumberOption = numberFormatFlyout.getByRole(
+				'menuitemradio',
+				{
+					name: 'Number',
+					exact: true,
+				}
+			);
+			await expect( plainNumberOption ).toBeFocused();
+
+			await page.keyboard.press( 'ArrowDown' );
 			await expect(
-				formatPanel.getByRole( 'button', { name: /Decimal places/ } )
+				numberFormatFlyout.getByRole( 'menuitemradio', {
+					name: 'Number with commas',
+				} )
 			).toBeFocused();
+
+			await page.keyboard.press( 'ArrowLeft' );
+			await expect( numberFormatFlyout ).toHaveCount( 0 );
+			await expect( numberFormatRow ).toBeFocused();
+
+			const decimalPlacesRow = formatPanel.getByRole( 'button', {
+				name: /Decimal places/,
+			} );
+
+			await page.keyboard.press( 'ArrowDown' );
+			await expect( decimalPlacesRow ).toBeFocused();
+
+			await page.keyboard.press( 'ArrowUp' );
+			await expect( numberFormatRow ).toBeFocused();
+
+			await page.keyboard.press( 'ArrowDown' );
+			await expect( decimalPlacesRow ).toBeFocused();
 
 			await page.keyboard.press( 'ArrowLeft' );
 			await expect( formatPanel ).toHaveCount( 0 );


### PR DESCRIPTION
## What

Part of #99

Rebuilds the custom-field column header menu on top of WordPress' `Menu` component.

The old dropdown had a few cracks after the field-format work: outside clicks could leave it open, sort actions did not close it, Delete lost its destructive styling, and keyboard navigation switched from arrows to Tab once you entered `Edit field`.

This keeps the menu behavior closer to core DataViews while still letting the field settings panel and nested flyouts stay open while you work. The remaining upstream `Menu` gaps are noted in `docs/tech-debt.md`.

## Testing

1. Open a Cortext collection with custom fields.
2. Open a custom-field column header menu.
3. Click outside it and confirm it closes.
4. Open `Edit field` and interact with its controls; the column menu should stay open.
5. Use the keyboard through the main menu, `Edit field`, and nested option lists.
6. In a Collection view block, open a column menu and click the editor sidebar or toolbar. The menu should close.

## Screenshots

| Before | After |
| - | - |
| <img width="1144" height="614" alt="image" src="https://github.com/user-attachments/assets/b57e4858-58ba-4776-b51f-e9de6bd26263" /> | <img width="1179" height="579" alt="image" src="https://github.com/user-attachments/assets/509c3bcb-bbf9-4efb-945b-eb389d18ec71" /> |

Outside click:

https://github.com/user-attachments/assets/37a735fa-a0d3-4edd-b22c-c15348dc4485

Keyboard navigation:

https://github.com/user-attachments/assets/02a13579-b991-4e45-a28d-2a02a634cef6