### PR TITLE
Collections: Add option management for select fields

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -58,11 +58,11 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 ## 6. DataViews has no multiselect form control `[upstream]`
 
-**What.** DataViews v6 ships `text`, `integer`, `email`, `datetime`, `radio`, `select`, `toggleGroup`, `boolean`, and `checkbox` controls but no multiselect. Our wrapper uses `FormTokenField` and translates between option labels (what the field shows) and option values (what we store as meta). Cost is small (the wrapper is short and self-contained) but every collection with a multiselect field carries the patch.
+**What.** DataViews v6 ships `text`, `integer`, `email`, `datetime`, `radio`, `select`, `toggleGroup`, `boolean`, and `checkbox` controls but no multiselect. Cortext used to bridge that with `FormTokenField`, but option editing outgrew it: multiselect now opens the same option picker as Select so users can create, recolor, rename, delete, and migrate options from the cell. That gives us one option-management surface, but it also means every multiselect cell still carries a custom editor instead of a DataViews-native control.
 
 **Where.** `src/components/MultiselectEdit.js`.
 
-**Solution.** A `multiselect` dataform-control upstream that DataForm and a future inline-edit mode (#1) resolve from `Edit: 'multiselect'`. File a Gutenberg issue or PR.
+**Solution.** A `multiselect` dataform-control upstream that DataForm and a future inline-edit mode (#1) resolve from `Edit: 'multiselect'`. It would need hooks for custom option rendering and option management, not just a token input, otherwise Cortext would still need the picker.
 
 ## 7. DataViews has no `footer` slot `[upstream, soft]`
 
@@ -259,3 +259,11 @@ Double-click autofit is the trickiest piece. With no measurement hook upstream, 
 **Where.** `openFormat` / `scheduleClose` and `hideMenuOnInteractOutside` in `src/components/fields/ColumnHeaderActions.js`. `FieldFormatPopover` and its flyouts in `src/components/fields/FieldFormatPopover.js`.
 
 **Solution.** An arbitrary-content submenu variant in WP's `Menu` (or upstream Ariakit) would let the format panel mount as a real submenu, with outside-click and focus management owned by the library. Until then the manual bridge stays.
+
+## 31. Nested `Popover` outside clicks do not close the host `[upstream]`
+
+**What.** `Popover` handles outside clicks one popover at a time. In the option editor, the main picker opens a second popover for an individual option's color/menu controls. After a color edit, the first click outside both popovers closed only the small option menu; the main picker stayed open because the host never saw that same outside click. We now listen for `pointerdown` while the option menu is open and ask the host to close when the click lands outside both popovers.
+
+**Where.** The pointer listener in `EditOptionsPopover` (`src/components/fields/EditOptionsPopover.js`) and the `onRequestClose` plumbing through `EditableCell`, `MultiselectEdit`, and `ColumnHeaderActions`.
+
+**Solution.** `Popover` needs a parent/child dismissal story: either close the whole stack when a click lands outside all related popovers, or expose enough event detail for a host popover to opt into that behavior without a document-level listener.

--- a/includes/OptionPalette.php
+++ b/includes/OptionPalette.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Whitelist of named colors usable on select/multiselect option chips.
+ *
+ * Stored on `crtxt_field` option records as a string name (e.g. `"blue"`)
+ * and resolved to CSS custom properties on the JS side so chips re-skin
+ * under the editor's light/dark theme. Anything outside this list is
+ * dropped silently during normalization.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext;
+
+final class OptionPalette {
+
+	private const NAMES = array(
+		'default',
+		'gray',
+		'brown',
+		'orange',
+		'yellow',
+		'green',
+		'blue',
+		'purple',
+		'pink',
+		'red',
+	);
+
+	/**
+	 * Returns every palette name. Order is intentional and surfaces in the UI.
+	 *
+	 * @return array<int,string>
+	 */
+	public static function names(): array {
+		return self::NAMES;
+	}
+
+	public static function is_valid( string $name ): bool {
+		return in_array( $name, self::NAMES, true );
+	}
+}

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+use Cortext\OptionPalette;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\Field;
@@ -68,6 +69,7 @@ final class FieldsController {
 								'properties' => array(
 									'value' => array( 'type' => 'string' ),
 									'label' => array( 'type' => 'string' ),
+									'color' => array( 'type' => 'string' ),
 								),
 							),
 						),
@@ -97,6 +99,73 @@ final class FieldsController {
 				),
 			)
 		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/fields/(?P<field_id>\d+)/options',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'update_options' ),
+					'permission_callback' => array( $this, 'can_edit_field' ),
+					'args'                => array(
+						'field_id'   => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'options'    => array(
+							'type'     => 'array',
+							'required' => true,
+							'items'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'value' => array( 'type' => 'string' ),
+									'label' => array( 'type' => 'string' ),
+									'color' => array( 'type' => 'string' ),
+								),
+							),
+						),
+						'migrations' => array(
+							'type'     => 'array',
+							'required' => false,
+							'items'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'from'   => array( 'type' => 'string' ),
+									'action' => array(
+										'type' => 'string',
+										'enum' => array( 'clear', 'replace' ),
+									),
+									'to'     => array( 'type' => 'string' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/fields/(?P<field_id>\d+)/options/(?P<value>[^/]+)/usage',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'option_usage' ),
+					'permission_callback' => array( $this, 'can_edit_field' ),
+					'args'                => array(
+						'field_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'value'    => array(
+							'type'     => 'string',
+							'required' => true,
+						),
+					),
+				),
+			)
+		);
 	}
 
 	public function can_edit_collection( WP_REST_Request $request ): bool|WP_Error {
@@ -110,6 +179,19 @@ final class FieldsController {
 			);
 		}
 		return current_user_can( 'edit_post', $collection_id );
+	}
+
+	public function can_edit_field( WP_REST_Request $request ): bool|WP_Error {
+		$field_id = (int) $request->get_param( 'field_id' );
+		$field    = get_post( $field_id );
+		if ( ! $field instanceof WP_Post || Field::POST_TYPE !== $field->post_type ) {
+			return new WP_Error(
+				'cortext_field_not_found',
+				__( 'Field not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+		return current_user_can( 'edit_post', $field_id );
 	}
 
 	public function create( WP_REST_Request $request ): WP_REST_Response|WP_Error {
@@ -188,6 +270,182 @@ final class FieldsController {
 		}
 
 		return $this->insert_and_attach( $collection_id, $copy_title, $meta, (string) $field_id );
+	}
+
+	public function update_options( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$field_id = (int) $request->get_param( 'field_id' );
+		$field    = get_post( $field_id );
+		if ( ! $field instanceof WP_Post || Field::POST_TYPE !== $field->post_type ) {
+			return new WP_Error(
+				'cortext_field_not_found',
+				__( 'Field not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$type = (string) get_post_meta( $field_id, 'type', true );
+		if ( ! $this->type_supports_options( $type ) ) {
+			return new WP_Error(
+				'cortext_field_type_unsupported',
+				__( 'This field type does not support options.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$options = $request->get_param( 'options' );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+		$normalized = $this->normalize_options( $options );
+
+		$migrations = $request->get_param( 'migrations' );
+		$migrated   = array();
+		if ( is_array( $migrations ) ) {
+			$valid_values = array_column( $normalized, 'value' );
+			foreach ( $migrations as $migration ) {
+				$from   = isset( $migration['from'] ) ? (string) $migration['from'] : '';
+				$action = isset( $migration['action'] ) ? (string) $migration['action'] : '';
+				$to     = isset( $migration['to'] ) ? (string) $migration['to'] : '';
+				if ( '' === $from || ! in_array( $action, array( 'clear', 'replace' ), true ) ) {
+					continue;
+				}
+				if ( 'replace' === $action && ! in_array( $to, $valid_values, true ) ) {
+					return new WP_Error(
+						'cortext_invalid_replacement',
+						__( 'Replacement option does not exist in the new option list.', 'cortext' ),
+						array( 'status' => 400 )
+					);
+				}
+				$count             = $this->migrate_rows( $field_id, $type, $from, $action, $to );
+				$migrated[ $from ] = $count;
+			}
+		}
+
+		update_post_meta( $field_id, 'options', wp_json_encode( $normalized ) );
+
+		return new WP_REST_Response(
+			array(
+				'id'       => $field_id,
+				'options'  => $normalized,
+				'migrated' => (object) $migrated,
+			),
+			200
+		);
+	}
+
+	public function option_usage( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$field_id = (int) $request->get_param( 'field_id' );
+		$value    = (string) $request->get_param( 'value' );
+
+		$field = get_post( $field_id );
+		if ( ! $field instanceof WP_Post || Field::POST_TYPE !== $field->post_type ) {
+			return new WP_Error(
+				'cortext_field_not_found',
+				__( 'Field not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'value' => $value,
+				'count' => $this->count_rows_with_value( $field_id, $value ),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Walks every Cortext entry CPT and applies the migration on rows that
+	 * carry the old value in `field-<id>` postmeta.
+	 *
+	 * - clear: removes every matching meta row.
+	 * - replace on a single-value (select) field: rewrites the row.
+	 * - replace on a multi-value (multiselect) field: removes the old value
+	 *   and adds the new one only when it is not already present, so a row
+	 *   that already had both options does not gain a duplicate.
+	 *
+	 * @param int    $field_id Field post ID whose row meta is being rewritten.
+	 * @param string $type     Field type (`select` or `multiselect`).
+	 * @param string $from     Existing option value to migrate away from.
+	 * @param string $action   `clear` or `replace`.
+	 * @param string $to       New value when `$action` is `replace`.
+	 * @return int Number of rows touched.
+	 */
+	private function migrate_rows( int $field_id, string $type, string $from, string $action, string $to ): int {
+		$meta_key      = "field-{$field_id}";
+		$is_multivalue = 'multiselect' === $type;
+		$touched       = 0;
+
+		foreach ( CollectionEntries::get_entry_post_types() as $post_type ) {
+			$row_ids = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit' ),
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- bounded migration over Cortext rows.
+					'meta_query'     => array(
+						array(
+							'key'     => $meta_key,
+							'value'   => $from,
+							'compare' => '=',
+						),
+					),
+				)
+			);
+
+			foreach ( $row_ids as $row_id ) {
+				$row_id = (int) $row_id;
+				if ( 'clear' === $action ) {
+					if ( delete_post_meta( $row_id, $meta_key, $from ) ) {
+						++$touched;
+					}
+					continue;
+				}
+
+				// Replace branch.
+				if ( $is_multivalue ) {
+					$existing = get_post_meta( $row_id, $meta_key, false );
+					$has_to   = is_array( $existing ) && in_array( $to, $existing, true );
+					if ( delete_post_meta( $row_id, $meta_key, $from ) ) {
+						++$touched;
+					}
+					if ( ! $has_to ) {
+						add_post_meta( $row_id, $meta_key, $to );
+					}
+				} elseif ( update_post_meta( $row_id, $meta_key, $to ) ) {
+						++$touched;
+				}
+			}
+		}
+
+		return $touched;
+	}
+
+	private function count_rows_with_value( int $field_id, string $value ): int {
+		$meta_key = "field-{$field_id}";
+		$count    = 0;
+		foreach ( CollectionEntries::get_entry_post_types() as $post_type ) {
+			$row_ids = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit' ),
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- bounded count over Cortext rows.
+					'meta_query'     => array(
+						array(
+							'key'     => $meta_key,
+							'value'   => $value,
+							'compare' => '=',
+						),
+					),
+				)
+			);
+			$count += count( $row_ids );
+		}
+		return $count;
 	}
 
 	/**
@@ -331,10 +589,11 @@ final class FieldsController {
 	}
 
 	/**
-	 * Trims and rejects empty entries; preserves order.
+	 * Trims and rejects empty entries; preserves order. Keeps an optional
+	 * `color` when it names a palette entry, drops it otherwise.
 	 *
 	 * @param array<int,array<string,mixed>> $options Raw option records.
-	 * @return array<int,array{value:string,label:string}>
+	 * @return array<int,array{value:string,label:string,color?:string}>
 	 */
 	private function normalize_options( array $options ): array {
 		$normalized = array();
@@ -350,10 +609,17 @@ final class FieldsController {
 			if ( '' === $label ) {
 				$label = $value;
 			}
-			$normalized[] = array(
+			$record = array(
 				'value' => $value,
 				'label' => $label,
 			);
+			if ( isset( $option['color'] ) ) {
+				$color = trim( (string) $option['color'] );
+				if ( '' !== $color && OptionPalette::is_valid( $color ) ) {
+					$record['color'] = $color;
+				}
+			}
+			$normalized[] = $record;
 		}
 		return $normalized;
 	}

--- a/includes/Theming/Preferences.php
+++ b/includes/Theming/Preferences.php
@@ -65,6 +65,9 @@ final class Preferences {
 		root.setAttribute( 'data-sidebar-collapsed', sidebarCollapsed ? 'true' : 'false' );
 		root.style.setProperty( '--cortext-sidebar-width', sidebarWidth + 'px' );
 	}
+	if ( document.body ) {
+		document.body.setAttribute( 'data-cortext-theme', resolved );
+	}
 
 	window.cortextBootstrap = {
 		colorScheme: pref,

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -21,6 +21,7 @@ import {
 } from './dataViewColumns';
 import useCollectionFields from '../hooks/useCollectionFields';
 import useCollectionRows from '../hooks/useCollectionRows';
+import { elementsFromOptions } from '../hooks/optionElements';
 
 const DEFAULT_LAYOUTS = { table: { density: 'compact' }, grid: {}, list: {} };
 const TITLE_LABEL = __( 'Title', 'cortext' );
@@ -234,6 +235,15 @@ export default function CollectionDataViews( {
 	// navigation between cells.
 	const [ editRequest, setEditRequest ] = useState( null );
 	const clearEditRequest = useCallback( () => setEditRequest( null ), [] );
+	const [ optionOverrides, setOptionOverrides ] = useState( {} );
+	const updateFieldOptions = useCallback( ( recordId, nextOptions ) => {
+		const fieldId = `field-${ recordId }`;
+		const elements = elementsFromOptions( nextOptions ) || [];
+		setOptionOverrides( ( current ) => ( {
+			...current,
+			[ fieldId ]: elements,
+		} ) );
+	}, [] );
 
 	// Editable, currently-visible columns in the order DataViews renders
 	// them. Drives Tab/Shift+Tab cell-to-cell navigation. See
@@ -315,8 +325,17 @@ export default function CollectionDataViews( {
 			editRequest,
 			clearEditRequest,
 			requestNext,
+			optionOverrides,
+			updateFieldOptions,
 		} ),
-		[ saveRowField, editRequest, clearEditRequest, requestNext ]
+		[
+			saveRowField,
+			editRequest,
+			clearEditRequest,
+			requestNext,
+			optionOverrides,
+			updateFieldOptions,
+		]
 	);
 
 	const onCreated = useCallback(
@@ -593,6 +612,7 @@ export default function CollectionDataViews( {
 						collectionId={ collectionId }
 						view={ view }
 						onChangeView={ onChangeView }
+						onFieldOptionsSaved={ updateFieldOptions }
 					/>
 				) }
 				{ /* tech-debt.md#7: DataViews has no footer slot, so the

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -327,6 +327,7 @@ export default function CollectionDataViews( {
 			requestNext,
 			optionOverrides,
 			updateFieldOptions,
+			refreshRows: refresh,
 		} ),
 		[
 			saveRowField,
@@ -335,6 +336,7 @@ export default function CollectionDataViews( {
 			requestNext,
 			optionOverrides,
 			updateFieldOptions,
+			refresh,
 		]
 	);
 
@@ -613,6 +615,7 @@ export default function CollectionDataViews( {
 						view={ view }
 						onChangeView={ onChangeView }
 						onFieldOptionsSaved={ updateFieldOptions }
+						onRowsChanged={ refresh }
 					/>
 				) }
 				{ /* tech-debt.md#7: DataViews has no footer slot, so the

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -4,9 +4,8 @@ import {
 	CheckboxControl,
 	DateTimePicker,
 	Dropdown,
-	MenuGroup,
-	MenuItem,
 	Notice,
+	Popover,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
 	TextControl,
@@ -24,7 +23,9 @@ import { Icon, check } from '@wordpress/icons';
 
 import MultiselectEdit from './MultiselectEdit';
 import Chip from './fields/Chip';
+import EditOptionsPopover from './fields/EditOptionsPopover';
 import { resolveFormatColor } from './fields/formatColors';
+import { toRecordId } from '../hooks/fieldIds';
 
 // Resolves the WordPress site locale into a BCP 47 tag for Intl. WP
 // stores locales as `en_US` / `de_DE`; Intl expects `en-US` / `de-DE`.
@@ -55,6 +56,8 @@ export const RowMutationContext = createContext( {
 	// Asks the parent to set editRequest to the next/prev editable cell.
 	// `direction` is 1 for Tab, -1 for Shift+Tab.
 	requestNext: () => {},
+	optionOverrides: {},
+	updateFieldOptions: () => {},
 } );
 
 const TEXT_INPUT_TYPES = new Set( [ 'text', 'email', 'url', 'number' ] );
@@ -521,7 +524,26 @@ function TextLikeEditor( {
 	);
 }
 
-function SelectEditor( { value, elements, onCommit, onCancel, onTab, label } ) {
+// Cell-side select editor: a button trigger plus a controlled `Popover`
+// hosting the unified `EditOptionsPopover` in pick mode. We use a
+// controlled Popover (rather than `Dropdown`) so the editor's lifetime
+// is owned by the cell's `isEditing` flag — option mutations cause the
+// entity store to refetch and re-render the cell, and `Dropdown`'s
+// outside-click heuristics could close everything mid-interaction
+// (creating an option, picking a color in the per-option submenu).
+// `Popover` here lets the parent unmount it explicitly when editing
+// ends, while still closing on outside click + Escape via `onClose`.
+function SelectEditor( {
+	value,
+	elements,
+	onCommit,
+	onOptionsSaved,
+	onCancel,
+	onTab,
+	recordId,
+	label,
+} ) {
+	const [ anchor, setAnchor ] = useState( null );
 	const items = useMemo( () => elements ?? [], [ elements ] );
 	const labelFor = useMemo( () => {
 		const map = new Map( items.map( ( e ) => [ e.value, e.label ] ) );
@@ -529,9 +551,19 @@ function SelectEditor( { value, elements, onCommit, onCancel, onTab, label } ) {
 	}, [ items ] );
 
 	const hasValue = value !== null && value !== undefined && value !== '';
-	const triggerLabel = hasValue
-		? labelFor( value )
-		: __( 'Select…', 'cortext' );
+	const currentChip = hasValue
+		? items.find( ( e ) => e.value === value )
+		: null;
+	const triggerContent = hasValue ? (
+		<Chip
+			label={ currentChip?.label ?? labelFor( value ) }
+			color={ currentChip?.color }
+		/>
+	) : (
+		<span className="cortext-select-edit__placeholder">
+			{ __( 'Select…', 'cortext' ) }
+		</span>
+	);
 
 	const handleTriggerKeyDown = ( event ) => {
 		if ( event.key === 'Tab' && onTab ) {
@@ -541,48 +573,38 @@ function SelectEditor( { value, elements, onCommit, onCancel, onTab, label } ) {
 	};
 
 	return (
-		<Dropdown
-			defaultOpen
-			onClose={ onCancel }
-			popoverProps={ { placement: 'bottom-start' } }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					variant="tertiary"
-					className="cortext-select-edit__toggle"
-					onClick={ onToggle }
-					onKeyDown={ handleTriggerKeyDown }
-					aria-expanded={ isOpen }
-					aria-label={ label }
+		<>
+			<Button
+				ref={ setAnchor }
+				variant="tertiary"
+				className="cortext-select-edit__toggle"
+				onKeyDown={ handleTriggerKeyDown }
+				aria-expanded
+				aria-label={ label }
+			>
+				{ triggerContent }
+			</Button>
+			{ anchor ? (
+				<Popover
+					anchor={ anchor }
+					placement="bottom-start"
+					onClose={ onCancel }
+					focusOnMount="firstElement"
 				>
-					{ triggerLabel }
-				</Button>
-			) }
-			renderContent={ ( { onClose } ) => (
-				<MenuGroup>
-					<MenuItem
-						isSelected={ ! hasValue }
-						onClick={ async () => {
-							await onCommit( null );
-							onClose();
+					<EditOptionsPopover
+						recordId={ recordId }
+						fieldType="select"
+						initialOptions={ items }
+						value={ value }
+						onOptionsSaved={ onOptionsSaved }
+						onPick={ async ( next ) => {
+							await onCommit( next );
+							onCancel();
 						} }
-					>
-						{ __( 'Clear', 'cortext' ) }
-					</MenuItem>
-					{ items.map( ( opt ) => (
-						<MenuItem
-							key={ opt.value }
-							isSelected={ opt.value === value }
-							onClick={ async () => {
-								await onCommit( opt.value );
-								onClose();
-							} }
-						>
-							{ opt.label }
-						</MenuItem>
-					) ) }
-				</MenuGroup>
-			) }
-		/>
+					/>
+				</Popover>
+			) : null }
+		</>
 	);
 }
 
@@ -634,8 +656,14 @@ export default function EditableCell( {
 	getValue,
 	readOnly = false,
 } ) {
-	const { saveRowField, editRequest, clearEditRequest, requestNext } =
-		useContext( RowMutationContext );
+	const {
+		saveRowField,
+		editRequest,
+		clearEditRequest,
+		requestNext,
+		optionOverrides,
+		updateFieldOptions,
+	} = useContext( RowMutationContext );
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ error, setError ] = useState( null );
@@ -645,7 +673,11 @@ export default function EditableCell( {
 	const value = getValue
 		? getValue( { item } )
 		: item?.meta?.[ fieldId ] ?? null;
-	const display = formatDisplay( value, fieldType, { elements, format } );
+	const effectiveElements = optionOverrides?.[ fieldId ] ?? elements;
+	const display = formatDisplay( value, fieldType, {
+		elements: effectiveElements,
+		format,
+	} );
 
 	// Open this cell when the parent targets it via editRequest (new-row
 	// title auto-open, Tab navigation, etc.), then clear the request so
@@ -752,16 +784,23 @@ export default function EditableCell( {
 	let editor = null;
 	if ( isEditing ) {
 		if ( fieldType === 'multiselect' ) {
-			// Multiselect persists on each token change rather than on a
-			// single commit (Notion-style: no Save button). Wire onSave
-			// straight to saveRowField so saving doesn't close the cell;
-			// closing happens via Dropdown's onClose firing onCancel.
+			// Multiselect persists on each toggle (Notion-style: no Save
+			// button). Wire onSave straight to saveRowField so saving
+			// doesn't close the cell; closing happens via Dropdown's
+			// onClose firing onCancel.
 			editor = (
 				<MultiselectEdit
+					recordId={ toRecordId( fieldId ) }
 					value={ Array.isArray( value ) ? value : [] }
-					elements={ elements ?? [] }
+					elements={ effectiveElements ?? [] }
 					onSave={ ( nextValues ) =>
 						saveRowField?.( rowId, fieldId, nextValues )
+					}
+					onOptionsSaved={ ( nextOptions ) =>
+						updateFieldOptions?.(
+							toRecordId( fieldId ),
+							nextOptions
+						)
 					}
 					onCancel={ closeEditor }
 					label={ label }
@@ -770,9 +809,16 @@ export default function EditableCell( {
 		} else if ( fieldType === 'select' ) {
 			editor = (
 				<SelectEditor
+					recordId={ toRecordId( fieldId ) }
 					value={ value }
-					elements={ elements }
+					elements={ effectiveElements }
 					onCommit={ commit }
+					onOptionsSaved={ ( nextOptions ) =>
+						updateFieldOptions?.(
+							toRecordId( fieldId ),
+							nextOptions
+						)
+					}
 					onCancel={ closeEditor }
 					onTab={ ( direction ) =>
 						requestNext?.( rowId, fieldId, direction )

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -58,6 +58,7 @@ export const RowMutationContext = createContext( {
 	requestNext: () => {},
 	optionOverrides: {},
 	updateFieldOptions: () => {},
+	refreshRows: () => {},
 } );
 
 const TEXT_INPUT_TYPES = new Set( [ 'text', 'email', 'url', 'number' ] );
@@ -538,6 +539,7 @@ function SelectEditor( {
 	elements,
 	onCommit,
 	onOptionsSaved,
+	onRowsChanged,
 	onCancel,
 	onTab,
 	recordId,
@@ -597,6 +599,7 @@ function SelectEditor( {
 						initialOptions={ items }
 						value={ value }
 						onOptionsSaved={ onOptionsSaved }
+						onRowsChanged={ onRowsChanged }
 						onPick={ async ( next ) => {
 							await onCommit( next );
 							onCancel();
@@ -663,6 +666,7 @@ export default function EditableCell( {
 		requestNext,
 		optionOverrides,
 		updateFieldOptions,
+		refreshRows,
 	} = useContext( RowMutationContext );
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ isSaving, setIsSaving ] = useState( false );
@@ -802,6 +806,7 @@ export default function EditableCell( {
 							nextOptions
 						)
 					}
+					onRowsChanged={ refreshRows }
 					onCancel={ closeEditor }
 					label={ label }
 				/>
@@ -819,6 +824,7 @@ export default function EditableCell( {
 							nextOptions
 						)
 					}
+					onRowsChanged={ refreshRows }
 					onCancel={ closeEditor }
 					onTab={ ( direction ) =>
 						requestNext?.( rowId, fieldId, direction )

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -540,6 +540,7 @@ function SelectEditor( {
 	onCommit,
 	onOptionsSaved,
 	onRowsChanged,
+	onRequestClose,
 	onCancel,
 	onTab,
 	recordId,
@@ -600,6 +601,7 @@ function SelectEditor( {
 						value={ value }
 						onOptionsSaved={ onOptionsSaved }
 						onRowsChanged={ onRowsChanged }
+						onRequestClose={ onRequestClose }
 						onPick={ async ( next ) => {
 							await onCommit( next );
 							onCancel();
@@ -807,6 +809,7 @@ export default function EditableCell( {
 						)
 					}
 					onRowsChanged={ refreshRows }
+					onRequestClose={ closeEditor }
 					onCancel={ closeEditor }
 					label={ label }
 				/>
@@ -825,6 +828,7 @@ export default function EditableCell( {
 						)
 					}
 					onRowsChanged={ refreshRows }
+					onRequestClose={ closeEditor }
 					onCancel={ closeEditor }
 					onTab={ ( direction ) =>
 						requestNext?.( rowId, fieldId, direction )

--- a/src/components/MultiselectEdit.js
+++ b/src/components/MultiselectEdit.js
@@ -27,6 +27,7 @@ export default function MultiselectEdit( {
 	onSave,
 	onOptionsSaved,
 	onRowsChanged,
+	onRequestClose,
 	onCancel,
 	label,
 } ) {
@@ -91,6 +92,7 @@ export default function MultiselectEdit( {
 						value={ current }
 						onOptionsSaved={ onOptionsSaved }
 						onRowsChanged={ onRowsChanged }
+						onRequestClose={ onRequestClose }
 						onPick={ handleToggle }
 					/>
 				</Popover>

--- a/src/components/MultiselectEdit.js
+++ b/src/components/MultiselectEdit.js
@@ -1,90 +1,95 @@
 import { __ } from '@wordpress/i18n';
-import { Button, Dropdown, FormTokenField } from '@wordpress/components';
+import { Button, Popover } from '@wordpress/components';
 import { useMemo, useState } from '@wordpress/element';
 
-// tech-debt.md#6: DataViews v6 ships no `multiselect` dataform-control,
-// so this component fills the gap with FormTokenField. Once upstream
-// adds one, this file collapses to a thin wrapper or disappears.
+import Chip from './fields/Chip';
+import EditOptionsPopover from './fields/EditOptionsPopover';
+
+// Multiselect cell editor: a button trigger that shows the selected
+// chips, plus a controlled `Popover` hosting the unified
+// `EditOptionsPopover` in pick mode. `onPick` toggles the clicked value
+// in/out of the cell's array, so the popover stays open while the user
+// adjusts multiple values; `onSave` fires after each toggle so the row
+// meta updates incrementally (Notion-style, no Save button). Closing
+// happens via the Popover's outside-click which fires `onCancel`.
 //
-// FormTokenField speaks in labels but our row meta stores raw values.
-// Keep two parallel maps and translate at the boundaries.
-//
-// `label` is intentionally not forwarded to FormTokenField: the prop
-// always renders a visible <label> regardless of hideLabelFromVision
-// (same upstream quirk as tech-debt.md#8 for CheckboxControl), and the
-// DataViews column header already announces the field.
+// Replaces the previous `FormTokenField` implementation
+// (tech-debt.md#6) so the cell picker matches the column-header "Edit
+// options" surface: same chips, same per-option submenu, same
+// search-or-create input. Uses a controlled Popover (instead of
+// `Dropdown`) so the editor isn't torn down by Dropdown's outside-click
+// heuristics during option mutations (create / recolor / delete) that
+// cascade into a re-render of the row cell.
 export default function MultiselectEdit( {
+	recordId,
 	value,
 	elements,
 	onSave,
+	onOptionsSaved,
 	onCancel,
 	label,
 } ) {
-	const valueToLabel = useMemo( () => {
-		const map = new Map();
-		( elements ?? [] ).forEach( ( e ) => map.set( e.value, e.label ) );
-		return map;
-	}, [ elements ] );
-
-	const labelToValue = useMemo( () => {
-		const map = new Map();
-		( elements ?? [] ).forEach( ( e ) => map.set( e.label, e.value ) );
-		return map;
-	}, [ elements ] );
-
-	const [ tokens, setTokens ] = useState( () =>
-		( value ?? [] ).map( ( v ) => valueToLabel.get( v ) ?? String( v ) )
+	const [ anchor, setAnchor ] = useState( null );
+	const items = useMemo( () => elements ?? [], [ elements ] );
+	const current = useMemo(
+		() => ( Array.isArray( value ) ? value : [] ),
+		[ value ]
 	);
 
-	const suggestions = useMemo(
-		() => ( elements ?? [] ).map( ( e ) => e.label ),
-		[ elements ]
-	);
-
-	// Persist on every change so adding or removing a token saves
-	// immediately. The popover stays open while the user keeps editing;
-	// closing the popover (click outside or trigger) just dismisses it.
-	const handleChange = ( nextTokens ) => {
-		setTokens( nextTokens );
-		const nextValues = nextTokens
-			.map( ( token ) => labelToValue.get( token ) ?? token )
-			.filter( ( v ) => v !== '' && v !== null && v !== undefined );
-		onSave( nextValues );
+	const handleToggle = ( optionValue ) => {
+		const next = current.includes( optionValue )
+			? current.filter( ( v ) => v !== optionValue )
+			: [ ...current, optionValue ];
+		onSave( next );
 	};
 
-	const triggerLabel = tokens.length
-		? tokens.join( ', ' )
-		: __( 'Select…', 'cortext' );
+	const triggerContent = current.length ? (
+		<span className="cortext-chips">
+			{ current.map( ( v ) => {
+				const element = items.find( ( e ) => e.value === v );
+				return (
+					<Chip
+						key={ v }
+						label={ element?.label ?? String( v ) }
+						color={ element?.color }
+					/>
+				);
+			} ) }
+		</span>
+	) : (
+		<span className="cortext-select-edit__placeholder">
+			{ __( 'Select…', 'cortext' ) }
+		</span>
+	);
 
 	return (
-		<Dropdown
-			defaultOpen
-			onClose={ onCancel }
-			popoverProps={ { placement: 'bottom-start' } }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					className="cortext-multiselect-edit__toggle"
-					variant="tertiary"
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-					aria-label={ label }
+		<>
+			<Button
+				ref={ setAnchor }
+				className="cortext-multiselect-edit__toggle"
+				variant="tertiary"
+				aria-expanded
+				aria-label={ label }
+			>
+				{ triggerContent }
+			</Button>
+			{ anchor ? (
+				<Popover
+					anchor={ anchor }
+					placement="bottom-start"
+					onClose={ onCancel }
+					focusOnMount="firstElement"
 				>
-					{ triggerLabel }
-				</Button>
-			) }
-			renderContent={ () => (
-				<div className="cortext-multiselect-edit__popover">
-					<FormTokenField
-						value={ tokens }
-						suggestions={ suggestions }
-						onChange={ handleChange }
-						label=""
-						__experimentalExpandOnFocus
-						__experimentalShowHowTo={ false }
-						__nextHasNoMarginBottom
+					<EditOptionsPopover
+						recordId={ recordId }
+						fieldType="multiselect"
+						initialOptions={ items }
+						value={ current }
+						onOptionsSaved={ onOptionsSaved }
+						onPick={ handleToggle }
 					/>
-				</div>
-			) }
-		/>
+				</Popover>
+			) : null }
+		</>
 	);
 }

--- a/src/components/MultiselectEdit.js
+++ b/src/components/MultiselectEdit.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { Button, Popover } from '@wordpress/components';
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo, useRef, useState } from '@wordpress/element';
 
 import Chip from './fields/Chip';
 import EditOptionsPopover from './fields/EditOptionsPopover';
@@ -26,20 +26,24 @@ export default function MultiselectEdit( {
 	elements,
 	onSave,
 	onOptionsSaved,
+	onRowsChanged,
 	onCancel,
 	label,
 } ) {
 	const [ anchor, setAnchor ] = useState( null );
 	const items = useMemo( () => elements ?? [], [ elements ] );
-	const current = useMemo(
-		() => ( Array.isArray( value ) ? value : [] ),
-		[ value ]
+	const [ current, setCurrent ] = useState( () =>
+		Array.isArray( value ) ? value : []
 	);
+	const currentRef = useRef( current );
 
 	const handleToggle = ( optionValue ) => {
-		const next = current.includes( optionValue )
-			? current.filter( ( v ) => v !== optionValue )
-			: [ ...current, optionValue ];
+		const selected = currentRef.current;
+		const next = selected.includes( optionValue )
+			? selected.filter( ( v ) => v !== optionValue )
+			: [ ...selected, optionValue ];
+		currentRef.current = next;
+		setCurrent( next );
 		onSave( next );
 	};
 
@@ -86,6 +90,7 @@ export default function MultiselectEdit( {
 						initialOptions={ items }
 						value={ current }
 						onOptionsSaved={ onOptionsSaved }
+						onRowsChanged={ onRowsChanged }
 						onPick={ handleToggle }
 					/>
 				</Popover>

--- a/src/components/MultiselectEdit.js
+++ b/src/components/MultiselectEdit.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { Button, Popover } from '@wordpress/components';
-import { useMemo, useRef, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 import Chip from './fields/Chip';
 import EditOptionsPopover from './fields/EditOptionsPopover';
@@ -37,6 +37,12 @@ export default function MultiselectEdit( {
 		Array.isArray( value ) ? value : []
 	);
 	const currentRef = useRef( current );
+
+	useEffect( () => {
+		const next = Array.isArray( value ) ? value : [];
+		currentRef.current = next;
+		setCurrent( next );
+	}, [ value ] );
 
 	const handleToggle = ( optionValue ) => {
 		const selected = currentRef.current;

--- a/src/components/fields/Chip.js
+++ b/src/components/fields/Chip.js
@@ -1,3 +1,11 @@
+import { __ } from '@wordpress/i18n';
+
+import {
+	optionColorVars,
+	isOptionColorName,
+	resolveDisplayColor,
+} from './optionPalette';
+
 // Picks a readable foreground for a hex background by computing relative
 // luminance. Returns null for non-hex CSS colors (named, rgb(), hsl(), …),
 // where we let the inherited cell text color stand.
@@ -31,15 +39,66 @@ function parseHex( value ) {
 	];
 }
 
-export default function Chip( { label, color } ) {
-	if ( ! color || typeof color !== 'string' ) {
+function RemoveButton( { onRemove, foreground } ) {
+	return (
+		<button
+			type="button"
+			className="cortext-chip__remove"
+			aria-label={ __( 'Remove', 'cortext' ) }
+			style={ foreground ? { color: foreground } : undefined }
+			onClick={ ( event ) => {
+				event.preventDefault();
+				event.stopPropagation();
+				onRemove();
+			} }
+		>
+			×
+		</button>
+	);
+}
+
+// Two color shapes are accepted: a palette name (`'blue'`) resolved
+// through the Cortext shell tokens so chips re-skin under light/dark, or
+// a raw CSS color (legacy seeds, Notion imports). The `'default'` palette
+// name renders as the neutral chip so saved options can opt out of color
+// without dropping the field. When `onRemove` is provided, a `×` button
+// is rendered inside the pill so dismiss controls live with the chip
+// background instead of as an external sibling — matches Notion's
+// selected-token strip in the multiselect picker.
+export default function Chip( { label, color, onRemove } ) {
+	const effective = resolveDisplayColor( color, label );
+
+	if ( effective === 'default' ) {
 		return (
 			<span className="cortext-chip cortext-chip--neutral">
 				{ label }
+				{ onRemove ? <RemoveButton onRemove={ onRemove } /> : null }
 			</span>
 		);
 	}
-	const background = color.trim();
+
+	if ( isOptionColorName( effective ) ) {
+		const vars = optionColorVars( effective );
+		return (
+			<span
+				className={ `cortext-chip cortext-chip--${ effective }` }
+				style={ {
+					backgroundColor: vars.background,
+					color: vars.foreground,
+				} }
+			>
+				{ label }
+				{ onRemove ? (
+					<RemoveButton
+						onRemove={ onRemove }
+						foreground={ vars.foreground }
+					/>
+				) : null }
+			</span>
+		);
+	}
+
+	const background = effective.trim();
 	const foreground = foregroundFor( background );
 	const style = { backgroundColor: background };
 	if ( foreground ) {
@@ -48,6 +107,9 @@ export default function Chip( { label, color } ) {
 	return (
 		<span className="cortext-chip" style={ style }>
 			{ label }
+			{ onRemove ? (
+				<RemoveButton onRemove={ onRemove } foreground={ foreground } />
+			) : null }
 		</span>
 	);
 }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -58,6 +58,7 @@ export default function ColumnHeaderActions( {
 	view,
 	onChangeView,
 	onFieldOptionsSaved,
+	onRowsChanged,
 } ) {
 	const anchorRef = useRef( null );
 	const [ targets, setTargets ] = useState( [] );
@@ -141,6 +142,7 @@ export default function ColumnHeaderActions( {
 							view={ view }
 							onChangeView={ onChangeView }
 							onFieldOptionsSaved={ onFieldOptionsSaved }
+							onRowsChanged={ onRowsChanged }
 						/>,
 						target.th,
 						target.key
@@ -162,6 +164,7 @@ function FieldActions( {
 	view,
 	onChangeView,
 	onFieldOptionsSaved,
+	onRowsChanged,
 } ) {
 	const [ isRenaming, setIsRenaming ] = useState( false );
 	const [ isFormatting, setIsFormatting ] = useState( false );
@@ -483,6 +486,7 @@ function FieldActions( {
 						onOptionsSaved={ ( nextOptions ) =>
 							onFieldOptionsSaved?.( recordId, nextOptions )
 						}
+						onRowsChanged={ onRowsChanged }
 					/>
 				</Popover>
 			) : null }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -6,6 +6,7 @@ import {
 	Icon,
 	MenuGroup,
 	MenuItem,
+	Popover,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
@@ -21,14 +22,17 @@ import {
 import { chevronRight, plus } from '@wordpress/icons';
 
 import AddFieldPopover from './AddFieldPopover';
+import EditOptionsPopover from './EditOptionsPopover';
 import FieldFormatPopover from './FieldFormatPopover';
 import RenameFieldInline from './RenameFieldInline';
+import { elementsFromOptions } from '../../hooks/fieldMapping';
 import {
 	useDeleteField,
 	useDuplicateField,
 } from '../../hooks/useFieldMutations';
 import { GHOST_FIELD_ID, TITLE_FIELD_ID } from '../dataViewColumns';
 
+const TYPES_WITH_OPTIONS = new Set( [ 'select', 'multiselect' ] );
 const FORMATTABLE_TYPES = new Set( [ 'number', 'date', 'datetime' ] );
 
 // Projects two kinds of triggers into the DataViews table header:
@@ -53,6 +57,7 @@ export default function ColumnHeaderActions( {
 	collectionId,
 	view,
 	onChangeView,
+	onFieldOptionsSaved,
 } ) {
 	const anchorRef = useRef( null );
 	const [ targets, setTargets ] = useState( [] );
@@ -135,6 +140,7 @@ export default function ColumnHeaderActions( {
 							collectionId={ collectionId }
 							view={ view }
 							onChangeView={ onChangeView }
+							onFieldOptionsSaved={ onFieldOptionsSaved }
 						/>,
 						target.th,
 						target.key
@@ -150,17 +156,33 @@ export default function ColumnHeaderActions( {
 	);
 }
 
-function FieldActions( { recordId, collectionId, view, onChangeView } ) {
+function FieldActions( {
+	recordId,
+	collectionId,
+	view,
+	onChangeView,
+	onFieldOptionsSaved,
+} ) {
 	const [ isRenaming, setIsRenaming ] = useState( false );
 	const [ isFormatting, setIsFormatting ] = useState( false );
+	const [ isEditingOptions, setIsEditingOptions ] = useState( false );
 	const [ confirmDelete, setConfirmDelete ] = useState( false );
 	const formatItemRef = useRef( null );
 	const closeTimerRef = useRef( null );
+	const optionsAnchorRef = useRef( null );
 	const duplicate = useDuplicateField( collectionId );
 	const remove = useDeleteField( collectionId );
 	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
 	const fieldType = record?.meta?.type;
 	const canFormat = FORMATTABLE_TYPES.has( fieldType );
+	const supportsOptions = TYPES_WITH_OPTIONS.has( fieldType );
+	const initialOptions = useMemo(
+		() =>
+			supportsOptions
+				? elementsFromOptions( record?.meta?.options ) || []
+				: [],
+		[ supportsOptions, record?.meta?.options ]
+	);
 
 	// Format submenu uses a hover-with-grace pattern: the panel stays
 	// visible while the cursor is over either the trigger row or the
@@ -274,7 +296,10 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 	}
 
 	return (
-		<span className="cortext-column-header-actions">
+		<span
+			className="cortext-column-header-actions"
+			ref={ optionsAnchorRef }
+		>
 			<Dropdown
 				contentClassName="cortext-field-actions-popover"
 				popoverProps={ { placement: 'bottom-start' } }
@@ -328,6 +353,16 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 									}
 								>
 									{ __( 'Edit field', 'cortext' ) }
+								</MenuItem>
+							) : null }
+							{ supportsOptions ? (
+								<MenuItem
+									onClick={ () => {
+										onClose();
+										setIsEditingOptions( true );
+									} }
+								>
+									{ __( 'Edit options', 'cortext' ) }
 								</MenuItem>
 							) : null }
 						</MenuGroup>
@@ -432,6 +467,24 @@ function FieldActions( { recordId, collectionId, view, onChangeView } ) {
 						'cortext'
 					) }
 				</ConfirmDialog>
+			) : null }
+			{ isEditingOptions && supportsOptions ? (
+				<Popover
+					anchor={ optionsAnchorRef.current }
+					placement="bottom-start"
+					onClose={ () => setIsEditingOptions( false ) }
+					focusOnMount="firstElement"
+					className="cortext-edit-options-popover-host"
+				>
+					<EditOptionsPopover
+						recordId={ recordId }
+						fieldType={ fieldType }
+						initialOptions={ initialOptions }
+						onOptionsSaved={ ( nextOptions ) =>
+							onFieldOptionsSaved?.( recordId, nextOptions )
+						}
+					/>
+				</Popover>
 			) : null }
 		</span>
 	);

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -601,6 +601,7 @@ function FieldActions( {
 							onFieldOptionsSaved?.( recordId, nextOptions )
 						}
 						onRowsChanged={ onRowsChanged }
+						onRequestClose={ () => setIsEditingOptions( false ) }
 					/>
 				</Popover>
 			) : null }

--- a/src/components/fields/DeleteOptionDialog.js
+++ b/src/components/fields/DeleteOptionDialog.js
@@ -1,0 +1,150 @@
+import { __, sprintf, _n } from '@wordpress/i18n';
+import {
+	SelectControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import { useEffect, useMemo, useState } from '@wordpress/element';
+
+import { useOptionUsage } from '../../hooks/useFieldMutations';
+
+const ACTION_CLEAR = 'clear';
+const ACTION_REPLACE = 'replace';
+
+// Lazy-fetches the row count for the option being deleted, then asks the
+// user to either clear the value across those rows or replace it with
+// another option. When no row uses the value, `onConfirm` fires
+// immediately with no migration so the parent can simply drop the option
+// without prompting.
+export default function DeleteOptionDialog( {
+	recordId,
+	option,
+	remainingOptions,
+	onConfirm,
+	onCancel,
+} ) {
+	const usage = useOptionUsage();
+	const [ count, setCount ] = useState( null );
+	const [ action, setAction ] = useState( ACTION_CLEAR );
+	const [ replacement, setReplacement ] = useState(
+		remainingOptions[ 0 ]?.value ?? ''
+	);
+	const [ submitting, setSubmitting ] = useState( false );
+
+	useEffect( () => {
+		let cancelled = false;
+		usage
+			.run( recordId, option.value )
+			.then( ( next ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setCount( next );
+				if ( next === 0 ) {
+					onConfirm( null );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					onConfirm( null );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ recordId, option.value ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	const replacementChoices = useMemo(
+		() =>
+			remainingOptions.map( ( o ) => ( {
+				value: o.value,
+				label: o.label || o.value,
+			} ) ),
+		[ remainingOptions ]
+	);
+
+	if ( count === null || count === 0 ) {
+		return null;
+	}
+
+	const canReplace = replacementChoices.length > 0;
+
+	const handleConfirm = async () => {
+		setSubmitting( true );
+		try {
+			if ( action === ACTION_REPLACE && canReplace && replacement ) {
+				await onConfirm( {
+					from: option.value,
+					action: ACTION_REPLACE,
+					to: replacement,
+				} );
+			} else {
+				await onConfirm( {
+					from: option.value,
+					action: ACTION_CLEAR,
+				} );
+			}
+		} finally {
+			setSubmitting( false );
+		}
+	};
+
+	return (
+		<ConfirmDialog
+			onConfirm={ handleConfirm }
+			onCancel={ onCancel }
+			confirmButtonText={
+				submitting
+					? __( 'Working…', 'cortext' )
+					: __( 'Delete option', 'cortext' )
+			}
+		>
+			<p>
+				{ sprintf(
+					/* translators: 1: option label, 2: number of rows referencing it */
+					_n(
+						'%2$d row currently uses "%1$s".',
+						'%2$d rows currently use "%1$s".',
+						count,
+						'cortext'
+					),
+					option.label || option.value,
+					count
+				) }
+			</p>
+			<div className="cortext-delete-option-dialog__choice">
+				<label htmlFor="cortext-delete-option-action-clear">
+					<input
+						id="cortext-delete-option-action-clear"
+						type="radio"
+						name="cortext-delete-option-action"
+						checked={ action === ACTION_CLEAR }
+						onChange={ () => setAction( ACTION_CLEAR ) }
+					/>
+					{ __( 'Clear the value on those rows.', 'cortext' ) }
+				</label>
+				<label htmlFor="cortext-delete-option-action-replace">
+					<input
+						id="cortext-delete-option-action-replace"
+						type="radio"
+						name="cortext-delete-option-action"
+						checked={ action === ACTION_REPLACE }
+						disabled={ ! canReplace }
+						onChange={ () => setAction( ACTION_REPLACE ) }
+					/>
+					{ __( 'Replace with another option.', 'cortext' ) }
+				</label>
+				{ action === ACTION_REPLACE && canReplace ? (
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Replacement', 'cortext' ) }
+						value={ replacement }
+						options={ replacementChoices }
+						onChange={ setReplacement }
+					/>
+				) : null }
+			</div>
+		</ConfirmDialog>
+	);
+}

--- a/src/components/fields/DeleteOptionDialog.js
+++ b/src/components/fields/DeleteOptionDialog.js
@@ -30,6 +30,7 @@ export default function DeleteOptionDialog( {
 		remainingOptions[ 0 ]?.value ?? ''
 	);
 	const [ submitting, setSubmitting ] = useState( false );
+	const [ error, setError ] = useState( null );
 
 	useEffect( () => {
 		let cancelled = false;
@@ -46,7 +47,12 @@ export default function DeleteOptionDialog( {
 			} )
 			.catch( () => {
 				if ( ! cancelled ) {
-					onConfirm( null );
+					setError(
+						__(
+							'Could not check whether rows use this option.',
+							'cortext'
+						)
+					);
 				}
 			} );
 		return () => {
@@ -62,6 +68,18 @@ export default function DeleteOptionDialog( {
 			} ) ),
 		[ remainingOptions ]
 	);
+
+	if ( error ) {
+		return (
+			<ConfirmDialog
+				onConfirm={ onCancel }
+				onCancel={ onCancel }
+				confirmButtonText={ __( 'Close', 'cortext' ) }
+			>
+				<p>{ error }</p>
+			</ConfirmDialog>
+		);
+	}
 
 	if ( count === null || count === 0 ) {
 		return null;

--- a/src/components/fields/EditOptionsPopover.js
+++ b/src/components/fields/EditOptionsPopover.js
@@ -1,0 +1,541 @@
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Icon,
+	MenuGroup,
+	MenuItem,
+	Notice,
+	Popover,
+} from '@wordpress/components';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { dragHandle, moreHorizontal } from '@wordpress/icons';
+import {
+	DndContext,
+	PointerSensor,
+	closestCenter,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core';
+import {
+	SortableContext,
+	arrayMove,
+	useSortable,
+	verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+
+import Chip from './Chip';
+import OptionMenu from './OptionMenu';
+import { isOptionColorName, pickNextOptionColor } from './optionPalette';
+import DeleteOptionDialog from './DeleteOptionDialog';
+import {
+	useFlushFieldRecord,
+	useUpdateFieldOptions,
+} from '../../hooks/useFieldMutations';
+
+// Inlined to avoid pulling `@dnd-kit/utilities` into our explicit deps; it
+// only ships `CSS.Transform.toString({x, y, scaleX, scaleY})`.
+function transformToString( transform ) {
+	if ( ! transform ) {
+		return undefined;
+	}
+	const { x = 0, y = 0, scaleX = 1, scaleY = 1 } = transform;
+	return `translate3d(${ x }px, ${ y }px, 0) scaleX(${ scaleX }) scaleY(${ scaleY })`;
+}
+
+function slugify( label ) {
+	return (
+		String( label )
+			.toLowerCase()
+			.trim()
+			.replace( /[^\p{L}\p{N}]+/gu, '-' )
+			.replace( /^-+|-+$/g, '' ) || 'option'
+	);
+}
+
+function uniqueValue( base, taken ) {
+	if ( ! taken.includes( base ) ) {
+		return base;
+	}
+	let n = 2;
+	while ( taken.includes( `${ base }-${ n }` ) ) {
+		n++;
+	}
+	return `${ base }-${ n }`;
+}
+
+function SortableOptionRow( {
+	option,
+	isMenuOpen,
+	isSelected,
+	onPick,
+	onToggleMenu,
+	onCloseMenu,
+	onLabelChange,
+	onColorChange,
+	onDelete,
+} ) {
+	const { attributes, listeners, setNodeRef, transform, transition } =
+		useSortable( { id: option.value } );
+	const moreRef = useRef( null );
+	const style = {
+		transform: transformToString( transform ),
+		transition,
+	};
+	const displayColor = isOptionColorName( option.color )
+		? option.color
+		: undefined;
+	const isPickable = typeof onPick === 'function';
+
+	return (
+		<div
+			ref={ setNodeRef }
+			style={ style }
+			className={
+				'cortext-edit-options-popover__row' +
+				( isSelected ? ' is-selected' : '' )
+			}
+		>
+			<button
+				type="button"
+				className="cortext-edit-options-popover__handle"
+				aria-label={ __( 'Reorder option', 'cortext' ) }
+				{ ...attributes }
+				{ ...listeners }
+			>
+				<Icon icon={ dragHandle } size={ 18 } />
+			</button>
+			{ isPickable ? (
+				<button
+					type="button"
+					className="cortext-edit-options-popover__pick"
+					onClick={ onPick }
+					aria-pressed={ isSelected }
+				>
+					<Chip label={ option.label } color={ displayColor } />
+				</button>
+			) : (
+				<span className="cortext-edit-options-popover__row-chip">
+					<Chip label={ option.label } color={ displayColor } />
+				</span>
+			) }
+			<Button
+				ref={ moreRef }
+				icon={ moreHorizontal }
+				size="small"
+				className="cortext-edit-options-popover__more"
+				label={ __( 'Edit option', 'cortext' ) }
+				onClick={ onToggleMenu }
+				aria-haspopup="menu"
+				aria-expanded={ isMenuOpen }
+			/>
+			{ isMenuOpen ? (
+				<Popover
+					anchor={ moreRef.current }
+					placement="right-start"
+					offset={ 8 }
+					onClose={ onCloseMenu }
+					className="cortext-edit-options-popover__submenu"
+				>
+					<OptionMenu
+						option={ option }
+						onLabelChange={ onLabelChange }
+						onColorChange={ onColorChange }
+						onDelete={ onDelete }
+						onClose={ onCloseMenu }
+					/>
+				</Popover>
+			) : null }
+		</div>
+	);
+}
+
+// Unified options popover used by both the column-header "Edit options"
+// surface and the cell editor. When `onPick` is provided, the chip area
+// of each row becomes a click target that commits the option as the
+// cell's value; without `onPick` it is just a label and rows are pure
+// management. The single search-or-create input at the top filters the
+// list and offers a "Create [label]" suggestion when typing a value
+// that doesn't exist yet, matching Notion's pattern.
+//
+// Local state mirrors the saved option list so user edits feel instant;
+// each mutation calls `useUpdateFieldOptions` which refetches the field
+// record into the entity store, so the next render syncs up via
+// `initialOptions`. Deleting an option that has rows referencing it
+// pops `DeleteOptionDialog` so the user can clear or replace.
+export default function EditOptionsPopover( {
+	recordId,
+	fieldType,
+	initialOptions,
+	value,
+	onPick,
+	onOptionsSaved,
+} ) {
+	const update = useUpdateFieldOptions();
+	const flush = useFlushFieldRecord();
+	const [ options, setOptions ] = useState( () => initialOptions || [] );
+	const [ deleting, setDeleting ] = useState( null );
+	const [ search, setSearch ] = useState( '' );
+	const [ openMenuValue, setOpenMenuValue ] = useState( null );
+	const searchInputRef = useRef( null );
+	const lastInitialRef = useRef( initialOptions );
+	const dirtyRef = useRef( false );
+
+	useEffect( () => {
+		if ( lastInitialRef.current !== initialOptions ) {
+			lastInitialRef.current = initialOptions;
+			setOptions( initialOptions || [] );
+		}
+	}, [ initialOptions ] );
+
+	// On unmount, push the latest field record back into the entity
+	// store so the row cells (which subscribe through useEntityRecords)
+	// reflect any options the user added/recolored/deleted while the
+	// popover was open. Saves go through a write-only path that skips
+	// the store update so the table doesn't tear down the open editor
+	// on every keystroke; this is the catch-up.
+	useEffect( () => {
+		return () => {
+			if ( dirtyRef.current && recordId ) {
+				flush( recordId );
+			}
+		};
+	}, [ flush, recordId ] );
+
+	const sensors = useSensors(
+		useSensor( PointerSensor, { activationConstraint: { distance: 4 } } )
+	);
+
+	const isPickMode = typeof onPick === 'function';
+	const isMultiselect = fieldType === 'multiselect';
+	const selectedValues = useMemo( () => {
+		if ( ! isPickMode ) {
+			return new Set();
+		}
+		if ( Array.isArray( value ) ) {
+			return new Set( value );
+		}
+		if ( value === null || value === undefined || value === '' ) {
+			return new Set();
+		}
+		return new Set( [ value ] );
+	}, [ isPickMode, value ] );
+
+	const commit = useCallback(
+		async ( nextOptions, migration ) => {
+			setOptions( nextOptions );
+			const migrations = migration ? [ migration ] : undefined;
+			try {
+				const result = await update.run(
+					recordId,
+					nextOptions,
+					migrations
+				);
+				dirtyRef.current = true;
+				const savedOptions = Array.isArray( result?.options )
+					? result.options
+					: nextOptions;
+				onOptionsSaved?.( savedOptions );
+				return true;
+			} catch {
+				// surfaced via update.error.
+				return false;
+			}
+		},
+		[ onOptionsSaved, recordId, update ]
+	);
+
+	const handleLabelChange = ( optionValue, label ) => {
+		const next = options.map( ( o ) =>
+			o.value === optionValue ? { ...o, label } : o
+		);
+		commit( next );
+	};
+
+	const handleColorChange = async ( optionValue, color ) => {
+		const next = options.map( ( o ) => {
+			if ( o.value !== optionValue ) {
+				return o;
+			}
+			if ( ! color || ! isOptionColorName( color ) ) {
+				const cleared = { ...o };
+				delete cleared.color;
+				return cleared;
+			}
+			return { ...o, color };
+		} );
+		const didSave = await commit( next );
+		if ( ! didSave ) {
+			return;
+		}
+		setOpenMenuValue( null );
+	};
+
+	const handleAdd = async ( rawLabel ) => {
+		const label = ( rawLabel ?? search ).trim();
+		if ( ! label ) {
+			return null;
+		}
+		const taken = options.map( ( o ) => o.value );
+		const newValue = uniqueValue( slugify( label ), taken );
+		const color = pickNextOptionColor( options );
+		const created = { value: newValue, label, color };
+		await commit( [ ...options, created ] );
+		setSearch( '' );
+		return created;
+	};
+
+	const handleDragEnd = ( event ) => {
+		const { active, over } = event;
+		if ( ! over || active.id === over.id ) {
+			return;
+		}
+		const from = options.findIndex( ( o ) => o.value === active.id );
+		const to = options.findIndex( ( o ) => o.value === over.id );
+		if ( from < 0 || to < 0 ) {
+			return;
+		}
+		commit( arrayMove( options, from, to ) );
+	};
+
+	const handleDeleteRequest = ( option ) => {
+		setOpenMenuValue( null );
+		setDeleting( option );
+	};
+
+	const remainingForReplacement = useMemo(
+		() =>
+			deleting
+				? options.filter( ( o ) => o.value !== deleting.value )
+				: [],
+		[ deleting, options ]
+	);
+
+	const handleDeleteConfirm = async ( migration ) => {
+		const target = deleting;
+		const next = options.filter( ( o ) => o.value !== target.value );
+		await commit( next, migration );
+		setDeleting( null );
+	};
+
+	const sortableIds = useMemo(
+		() => options.map( ( o ) => o.value ),
+		[ options ]
+	);
+
+	const trimmedSearch = search.trim();
+	const lowerSearch = trimmedSearch.toLowerCase();
+	const filteredOptions = useMemo( () => {
+		if ( ! trimmedSearch ) {
+			return options;
+		}
+		return options.filter( ( o ) =>
+			String( o.label ).toLowerCase().includes( lowerSearch )
+		);
+	}, [ options, trimmedSearch, lowerSearch ] );
+	const exactMatch = useMemo(
+		() =>
+			options.find(
+				( o ) => String( o.label ).toLowerCase() === lowerSearch
+			),
+		[ options, lowerSearch ]
+	);
+	const canCreate = trimmedSearch && ! exactMatch;
+	const previewColor = useMemo(
+		() => ( canCreate ? pickNextOptionColor( options ) : null ),
+		[ canCreate, options ]
+	);
+	const selectedOptions = useMemo( () => {
+		if ( ! isPickMode || selectedValues.size === 0 ) {
+			return [];
+		}
+		// Preserve the cell's value order rather than the option list's
+		// order so newly toggled chips appear at the end where the user
+		// last interacted.
+		const ordered =
+			Array.isArray( value ) && value.length
+				? value
+				: [ ...selectedValues ];
+		return ordered
+			.map( ( v ) => options.find( ( o ) => o.value === v ) )
+			.filter( Boolean );
+	}, [ isPickMode, selectedValues, value, options ] );
+
+	const handleRemoveSelected = ( optionValue ) => {
+		if ( isMultiselect ) {
+			onPick( optionValue );
+		} else {
+			onPick( null );
+		}
+	};
+
+	const inputPrompt = isPickMode
+		? __( 'Search or create option', 'cortext' )
+		: __( 'Add option', 'cortext' );
+
+	const handleCreateAndPick = async () => {
+		const created = await handleAdd();
+		if ( isPickMode && created?.value ) {
+			await onPick( created.value );
+		}
+	};
+
+	const handlePickExisting = async ( optionValue ) => {
+		await onPick( optionValue );
+	};
+
+	return (
+		<div className="cortext-edit-options-popover">
+			{ update.error ? (
+				<Notice status="error" isDismissible={ false }>
+					{ update.error?.message ||
+						__( 'Could not save options.', 'cortext' ) }
+				</Notice>
+			) : null }
+			<div
+				className={
+					'cortext-edit-options-popover__token-input' +
+					( selectedOptions.length === 0 ? ' is-empty' : '' )
+				}
+				onPointerDown={ ( event ) => {
+					if ( event.target === event.currentTarget ) {
+						searchInputRef.current?.focus();
+					}
+				} }
+			>
+				{ selectedOptions.map( ( opt ) => (
+					<Chip
+						key={ opt.value }
+						label={ opt.label }
+						color={ opt.color }
+						onRemove={ () => handleRemoveSelected( opt.value ) }
+					/>
+				) ) }
+				<input
+					ref={ searchInputRef }
+					type="text"
+					className="cortext-edit-options-popover__token-input-field"
+					value={ search }
+					placeholder={
+						selectedOptions.length > 0 ? '' : inputPrompt
+					}
+					aria-label={ inputPrompt }
+					onChange={ ( event ) => setSearch( event.target.value ) }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'Enter' && canCreate ) {
+							event.preventDefault();
+							if ( isPickMode ) {
+								handleCreateAndPick();
+							} else {
+								handleAdd();
+							}
+							return;
+						}
+						if (
+							event.key === 'Backspace' &&
+							search === '' &&
+							selectedOptions.length > 0
+						) {
+							event.preventDefault();
+							handleRemoveSelected(
+								selectedOptions[ selectedOptions.length - 1 ]
+									.value
+							);
+						}
+					} }
+				/>
+			</div>
+			{ filteredOptions.length === 0 && ! canCreate ? (
+				<p className="cortext-edit-options-popover__empty">
+					{ trimmedSearch
+						? __( 'No matching options.', 'cortext' )
+						: __( 'No options yet.', 'cortext' ) }
+				</p>
+			) : (
+				<DndContext
+					sensors={ sensors }
+					collisionDetection={ closestCenter }
+					onDragEnd={ handleDragEnd }
+				>
+					<SortableContext
+						items={ sortableIds }
+						strategy={ verticalListSortingStrategy }
+					>
+						<div className="cortext-edit-options-popover__list">
+							{ filteredOptions.map( ( option ) => (
+								<SortableOptionRow
+									key={ option.value }
+									option={ option }
+									isSelected={ selectedValues.has(
+										option.value
+									) }
+									isMenuOpen={
+										openMenuValue === option.value
+									}
+									onPick={
+										isPickMode
+											? () =>
+													handlePickExisting(
+														option.value
+													)
+											: undefined
+									}
+									onToggleMenu={ () =>
+										setOpenMenuValue( ( prev ) =>
+											prev === option.value
+												? null
+												: option.value
+										)
+									}
+									onCloseMenu={ () =>
+										setOpenMenuValue( ( prev ) =>
+											prev === option.value ? null : prev
+										)
+									}
+									onLabelChange={ ( label ) =>
+										handleLabelChange( option.value, label )
+									}
+									onColorChange={ ( color ) =>
+										handleColorChange( option.value, color )
+									}
+									onDelete={ () =>
+										handleDeleteRequest( option )
+									}
+								/>
+							) ) }
+						</div>
+					</SortableContext>
+				</DndContext>
+			) }
+			{ canCreate ? (
+				<MenuGroup>
+					<MenuItem
+						className="cortext-edit-options-popover__create"
+						onClick={
+							isPickMode ? handleCreateAndPick : () => handleAdd()
+						}
+					>
+						<span className="cortext-edit-options-popover__create-label">
+							{ __( 'Create', 'cortext' ) }
+						</span>
+						<Chip label={ trimmedSearch } color={ previewColor } />
+					</MenuItem>
+				</MenuGroup>
+			) : null }
+			{ deleting ? (
+				<DeleteOptionDialog
+					recordId={ recordId }
+					option={ deleting }
+					remainingOptions={ remainingForReplacement }
+					onConfirm={ handleDeleteConfirm }
+					onCancel={ () => setDeleting( null ) }
+				/>
+			) : null }
+		</div>
+	);
+}

--- a/src/components/fields/EditOptionsPopover.js
+++ b/src/components/fields/EditOptionsPopover.js
@@ -175,6 +175,7 @@ export default function EditOptionsPopover( {
 	value,
 	onPick,
 	onOptionsSaved,
+	onRowsChanged,
 } ) {
 	const update = useUpdateFieldOptions();
 	const flush = useFlushFieldRecord();
@@ -241,13 +242,16 @@ export default function EditOptionsPopover( {
 					? result.options
 					: nextOptions;
 				onOptionsSaved?.( savedOptions );
+				if ( migration ) {
+					onRowsChanged?.();
+				}
 				return true;
 			} catch {
 				// surfaced via update.error.
 				return false;
 			}
 		},
-		[ onOptionsSaved, recordId, update ]
+		[ onOptionsSaved, onRowsChanged, recordId, update ]
 	);
 
 	const handleLabelChange = ( optionValue, label ) => {
@@ -269,11 +273,7 @@ export default function EditOptionsPopover( {
 			}
 			return { ...o, color };
 		} );
-		const didSave = await commit( next );
-		if ( ! didSave ) {
-			return;
-		}
-		setOpenMenuValue( null );
+		await commit( next );
 	};
 
 	const handleAdd = async ( rawLabel ) => {
@@ -285,7 +285,11 @@ export default function EditOptionsPopover( {
 		const newValue = uniqueValue( slugify( label ), taken );
 		const color = pickNextOptionColor( options );
 		const created = { value: newValue, label, color };
-		await commit( [ ...options, created ] );
+		const didSave = await commit( [ ...options, created ] );
+		if ( ! didSave ) {
+			setOptions( options );
+			return null;
+		}
 		setSearch( '' );
 		return created;
 	};
@@ -319,8 +323,10 @@ export default function EditOptionsPopover( {
 	const handleDeleteConfirm = async ( migration ) => {
 		const target = deleting;
 		const next = options.filter( ( o ) => o.value !== target.value );
-		await commit( next, migration );
-		setDeleting( null );
+		const didSave = await commit( next, migration );
+		if ( didSave ) {
+			setDeleting( null );
+		}
 	};
 
 	const sortableIds = useMemo(

--- a/src/components/fields/EditOptionsPopover.js
+++ b/src/components/fields/EditOptionsPopover.js
@@ -221,6 +221,8 @@ export default function EditOptionsPopover( {
 		if ( ! openMenuValue || typeof onRequestClose !== 'function' ) {
 			return undefined;
 		}
+		// tech-debt.md#31: nested Popovers do not close the host picker
+		// when the first outside click is consumed by the child menu.
 		const onPointerDown = ( event ) => {
 			const target = event.target;
 			if ( ! target || typeof target.closest !== 'function' ) {

--- a/src/components/fields/EditOptionsPopover.js
+++ b/src/components/fields/EditOptionsPopover.js
@@ -176,6 +176,7 @@ export default function EditOptionsPopover( {
 	onPick,
 	onOptionsSaved,
 	onRowsChanged,
+	onRequestClose,
 } ) {
 	const update = useUpdateFieldOptions();
 	const flush = useFlushFieldRecord();
@@ -184,6 +185,7 @@ export default function EditOptionsPopover( {
 	const [ search, setSearch ] = useState( '' );
 	const [ openMenuValue, setOpenMenuValue ] = useState( null );
 	const searchInputRef = useRef( null );
+	const popoverRef = useRef( null );
 	const lastInitialRef = useRef( initialOptions );
 	const dirtyRef = useRef( false );
 
@@ -214,6 +216,29 @@ export default function EditOptionsPopover( {
 
 	const isPickMode = typeof onPick === 'function';
 	const isMultiselect = fieldType === 'multiselect';
+
+	useEffect( () => {
+		if ( ! openMenuValue || typeof onRequestClose !== 'function' ) {
+			return undefined;
+		}
+		const onPointerDown = ( event ) => {
+			const target = event.target;
+			if ( ! target || typeof target.closest !== 'function' ) {
+				return;
+			}
+			if (
+				popoverRef.current?.contains( target ) ||
+				target.closest( '.cortext-edit-options-popover__submenu' )
+			) {
+				return;
+			}
+			onRequestClose();
+		};
+		document.addEventListener( 'pointerdown', onPointerDown, true );
+		return () =>
+			document.removeEventListener( 'pointerdown', onPointerDown, true );
+	}, [ onRequestClose, openMenuValue ] );
+
 	const selectedValues = useMemo( () => {
 		if ( ! isPickMode ) {
 			return new Set();
@@ -396,7 +421,7 @@ export default function EditOptionsPopover( {
 	};
 
 	return (
-		<div className="cortext-edit-options-popover">
+		<div className="cortext-edit-options-popover" ref={ popoverRef }>
 			{ update.error ? (
 				<Notice status="error" isDismissible={ false }>
 					{ update.error?.message ||

--- a/src/components/fields/EditOptionsPopover.js
+++ b/src/components/fields/EditOptionsPopover.js
@@ -392,9 +392,10 @@ export default function EditOptionsPopover( {
 			Array.isArray( value ) && value.length
 				? value
 				: [ ...selectedValues ];
-		return ordered
-			.map( ( v ) => options.find( ( o ) => o.value === v ) )
-			.filter( Boolean );
+		return ordered.map( ( v ) => {
+			const found = options.find( ( o ) => o.value === v );
+			return found ?? { value: v, label: String( v ), color: 'default' };
+		} );
 	}, [ isPickMode, selectedValues, value, options ] );
 
 	const handleRemoveSelected = ( optionValue ) => {

--- a/src/components/fields/OptionMenu.js
+++ b/src/components/fields/OptionMenu.js
@@ -1,0 +1,181 @@
+import { __ } from '@wordpress/i18n';
+import { Icon, MenuGroup, MenuItem, TextControl } from '@wordpress/components';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { check, trash } from '@wordpress/icons';
+
+import {
+	OPTION_COLOR_NAMES,
+	optionColorVars,
+	resolveDisplayColor,
+} from './optionPalette';
+
+const DEFAULT_COLOR = 'default';
+
+function colorLabel( name ) {
+	switch ( name ) {
+		case 'default':
+			return __( 'Default', 'cortext' );
+		case 'gray':
+			return __( 'Gray', 'cortext' );
+		case 'brown':
+			return __( 'Brown', 'cortext' );
+		case 'orange':
+			return __( 'Orange', 'cortext' );
+		case 'yellow':
+			return __( 'Yellow', 'cortext' );
+		case 'green':
+			return __( 'Green', 'cortext' );
+		case 'blue':
+			return __( 'Blue', 'cortext' );
+		case 'purple':
+			return __( 'Purple', 'cortext' );
+		case 'pink':
+			return __( 'Pink', 'cortext' );
+		case 'red':
+			return __( 'Red', 'cortext' );
+		default:
+			return name;
+	}
+}
+
+// Small filled square shown next to each color in the menu and as the
+// option's color preview. The "default" name renders as the no-color
+// indicator (slash) so users can opt out of color without dropping the
+// option.
+export function SwatchSquare( { color } ) {
+	if ( ! color || color === DEFAULT_COLOR ) {
+		return (
+			<span className="cortext-edit-options-popover__swatch-square cortext-edit-options-popover__swatch-square--default" />
+		);
+	}
+	const vars = optionColorVars( color );
+	return (
+		<span
+			className="cortext-edit-options-popover__swatch-square"
+			style={ { backgroundColor: vars?.background } }
+		/>
+	);
+}
+
+// Per-option config menu, modeled on Notion's "..." popover: rename
+// input at the top, Delete, then a vertical list of named colors with a
+// check on the active one. Owns its own draft label state so typing
+// doesn't fire saves on every keystroke; commits on Enter or blur. Used
+// by both `EditOptionsPopover` (column-header surface) and the
+// cell-picker editors so editing chips works the same in either place.
+export default function OptionMenu( {
+	option,
+	onLabelChange,
+	onColorChange,
+	onDelete,
+	onClose,
+} ) {
+	// Use the same resolver the chip renderer uses so the check appears
+	// next to the color the user actually sees on the chip — including
+	// the hash fallback for legacy options that were saved without a
+	// stored color.
+	const current = resolveDisplayColor( option.color, option.label );
+	const [ draftLabel, setDraftLabel ] = useState( option.label );
+	const renameRef = useRef( null );
+
+	useEffect( () => {
+		setDraftLabel( option.label );
+	}, [ option.label ] );
+
+	// Focus the rename input when the menu opens so the user can start
+	// typing immediately. Imperative focus avoids the `autoFocus` lint
+	// warning while preserving the same affordance.
+	useEffect( () => {
+		const input = renameRef.current?.querySelector( 'input' );
+		input?.focus();
+		input?.select();
+	}, [] );
+
+	const commitLabel = () => {
+		const next = draftLabel.trim();
+		if ( ! next || next === option.label ) {
+			setDraftLabel( option.label );
+			return;
+		}
+		onLabelChange( next );
+	};
+
+	return (
+		<div className="cortext-edit-options-popover__menu">
+			<div
+				className="cortext-edit-options-popover__menu-rename"
+				ref={ renameRef }
+			>
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					hideLabelFromVision
+					label={ __( 'Option label', 'cortext' ) }
+					value={ draftLabel }
+					onChange={ setDraftLabel }
+					onBlur={ commitLabel }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'Enter' ) {
+							event.preventDefault();
+							commitLabel();
+							onClose();
+						}
+						if ( event.key === 'Escape' ) {
+							setDraftLabel( option.label );
+							onClose();
+						}
+					} }
+				/>
+			</div>
+			<MenuGroup>
+				<MenuItem
+					icon={ trash }
+					isDestructive
+					onClick={ () => {
+						onClose();
+						onDelete();
+					} }
+				>
+					{ __( 'Delete', 'cortext' ) }
+				</MenuItem>
+			</MenuGroup>
+			<div className="cortext-option-menu__colors">
+				<div
+					className="cortext-option-menu__colors-label"
+					role="presentation"
+				>
+					{ __( 'Colors', 'cortext' ) }
+				</div>
+				<ul className="cortext-option-menu__color-list" role="menu">
+					{ OPTION_COLOR_NAMES.map( ( name ) => {
+						const selected = name === current;
+						return (
+							<li key={ name } role="none">
+								<button
+									type="button"
+									role="menuitemradio"
+									aria-checked={ selected }
+									className={
+										'cortext-option-menu__color-item' +
+										( selected ? ' is-selected' : '' )
+									}
+									onClick={ () => onColorChange( name ) }
+								>
+									<span className="cortext-option-menu__color-check">
+										{ selected ? (
+											<Icon icon={ check } size={ 18 } />
+										) : null }
+									</span>
+									<SwatchSquare color={ name } />
+									<span className="cortext-option-menu__color-label">
+										{ colorLabel( name ) }
+									</span>
+								</button>
+							</li>
+						);
+					} ) }
+				</ul>
+			</div>
+		</div>
+	);
+}

--- a/src/components/fields/optionPalette.js
+++ b/src/components/fields/optionPalette.js
@@ -1,0 +1,84 @@
+// Mirrors `Cortext\OptionPalette::names()`. Stored as the option's
+// `color` value; resolved at render time via the SCSS tokens defined in
+// `src/styles/_tokens.scss` so chips re-skin under the editor's
+// light/dark theme.
+export const OPTION_COLOR_NAMES = [
+	'default',
+	'gray',
+	'brown',
+	'orange',
+	'yellow',
+	'green',
+	'blue',
+	'purple',
+	'pink',
+	'red',
+];
+
+export function isOptionColorName( value ) {
+	return typeof value === 'string' && OPTION_COLOR_NAMES.includes( value );
+}
+
+export function optionColorVars( name ) {
+	if ( ! isOptionColorName( name ) ) {
+		return null;
+	}
+	return {
+		background: `var(--cortext-option-${ name }-bg)`,
+		foreground: `var(--cortext-option-${ name }-fg)`,
+	};
+}
+
+// Stable display fallback for chips that have no `color` stored, or
+// whose stored color isn't one of our palette names (e.g. legacy hex
+// values from seeds or Notion imports). Always returns either
+// `'default'` (the explicit neutral opt-out) or one of the named
+// palette colors, so chips always resolve through the SCSS tokens and
+// re-skin under light/dark theme. Raw hex values would otherwise paint
+// the same color in both themes, leaving them stuck in the wrong
+// palette when the user toggles dark mode.
+export function resolveDisplayColor( color, label ) {
+	if ( color === 'default' ) {
+		return 'default';
+	}
+	if ( isOptionColorName( color ) ) {
+		return color;
+	}
+	const palette = OPTION_COLOR_NAMES.filter( ( c ) => c !== 'default' );
+	const text = String( label ?? '' );
+	if ( ! text ) {
+		return palette[ 0 ];
+	}
+	let hash = 0;
+	for ( let i = 0; i < text.length; i++ ) {
+		// Plain modulo arithmetic; bit ops are blocked by lint and the
+		// modest overflow risk doesn't matter for a stable color pick.
+		hash = ( hash * 31 + text.charCodeAt( i ) ) % 2147483647;
+	}
+	return palette[ hash % palette.length ];
+}
+
+// Picks the next palette color for a freshly created option, mirroring
+// Notion's behavior of giving each new chip a distinct hue. Ranks colors
+// by how often they already appear in the option list and returns the
+// least-used one, preferring earlier palette entries when tied. Skips
+// `'default'` so new chips are visually distinct out of the box.
+export function pickNextOptionColor( existingOptions ) {
+	const palette = OPTION_COLOR_NAMES.filter( ( c ) => c !== 'default' );
+	const used = new Map();
+	( existingOptions ?? [] ).forEach( ( o ) => {
+		if ( o?.color && o.color !== 'default' ) {
+			used.set( o.color, ( used.get( o.color ) ?? 0 ) + 1 );
+		}
+	} );
+	let best = palette[ 0 ];
+	let bestCount = used.get( best ) ?? Infinity;
+	for ( const name of palette ) {
+		const count = used.get( name ) ?? 0;
+		if ( count < bestCount ) {
+			best = name;
+			bestCount = count;
+		}
+	}
+	return best;
+}

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -2,38 +2,13 @@ import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 
 import EditableCell from '../components/EditableCell';
+import { elementsFromOptions } from './optionElements';
 
-// Parses stored option records into the DataViews `elements` shape.
-// Accepts a string shorthand (`'red'` becomes `{ value: 'red', label: 'red' }`)
-// or `{ value, label, color? }`. `color` is an optional CSS color the chip
-// renderer reads — tech-debt.md#11: DataViews's `Option` type doesn't
-// declare `color`, but it tolerates extra keys on element entries.
-export function elementsFromOptions( raw ) {
-	if ( ! raw ) {
-		return undefined;
-	}
-	let options;
-	try {
-		options = typeof raw === 'string' ? JSON.parse( raw ) : raw;
-	} catch {
-		return undefined;
-	}
-	if ( ! Array.isArray( options ) ) {
-		return undefined;
-	}
-	return options.map( ( option ) => {
-		if ( typeof option === 'string' ) {
-			return { value: option, label: option };
-		}
-		const value = option.value ?? '';
-		const label = option.label ?? option.value ?? '';
-		const element = { value, label };
-		if ( option.color ) {
-			element.color = option.color;
-		}
-		return element;
-	} );
-}
+// Re-export for existing call sites. The implementation lives in
+// `optionElements` (a leaf module with no React/component imports) so
+// it can be pulled into both UI code and Jest unit tests of
+// `useFieldMutations` without dragging `@wordpress/components` along.
+export { elementsFromOptions };
 
 // Parses stored format meta (number_format / date_format) into a plain
 // object. Same forgiving contract as `elementsFromOptions`: malformed

--- a/src/hooks/optionElements.js
+++ b/src/hooks/optionElements.js
@@ -1,0 +1,36 @@
+// Parses stored option records into the DataViews `elements` shape.
+// Accepts a string shorthand (`'red'` becomes `{ value: 'red', label: 'red' }`)
+// or `{ value, label, color? }`. `color` is an optional palette name (or
+// legacy CSS color) the chip renderer reads -- tech-debt.md#11: DataViews's
+// `Option` type doesn't declare `color`, but it tolerates extra keys on
+// element entries.
+//
+// Lives in a leaf module (no JS imports beyond plain helpers) so it can
+// be pulled into both UI code and Jest-only code paths without dragging
+// `@wordpress/components` along.
+export function elementsFromOptions( raw ) {
+	if ( ! raw ) {
+		return undefined;
+	}
+	let options;
+	try {
+		options = typeof raw === 'string' ? JSON.parse( raw ) : raw;
+	} catch {
+		return undefined;
+	}
+	if ( ! Array.isArray( options ) ) {
+		return undefined;
+	}
+	return options.map( ( option ) => {
+		if ( typeof option === 'string' ) {
+			return { value: option, label: option };
+		}
+		const value = option.value ?? '';
+		const label = option.label ?? option.value ?? '';
+		const element = { value, label };
+		if ( option.color ) {
+			element.color = option.color;
+		}
+		return element;
+	} );
+}

--- a/src/hooks/useColorScheme.js
+++ b/src/hooks/useColorScheme.js
@@ -19,6 +19,11 @@ function applyToRoot( resolved ) {
 	if ( root ) {
 		root.setAttribute( 'data-theme', resolved );
 	}
+	// Mirror onto body so Popover portals (mounted on body, outside the
+	// cortext-root subtree) can re-skin via `body[data-cortext-theme]`.
+	if ( typeof document !== 'undefined' && document.body ) {
+		document.body.setAttribute( 'data-cortext-theme', resolved );
+	}
 }
 
 // Single source of truth for shell color scheme. The PHP bootstrap script

--- a/src/hooks/useFieldMutations.js
+++ b/src/hooks/useFieldMutations.js
@@ -1,6 +1,8 @@
 import { useCallback, useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+
+import { elementsFromOptions } from './optionElements';
 
 // Field mutation hooks. Each hook returns `{ run, isBusy, error }`. UI
 // callers always pass numeric record IDs; conversion from DataViews row
@@ -124,6 +126,145 @@ export function useRenameField() {
 		[ saveEntityRecord, setIsBusy, setError ]
 	);
 	return { run, isBusy, error };
+}
+
+// Rewrites a select/multiselect field's option list and, when migrations
+// are supplied, applies them to row values in one server-side
+// transaction. The hook intentionally stays write-only: pushing a fresh
+// field record into core-data changes DataViews' `fields` prop and tears
+// down active cell editors. Callers that need live repainting keep local
+// option overrides until the editor closes and `useFlushFieldRecord`
+// catches the entity store up.
+export function useUpdateFieldOptions() {
+	const { isBusy, setIsBusy, error, setError } = useMutationState();
+	const run = useCallback(
+		async ( recordId, options, migrations ) => {
+			setIsBusy( true );
+			setError( null );
+			try {
+				const data = { options };
+				if ( Array.isArray( migrations ) && migrations.length > 0 ) {
+					data.migrations = migrations;
+				}
+				const result = await apiFetch( {
+					path: `/cortext/v1/fields/${ recordId }/options`,
+					method: 'POST',
+					data,
+				} );
+				return result;
+			} catch ( apiError ) {
+				setError( apiError );
+				throw apiError;
+			} finally {
+				setIsBusy( false );
+			}
+		},
+		[ setIsBusy, setError ]
+	);
+	return { run, isBusy, error };
+}
+
+// Refetches a single `crtxt_field` record and pushes it into the
+// entity store, replacing whatever is there. Called by the option
+// popover hosts when they unmount, so the row cells (which read
+// through `useEntityRecords`) catch up with whatever the user changed
+// while the popover was open. Kept separate from `useUpdateFieldOptions`
+// so saves stay write-only and free of cascading re-renders.
+export function useFlushFieldRecord() {
+	const { receiveEntityRecords } = useDispatch( 'core' );
+	return useCallback(
+		async ( recordId ) => {
+			if ( ! recordId ) {
+				return;
+			}
+			try {
+				const fresh = await apiFetch( {
+					path: `/wp/v2/crtxt_fields/${ recordId }?context=edit`,
+				} );
+				receiveEntityRecords(
+					'postType',
+					'crtxt_field',
+					[ fresh ],
+					undefined,
+					true
+				);
+			} catch {
+				// Best-effort: if the refetch fails, the cell stays on
+				// its previous chip set until the next read triggers a
+				// natural refetch.
+			}
+		},
+		[ receiveEntityRecords ]
+	);
+}
+
+// Appends a new option to a field's existing list and saves. Used by the
+// cell editors so users can create a chip on the fly while picking a
+// value, matching Notion's "Create [foo]" suggestion. Reads the
+// freshest options from the entity store at call time (rather than
+// subscribing through `useEntityRecord`) and generates a unique slug-style
+// `value` from the label, deduping against existing option values.
+export function useCreateFieldOption( recordId ) {
+	const update = useUpdateFieldOptions();
+
+	const run = useCallback(
+		async ( label ) => {
+			const trimmed = String( label ?? '' ).trim();
+			if ( ! trimmed || ! recordId ) {
+				return null;
+			}
+			const record = select( 'core' ).getEntityRecord(
+				'postType',
+				'crtxt_field',
+				recordId
+			);
+			if ( ! record ) {
+				// Field hasn't been resolved into the entity store yet.
+				// Refusing to write avoids clobbering the existing
+				// options with an empty list; the caller surfaces this
+				// as a no-op (the new chip simply doesn't appear).
+				return null;
+			}
+			const current = elementsFromOptions( record?.meta?.options ) || [];
+			const taken = current.map( ( o ) => o.value );
+			const value = uniqueSlug( trimmed, taken );
+			const next = [ ...current, { value, label: trimmed } ];
+			await update.run( recordId, next );
+			return { value, label: trimmed };
+		},
+		[ recordId, update ]
+	);
+
+	return { run, isBusy: update.isBusy, error: update.error };
+}
+
+function uniqueSlug( label, taken ) {
+	const base =
+		String( label )
+			.toLowerCase()
+			.trim()
+			.replace( /[^\p{L}\p{N}]+/gu, '-' )
+			.replace( /^-+|-+$/g, '' ) || 'option';
+	if ( ! taken.includes( base ) ) {
+		return base;
+	}
+	let n = 2;
+	while ( taken.includes( `${ base }-${ n }` ) ) {
+		n++;
+	}
+	return `${ base }-${ n }`;
+}
+
+export function useOptionUsage() {
+	const run = useCallback( async ( recordId, value ) => {
+		const result = await apiFetch( {
+			path: `/cortext/v1/fields/${ recordId }/options/${ encodeURIComponent(
+				value
+			) }/usage`,
+		} );
+		return Number( result?.count ?? 0 );
+	}, [] );
+	return { run };
 }
 
 export function useDeleteField( collectionId ) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1494,6 +1494,7 @@ tbody > tr > td:not(:first-child) {
 .cortext-chip {
 	display: inline-flex;
 	align-items: center;
+	gap: 4px;
 	padding: 0 $grid-unit-10;
 	height: $grid-unit-30;
 	line-height: 1;
@@ -1505,9 +1506,37 @@ tbody > tr > td:not(:first-child) {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 
+	// `default` renders as a dark gray pill so the explicit "Default"
+	// choice in the per-option color menu reads as a deliberate color
+	// rather than "no color" (which would be visually identical to the
+	// neutral gray of an unconfigured chip).
 	&--neutral {
-		background-color: $gray-100;
-		color: $gray-900;
+		background-color: $gray-700;
+		color: $white;
+	}
+
+	&__remove {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 14px;
+		height: 14px;
+		margin-inline-end: -4px;
+		padding: 0;
+		border: 0;
+		border-radius: 999px;
+		background: transparent;
+		color: inherit;
+		opacity: 0.6;
+		cursor: pointer;
+		font-size: 13px;
+		line-height: 1;
+
+		&:hover,
+		&:focus-visible {
+			opacity: 1;
+			background: rgba(0, 0, 0, 0.1);
+		}
 	}
 }
 
@@ -1561,6 +1590,277 @@ tbody > tr > td:not(:first-child) {
 		gap: $grid-unit-10;
 		padding: $grid-unit-15;
 		min-width: 280px;
+	}
+}
+
+.cortext-select-edit__placeholder {
+	color: $gray-700;
+}
+
+.cortext-edit-options-popover {
+	display: grid;
+	gap: $grid-unit-10;
+	padding: $grid-unit-15;
+	width: 320px;
+
+	&__header {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		color: $gray-700;
+	}
+
+	&__empty {
+		margin: 0;
+		color: $gray-700;
+		font-style: italic;
+	}
+
+	&__list {
+		display: grid;
+		gap: 2px;
+	}
+
+	&__row {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		padding: 2px;
+		border-radius: 2px;
+
+		&:hover {
+			background: $gray-100;
+		}
+	}
+
+	&__handle {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: $grid-unit-20;
+		height: $grid-unit-30;
+		cursor: grab;
+		background: transparent;
+		border: 0;
+		color: $gray-600;
+		padding: 0;
+		flex-shrink: 0;
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+
+	&__row-chip {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		align-items: center;
+		overflow: hidden;
+	}
+
+	&__pick {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		align-items: center;
+		background: transparent;
+		border: 0;
+		padding: 2px 0;
+		cursor: pointer;
+		text-align: start;
+
+		&:focus-visible {
+			outline: 2px solid var(--cortext-accent, #3858e9);
+			outline-offset: 1px;
+			border-radius: 2px;
+		}
+	}
+
+	&__row.is-selected &__pick {
+		font-weight: 600;
+	}
+
+	&__more {
+		flex-shrink: 0;
+	}
+
+	&__token-input {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: $grid-unit-05;
+		padding: $grid-unit-05;
+		border: 1px solid $gray-300;
+		border-radius: 2px;
+		background: $white;
+		min-height: $grid-unit-30;
+		cursor: text;
+
+		&:focus-within {
+			border-color: var(--cortext-accent, #3858e9);
+			box-shadow: 0 0 0 1px var(--cortext-accent, #3858e9);
+		}
+	}
+
+	// Higher specificity than wp-admin's `input[type="text"]` defaults
+	// (which paint a border + box-shadow). The wrapper carries the
+	// border/focus state; the input itself stays invisible so it reads
+	// as part of the same surface as the chips beside it. A tiny basis
+	// and explicit zero width override wp-admin's native input sizing so
+	// the cursor stays beside the trailing chip until the row is truly
+	// full.
+	input.cortext-edit-options-popover__token-input-field {
+		flex: 1 1 8px;
+		width: 0;
+		min-width: 8px;
+		border: 0;
+		outline: 0;
+		box-shadow: none;
+		background: transparent;
+		padding: 2px;
+		margin: 0;
+		font-size: 13px;
+		color: inherit;
+		min-height: $grid-unit-30 - 4px;
+		appearance: none;
+
+		&:focus,
+		&:focus-visible {
+			border: 0;
+			outline: 0;
+			box-shadow: none;
+		}
+
+		&::placeholder {
+			color: $gray-700;
+		}
+	}
+
+	&__create {
+
+		.components-menu-item__item {
+			display: inline-flex;
+			align-items: center;
+			gap: $grid-unit-05;
+			flex: 1 1 auto;
+		}
+	}
+
+	&__create-label {
+		color: $gray-700;
+	}
+
+	&__add {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+	}
+
+	// Per-option config menu (Notion-style "..." popover): rename input,
+	// Delete, then a vertical list of named colors.
+	&__menu {
+		width: 220px;
+	}
+
+	&__menu-popover {
+		padding: 0;
+	}
+
+	&__menu-rename {
+		padding: $grid-unit-10 $grid-unit-10 $grid-unit-05;
+	}
+
+	&__color-item {
+
+		.components-menu-items__item-icon {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+		}
+	}
+
+	&__swatch-square {
+		display: block;
+		width: 16px;
+		height: 16px;
+		border-radius: 3px;
+		border: 1px solid rgba(0, 0, 0, 0.08);
+
+		// Mirrors `.cortext-chip--neutral` so the picker preview matches
+		// the rendered chip when "Default" is selected.
+		&--default {
+			background: $gray-700;
+		}
+	}
+}
+
+.cortext-option-menu__colors {
+	padding: $grid-unit-05 0;
+	border-top: 1px solid $gray-200;
+}
+
+.cortext-option-menu__colors-label {
+	font-size: 11px;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: $gray-700;
+	padding: $grid-unit-05 $grid-unit-10;
+}
+
+.cortext-option-menu__color-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.cortext-option-menu__color-item {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-10;
+	width: 100%;
+	padding: $grid-unit-05 $grid-unit-10;
+	border: 0;
+	background: transparent;
+	text-align: start;
+	font-size: 13px;
+	color: $gray-900;
+	cursor: pointer;
+
+	&:hover {
+		background: $gray-100;
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--cortext-accent, #3858e9);
+		outline-offset: -2px;
+	}
+}
+
+.cortext-option-menu__color-check {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	flex: 0 0 auto;
+}
+
+.cortext-option-menu__color-label {
+	flex: 1 1 auto;
+}
+
+.cortext-delete-option-dialog__choice {
+	display: grid;
+	gap: $grid-unit-10;
+	margin-top: $grid-unit-10;
+
+	label {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
 	}
 }
 

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -8,8 +8,9 @@
 // content/theme tokens stay inside the editor iframe and published frontend.
 
 // At `:root` so the tokens reach inside the block-editor iframe (which has
-// its own document, no `.cortext-root` ancestor). Our CSS only enqueues in
-// cortext-owned contexts, so the global tokens don't leak.
+// its own document, no `.cortext-root` ancestor) and inside `Popover`
+// portals (which mount on body, also outside `.cortext-root`). Our CSS
+// only enqueues in cortext-owned contexts, so the global tokens don't leak.
 :root {
 	--cortext-scrollbar-size: 8px;
 	--cortext-scrollbar-track: transparent;
@@ -20,7 +21,39 @@
 	// pagination row, and ~10 compact rows so a fresh insertion is usable;
 	// override the variable to give the block a different default.
 	--cortext-data-view-block-min-height: 480px;
+
+	// Option chip palette. Backgrounds are muted tints; foregrounds are a
+	// matching hue dark enough to read on the background. Names mirror
+	// `Cortext\OptionPalette::names()` and the JS `OPTION_COLOR_NAMES`
+	// constant. Lives on `:root` (not `.cortext-root`) so popover portals
+	// can resolve the variables. `default` is intentionally absent: the
+	// neutral chip renders without a color and inherits `cortext-chip--neutral`.
+	--cortext-option-gray-bg: #ebeced;
+	--cortext-option-gray-fg: #5a5a5a;
+	--cortext-option-brown-bg: #f4eee5;
+	--cortext-option-brown-fg: #774f3a;
+	--cortext-option-orange-bg: #fbecdd;
+	--cortext-option-orange-fg: #b35a13;
+	--cortext-option-yellow-bg: #fbf3db;
+	--cortext-option-yellow-fg: #8a6018;
+	--cortext-option-green-bg: #ddedea;
+	--cortext-option-green-fg: #2a6b5b;
+	--cortext-option-blue-bg: #ddebf1;
+	--cortext-option-blue-fg: #2a5a82;
+	--cortext-option-purple-bg: #eae4f2;
+	--cortext-option-purple-fg: #5a3f9f;
+	--cortext-option-pink-bg: #f4dfeb;
+	--cortext-option-pink-fg: #9c3a6b;
+	--cortext-option-red-bg: #fbe4e4;
+	--cortext-option-red-fg: #a82a2a;
 }
+
+// Note: option chips intentionally don't have a dark-mode variant yet.
+// The shell can switch to dark theme but the canvas (where the table
+// rows live) is still painted with the light surface, so dark chips
+// would float on a light canvas and look out of place. Once the canvas
+// gets a real dark theme, mirror the palette under
+// `body[data-cortext-theme="dark"]` so popover portals re-skin too.
 
 .cortext-root {
 

--- a/tests/js/components/EditOptionsPopover.test.js
+++ b/tests/js/components/EditOptionsPopover.test.js
@@ -230,6 +230,32 @@ describe( 'EditOptionsPopover', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'requests the host popover to close when clicking outside an open option menu', async () => {
+		const onRequestClose = jest.fn();
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="select"
+				initialOptions={ [
+					{ value: 'high', label: 'High', color: 'orange' },
+				] }
+				value="high"
+				onPick={ jest.fn() }
+				onRequestClose={ onRequestClose }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Edit option' } )
+		);
+		fireEvent.click( screen.getByRole( 'menuitemradio', { name: /Red/ } ) );
+		await waitFor( () => expect( mockUpdateRun ).toHaveBeenCalled() );
+
+		fireEvent.pointerDown( document.body );
+
+		expect( onRequestClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'does not pick a newly-created option when saving it fails', async () => {
 		const onPick = jest.fn();
 		mockUpdateRun.mockRejectedValueOnce( new Error( 'nope' ) );

--- a/tests/js/components/EditOptionsPopover.test.js
+++ b/tests/js/components/EditOptionsPopover.test.js
@@ -37,6 +37,25 @@ jest.mock( '@wordpress/components', () => {
 	const Notice = ( { children } ) =>
 		createElement( 'div', { role: 'alert' }, children );
 	const Popover = ( { children } ) => createElement( 'div', null, children );
+	const SelectControl = ( { label, value, options, onChange } ) =>
+		createElement( 'label', null, [
+			label,
+			createElement(
+				'select',
+				{
+					key: 'select',
+					value,
+					onChange: ( event ) => onChange( event.target.value ),
+				},
+				options.map( ( option ) =>
+					createElement(
+						'option',
+						{ key: option.value, value: option.value },
+						option.label
+					)
+				)
+			),
+		] );
 	const TextControl = ( { label, value, onChange, onBlur, onKeyDown } ) =>
 		createElement( 'label', null, [
 			label,
@@ -48,6 +67,25 @@ jest.mock( '@wordpress/components', () => {
 				onKeyDown,
 			} ),
 		] );
+	const ConfirmDialog = ( {
+		children,
+		onConfirm,
+		onCancel,
+		confirmButtonText,
+	} ) =>
+		createElement( 'div', { role: 'dialog' }, [
+			children,
+			createElement(
+				'button',
+				{ key: 'confirm', type: 'button', onClick: onConfirm },
+				confirmButtonText
+			),
+			createElement(
+				'button',
+				{ key: 'cancel', type: 'button', onClick: onCancel },
+				'Cancel'
+			),
+		] );
 
 	return {
 		__esModule: true,
@@ -57,7 +95,9 @@ jest.mock( '@wordpress/components', () => {
 		MenuItem,
 		Notice,
 		Popover,
+		SelectControl,
 		TextControl,
+		__experimentalConfirmDialog: ConfirmDialog,
 	};
 } );
 
@@ -99,6 +139,7 @@ jest.mock( '@dnd-kit/sortable', () => ( {
 
 const mockUpdateRun = jest.fn();
 const mockFlushRun = jest.fn();
+const mockUsageRun = jest.fn();
 
 jest.mock( '../../../src/hooks/useFieldMutations', () => ( {
 	__esModule: true,
@@ -107,6 +148,10 @@ jest.mock( '../../../src/hooks/useFieldMutations', () => ( {
 		error: null,
 	} ),
 	useFlushFieldRecord: () => mockFlushRun,
+	useOptionUsage: () => ( {
+		run: mockUsageRun,
+		error: null,
+	} ),
 } ) );
 
 import EditOptionsPopover from '../../../src/components/fields/EditOptionsPopover';
@@ -116,6 +161,8 @@ describe( 'EditOptionsPopover', () => {
 		mockUpdateRun.mockReset();
 		mockUpdateRun.mockResolvedValue( { id: 7 } );
 		mockFlushRun.mockReset();
+		mockUsageRun.mockReset();
+		mockUsageRun.mockResolvedValue( 0 );
 	} );
 
 	it( 'stores explicit default color instead of clearing it', async () => {
@@ -178,6 +225,88 @@ describe( 'EditOptionsPopover', () => {
 		expect( onOptionsSaved ).toHaveBeenCalledWith( [
 			{ value: 'high', label: 'High', color: 'red' },
 		] );
+		expect(
+			screen.getByRole( 'menuitemradio', { name: /Red/ } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not pick a newly-created option when saving it fails', async () => {
+		const onPick = jest.fn();
+		mockUpdateRun.mockRejectedValueOnce( new Error( 'nope' ) );
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="select"
+				initialOptions={ [] }
+				onPick={ onPick }
+			/>
+		);
+
+		fireEvent.change( screen.getByLabelText( 'Search or create option' ), {
+			target: { value: 'Critical' },
+		} );
+		fireEvent.click( screen.getByText( 'Create' ).closest( 'button' ) );
+
+		await waitFor( () => expect( mockUpdateRun ).toHaveBeenCalled() );
+		expect( onPick ).not.toHaveBeenCalled();
+		expect(
+			screen.getByLabelText( 'Search or create option' )
+		).toHaveValue( 'Critical' );
+	} );
+
+	it( 'refreshes rows after a delete migration succeeds', async () => {
+		const onRowsChanged = jest.fn();
+		mockUsageRun.mockResolvedValueOnce( 2 );
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="select"
+				initialOptions={ [
+					{ value: 'old', label: 'Old', color: 'red' },
+					{ value: 'next', label: 'Next', color: 'blue' },
+				] }
+				onRowsChanged={ onRowsChanged }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getAllByRole( 'button', { name: 'Edit option' } )[ 0 ]
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+		await screen.findByRole( 'dialog' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Delete option' } )
+		);
+
+		await waitFor( () =>
+			expect( mockUpdateRun ).toHaveBeenCalledWith(
+				7,
+				[ { value: 'next', label: 'Next', color: 'blue' } ],
+				[ { from: 'old', action: 'clear' } ]
+			)
+		);
+		expect( onRowsChanged ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'blocks deletion when option usage lookup fails', async () => {
+		mockUsageRun.mockRejectedValueOnce( new Error( 'nope' ) );
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="select"
+				initialOptions={ [ { value: 'old', label: 'Old' } ] }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Edit option' } )
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+
+		expect( await screen.findByRole( 'dialog' ) ).toHaveTextContent(
+			'Could not check whether rows use this option.'
+		);
+		expect( mockUpdateRun ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not close pick-mode editors when a color edit fails', async () => {

--- a/tests/js/components/EditOptionsPopover.test.js
+++ b/tests/js/components/EditOptionsPopover.test.js
@@ -256,6 +256,49 @@ describe( 'EditOptionsPopover', () => {
 		expect( onRequestClose ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'shows unknown selected values so they can be cleared', () => {
+		const onPick = jest.fn();
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="select"
+				initialOptions={ [ { value: 'known', label: 'Known' } ] }
+				value="stale"
+				onPick={ onPick }
+			/>
+		);
+
+		expect( screen.getByText( 'stale' ) ).toHaveClass(
+			'cortext-chip--neutral'
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Remove' } ) );
+
+		expect( onPick ).toHaveBeenCalledWith( null );
+	} );
+
+	it( 'shows unknown multiselect values so they can be cleared', () => {
+		const onPick = jest.fn();
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="multiselect"
+				initialOptions={ [ { value: 'known', label: 'Known' } ] }
+				value={ [ 'known', 'stale' ] }
+				onPick={ onPick }
+			/>
+		);
+
+		expect( screen.getAllByText( 'Known' ).length ).toBeGreaterThan( 0 );
+		expect( screen.getByText( 'stale' ) ).toHaveClass(
+			'cortext-chip--neutral'
+		);
+		fireEvent.click(
+			screen.getAllByRole( 'button', { name: 'Remove' } )[ 1 ]
+		);
+
+		expect( onPick ).toHaveBeenCalledWith( 'stale' );
+	} );
+
 	it( 'does not pick a newly-created option when saving it fails', async () => {
 		const onPick = jest.fn();
 		mockUpdateRun.mockRejectedValueOnce( new Error( 'nope' ) );

--- a/tests/js/components/EditOptionsPopover.test.js
+++ b/tests/js/components/EditOptionsPopover.test.js
@@ -1,0 +1,226 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/components', () => {
+	const { createElement, forwardRef } = require( '@wordpress/element' );
+
+	const Button = forwardRef( ( props, ref ) => {
+		const { children, label, onClick, ...rest } = props;
+		delete rest.icon;
+		delete rest.size;
+		return createElement(
+			'button',
+			{
+				ref,
+				type: 'button',
+				onClick,
+				'aria-label': label,
+				...rest,
+			},
+			children ?? label
+		);
+	} );
+	Button.displayName = 'Button';
+
+	const Icon = () => createElement( 'span', null );
+	const MenuGroup = ( { children } ) =>
+		createElement( 'div', null, children );
+	const MenuItem = ( props ) => {
+		const { children, onClick, ...rest } = props;
+		delete rest.icon;
+		delete rest.isDestructive;
+		return createElement(
+			'button',
+			{ type: 'button', onClick, ...rest },
+			children
+		);
+	};
+	const Notice = ( { children } ) =>
+		createElement( 'div', { role: 'alert' }, children );
+	const Popover = ( { children } ) => createElement( 'div', null, children );
+	const TextControl = ( { label, value, onChange, onBlur, onKeyDown } ) =>
+		createElement( 'label', null, [
+			label,
+			createElement( 'input', {
+				key: 'input',
+				value,
+				onChange: ( event ) => onChange( event.target.value ),
+				onBlur,
+				onKeyDown,
+			} ),
+		] );
+
+	return {
+		__esModule: true,
+		Button,
+		Icon,
+		MenuGroup,
+		MenuItem,
+		Notice,
+		Popover,
+		TextControl,
+	};
+} );
+
+jest.mock( '@wordpress/icons', () => ( {
+	__esModule: true,
+	check: 'check-icon',
+	dragHandle: 'drag-handle-icon',
+	moreHorizontal: 'more-horizontal-icon',
+	trash: 'trash-icon',
+} ) );
+
+jest.mock( '@dnd-kit/core', () => ( {
+	__esModule: true,
+	DndContext: ( { children } ) => children,
+	PointerSensor: jest.fn(),
+	closestCenter: jest.fn(),
+	useSensor: jest.fn( () => ( {} ) ),
+	useSensors: jest.fn( ( ...sensors ) => sensors ),
+} ) );
+
+jest.mock( '@dnd-kit/sortable', () => ( {
+	__esModule: true,
+	SortableContext: ( { children } ) => children,
+	arrayMove: jest.fn( ( items, from, to ) => {
+		const next = [ ...items ];
+		const [ item ] = next.splice( from, 1 );
+		next.splice( to, 0, item );
+		return next;
+	} ),
+	useSortable: jest.fn( () => ( {
+		attributes: {},
+		listeners: {},
+		setNodeRef: jest.fn(),
+		transform: null,
+		transition: undefined,
+	} ) ),
+	verticalListSortingStrategy: {},
+} ) );
+
+const mockUpdateRun = jest.fn();
+const mockFlushRun = jest.fn();
+
+jest.mock( '../../../src/hooks/useFieldMutations', () => ( {
+	__esModule: true,
+	useUpdateFieldOptions: () => ( {
+		run: mockUpdateRun,
+		error: null,
+	} ),
+	useFlushFieldRecord: () => mockFlushRun,
+} ) );
+
+import EditOptionsPopover from '../../../src/components/fields/EditOptionsPopover';
+
+describe( 'EditOptionsPopover', () => {
+	beforeEach( () => {
+		mockUpdateRun.mockReset();
+		mockUpdateRun.mockResolvedValue( { id: 7 } );
+		mockFlushRun.mockReset();
+	} );
+
+	it( 'stores explicit default color instead of clearing it', async () => {
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="select"
+				initialOptions={ [
+					{ value: 'todo', label: 'To do', color: 'blue' },
+				] }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Edit option' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'menuitemradio', { name: /Default/ } )
+		);
+
+		await waitFor( () =>
+			expect( mockUpdateRun ).toHaveBeenCalledWith(
+				7,
+				[ { value: 'todo', label: 'To do', color: 'default' } ],
+				undefined
+			)
+		);
+	} );
+
+	it( 'keeps pick-mode cell editors open after a color edit saves', async () => {
+		const onOptionsSaved = jest.fn();
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="select"
+				initialOptions={ [
+					{ value: 'high', label: 'High', color: 'orange' },
+				] }
+				value="high"
+				onPick={ jest.fn() }
+				onOptionsSaved={ onOptionsSaved }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Edit option' } )
+		);
+		fireEvent.click( screen.getByRole( 'menuitemradio', { name: /Red/ } ) );
+
+		await waitFor( () =>
+			expect( mockUpdateRun ).toHaveBeenCalledWith(
+				7,
+				[ { value: 'high', label: 'High', color: 'red' } ],
+				undefined
+			)
+		);
+		expect(
+			screen.getByLabelText( 'Search or create option' )
+		).toBeInTheDocument();
+		expect( onOptionsSaved ).toHaveBeenCalledWith( [
+			{ value: 'high', label: 'High', color: 'red' },
+		] );
+	} );
+
+	it( 'does not close pick-mode editors when a color edit fails', async () => {
+		mockUpdateRun.mockRejectedValueOnce( new Error( 'nope' ) );
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="select"
+				initialOptions={ [
+					{ value: 'high', label: 'High', color: 'orange' },
+				] }
+				value="high"
+				onPick={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Edit option' } )
+		);
+		fireEvent.click( screen.getByRole( 'menuitemradio', { name: /Red/ } ) );
+
+		await waitFor( () => expect( mockUpdateRun ).toHaveBeenCalled() );
+		expect(
+			screen.getByLabelText( 'Search or create option' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'focuses the search input when the token input surface is clicked', () => {
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="multiselect"
+				initialOptions={ [ { value: 'todo', label: 'To do' } ] }
+				value={ [ 'todo' ] }
+				onPick={ jest.fn() }
+			/>
+		);
+
+		const input = screen.getByLabelText( 'Search or create option' );
+		fireEvent.pointerDown(
+			input.closest( '.cortext-edit-options-popover__token-input' )
+		);
+
+		expect( input ).toHaveFocus();
+	} );
+} );

--- a/tests/js/components/EditableCell.test.js
+++ b/tests/js/components/EditableCell.test.js
@@ -5,7 +5,9 @@ import {
 	formatDateValue,
 	formatDisplay,
 	formatNumberValue,
+	RowMutationContext,
 } from '../../../src/components/EditableCell';
+import EditableCell from '../../../src/components/EditableCell';
 
 function renderDisplay( value, type, options ) {
 	return render( <>{ formatDisplay( value, type, options ) }</> );
@@ -129,18 +131,16 @@ describe( 'formatDisplay', () => {
 			// the regression.
 			const { getSettings } = require( '@wordpress/date' );
 			expect( getSettings().l10n.locale ).toBe( 'en' );
-			expect(
-				formatNumberValue( 1234567, { style: 'comma' } )
-			).toBe( '1,234,567' );
+			expect( formatNumberValue( 1234567, { style: 'comma' } ) ).toBe(
+				'1,234,567'
+			);
 		} );
 
 		it( 'renders a bar visual when display is "bar"', () => {
 			const { container } = renderDisplay( 0.4, 'number', {
 				format: { style: 'percent', display: 'bar' },
 			} );
-			const fill = container.querySelector(
-				'.cortext-cell-bar__fill'
-			);
+			const fill = container.querySelector( '.cortext-cell-bar__fill' );
 			expect( fill ).not.toBeNull();
 			expect( fill.style.width ).toBe( '40%' );
 			expect(
@@ -167,8 +167,7 @@ describe( 'formatDisplay', () => {
 				format: { style: 'plain', display: 'bar' },
 			} );
 			expect(
-				container.querySelector( '.cortext-cell-bar__fill' ).style
-					.width
+				container.querySelector( '.cortext-cell-bar__fill' ).style.width
 			).toBe( '100%' );
 		} );
 
@@ -185,8 +184,7 @@ describe( 'formatDisplay', () => {
 				},
 			} );
 			expect(
-				container.querySelector( '.cortext-cell-bar__fill' ).style
-					.width
+				container.querySelector( '.cortext-cell-bar__fill' ).style.width
 			).toBe( '98.3%' );
 		} );
 
@@ -272,30 +270,46 @@ describe( 'formatDisplay', () => {
 	} );
 
 	describe( 'select', () => {
-		it( 'renders a chip with the option color when one is set', () => {
+		it( 'renders a chip with a palette modifier when an option color is set', () => {
 			const elements = [
-				{ value: 'open', label: 'Open', color: '#ffe2dd' },
+				{ value: 'open', label: 'Open', color: 'blue' },
 			];
 			renderDisplay( 'open', 'select', { elements } );
 			const chip = screen.getByText( 'Open' );
-			expect( chip ).toHaveClass( 'cortext-chip' );
+			expect( chip ).toHaveClass( 'cortext-chip--blue' );
 			expect( chip ).not.toHaveClass( 'cortext-chip--neutral' );
-			expect( chip.style.backgroundColor ).not.toBe( '' );
 		} );
 
-		it( 'sets a contrasting foreground for hex colors', () => {
+		it( 'normalizes non-palette stored colors (e.g. legacy hex) into a palette modifier', () => {
+			// Hex from old seeds and Notion imports never themed under
+			// dark mode because raw colors don't follow the CSS-variable
+			// palette. `resolveDisplayColor` rounds them to a hashed
+			// palette name so chips re-skin alongside the rest of the UI.
 			renderDisplay( 'open', 'select', {
 				elements: [
 					{ value: 'open', label: 'Open', color: '#000000' },
 				],
 			} );
-			expect( screen.getByText( 'Open' ).style.color ).toBe(
-				'rgb(255, 255, 255)'
-			);
+			const chip = screen.getByText( 'Open' );
+			expect( chip.className ).toMatch( /cortext-chip--/ );
+			expect( chip ).not.toHaveClass( 'cortext-chip--neutral' );
 		} );
 
-		it( 'falls back to a neutral chip when the option has no color', () => {
+		it( 'derives a stable palette color when the option has no stored color', () => {
 			const elements = [ { value: 'open', label: 'Open' } ];
+			renderDisplay( 'open', 'select', { elements } );
+			const chip = screen.getByText( 'Open' );
+			// Hash-based fallback in `resolveDisplayColor` — assert the
+			// chip lands on a palette modifier (any of them) so legacy
+			// options without `color` still render colored.
+			expect( chip.className ).toMatch( /cortext-chip--/ );
+			expect( chip ).not.toHaveClass( 'cortext-chip--neutral' );
+		} );
+
+		it( 'renders the explicit default color as a neutral chip', () => {
+			const elements = [
+				{ value: 'open', label: 'Open', color: 'default' },
+			];
 			renderDisplay( 'open', 'select', { elements } );
 			expect( screen.getByText( 'Open' ) ).toHaveClass(
 				'cortext-chip--neutral'
@@ -336,5 +350,34 @@ describe( 'dateOnlyValue', () => {
 	it( 'preserves date-only storage when date editors emit datetimes', () => {
 		expect( dateOnlyValue( '2026-04-16T14:30:00' ) ).toBe( '2026-04-16' );
 		expect( dateOnlyValue( '2026-04-16' ) ).toBe( '2026-04-16' );
+	} );
+} );
+
+describe( 'EditableCell option overrides', () => {
+	it( 'uses live option overrides for chip display without remapping fields', () => {
+		render(
+			<RowMutationContext.Provider
+				value={ {
+					optionOverrides: {
+						'field-7': [
+							{ value: 'high', label: 'High', color: 'red' },
+						],
+					},
+				} }
+			>
+				<EditableCell
+					item={ { id: 1, meta: { 'field-7': 'high' } } }
+					fieldId="field-7"
+					fieldType="select"
+					elements={ [
+						{ value: 'high', label: 'High', color: 'orange' },
+					] }
+					label="Priority"
+					readOnly
+				/>
+			</RowMutationContext.Provider>
+		);
+
+		expect( screen.getByText( 'High' ) ).toHaveClass( 'cortext-chip--red' );
 	} );
 } );

--- a/tests/js/components/MultiselectEdit.test.js
+++ b/tests/js/components/MultiselectEdit.test.js
@@ -70,4 +70,38 @@ describe( 'MultiselectEdit', () => {
 		expect( onSave ).toHaveBeenNthCalledWith( 1, [ 'a' ] );
 		expect( onSave ).toHaveBeenNthCalledWith( 2, [ 'a', 'b' ] );
 	} );
+
+	it( 'syncs local selections when the row value changes while open', () => {
+		const onSave = jest.fn();
+		const { rerender } = render(
+			<MultiselectEdit
+				recordId={ 7 }
+				value={ [ 'removed' ] }
+				elements={ [
+					{ value: 'removed', label: 'Removed' },
+					{ value: 'b', label: 'B' },
+				] }
+				onSave={ onSave }
+				onCancel={ jest.fn() }
+				label="Tags"
+			/>
+		);
+
+		rerender(
+			<MultiselectEdit
+				recordId={ 7 }
+				value={ [] }
+				elements={ [
+					{ value: 'removed', label: 'Removed' },
+					{ value: 'b', label: 'B' },
+				] }
+				onSave={ onSave }
+				onCancel={ jest.fn() }
+				label="Tags"
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'B' } ) );
+
+		expect( onSave ).toHaveBeenCalledWith( [ 'b' ] );
+	} );
 } );

--- a/tests/js/components/MultiselectEdit.test.js
+++ b/tests/js/components/MultiselectEdit.test.js
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock( '@wordpress/components', () => {
+	const { createElement, forwardRef } = require( '@wordpress/element' );
+
+	const Button = forwardRef( ( props, ref ) => {
+		const { children, label, onClick, ...rest } = props;
+		return createElement(
+			'button',
+			{
+				ref,
+				type: 'button',
+				onClick,
+				'aria-label': label,
+				...rest,
+			},
+			children ?? label
+		);
+	} );
+	Button.displayName = 'Button';
+
+	const Popover = ( { children } ) => createElement( 'div', null, children );
+
+	return {
+		__esModule: true,
+		Button,
+		Popover,
+	};
+} );
+
+jest.mock( '../../../src/components/fields/EditOptionsPopover', () => ( {
+	__esModule: true,
+	default: ( { initialOptions, onPick } ) => (
+		<div>
+			{ initialOptions.map( ( option ) => (
+				<button
+					key={ option.value }
+					type="button"
+					onClick={ () => onPick( option.value ) }
+				>
+					{ option.label }
+				</button>
+			) ) }
+		</div>
+	),
+} ) );
+
+import MultiselectEdit from '../../../src/components/MultiselectEdit';
+
+describe( 'MultiselectEdit', () => {
+	it( 'keeps rapid toggles based on the local selected values', () => {
+		const onSave = jest.fn();
+		render(
+			<MultiselectEdit
+				recordId={ 7 }
+				value={ [] }
+				elements={ [
+					{ value: 'a', label: 'A' },
+					{ value: 'b', label: 'B' },
+				] }
+				onSave={ onSave }
+				onCancel={ jest.fn() }
+				label="Tags"
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'A' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'B' } ) );
+
+		expect( onSave ).toHaveBeenNthCalledWith( 1, [ 'a' ] );
+		expect( onSave ).toHaveBeenNthCalledWith( 2, [ 'a', 'b' ] );
+	} );
+} );

--- a/tests/js/hooks/useFieldMutations.test.js
+++ b/tests/js/hooks/useFieldMutations.test.js
@@ -16,10 +16,16 @@ const mockDispatch = {
 	invalidateResolution: jest.fn(),
 	saveEntityRecord: jest.fn(),
 	deleteEntityRecord: jest.fn(),
+	receiveEntityRecords: jest.fn(),
 };
+
+const mockSelectGetEntityRecord = jest.fn().mockReturnValue( null );
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn( () => mockDispatch ),
+	select: jest.fn( () => ( {
+		getEntityRecord: mockSelectGetEntityRecord,
+	} ) ),
 } ) );
 
 import apiFetch from '@wordpress/api-fetch';
@@ -28,6 +34,10 @@ import {
 	useDuplicateField,
 	useRenameField,
 	useDeleteField,
+	useUpdateFieldOptions,
+	useOptionUsage,
+	useCreateFieldOption,
+	useFlushFieldRecord,
 } from '../../../src/hooks/useFieldMutations';
 
 beforeEach( () => {
@@ -148,9 +158,9 @@ describe( 'useRenameField', () => {
 
 		const { result } = renderHook( () => useRenameField() );
 		await act( async () => {
-			await expect(
-				result.current.run( 42, 'X' )
-			).rejects.toThrow( 'cortext_rename_failed' );
+			await expect( result.current.run( 42, 'X' ) ).rejects.toThrow(
+				'cortext_rename_failed'
+			);
 		} );
 
 		expect( result.current.error ).toEqual(
@@ -161,7 +171,9 @@ describe( 'useRenameField', () => {
 
 describe( 'useDeleteField', () => {
 	it( 'dispatches deleteEntityRecord with force: true and invalidates the collection', async () => {
-		mockDispatch.deleteEntityRecord.mockResolvedValueOnce( { previous: { id: 42 } } );
+		mockDispatch.deleteEntityRecord.mockResolvedValueOnce( {
+			previous: { id: 42 },
+		} );
 
 		const { result } = renderHook( () => useDeleteField( 5 ) );
 		await act( async () => {
@@ -194,5 +206,234 @@ describe( 'useDeleteField', () => {
 			new Error( 'cortext_delete_failed' )
 		);
 		expect( mockDispatch.invalidateResolution ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'useUpdateFieldOptions', () => {
+	it( 'POSTs the new option list and does not push into the store', async () => {
+		// `useUpdateFieldOptions` stays write-only; callers that need live
+		// repainting use local option overrides while the popover is open.
+		// Pushing into core-data here changes DataViews' `fields` prop and
+		// tears down active cell editors.
+		const options = [
+			{ value: 'a', label: 'A', color: 'blue' },
+			{ value: 'b', label: 'B' },
+		];
+		apiFetch.mockResolvedValueOnce( { id: 42, options } );
+
+		const { result } = renderHook( () => useUpdateFieldOptions() );
+		await act( async () => {
+			await result.current.run( 42, options );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/fields/42/options',
+			method: 'POST',
+			data: { options },
+		} );
+		expect( mockDispatch.receiveEntityRecords ).not.toHaveBeenCalled();
+	} );
+
+	it( 'forwards migrations on the request body when provided', async () => {
+		apiFetch.mockResolvedValueOnce( { id: 42 } );
+		const migrations = [ { from: 'b', action: 'clear' } ];
+
+		const { result } = renderHook( () => useUpdateFieldOptions() );
+		await act( async () => {
+			await result.current.run(
+				42,
+				[ { value: 'a', label: 'A' } ],
+				migrations
+			);
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/fields/42/options',
+			method: 'POST',
+			data: {
+				options: [ { value: 'a', label: 'A' } ],
+				migrations,
+			},
+		} );
+	} );
+
+	it( 'omits migrations key when the array is empty', async () => {
+		apiFetch.mockResolvedValueOnce( { id: 42 } );
+
+		const { result } = renderHook( () => useUpdateFieldOptions() );
+		await act( async () => {
+			await result.current.run( 42, [], [] );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/fields/42/options',
+			method: 'POST',
+			data: { options: [] },
+		} );
+	} );
+
+	it( 'surfaces errors via `error` and skips invalidation', async () => {
+		const apiError = new Error( 'nope' );
+		apiFetch.mockRejectedValueOnce( apiError );
+
+		const { result } = renderHook( () => useUpdateFieldOptions() );
+		await act( async () => {
+			await expect(
+				result.current.run( 42, [ { value: 'a', label: 'A' } ] )
+			).rejects.toThrow( 'nope' );
+		} );
+
+		expect( result.current.error ).toBe( apiError );
+		expect( mockDispatch.invalidateResolution ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'useCreateFieldOption', () => {
+	beforeEach( () => {
+		mockSelectGetEntityRecord.mockReset();
+	} );
+
+	it( 'appends a unique option and POSTs the merged list', async () => {
+		mockSelectGetEntityRecord.mockReturnValue( {
+			meta: {
+				options: JSON.stringify( [
+					{ value: 'todo', label: 'To do' },
+				] ),
+			},
+		} );
+		apiFetch.mockResolvedValueOnce( { id: 42 } );
+
+		const { result } = renderHook( () => useCreateFieldOption( 42 ) );
+		let created;
+		await act( async () => {
+			created = await result.current.run( 'In progress' );
+		} );
+
+		expect( created ).toEqual( {
+			value: 'in-progress',
+			label: 'In progress',
+		} );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/fields/42/options',
+			method: 'POST',
+			data: {
+				options: [
+					{ value: 'todo', label: 'To do' },
+					{ value: 'in-progress', label: 'In progress' },
+				],
+			},
+		} );
+	} );
+
+	it( 'dedupes the slug when the base value is already taken', async () => {
+		mockSelectGetEntityRecord.mockReturnValue( {
+			meta: {
+				options: JSON.stringify( [
+					{ value: 'in-progress', label: 'In progress' },
+					{ value: 'in-progress-2', label: 'Other in progress' },
+				] ),
+			},
+		} );
+		apiFetch.mockResolvedValueOnce( { id: 42 } );
+
+		const { result } = renderHook( () => useCreateFieldOption( 42 ) );
+		let created;
+		await act( async () => {
+			created = await result.current.run( 'In progress' );
+		} );
+
+		expect( created.value ).toBe( 'in-progress-3' );
+	} );
+
+	it( 'refuses to write when the field record is not in the store', async () => {
+		mockSelectGetEntityRecord.mockReturnValue( null );
+		const { result } = renderHook( () => useCreateFieldOption( 42 ) );
+		let created;
+		await act( async () => {
+			created = await result.current.run( 'New' );
+		} );
+		expect( created ).toBeNull();
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'is a no-op for empty labels', async () => {
+		const { result } = renderHook( () => useCreateFieldOption( 42 ) );
+		let created;
+		await act( async () => {
+			created = await result.current.run( '   ' );
+		} );
+		expect( created ).toBeNull();
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'useFlushFieldRecord', () => {
+	it( 'refetches the field record and pushes it into the entity store', async () => {
+		const fresh = { id: 42, meta: { options: '[]' } };
+		apiFetch.mockResolvedValueOnce( fresh );
+
+		const { result } = renderHook( () => useFlushFieldRecord() );
+		await act( async () => {
+			await result.current( 42 );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/crtxt_fields/42?context=edit',
+		} );
+		expect( mockDispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'crtxt_field',
+			[ fresh ],
+			undefined,
+			true
+		);
+	} );
+
+	it( 'is a no-op when no record id is supplied', async () => {
+		const { result } = renderHook( () => useFlushFieldRecord() );
+		await act( async () => {
+			await result.current( null );
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( mockDispatch.receiveEntityRecords ).not.toHaveBeenCalled();
+	} );
+
+	it( 'swallows refetch errors so a failed flush never throws', async () => {
+		apiFetch.mockRejectedValueOnce( new Error( 'nope' ) );
+		const { result } = renderHook( () => useFlushFieldRecord() );
+		await act( async () => {
+			await result.current( 42 );
+		} );
+		expect( mockDispatch.receiveEntityRecords ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'useOptionUsage', () => {
+	it( 'GETs the per-value usage endpoint with the value URL-encoded', async () => {
+		apiFetch.mockResolvedValueOnce( { count: 3 } );
+
+		const { result } = renderHook( () => useOptionUsage() );
+		let count;
+		await act( async () => {
+			count = await result.current.run( 42, 'has spaces & ampersand' );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: `/cortext/v1/fields/42/options/${ encodeURIComponent(
+				'has spaces & ampersand'
+			) }/usage`,
+		} );
+		expect( count ).toBe( 3 );
+	} );
+
+	it( 'normalizes a missing count to zero', async () => {
+		apiFetch.mockResolvedValueOnce( {} );
+		const { result } = renderHook( () => useOptionUsage() );
+		let count;
+		await act( async () => {
+			count = await result.current.run( 42, 'x' );
+		} );
+		expect( count ).toBe( 0 );
 	} );
 } );

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -105,6 +105,39 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		);
 	}
 
+	public function test_create_preserves_color_from_palette_and_drops_unknown(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Palette', 'palette-c' );
+
+		$response = $this->create_field(
+			$collection_id,
+			array(
+				'title'   => 'Status',
+				'type'    => 'select',
+				'options' => array(
+					array(
+						'value' => 'todo',
+						'label' => 'To do',
+						'color' => 'blue',
+					),
+					array(
+						'value' => 'doing',
+						'label' => 'Doing',
+						'color' => 'neon-magenta', // not in palette
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$field_id = (int) $response->get_data()['id'];
+		$options  = json_decode( get_post_meta( $field_id, 'options', true ), true );
+
+		$this->assertSame( 'blue', $options[0]['color'] );
+		$this->assertArrayNotHasKey( 'color', $options[1] );
+	}
+
 	public function test_create_rejects_invalid_type(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		$collection_id = $this->create_collection_with_slug( 'Items', 'items' );
@@ -504,6 +537,219 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$response = $this->duplicate_field( $collection_id, (int) $source_id );
 
 		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_update_options_round_trips_label_color_order(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Update', 'update-o' );
+		$field_id      = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title'   => 'Status',
+				'type'    => 'select',
+				'options' => array(
+					array(
+						'value' => 'todo',
+						'label' => 'To do',
+					),
+				),
+			)
+		)->get_data()['id'];
+
+		$response = $this->update_options(
+			$field_id,
+			array(
+				'options' => array(
+					array(
+						'value' => 'doing',
+						'label' => 'In progress',
+						'color' => 'orange',
+					),
+					array(
+						'value' => 'todo',
+						'label' => 'To do',
+						'color' => 'default',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$stored = json_decode( get_post_meta( $field_id, 'options', true ), true );
+
+		$this->assertSame(
+			array(
+				array(
+					'value' => 'doing',
+					'label' => 'In progress',
+					'color' => 'orange',
+				),
+				array(
+					'value' => 'todo',
+					'label' => 'To do',
+					'color' => 'default',
+				),
+			),
+			$stored
+		);
+	}
+
+	public function test_update_options_strips_unknown_color(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Strip', 'strip-c' );
+		$field_id      = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Tag',
+				'type'  => 'multiselect',
+			)
+		)->get_data()['id'];
+
+		$this->update_options(
+			$field_id,
+			array(
+				'options' => array(
+					array(
+						'value' => 'one',
+						'label' => 'One',
+						'color' => 'sienna',
+					),
+				),
+			)
+		);
+
+		$stored = json_decode( get_post_meta( $field_id, 'options', true ), true );
+
+		$this->assertArrayNotHasKey( 'color', $stored[0] );
+	}
+
+	public function test_update_options_rejects_non_select_field(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Wrong', 'wrong-t' );
+		$field_id      = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Notes',
+				'type'  => 'text',
+			)
+		)->get_data()['id'];
+
+		$response = $this->update_options(
+			$field_id,
+			array(
+				'options' => array(
+					array(
+						'value' => 'a',
+						'label' => 'A',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_update_options_rejects_replace_to_unknown_value(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Replace', 'replace-x' );
+		$field_id      = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title'   => 'Status',
+				'type'    => 'select',
+				'options' => array(
+					array(
+						'value' => 'a',
+						'label' => 'A',
+					),
+				),
+			)
+		)->get_data()['id'];
+
+		$response = $this->update_options(
+			$field_id,
+			array(
+				'options'    => array(
+					array(
+						'value' => 'a',
+						'label' => 'A',
+					),
+				),
+				'migrations' => array(
+					array(
+						'from'   => 'b',
+						'action' => 'replace',
+						'to'     => 'ghost',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_update_options_requires_edit_capability(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Auth', 'auth-o' );
+		$field_id      = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Status',
+				'type'  => 'select',
+			)
+		)->get_data()['id'];
+
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$response = $this->update_options(
+			$field_id,
+			array(
+				'options' => array(
+					array(
+						'value' => 'a',
+						'label' => 'A',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_option_usage_returns_zero_when_no_rows_match(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Usage', 'usage-z' );
+		$field_id      = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Status',
+				'type'  => 'select',
+			)
+		)->get_data()['id'];
+
+		$request = new WP_REST_Request(
+			'GET',
+			"/cortext/v1/fields/{$field_id}/options/lonely/usage"
+		);
+		$request->set_param( 'field_id', $field_id );
+		$request->set_param( 'value', 'lonely' );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 0, $response->get_data()['count'] );
+	}
+
+	private function update_options( int $field_id, array $body ) {
+		$request = new WP_REST_Request(
+			'POST',
+			"/cortext/v1/fields/{$field_id}/options"
+		);
+		$request->set_param( 'field_id', $field_id );
+		foreach ( $body as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return rest_do_request( $request );
 	}
 
 	private function create_field( int $collection_id, array $body ) {


### PR DESCRIPTION
## What

Closes #121

Adds option management for Select and Multiselect fields.

Options can be created from a cell, edited from the column header or cell picker, reordered, renamed, recolored, and deleted. Deleting an option checks row usage first, then lets you clear or replace existing values.

Option colors now use named theme-aware values. `Default` is stored explicitly and renders as a dark gray chip; options with no saved color keep the automatic color fallback.

## Testing

1. Create options from Select and Multiselect cells.
2. Open `Edit options` from the column header and rename, reorder, recolor, and delete options.
3. Pick `Default`, reload, and confirm it stays dark gray.
4. Delete an option used by rows and test both clear and replace.
5. Run `npm run lint:js`.
6. Run `npm run test:unit`.
7. Run `composer run test:php -- --filter Test_Rest_Fields_Controller`.

## Screen capture

https://github.com/user-attachments/assets/f176a9d7-a60f-46ca-860f-741e2d3a9a39