### PR TITLE
Add top bar back and forward navigation

### DIFF
--- a/src/components/WorkspaceTopBar.js
+++ b/src/components/WorkspaceTopBar.js
@@ -1,4 +1,7 @@
-import { createSlotFill } from '@wordpress/components';
+import { Button, createSlotFill } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 
 import Breadcrumbs from './Breadcrumbs';
 
@@ -6,16 +9,76 @@ const SLOT_NAME = 'CortextTopBarActions';
 
 const { Slot, Fill } = createSlotFill( SLOT_NAME );
 
+function readHistoryIndex( history ) {
+	return history?.location?.state?.__TSR_index ?? 0;
+}
+
+function useHistoryNavigationState( history ) {
+	const [ state, setState ] = useState( () => {
+		const index = readHistoryIndex( history );
+		return { index, maxIndex: index };
+	} );
+
+	useEffect( () => {
+		const sync = ( action ) => {
+			const index = readHistoryIndex( history );
+			setState( ( previous ) => {
+				const maxIndex =
+					action?.type === 'PUSH'
+						? index
+						: Math.max( previous.maxIndex, index );
+				return { index, maxIndex };
+			} );
+		};
+
+		sync();
+		return history.subscribe( ( { action } ) => sync( action ) );
+	}, [ history ] );
+
+	return {
+		canGoBack: state.index > 0,
+		canGoForward: state.index < state.maxIndex,
+	};
+}
+
 // Surfaces inside the canvas (currently only the page editor) project their
 // document actions into the right side of the top bar via this Fill, which
 // lets them stay scoped to their own React context (EditorProvider, etc.)
 // while sharing chrome with the workspace shell.
 export const TopBarActionsFill = Fill;
 
-export default function WorkspaceTopBar( { paintedRoute } ) {
+export default function WorkspaceTopBar( { history, paintedRoute } ) {
+	const { canGoBack, canGoForward } = useHistoryNavigationState( history );
+
+	const goBack = useCallback( () => {
+		history.flush?.();
+		history.back();
+	}, [ history ] );
+
+	const goForward = useCallback( () => {
+		history.flush?.();
+		history.forward();
+	}, [ history ] );
+
 	return (
 		<div className="cortext-topbar">
 			<div className="cortext-topbar__lead">
+				<div className="cortext-topbar__history-nav">
+					<Button
+						className="cortext-topbar__history-button"
+						icon={ chevronLeft }
+						label={ __( 'Go back', 'cortext' ) }
+						disabled={ ! canGoBack }
+						onClick={ goBack }
+					/>
+					<Button
+						className="cortext-topbar__history-button"
+						icon={ chevronRight }
+						label={ __( 'Go forward', 'cortext' ) }
+						disabled={ ! canGoForward }
+						onClick={ goForward }
+					/>
+				</div>
 				<Breadcrumbs paintedRoute={ paintedRoute } />
 			</div>
 			<div className="cortext-topbar__actions">

--- a/src/index.scss
+++ b/src/index.scss
@@ -646,8 +646,34 @@ body.cortext-sidebar-resizing {
 		min-width: 0;
 		display: flex;
 		align-items: center;
+		gap: $grid-unit-10;
 		height: 20px;
 		line-height: 20px;
+	}
+
+	&__history-nav {
+		flex: 0 0 auto;
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		height: 24px;
+	}
+
+	&__history-button.components-button {
+		width: 24px;
+		min-width: 24px;
+		height: 24px;
+		padding: 0;
+		color: var(--cortext-text-muted);
+	}
+
+	&__history-button.components-button:disabled {
+		color: var(--cortext-text-muted);
+		opacity: 0.4;
+	}
+
+	&__history-button.components-button:not(:disabled):hover {
+		color: var(--cortext-text);
 	}
 
 	&__actions {

--- a/src/router.js
+++ b/src/router.js
@@ -67,7 +67,7 @@ function RootLayout() {
 					onWidthChange={ setWidth }
 				/>
 				<main className="cortext-shell__canvas">
-					<EntityRoute />
+					<EntityRoute history={ router.history } />
 				</main>
 			</div>
 		</SlotFillProvider>

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -99,7 +99,7 @@ function WorkspacePane( { active, preservePaint = false, children } ) {
 	);
 }
 
-export default function EntityRoute() {
+export default function EntityRoute( { history } ) {
 	const params = useParams( { strict: false } );
 	const splat = params._splat ?? '';
 	const target = useMemo( () => parseTarget( splat ), [ splat ] );
@@ -220,7 +220,10 @@ export default function EntityRoute() {
 
 	return (
 		<>
-			<WorkspaceTopBar paintedRoute={ paintedRoute } />
+			<WorkspaceTopBar
+				history={ history }
+				paintedRoute={ paintedRoute }
+			/>
 			<div className="cortext-workspace">
 				{ mountedPageId !== null && (
 					<WorkspacePane

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -9,6 +9,9 @@ const FIRST_PAGE_TITLE = `E2E Lifecycle Page A ${ SUFFIX }`;
 const SECOND_PAGE_TITLE = `E2E Lifecycle Page B ${ SUFFIX }`;
 const COLLECTION_TITLE = `E2E Lifecycle Collection ${ SUFFIX }`;
 const ENTRY_TITLE = `E2E Lifecycle Entry ${ SUFFIX }`;
+const HISTORY_FIRST_PAGE_TITLE = `E2E History Page A ${ SUFFIX }`;
+const HISTORY_SECOND_PAGE_TITLE = `E2E History Page B ${ SUFFIX }`;
+const HISTORY_COLLECTION_TITLE = `E2E History Collection ${ SUFFIX }`;
 
 async function deleteIfCreated( requestUtils, path ) {
 	if ( ! path ) {
@@ -37,6 +40,114 @@ async function waitForEditorPost( page, postId ) {
 }
 
 test.describe( 'Navigation lifecycle', () => {
+	test( 'top bar back and forward stay in sync with browser history', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			fixture.firstPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: { title: HISTORY_FIRST_PAGE_TITLE, status: 'private' },
+			} );
+			fixture.secondPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: { title: HISTORY_SECOND_PAGE_TITLE, status: 'private' },
+			} );
+			fixture.slug = `e2ehist${ SUFFIX }`;
+			fixture.collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_collections',
+				data: {
+					title: HISTORY_COLLECTION_TITLE,
+					status: 'private',
+					meta: { slug: fixture.slug },
+				},
+			} );
+
+			const backButton = page.getByRole( 'button', {
+				name: 'Go back',
+			} );
+			const forwardButton = page.getByRole( 'button', {
+				name: 'Go forward',
+			} );
+			const sidebar = page.locator( '.cortext-sidebar' );
+			const breadcrumb = page.getByRole( 'navigation', {
+				name: 'Breadcrumb',
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.firstPage.id }`
+			);
+			await waitForEditorPost( page, fixture.firstPage.id );
+			await expect( backButton ).toBeDisabled();
+			await expect( forwardButton ).toBeDisabled();
+
+			await sidebar
+				.getByRole( 'button', {
+					name: HISTORY_SECOND_PAGE_TITLE,
+					exact: true,
+				} )
+				.click();
+			await waitForEditorPost( page, fixture.secondPage.id );
+			await expect( backButton ).toBeEnabled();
+			await expect( forwardButton ).toBeDisabled();
+
+			await backButton.click();
+			await waitForEditorPost( page, fixture.firstPage.id );
+			await expect( backButton ).toBeDisabled();
+			await expect( forwardButton ).toBeEnabled();
+
+			await forwardButton.click();
+			await waitForEditorPost( page, fixture.secondPage.id );
+			await expect( backButton ).toBeEnabled();
+			await expect( forwardButton ).toBeDisabled();
+
+			await sidebar
+				.getByRole( 'button', {
+					name: HISTORY_COLLECTION_TITLE,
+					exact: true,
+				} )
+				.click();
+			await expect( breadcrumb ).toContainText(
+				HISTORY_COLLECTION_TITLE
+			);
+			await expect( backButton ).toBeEnabled();
+			await expect( forwardButton ).toBeDisabled();
+
+			await page.goBack();
+			await waitForEditorPost( page, fixture.secondPage.id );
+			await expect( forwardButton ).toBeEnabled();
+
+			await page.goForward();
+			await expect( breadcrumb ).toContainText(
+				HISTORY_COLLECTION_TITLE
+			);
+			await expect( forwardButton ).toBeDisabled();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.secondPage &&
+					`/wp/v2/crtxt_pages/${ fixture.secondPage.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.firstPage &&
+					`/wp/v2/crtxt_pages/${ fixture.firstPage.id }`
+			);
+		}
+	} );
+
 	test( 'preserves the mounted page canvas and waits for collection rows', async ( {
 		admin,
 		page,

--- a/tests/js/components/WorkspaceTopBar.test.js
+++ b/tests/js/components/WorkspaceTopBar.test.js
@@ -1,0 +1,136 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock( '@wordpress/components', () => {
+	const ReactLib = require( 'react' );
+	const Button = ( {
+		children,
+		className,
+		disabled,
+		icon, // eslint-disable-line no-unused-vars
+		label,
+		onClick,
+		...rest
+	} ) =>
+		ReactLib.createElement(
+			'button',
+			{
+				...rest,
+				'aria-label': label,
+				className,
+				disabled,
+				onClick,
+			},
+			children ?? label
+		);
+	const createSlotFill = () => ( {
+		Slot: () => null,
+		Fill: ( { children } ) =>
+			ReactLib.createElement( ReactLib.Fragment, null, children ),
+	} );
+	return {
+		__esModule: true,
+		Button,
+		createSlotFill,
+	};
+} );
+
+jest.mock( '@wordpress/icons', () => ( {
+	__esModule: true,
+	chevronLeft: 'chevron-left-icon',
+	chevronRight: 'chevron-right-icon',
+} ) );
+
+jest.mock( '../../../src/components/Breadcrumbs', () => ( {
+	__esModule: true,
+	default: () => <nav aria-label="Breadcrumb">Current</nav>,
+} ) );
+
+import WorkspaceTopBar from '../../../src/components/WorkspaceTopBar';
+
+function createFakeHistory( initialIndex = 0 ) {
+	const subscribers = new Set();
+	const history = {
+		location: { state: { __TSR_index: initialIndex } },
+		subscribe: jest.fn( ( callback ) => {
+			subscribers.add( callback );
+			return () => subscribers.delete( callback );
+		} ),
+		back: jest.fn(),
+		forward: jest.fn(),
+		flush: jest.fn(),
+		emit( type, index ) {
+			act( () => {
+				history.location = { state: { __TSR_index: index } };
+				subscribers.forEach( ( callback ) =>
+					callback( {
+						location: history.location,
+						action: { type },
+					} )
+				);
+			} );
+		},
+	};
+	return history;
+}
+
+function renderTopBar( history = createFakeHistory() ) {
+	render(
+		<WorkspaceTopBar
+			history={ history }
+			paintedRoute={ { kind: 'unresolved' } }
+		/>
+	);
+	return history;
+}
+
+describe( 'WorkspaceTopBar', () => {
+	it( 'disables back and forward at the initial history index', () => {
+		renderTopBar();
+
+		expect(
+			screen.getByRole( 'button', { name: 'Go back' } )
+		).toBeDisabled();
+		expect(
+			screen.getByRole( 'button', { name: 'Go forward' } )
+		).toBeDisabled();
+	} );
+
+	it( 'enables back and keeps forward disabled after a push', () => {
+		const history = renderTopBar();
+
+		history.emit( 'PUSH', 1 );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Go back' } )
+		).not.toBeDisabled();
+		expect(
+			screen.getByRole( 'button', { name: 'Go forward' } )
+		).toBeDisabled();
+	} );
+
+	it( 'enables forward after going back and forwards on click', () => {
+		const history = renderTopBar();
+
+		history.emit( 'PUSH', 1 );
+		history.emit( 'BACK', 0 );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Go forward' } ) );
+
+		expect( history.flush ).toHaveBeenCalled();
+		expect( history.forward ).toHaveBeenCalled();
+	} );
+
+	it( 'clears the known forward branch after a new push', () => {
+		const history = renderTopBar();
+
+		history.emit( 'PUSH', 1 );
+		history.emit( 'BACK', 0 );
+		history.emit( 'PUSH', 1 );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Go back' } )
+		).not.toBeDisabled();
+		expect(
+			screen.getByRole( 'button', { name: 'Go forward' } )
+		).toBeDisabled();
+	} );
+} );


### PR DESCRIPTION
## What

Closes #148

Adds Back and Forward buttons to the Cortext top bar, before the breadcrumbs. They use the existing browser history, stay in sync with browser back/forward, and gray out when there is nowhere to go.

## Testing Instructions

1. Open Cortext in wp-admin.
2. Navigate from one page to another from the sidebar.
3. Click Back in the top bar and confirm it returns to the previous page.
4. Click Forward and confirm it returns to the page you just left.
5. Navigate to a collection, then use the browser back/forward buttons.
6. Confirm the top bar buttons update correctly and gray out when unavailable.

## Screen recording

https://github.com/user-attachments/assets/debadf50-8ba7-4dec-95f1-edf5bcadcb12