### PR TITLE
Set any page as workspace home

### DIFF
--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -18,6 +18,8 @@ use WP_CLI_Command;
 
 final class SeedDummyCollections extends WP_CLI_Command {
 
+	private const WORKSPACE_HOME_META_KEY = 'cortext_workspace_home';
+
 	/**
 	 * Seeds sample collections (Books, Paintings, Demo, Projects) plus a
 	 * realistic page hierarchy with embedded collection views.
@@ -27,7 +29,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * [--reset]
-	 * : Delete all Cortext data (collections, fields, entries, pages) before seeding.
+	 * : Delete all Cortext data and workspace home preferences before seeding.
 	 * Prompts for confirmation unless --force is also passed.
 	 *
 	 * [--force]
@@ -49,11 +51,12 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		// (otherwise CLI's user-0 context produces empty Created by /
 		// Last edited by columns) and the save_post hook records
 		// `_modified_by` against the same user.
-		wp_set_current_user( $this->default_seed_user_id() );
+		$seed_user_id = $this->default_seed_user_id();
+		wp_set_current_user( $seed_user_id );
 
 		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'reset', false ) ) {
 			WP_CLI::confirm(
-				'This will delete all Cortext collections, fields, and entries. Continue?',
+				'This will delete all Cortext collections, fields, entries, pages, and workspace home preferences. Continue?',
 				array( 'yes' => WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false ) )
 			);
 			$this->reset();
@@ -651,7 +654,8 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			$collection_ids[ $spec['slug'] ] = $this->seed_collection( $spec );
 		}
 
-		$this->seed_pages( $collection_ids );
+		$workspace_page_id = $this->seed_pages( $collection_ids );
+		$this->seed_workspace_home( $seed_user_id, $workspace_page_id );
 
 		WP_CLI::success( 'Seeding complete.' );
 	}
@@ -677,8 +681,9 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	 * Seeds a small realistic workspace hierarchy with starter content.
 	 *
 	 * @param array $collection_ids Collection IDs keyed by seeded collection slug.
+	 * @return int Seeded Workspace page ID.
 	 */
-	private function seed_pages( array $collection_ids ): void {
+	private function seed_pages( array $collection_ids ): int {
 		$tree = array(
 			array(
 				'title'    => 'Workspace',
@@ -803,9 +808,15 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			),
 		);
 
+		$workspace_page_id = 0;
 		foreach ( $tree as $node ) {
-			$this->seed_page_tree( $node, 0 );
+			$page_id = $this->seed_page_tree( $node, 0 );
+			if ( 'Workspace' === $node['title'] ) {
+				$workspace_page_id = $page_id;
+			}
 		}
+
+		return $workspace_page_id;
 	}
 
 	private function seed_page_tree( array $node, int $parent_id ): int {
@@ -858,6 +869,44 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		return (int) $page_id;
+	}
+
+	private function seed_workspace_home( int $user_id, int $page_id ): void {
+		if ( $page_id <= 0 ) {
+			return;
+		}
+
+		$current = get_user_meta( $user_id, self::WORKSPACE_HOME_META_KEY, true );
+		if ( is_string( $current ) && '' !== $current && $this->workspace_home_exists( $current ) ) {
+			WP_CLI::log( 'Workspace home already exists. Skipping.' );
+			return;
+		}
+
+		update_user_meta( $user_id, self::WORKSPACE_HOME_META_KEY, "page:{$page_id}" );
+		WP_CLI::log( "Set workspace home to page 'Workspace' (ID {$page_id})." );
+	}
+
+	private function workspace_home_exists( string $raw ): bool {
+		$parts = explode( ':', $raw, 2 );
+		if ( 2 !== count( $parts ) ) {
+			return false;
+		}
+
+		$id = (int) $parts[1];
+		if ( $id <= 0 ) {
+			return false;
+		}
+
+		$post = get_post( $id );
+		if ( ! $post || 'trash' === $post->post_status ) {
+			return false;
+		}
+
+		$post_type = 'page' === $parts[0]
+			? Page::POST_TYPE
+			: ( 'collection' === $parts[0] ? Collection::POST_TYPE : null );
+
+		return null !== $post_type && $post_type === $post->post_type;
 	}
 
 	private function page_content( array $blocks ): string {
@@ -1151,6 +1200,10 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 		if ( $pages ) {
 			WP_CLI::log( sprintf( 'Deleted %d pages.', count( $pages ) ) );
+		}
+
+		if ( delete_metadata( 'user', 0, self::WORKSPACE_HOME_META_KEY, '', true ) ) {
+			WP_CLI::log( 'Deleted workspace home preferences.' );
 		}
 
 		WP_CLI::success( 'Reset complete.' );

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -22,6 +22,7 @@ use Cortext\Rest\CollectionsController;
 use Cortext\Rest\FieldsController;
 use Cortext\Rest\PageTrashController;
 use Cortext\Rest\RowsController;
+use Cortext\Rest\WorkspaceHomeController;
 use Cortext\Theming\Preferences;
 
 final class Plugin {
@@ -47,6 +48,7 @@ final class Plugin {
 		( new FieldsController() )->register();
 		( new PageTrashController() )->register();
 		( new RowsController() )->register();
+		( new WorkspaceHomeController() )->register();
 		( new Template() )->register();
 		( new Assets() )->register();
 		( new Preferences() )->register();

--- a/includes/Rest/WorkspaceHomeController.php
+++ b/includes/Rest/WorkspaceHomeController.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * REST endpoint for the current user's workspace home preference.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\Page;
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class WorkspaceHomeController {
+
+	private const NAMESPACE = 'cortext/v1';
+	private const META_KEY  = 'cortext_workspace_home';
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/workspace-home',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_home' ),
+					'permission_callback' => array( $this, 'can_read' ),
+				),
+				array(
+					'methods'             => 'PUT',
+					'callback'            => array( $this, 'update_home' ),
+					'permission_callback' => array( $this, 'can_read' ),
+					'args'                => array(
+						'kind' => array(
+							'type'     => 'string',
+							'required' => true,
+							'enum'     => array( 'page', 'collection' ),
+						),
+						'id'   => array(
+							'type'     => 'integer',
+							'required' => true,
+							'minimum'  => 1,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function can_read(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	public function get_home(): WP_REST_Response {
+		$home = $this->resolve_stored_home( get_current_user_id() );
+
+		return new WP_REST_Response(
+			array(
+				'home' => $home,
+			),
+			200
+		);
+	}
+
+	public function update_home( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$kind = (string) $request->get_param( 'kind' );
+		$id   = (int) $request->get_param( 'id' );
+
+		$home = $this->format_target( $kind, $id, true );
+		if ( is_wp_error( $home ) ) {
+			return $home;
+		}
+
+		update_user_meta( get_current_user_id(), self::META_KEY, "{$kind}:{$id}" );
+
+		return new WP_REST_Response(
+			array(
+				'home' => $home,
+			),
+			200
+		);
+	}
+
+	private function resolve_stored_home( int $user_id ): ?array {
+		$raw = get_user_meta( $user_id, self::META_KEY, true );
+		if ( ! is_string( $raw ) || '' === $raw ) {
+			return null;
+		}
+
+		$parts = explode( ':', $raw, 2 );
+		if ( 2 !== count( $parts ) ) {
+			return null;
+		}
+
+		$home = $this->format_target( $parts[0], (int) $parts[1], true );
+		return is_wp_error( $home ) ? null : $home;
+	}
+
+	/**
+	 * Formats a page or collection target into the shell route contract.
+	 *
+	 * @param string $kind Target kind.
+	 * @param int    $id Target post ID.
+	 * @param bool   $require_edit Whether to enforce edit_post capability.
+	 * @return array{kind:string,id:int,path:string}|WP_Error
+	 */
+	private function format_target( string $kind, int $id, bool $require_edit ) {
+		if ( ! in_array( $kind, array( 'page', 'collection' ), true ) || $id < 1 ) {
+			return new WP_Error(
+				'cortext_workspace_home_invalid_target',
+				__( 'Workspace home target is invalid.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$post = get_post( $id );
+		if ( ! $this->is_supported_target( $post, $kind ) ) {
+			return new WP_Error(
+				'cortext_workspace_home_not_found',
+				__( 'Workspace home target was not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( $require_edit && ! current_user_can( 'edit_post', $id ) ) {
+			return new WP_Error(
+				'cortext_workspace_home_forbidden',
+				__( 'You are not allowed to use this target as your workspace home.', 'cortext' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return array(
+			'kind' => $kind,
+			'id'   => $id,
+			'path' => $this->target_path( $post, $kind ),
+		);
+	}
+
+	private function is_supported_target( ?WP_Post $post, string $kind ): bool {
+		if ( ! $post || 'trash' === $post->post_status ) {
+			return false;
+		}
+
+		$type = 'page' === $kind ? Page::POST_TYPE : Collection::POST_TYPE;
+		return $type === $post->post_type;
+	}
+
+	private function target_path( WP_Post $post, string $kind ): string {
+		if ( 'collection' === $kind ) {
+			$slug = get_post_meta( (int) $post->ID, 'slug', true );
+			$slug = is_string( $slug ) ? trim( $slug ) : '';
+		} else {
+			$slug = trim( $post->post_name );
+		}
+
+		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
+		return "{$kind}/{$tail}";
+	}
+}

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -7,7 +7,12 @@ import {
 	MenuItem,
 	TextControl,
 } from '@wordpress/components';
-import { chevronRight, moreVertical, plus } from '@wordpress/icons';
+import {
+	chevronRight,
+	home as homeIcon,
+	moreVertical,
+	plus,
+} from '@wordpress/icons';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 
 const GRID_UNIT = 20; // matches $grid-unit-20 in index.scss
@@ -31,6 +36,9 @@ export default function PageRow( {
 	onRename,
 	onDuplicate,
 	onDelete,
+	onSetHome,
+	home,
+	isHomeUpdating = false,
 	autoRenameId, // page id that should immediately enter rename mode
 	onAutoRenameConsumed,
 	// True when an ancestor is collapsed: this row and its subtree are
@@ -43,6 +51,7 @@ export default function PageRow( {
 	const hasChildren = children.length > 0;
 	const isExpanded = expandedIds.has( page.id );
 	const isSelected = page.id === selectedId;
+	const isHome = home?.kind === 'page' && home.id === page.id;
 	const isBeingDragged = draggedId === page.id;
 
 	const [ isRenaming, setIsRenaming ] = useState( false );
@@ -250,6 +259,18 @@ export default function PageRow( {
 						renderContent={ ( { onClose } ) => (
 							<MenuGroup>
 								<MenuItem
+									icon={ homeIcon }
+									disabled={ isHome || isHomeUpdating }
+									onClick={ () => {
+										onSetHome( page.id );
+										onClose();
+									} }
+								>
+									{ isHome
+										? __( 'Home', 'cortext' )
+										: __( 'Set as home', 'cortext' ) }
+								</MenuItem>
+								<MenuItem
 									icon="edit"
 									onClick={ () => {
 										startRename();
@@ -325,6 +346,9 @@ export default function PageRow( {
 								onRename={ onRename }
 								onDuplicate={ onDuplicate }
 								onDelete={ onDelete }
+								onSetHome={ onSetHome }
+								home={ home }
+								isHomeUpdating={ isHomeUpdating }
 								autoRenameId={ autoRenameId }
 								onAutoRenameConsumed={ onAutoRenameConsumed }
 								isHidden={ isHidden || ! isExpanded }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,8 +9,20 @@ import {
 	useCallback,
 	useEffect,
 } from '@wordpress/element';
-import { Button, Icon, Spinner } from '@wordpress/components';
-import { plus, wordpress } from '@wordpress/icons';
+import {
+	Button,
+	Dropdown,
+	Icon,
+	MenuGroup,
+	MenuItem,
+	Spinner,
+} from '@wordpress/components';
+import {
+	home as homeIcon,
+	moreVertical,
+	plus,
+	wordpress,
+} from '@wordpress/icons';
 
 // Notion-style sidebar toggle: panel outline with a vertical accent on
 // the left side. Same icon for both states; the aria-label tells the
@@ -63,6 +75,7 @@ import {
 	buildTree,
 	collectAncestorIds,
 	computeDropTarget,
+	firstPageInTree,
 	isDescendantOf,
 	nextChildOrder,
 } from './pages-tree';
@@ -77,6 +90,7 @@ import {
 	parseSplatUri,
 } from '../router/useResolveEntity';
 import { COLLECTION_QUERY } from '../collections';
+import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 
 const AUTO_EXPAND_DELAY = 700;
 
@@ -90,6 +104,82 @@ function parseDropId( id ) {
 		return null;
 	}
 	return { zone, targetId: pageId };
+}
+
+function collectionTitle( collection ) {
+	return (
+		collection.title?.rendered?.trim() ||
+		collection.title?.raw?.trim() ||
+		collection.title?.trim?.() ||
+		__( '(untitled)', 'cortext' )
+	);
+}
+
+function CollectionRow( {
+	collection,
+	isSelected,
+	isHome,
+	isHomeUpdating,
+	onSelect,
+	onSetHome,
+} ) {
+	const title = collectionTitle( collection );
+	const rowClasses = [ 'cortext-sidebar__row' ];
+	if ( isSelected ) {
+		rowClasses.push( 'is-selected' );
+	}
+
+	return (
+		<li className="cortext-sidebar__node">
+			<div className={ rowClasses.join( ' ' ) }>
+				<Button
+					className="cortext-sidebar__title"
+					size="compact"
+					variant="tertiary"
+					onClick={ onSelect }
+					isPressed={ isSelected }
+				>
+					{ title }
+				</Button>
+				<Dropdown
+					popoverProps={ { placement: 'bottom-end' } }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							className={
+								'cortext-sidebar__menu' +
+								( isOpen ? ' is-opened' : '' )
+							}
+							icon={ moreVertical }
+							size="small"
+							label={ sprintf(
+								/* translators: %s: collection title */
+								__( 'Actions for %s', 'cortext' ),
+								title
+							) }
+							onClick={ onToggle }
+							aria-expanded={ isOpen }
+						/>
+					) }
+					renderContent={ ( { onClose } ) => (
+						<MenuGroup>
+							<MenuItem
+								icon={ homeIcon }
+								disabled={ isHome || isHomeUpdating }
+								onClick={ () => {
+									onSetHome( collection.id );
+									onClose();
+								} }
+							>
+								{ isHome
+									? __( 'Home', 'cortext' )
+									: __( 'Set as home', 'cortext' ) }
+							</MenuItem>
+						</MenuGroup>
+					) }
+				/>
+			</div>
+		</li>
+	);
 }
 
 export default function Sidebar( {
@@ -110,6 +200,12 @@ export default function Sidebar( {
 
 	const { records: collections, isResolving: isResolvingCollections } =
 		useEntityRecords( 'postType', 'crtxt_collection', COLLECTION_QUERY );
+	const {
+		home,
+		setHome,
+		isResolving: isResolvingHome,
+		isUpdating: isHomeUpdating,
+	} = useWorkspaceHome();
 	const {
 		saveEntityRecord,
 		deleteEntityRecord,
@@ -139,6 +235,11 @@ export default function Sidebar( {
 			activePrefix === 'page' || activePrefix === null
 				? parseIdFromUri( activeTail )
 				: null,
+		[ activePrefix, activeTail ]
+	);
+	const selectedCollectionId = useMemo(
+		() =>
+			activePrefix === 'collection' ? parseIdFromUri( activeTail ) : null,
 		[ activePrefix, activeTail ]
 	);
 
@@ -182,6 +283,42 @@ export default function Sidebar( {
 			} );
 		},
 		[ navigate, pages ]
+	);
+
+	const fallbackHomePage = useMemo(
+		() => firstPageInTree( pages ),
+		[ pages ]
+	);
+	const homePath =
+		home?.path ??
+		( fallbackHomePage ? computeUri( fallbackHomePage ) : null );
+	const isHomeSelected = Boolean( homePath && activeUri === homePath );
+	const goHome = useCallback( () => {
+		if ( ! homePath ) {
+			return;
+		}
+		navigate( {
+			to: '/$',
+			params: { _splat: homePath },
+		} );
+	}, [ homePath, navigate ] );
+
+	const setPageHome = useCallback(
+		async ( id ) => {
+			try {
+				await setHome( { kind: 'page', id } );
+			} catch {}
+		},
+		[ setHome ]
+	);
+
+	const setCollectionHome = useCallback(
+		async ( id ) => {
+			try {
+				await setHome( { kind: 'collection', id } );
+			} catch {}
+		},
+		[ setHome ]
 	);
 
 	const tree = useMemo( () => buildTree( pages ), [ pages ] );
@@ -503,8 +640,31 @@ export default function Sidebar( {
 					onClick={ onToggleCollapsed }
 				/>
 			</div>
+			{ collapsed && (
+				<div className="cortext-sidebar__rail">
+					<Button
+						className="cortext-sidebar__rail-button"
+						icon={ homeIcon }
+						label={ __( 'Home', 'cortext' ) }
+						isPressed={ isHomeSelected }
+						disabled={ ! homePath || isResolvingHome }
+						onClick={ goHome }
+					/>
+				</div>
+			) }
 			{ ! collapsed && (
 				<div className="cortext-sidebar__content">
+					<div className="cortext-sidebar__home">
+						<Button
+							className="cortext-sidebar__home-button"
+							icon={ homeIcon }
+							isPressed={ isHomeSelected }
+							disabled={ ! homePath || isResolvingHome }
+							onClick={ goHome }
+						>
+							{ __( 'Home', 'cortext' ) }
+						</Button>
+					</div>
 					<div className="cortext-sidebar__section-header">
 						<h2 className="cortext-sidebar__section-title">
 							{ __( 'Pages', 'cortext' ) }
@@ -552,6 +712,9 @@ export default function Sidebar( {
 									onRename={ renamePage }
 									onDuplicate={ duplicatePage }
 									onDelete={ trashPage }
+									onSetHome={ setPageHome }
+									home={ home }
+									isHomeUpdating={ isHomeUpdating }
 									autoRenameId={ autoRenameId }
 									onAutoRenameConsumed={ () =>
 										setAutoRenameId( null )
@@ -595,31 +758,30 @@ export default function Sidebar( {
 					{ collections?.length > 0 && (
 						<ul className="cortext-sidebar__list">
 							{ collections.map( ( collection ) => (
-								<li
+								<CollectionRow
 									key={ collection.id }
-									className="cortext-sidebar__node"
-								>
-									<div className="cortext-sidebar__row">
-										<Button
-											className="cortext-sidebar__title"
-											size="compact"
-											variant="tertiary"
-											onClick={ () =>
-												navigate( {
-													to: '/$',
-													params: {
-														_splat: computeUri(
-															collection,
-															'collection'
-														),
-													},
-												} )
-											}
-										>
-											{ collection.title.rendered }
-										</Button>
-									</div>
-								</li>
+									collection={ collection }
+									isSelected={
+										selectedCollectionId === collection.id
+									}
+									isHome={
+										home?.kind === 'collection' &&
+										home.id === collection.id
+									}
+									isHomeUpdating={ isHomeUpdating }
+									onSetHome={ setCollectionHome }
+									onSelect={ () =>
+										navigate( {
+											to: '/$',
+											params: {
+												_splat: computeUri(
+													collection,
+													'collection'
+												),
+											},
+										} )
+									}
+								/>
 							) ) }
 						</ul>
 					) }

--- a/src/components/pages-tree.js
+++ b/src/components/pages-tree.js
@@ -45,6 +45,16 @@ export function buildTree( pages ) {
 }
 
 /**
+ * Returns the first page in the same ordering used by the sidebar tree.
+ *
+ * @param {Array} pages Flat page list.
+ * @return {Object|null} First root page, or null when there are no pages.
+ */
+export function firstPageInTree( pages ) {
+	return buildTree( pages )[ 0 ]?.page ?? null;
+}
+
+/**
  * Collect all descendant page IDs of a root page (root not included).
  * Used by the cascading delete path.
  *

--- a/src/hooks/useWorkspaceHome.js
+++ b/src/hooks/useWorkspaceHome.js
@@ -1,0 +1,85 @@
+import apiFetch from '@wordpress/api-fetch';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
+
+const WorkspaceHomeContext = createContext( null );
+
+export function WorkspaceHomeProvider( { children } ) {
+	const [ home, setHomeState ] = useState( null );
+	const [ isResolving, setIsResolving ] = useState( true );
+	const [ isUpdating, setIsUpdating ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	useEffect( () => {
+		let cancelled = false;
+		setIsResolving( true );
+		setError( null );
+
+		apiFetch( { path: '/cortext/v1/workspace-home' } )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setHomeState( response?.home ?? null );
+				setIsResolving( false );
+			} )
+			.catch( ( nextError ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setHomeState( null );
+				setError( nextError );
+				setIsResolving( false );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const setHome = useCallback( async ( target ) => {
+		setIsUpdating( true );
+		setError( null );
+		try {
+			const response = await apiFetch( {
+				path: '/cortext/v1/workspace-home',
+				method: 'PUT',
+				data: target,
+			} );
+			setHomeState( response?.home ?? null );
+			return response?.home ?? null;
+		} catch ( nextError ) {
+			setError( nextError );
+			throw nextError;
+		} finally {
+			setIsUpdating( false );
+		}
+	}, [] );
+
+	const value = useMemo(
+		() => ( { home, isResolving, isUpdating, error, setHome } ),
+		[ home, isResolving, isUpdating, error, setHome ]
+	);
+
+	return (
+		<WorkspaceHomeContext.Provider value={ value }>
+			{ children }
+		</WorkspaceHomeContext.Provider>
+	);
+}
+
+export function useWorkspaceHome() {
+	const value = useContext( WorkspaceHomeContext );
+	if ( ! value ) {
+		throw new Error(
+			'useWorkspaceHome must be used inside WorkspaceHomeProvider'
+		);
+	}
+	return value;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -165,6 +165,34 @@ body.cortext-fullscreen {
 		padding: 0 $grid-unit-15 $grid-unit-15;
 	}
 
+	&__home {
+		padding: $grid-unit-10 0 $grid-unit-05;
+	}
+
+	&__home-button.components-button {
+		width: 100%;
+		height: $grid-unit-40;
+		justify-content: flex-start;
+		gap: $grid-unit-05;
+	}
+
+	&__rail {
+		display: flex;
+		flex: 0 0 auto;
+		flex-direction: column;
+		align-items: center;
+		gap: $grid-unit-05;
+		padding: $grid-unit-05 0;
+	}
+
+	&__rail-button.components-button {
+		width: $grid-unit-40;
+		min-width: $grid-unit-40;
+		height: $grid-unit-40;
+		padding: 0;
+		justify-content: center;
+	}
+
 	&__footer {
 		flex: 0 0 auto;
 		// Keeps the footer at the bottom in collapsed mode, where the

--- a/src/router.js
+++ b/src/router.js
@@ -12,6 +12,7 @@ import { SlotFillProvider } from '@wordpress/components';
 import Sidebar from './components/Sidebar';
 import EntityRoute from './router/EntityRoute';
 import useSidebarLayout from './hooks/useSidebarLayout';
+import { WorkspaceHomeProvider } from './hooks/useWorkspaceHome';
 import { unlock } from './lock-unlock';
 
 const {
@@ -59,17 +60,19 @@ function RootLayout() {
 
 	return (
 		<SlotFillProvider>
-			<div className="cortext-shell">
-				<Sidebar
-					collapsed={ collapsed }
-					width={ width }
-					onToggleCollapsed={ toggleCollapsed }
-					onWidthChange={ setWidth }
-				/>
-				<main className="cortext-shell__canvas">
-					<EntityRoute />
-				</main>
-			</div>
+			<WorkspaceHomeProvider>
+				<div className="cortext-shell">
+					<Sidebar
+						collapsed={ collapsed }
+						width={ width }
+						onToggleCollapsed={ toggleCollapsed }
+						onWidthChange={ setWidth }
+					/>
+					<main className="cortext-shell__canvas">
+						<EntityRoute />
+					</main>
+				</div>
+			</WorkspaceHomeProvider>
 		</SlotFillProvider>
 	);
 }

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -1,5 +1,6 @@
-import { useParams } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { Spinner } from '@wordpress/components';
+import { useEntityRecords } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
 	useCallback,
@@ -13,9 +14,16 @@ import {
 import Canvas from '../components/Canvas';
 import CollectionDataViews from '../components/CollectionDataViews';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
+import { ACTIVE_PAGES_QUERY, POST_TYPE } from '../components/page-queries';
+import { firstPageInTree } from '../components/pages-tree';
 import { withViewTransition } from '../hooks/viewTransition';
+import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 import EmptyState from './EmptyState';
-import { useResolveEntity, useResolveCollection } from './useResolveEntity';
+import {
+	computeUri,
+	useResolveEntity,
+	useResolveCollection,
+} from './useResolveEntity';
 import { init, parseTarget, reducer } from './entityRouteReducer';
 
 const DEFAULT_VIEW = {
@@ -101,8 +109,15 @@ function WorkspacePane( { active, preservePaint = false, children } ) {
 
 export default function EntityRoute() {
 	const params = useParams( { strict: false } );
+	const navigate = useNavigate();
 	const splat = params._splat ?? '';
 	const target = useMemo( () => parseTarget( splat ), [ splat ] );
+	const { home, isResolving: isResolvingHome } = useWorkspaceHome();
+	const { records: pages, isResolving: isResolvingPages } = useEntityRecords(
+		'postType',
+		POST_TYPE,
+		ACTIVE_PAGES_QUERY
+	);
 
 	const [ state, rawDispatch ] = useReducer( reducer, target, init );
 	const { active, mountedPageId, displayedPageId, mountedCollectionIds } =
@@ -137,6 +152,34 @@ export default function EntityRoute() {
 	useEffect( () => {
 		dispatch( { type: 'TARGET_CHANGED', target } );
 	}, [ target, dispatch ] );
+
+	useEffect( () => {
+		if ( target.kind !== 'empty' ) {
+			return;
+		}
+		if ( isResolvingHome || isResolvingPages ) {
+			return;
+		}
+
+		const fallback = firstPageInTree( pages ?? [] );
+		const path = home?.path ?? ( fallback ? computeUri( fallback ) : null );
+		if ( ! path ) {
+			return;
+		}
+
+		navigate( {
+			to: '/$',
+			params: { _splat: path },
+			replace: true,
+		} );
+	}, [
+		target.kind,
+		home,
+		isResolvingHome,
+		pages,
+		isResolvingPages,
+		navigate,
+	] );
 
 	useEffect( () => {
 		if ( target.kind !== 'page' || target.id === null ) {

--- a/tests/e2e/specs/shell.spec.js
+++ b/tests/e2e/specs/shell.spec.js
@@ -22,7 +22,7 @@ test.describe( 'Cortext shell', () => {
 		await admin.visitAdminPage( 'admin.php', 'page=cortext' );
 
 		await expect( page ).toHaveURL(
-			/\/wp-admin\/admin\.php\?page=cortext$/
+			/\/wp-admin\/admin\.php\?page=cortext(?:&p=.*)?$/
 		);
 
 		const root = page.locator( '#cortext-root' );

--- a/tests/e2e/specs/workspace-home.spec.js
+++ b/tests/e2e/specs/workspace-home.spec.js
@@ -1,0 +1,252 @@
+/**
+ * E2E coverage for the per-user workspace home preference.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SUFFIX = Date.now().toString( 36 ).slice( -4 );
+const PAGE_HOME_TITLE = `E2E Home Page ${ SUFFIX }`;
+const OTHER_PAGE_TITLE = `E2E Other Page ${ SUFFIX }`;
+const COLLECTION_HOME_TITLE = `E2E Home Collection ${ SUFFIX }`;
+const FALLBACK_TITLE = `E2E Home Fallback ${ SUFFIX }`;
+const DELETED_HOME_TITLE = `E2E Deleted Home ${ SUFFIX }`;
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch ( _error ) {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+async function waitForEditorPost( page, postId ) {
+	await page.waitForFunction(
+		( expectedPostId ) =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ===
+			expectedPostId,
+		postId,
+		{ timeout: 15_000 }
+	);
+}
+
+async function appPath( page ) {
+	return page.evaluate(
+		() => new URL( window.location.href ).searchParams.get( 'p' ) || '/'
+	);
+}
+
+async function setSidebarItemAsHome( page, title ) {
+	const sidebar = page.locator( '.cortext-sidebar' );
+	const rowTitle = sidebar.getByRole( 'button', {
+		name: title,
+		exact: true,
+	} );
+	await expect( rowTitle ).toBeVisible();
+	await rowTitle.hover();
+
+	const request = page.waitForResponse(
+		( response ) =>
+			response.url().includes( 'workspace-home' ) &&
+			response.request().method() !== 'GET'
+	);
+
+	await sidebar
+		.getByRole( 'button', {
+			name: `Actions for ${ title }`,
+			exact: true,
+		} )
+		.click( { force: true } );
+	await page.getByRole( 'menuitem', { name: 'Set as home' } ).click();
+	expect( ( await request ).status() ).toBe( 200 );
+}
+
+test.describe( 'Workspace home', () => {
+	test( 'set a page as home and land there from the workspace root', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let homePage;
+		let otherPage;
+
+		try {
+			homePage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: PAGE_HOME_TITLE,
+					status: 'private',
+				},
+			} );
+			otherPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: OTHER_PAGE_TITLE,
+					status: 'private',
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ homePage.id }`
+			);
+			await waitForEditorPost( page, homePage.id );
+			await setSidebarItemAsHome( page, PAGE_HOME_TITLE );
+
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: OTHER_PAGE_TITLE,
+					exact: true,
+				} )
+				.click();
+			await waitForEditorPost( page, otherPage.id );
+
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', { name: 'Home', exact: true } )
+				.click();
+			await waitForEditorPost( page, homePage.id );
+
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: OTHER_PAGE_TITLE,
+					exact: true,
+				} )
+				.click();
+			await waitForEditorPost( page, otherPage.id );
+
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: 'Collapse sidebar',
+					exact: true,
+				} )
+				.click();
+			const collapsedSidebar = page.locator(
+				'.cortext-sidebar[data-collapsed="true"]'
+			);
+			await expect( collapsedSidebar ).toBeVisible();
+			await collapsedSidebar
+				.getByRole( 'button', { name: 'Home', exact: true } )
+				.click();
+			await waitForEditorPost( page, homePage.id );
+
+			await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+			await waitForEditorPost( page, homePage.id );
+			await expect.poll( () => appPath( page ) ).toContain( '/page/' );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				otherPage && `/wp/v2/crtxt_pages/${ otherPage.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				homePage && `/wp/v2/crtxt_pages/${ homePage.id }`
+			);
+		}
+	} );
+
+	test( 'set a collection as home and land there from the workspace root', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let collection;
+
+		try {
+			collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/cortext/v1/collections',
+				data: { title: COLLECTION_HOME_TITLE },
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/collection/${ collection.slug }-${ collection.id }`
+			);
+			await expect(
+				page.locator(
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+				)
+			).toBeVisible( { timeout: 15_000 } );
+			await setSidebarItemAsHome( page, COLLECTION_HOME_TITLE );
+
+			await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+			await expect
+				.poll( () => appPath( page ) )
+				.toContain( '/collection/' );
+			await expect(
+				page.locator(
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+				)
+			).toBeVisible( { timeout: 15_000 } );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				collection && `/wp/v2/crtxt_collections/${ collection.id }`
+			);
+		}
+	} );
+
+	test( 'falls back to the first page when the home is trashed', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let fallback;
+		let deletedHome;
+
+		try {
+			fallback = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: FALLBACK_TITLE,
+					status: 'private',
+					menu_order: -100000,
+				},
+			} );
+			deletedHome = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: DELETED_HOME_TITLE,
+					status: 'private',
+					menu_order: -99999,
+				},
+			} );
+			await requestUtils.rest( {
+				method: 'PUT',
+				path: '/cortext/v1/workspace-home',
+				data: { kind: 'page', id: deletedHome.id },
+			} );
+			await requestUtils.rest( {
+				method: 'DELETE',
+				path: `/wp/v2/crtxt_pages/${ deletedHome.id }`,
+			} );
+
+			await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+			await waitForEditorPost( page, fallback.id );
+			await expect.poll( () => appPath( page ) ).toContain( '/page/' );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				deletedHome && `/wp/v2/crtxt_pages/${ deletedHome.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fallback && `/wp/v2/crtxt_pages/${ fallback.id }`
+			);
+		}
+	} );
+} );

--- a/tests/js/components/PageRow.test.js
+++ b/tests/js/components/PageRow.test.js
@@ -7,7 +7,7 @@
  * don't throw.
  */
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { DndContext } from '@dnd-kit/core';
 
 import PageRow from '../../../src/components/PageRow';
@@ -38,6 +38,9 @@ function baseProps( overrides = {} ) {
 		onRename: jest.fn(),
 		onDuplicate: jest.fn(),
 		onDelete: jest.fn(),
+		onSetHome: jest.fn(),
+		home: null,
+		isHomeUpdating: false,
 		autoRenameId: null,
 		onAutoRenameConsumed: jest.fn(),
 		...overrides,
@@ -134,5 +137,15 @@ describe( 'PageRow', () => {
 			container.querySelector( '.cortext-sidebar__rename input' )
 		).toBeTruthy();
 		expect( props.onAutoRenameConsumed ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'calls onSetHome from the action menu', () => {
+		const { container, props } = renderRow();
+		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
+		fireEvent.click(
+			screen.getByRole( 'menuitem', { name: 'Set as home' } )
+		);
+
+		expect( props.onSetHome ).toHaveBeenCalledWith( 1 );
 	} );
 } );

--- a/tests/js/pages-tree.test.js
+++ b/tests/js/pages-tree.test.js
@@ -8,6 +8,7 @@ import {
 	buildTree,
 	collectAncestorIds,
 	collectDescendants,
+	firstPageInTree,
 	isDescendantOf,
 	computeDropTarget,
 	nextChildOrder,
@@ -45,6 +46,23 @@ describe( 'buildTree', () => {
 		const roots = buildTree( pages );
 
 		expect( roots.map( ( r ) => r.page.id ) ).toEqual( [ 2, 3, 1 ] );
+	} );
+} );
+
+describe( 'firstPageInTree', () => {
+	it( 'returns null when there are no pages', () => {
+		expect( firstPageInTree( [] ) ).toBeNull();
+	} );
+
+	it( 'returns the first root page using sidebar tree ordering', () => {
+		const pages = [
+			makePage( 3, 0, 0 ),
+			makePage( 1, 0, 2 ),
+			makePage( 2, 0, 0 ),
+			makePage( 4, 2, 0 ),
+		];
+
+		expect( firstPageInTree( pages ).id ).toBe( 2 );
 	} );
 } );
 

--- a/tests/php/test-rest-workspace-home-controller.php
+++ b/tests/php/test-rest-workspace-home-controller.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Tests for Cortext\Rest\WorkspaceHomeController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\Page;
+use Cortext\Rest\WorkspaceHomeController;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Workspace_Home_Controller extends BaseTestCase {
+
+	private const META_KEY = 'cortext_workspace_home';
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Page() )->register_post_type();
+		( new Collection() )->register_post_type();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new WorkspaceHomeController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_get_returns_null_when_no_home_is_set(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$response = $this->get_home();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $response->get_data()['home'] );
+	}
+
+	public function test_sets_and_reads_a_page_home(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_id = $this->create_page(
+			array(
+				'post_name' => 'daily-notes',
+			)
+		);
+
+		$set_response = $this->set_home( 'page', $page_id );
+		$get_response = $this->get_home();
+
+		$expected = array(
+			'kind' => 'page',
+			'id'   => $page_id,
+			'path' => "page/daily-notes-{$page_id}",
+		);
+		$this->assertSame( 200, $set_response->get_status() );
+		$this->assertSame( $expected, $set_response->get_data()['home'] );
+		$this->assertSame( $expected, $get_response->get_data()['home'] );
+		$this->assertSame(
+			"page:{$page_id}",
+			get_user_meta( get_current_user_id(), self::META_KEY, true )
+		);
+	}
+
+	public function test_sets_and_reads_a_collection_home(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'books' );
+
+		$set_response = $this->set_home( 'collection', $collection_id );
+		$get_response = $this->get_home();
+
+		$expected = array(
+			'kind' => 'collection',
+			'id'   => $collection_id,
+			'path' => "collection/books-{$collection_id}",
+		);
+		$this->assertSame( 200, $set_response->get_status() );
+		$this->assertSame( $expected, $set_response->get_data()['home'] );
+		$this->assertSame( $expected, $get_response->get_data()['home'] );
+	}
+
+	public function test_home_is_stored_per_user(): void {
+		$user_a = $this->create_user( 'administrator' );
+		$user_b = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_a );
+		$page_id = $this->create_page();
+
+		$this->set_home( 'page', $page_id );
+
+		wp_set_current_user( $user_b );
+		$response = $this->get_home();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $response->get_data()['home'] );
+	}
+
+	public function test_rejects_a_non_cortext_target(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$post_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular post',
+			)
+		);
+
+		$response = $this->set_home( 'page', $post_id );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame(
+			'cortext_workspace_home_not_found',
+			$response->get_data()['code']
+		);
+	}
+
+	public function test_rejects_a_target_the_user_cannot_edit(): void {
+		$owner_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $owner_id );
+		$page_id = $this->create_page(
+			array(
+				'post_author' => $owner_id,
+				'post_status' => 'private',
+			)
+		);
+
+		wp_set_current_user( $this->create_user( 'contributor' ) );
+		$response = $this->set_home( 'page', $page_id );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame(
+			'cortext_workspace_home_forbidden',
+			$response->get_data()['code']
+		);
+	}
+
+	public function test_get_returns_null_when_stored_home_is_trashed(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_id = $this->create_page();
+		$this->set_home( 'page', $page_id );
+
+		wp_trash_post( $page_id );
+		$response = $this->get_home();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $response->get_data()['home'] );
+	}
+
+	public function test_get_returns_null_when_stored_home_is_deleted(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_id = $this->create_page();
+		$this->set_home( 'page', $page_id );
+
+		wp_delete_post( $page_id, true );
+		$response = $this->get_home();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( $response->get_data()['home'] );
+	}
+
+	public function test_requires_edit_posts_capability(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$response = $this->get_home();
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	private function get_home() {
+		$request = new WP_REST_Request( 'GET', '/cortext/v1/workspace-home' );
+		return rest_do_request( $request );
+	}
+
+	private function set_home( string $kind, int $id ) {
+		$request = new WP_REST_Request( 'PUT', '/cortext/v1/workspace-home' );
+		$request->set_body_params(
+			array(
+				'kind' => $kind,
+				'id'   => $id,
+			)
+		);
+		return rest_do_request( $request );
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+
+	private function create_page( array $args = array() ): int {
+		$defaults = array(
+			'post_type'   => Page::POST_TYPE,
+			'post_status' => 'private',
+			'post_title'  => 'Test page ' . wp_generate_uuid4(),
+		);
+
+		$id = wp_insert_post( array_merge( $defaults, $args ) );
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+		return (int) $id;
+	}
+
+	private function create_collection( string $slug ): int {
+		$id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Test collection ' . wp_generate_uuid4(),
+				'meta_input'  => array(
+					'slug' => $slug,
+				),
+			)
+		);
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+		return (int) $id;
+	}
+}


### PR DESCRIPTION
## What

Closes #139

- Lets each user choose a page or collection as their workspace home.
- Opens the chosen home when the user enters the workspace root.
- Falls back to the first page when no home is set, or when the saved home was deleted.
- Adds `Set as home` to page and collection menus in the sidebar.
- Adds a Home button in both expanded and collapsed sidebar states.
- Updates the demo seeder so new local workspaces open on the seeded `Workspace` page.

## Testing Instructions

- Open Cortext from wp-admin.
- Set a sidebar page as home, move to another page, then click Home. Confirm it returns to that page.
- Reload the Cortext root URL and confirm it opens the chosen page.
- Set a collection as home, reload the Cortext root URL, and confirm it opens the collection.
- Collapse the sidebar and confirm the icon-only Home button still works.
- Trash the selected home page, reload the root URL, and confirm Cortext falls back to the first page.
- Run the demo seeder in a fresh or reset local environment and confirm Cortext opens on the `Workspace` page.

## Screen recording

https://github.com/user-attachments/assets/55044c2a-b3cd-48be-b1e2-34acaef62409