### PR TITLE
Polish sidebar chrome states

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -87,6 +87,7 @@ function DocumentActions( { isActive } ) {
 			<div className="cortext-document-actions">
 				<PublishToggle />
 				<Button
+					className="cortext-document-actions__settings"
 					icon={ cog }
 					size="compact"
 					label={ __( 'Settings', 'cortext' ) }

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -231,10 +231,7 @@ export default function PageRow( {
 						popoverProps={ { placement: 'bottom-end' } }
 						renderToggle={ ( { isOpen, onToggle } ) => (
 							<Button
-								className={
-									'cortext-sidebar__menu' +
-									( isOpen ? ' is-opened' : '' )
-								}
+								className="cortext-sidebar__menu"
 								icon={ moreVertical }
 								size="small"
 								label={ sprintf(
@@ -243,6 +240,7 @@ export default function PageRow( {
 									title
 								) }
 								onClick={ onToggle }
+								isPressed={ isOpen }
 								aria-expanded={ isOpen }
 								onPointerDown={ ( e ) => e.stopPropagation() }
 							/>

--- a/src/components/PublishToggle.js
+++ b/src/components/PublishToggle.js
@@ -46,6 +46,7 @@ export default function PublishToggle() {
 				disabled={ isSaving }
 				variant="tertiary"
 				size="compact"
+				isPressed={ isPublic }
 			>
 				{ isPublic
 					? __( 'Public', 'cortext' )

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -500,6 +500,7 @@ export default function Sidebar( {
 							? __( 'Expand sidebar', 'cortext' )
 							: __( 'Collapse sidebar', 'cortext' )
 					}
+					isPressed={ collapsed }
 					onClick={ onToggleCollapsed }
 				/>
 			</div>

--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -38,6 +38,7 @@ export default function ThemeToggle() {
 					icon={ triggerIcon }
 					label={ __( 'Color scheme', 'cortext' ) }
 					onClick={ onToggle }
+					isPressed={ isOpen }
 					aria-expanded={ isOpen }
 				/>
 			) }

--- a/src/index.scss
+++ b/src/index.scss
@@ -233,17 +233,24 @@ body.cortext-fullscreen {
 		// Hover paints the whole row, not just the inner title button, so
 		// the chevron and kebab areas feel like part of what you're hovering.
 		// `:not(.is-selected)` keeps the active row on its selected
-		// background even while the cursor sits on it.
-		&:hover:not(.is-selected) {
-			background: var(--cortext-sidebar-item-hover-surface);
-		}
-
+		// background even while the cursor sits on it. Title-text brightening
+		// is handled in the .cortext-sidebar block below so its specificity
+		// beats the @wordpress/components button :hover color rule.
+		&:hover:not(.is-selected),
 		&:focus-within:not(.is-selected) {
-			background: var(--cortext-sidebar-item-hover-surface);
+			background: var(--cortext-state-hover);
 		}
 
 		&.is-selected {
-			background: var(--cortext-sidebar-item-selected-surface);
+			background: var(--cortext-state-selected);
+			// Hairline top-edge highlight on the row gives the active page a
+			// soft "lift" without reading as a border.
+			box-shadow: inset 0 1px 0 var(--cortext-state-selected-highlight);
+
+			/* stylelint-disable-next-line no-descending-specificity */
+			.cortext-sidebar__title.components-button {
+				font-weight: 500;
+			}
 		}
 
 		&.is-dragging {
@@ -270,7 +277,7 @@ body.cortext-fullscreen {
 		}
 
 		&.is-drop-inside {
-			background: var(--cortext-sidebar-item-selected-surface);
+			background: var(--cortext-state-selected);
 			outline: var(--cortext-shell-border-width) dashed var(--cortext-accent);
 			outline-offset: -1px;
 		}
@@ -315,6 +322,7 @@ body.cortext-fullscreen {
 		}
 	}
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	&__title.components-button {
 		flex: 1 1 auto;
 		min-width: 0;
@@ -372,7 +380,7 @@ body.cortext-fullscreen {
 
 		&__row:hover &__menu,
 		&__row:focus-within &__menu,
-		&__menu.is-opened,
+		&__menu.is-pressed,
 		&__row:hover &__add-child,
 		&__row:focus-within &__add-child {
 			opacity: 1;
@@ -735,12 +743,12 @@ body.cortext-sidebar-resizing {
 
 		&:hover:not(.is-current),
 		&:focus:not(.is-current) {
-			color: var(--cortext-text);
+			color: var(--cortext-text-strong);
 			background: var(--cortext-button-hover-surface);
 		}
 
 		&.is-current {
-			color: var(--cortext-text);
+			color: var(--cortext-text-strong);
 			cursor: default;
 		}
 	}
@@ -1831,19 +1839,58 @@ thead > tr > th {
 		background: var(--cortext-button-surface);
 		color: var(--cortext-button-text);
 
-		&:hover:not(:disabled),
-		&:focus:not(:disabled) {
+		// Skip pressed buttons: their .is-pressed rule below paints both
+		// background and text-strong, and we don't want hover/focus to revert
+		// either back to the default tier. Unpressed buttons brighten to
+		// strong on hover/focus so the icon/label pops alongside the overlay.
+		&:not(.is-pressed):hover:not(:disabled),
+		&:not(.is-pressed):focus-visible:not(:disabled) {
 			background: var(--cortext-button-hover-surface);
-			color: var(--cortext-button-text);
+			color: var(--cortext-text-strong);
 		}
 	}
 
-	// Keep hover/focus from painting only the inner title/action button, which
-	// makes the row look split into separate cells. The row itself handles
-	// the focus background.
+	.cortext-document-actions__settings.components-button:not(.is-primary):not(.is-pressed):hover:not(:disabled, [aria-disabled="true"]) {
+		background: var(--cortext-state-hover-strong, var(--cortext-button-hover-surface));
+		color: var(--cortext-text-strong);
+	}
+
+	.components-button.is-pressed {
+		// Strong text/icon so the toggled-on state pops, matching the sidebar
+		// selected row and the breadcrumb is-current treatment.
+		color: var(--cortext-text-strong);
+		background: var(--cortext-button-pressed-surface);
+
+		// Selectors match WP's own .is-pressed:hover specificity (which would
+		// otherwise flip the background to solid #1e1e1e); ours wins by source
+		// order and gives pressed chrome a stronger hover state.
+		/* stylelint-disable-next-line no-descending-specificity */
+		&:hover:not(:disabled, [aria-disabled="true"]) {
+			background: var(--cortext-state-selected-hover);
+			color: var(--cortext-text-strong);
+		}
+	}
+
+	// Keep hover/focus/pressed from painting only the inner title/action
+	// button, which makes the row look split into separate cells (or, with
+	// alpha overlays, visibly doubles the fill on the button). The row itself
+	// handles every state's background.
+	/* stylelint-disable no-descending-specificity */
 	.cortext-sidebar__row .components-button:not(.is-primary):hover:not(:disabled),
-	.cortext-sidebar__row .components-button:not(.is-primary):focus:not(:disabled) {
+	.cortext-sidebar__row .components-button:not(.is-primary):focus:not(:disabled),
+	.cortext-sidebar__row .components-button.is-pressed,
+	.cortext-sidebar__row .components-button.is-pressed:hover:not(:disabled, [aria-disabled="true"]) {
 		background: transparent;
+	}
+	/* stylelint-enable no-descending-specificity */
+
+	// Title text brightens whenever the row is hovered, focused, or selected.
+	// Lives in this block so its specificity sits above the button :hover/:focus
+	// color rule above (which would otherwise pin the title to default text).
+	.cortext-sidebar__row:hover .cortext-sidebar__title.components-button,
+	.cortext-sidebar__row:focus-within .cortext-sidebar__title.components-button,
+	.cortext-sidebar__row.is-selected .cortext-sidebar__title.components-button {
+		color: var(--cortext-text-strong);
 	}
 
 	.components-button.is-primary {
@@ -1857,11 +1904,6 @@ thead > tr > th {
 			box-shadow: inset 0 0 0 var(--cortext-shell-border-width) var(--cortext-button-primary-hover-surface);
 			color: var(--cortext-button-primary-text);
 		}
-	}
-
-	.components-button.is-pressed {
-		background: var(--cortext-button-pressed-surface);
-		color: var(--cortext-button-text);
 	}
 
 	.components-button svg {

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -27,17 +27,27 @@
 	// Shell surfaces
 	--cortext-shell-surface: #{colors.$white};
 	// Warm off-white for the sidebar (and topbar, which inherits this) so
-	// it reads as chrome rather than canvas. Hover and selected step a few
-	// values darker so the active page doesn't blur into a hover preview.
-	// The values aren't from the WP palette (which has no warm tones);
-	// they're picked to match a Notion-style chrome.
+	// it reads as chrome rather than canvas. Hover and selected ride on top
+	// as alpha overlays so the same tokens read in both themes and over any
+	// future surface (canvas, popovers, nested shells).
 	--cortext-sidebar-surface: #f7f6f3;
-	--cortext-sidebar-item-hover-surface: #ebeae6;
-	--cortext-sidebar-item-selected-surface: #e3e1dc;
+	// Interaction-state overlays. Apply on top of any chrome surface so the
+	// same tokens read in light, dark, and over future surfaces (canvas,
+	// popovers, nested shells) without per-context calibration.
+	// Light-mode alphas run a touch higher than dark's because black overlays
+	// on a near-white surface read more subtly than white overlays on a dark
+	// surface at the same alpha (perceptually).
+	--cortext-state-hover: rgba(0, 0, 0, 0.07);
+	--cortext-state-hover-strong: rgba(0, 0, 0, 0.09);
+	--cortext-state-selected: rgba(0, 0, 0, 0.09);
+	--cortext-state-selected-hover: rgba(0, 0, 0, 0.14);
+	// Hairline top-edge highlight on the active row to suggest a soft "lift".
+	--cortext-state-selected-highlight: rgba(255, 255, 255, 0.6);
 	--cortext-canvas-frame-surface: #{colors.$white};
 	--cortext-chrome-border: #{colors.$gray-200};
 	--cortext-text: #{colors.$gray-900};
 	--cortext-text-muted: #{colors.$gray-700};
+	--cortext-text-strong: #{colors.$gray-900};
 	--cortext-shadow-color: rgba(0, 0, 0, 0.12);
 
 	// Accent follows the active admin/components theme by default, but is
@@ -47,10 +57,13 @@
 
 	// Shell buttons. These map onto @wordpress/components buttons only inside
 	// Cortext-owned chrome, not globally in wp-admin or inside the iframe.
+	// Button text sits a tier below body text (gray-700 vs gray-900 in light;
+	// 78% vs 100% white in dark via dark-mode override) so hover/pressed can
+	// climb to --cortext-text-strong and the icon visibly responds.
 	--cortext-button-surface: transparent;
-	--cortext-button-text: var(--cortext-text);
-	--cortext-button-hover-surface: var(--cortext-sidebar-item-hover-surface);
-	--cortext-button-pressed-surface: var(--cortext-sidebar-item-selected-surface);
+	--cortext-button-text: #{colors.$gray-700};
+	--cortext-button-hover-surface: var(--cortext-state-hover);
+	--cortext-button-pressed-surface: var(--cortext-state-selected);
 	--cortext-button-primary-surface: var(--cortext-accent);
 	--cortext-button-primary-hover-surface: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, var(--cortext-accent)));
 	--cortext-button-primary-text: var(--cortext-accent-contrast);
@@ -78,12 +91,22 @@
 	&[data-theme="dark"] {
 		--cortext-shell-surface: #2a2a2a;
 		--cortext-sidebar-surface: #2a2a2a;
-		--cortext-sidebar-item-hover-surface: #333;
-		--cortext-sidebar-item-selected-surface: #383838;
+		// Alphas run a touch stronger than Linear's defaults because the
+		// surface stays at #2a2a2a (not pushed toward true black), so the
+		// overlays need more weight to register.
+		--cortext-state-hover: rgba(255, 255, 255, 0.05);
+		--cortext-state-hover-strong: rgba(255, 255, 255, 0.075);
+		--cortext-state-selected: rgba(255, 255, 255, 0.09);
+		--cortext-state-selected-hover: rgba(255, 255, 255, 0.14);
+		--cortext-state-selected-highlight: rgba(255, 255, 255, 0.06);
 		--cortext-canvas-frame-surface: #2a2a2a;
 		--cortext-chrome-border: #3e3e3e;
-		--cortext-text: #f0f0f0;
-		--cortext-text-muted: #a0a0a0;
+		--cortext-text: rgba(255, 255, 255, 0.78);
+		--cortext-text-muted: rgba(255, 255, 255, 0.5);
+		--cortext-text-strong: #fff;
+		// Sit a tier below body text so hover/pressed (→ #fff) actually shows.
+		// 0.78 → 1.0 was too narrow on small icons; 0.6 → 1.0 reads.
+		--cortext-button-text: rgba(255, 255, 255, 0.6);
 		--cortext-shadow-color: rgba(0, 0, 0, 0.4);
 		--cortext-scrollbar-thumb: rgba(255, 255, 255, 0.16);
 		--cortext-scrollbar-thumb-hover: rgba(255, 255, 255, 0.32);

--- a/tests/e2e/specs/sidebar-layout.spec.js
+++ b/tests/e2e/specs/sidebar-layout.spec.js
@@ -175,6 +175,16 @@ async function readThemePopoverPlacement( page ) {
 	} );
 }
 
+async function readButtonChromeState( locator ) {
+	return locator.evaluate( ( element ) => {
+		const styles = window.getComputedStyle( element );
+		return {
+			backgroundColor: styles.backgroundColor,
+			color: styles.color,
+		};
+	} );
+}
+
 async function clearSidebarPrefs( page ) {
 	await page.evaluate( () => {
 		try {
@@ -294,6 +304,166 @@ test.describe( 'Sidebar layout controls', () => {
 			expect( alignment ).not.toBeNull();
 			expect( alignment.labelDelta ).toBeLessThanOrEqual( 2 );
 			expect( alignment.headerDelta ).toBeLessThanOrEqual( 2 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page ? `/wp/v2/crtxt_pages/${ fixture.page.id }` : null
+			);
+		}
+	} );
+
+	test( 'keeps settings chrome responsive on hover in both themes', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const fixture = {};
+
+		try {
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: `E2E Cog Chrome ${ suffix }`,
+					status: 'private',
+				},
+			} );
+
+			await admin.visitAdminPage(
+				SHELL_PATH,
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			const settings = page.locator(
+				'.cortext-document-actions .components-button[aria-label="Settings"]'
+			);
+			await expect( settings ).toBeVisible();
+
+			await page.evaluate( () => {
+				document
+					.getElementById( 'cortext-root' )
+					?.setAttribute( 'data-theme', 'light' );
+			} );
+
+			if (
+				await settings.evaluate( ( element ) =>
+					element.classList.contains( 'is-pressed' )
+				)
+			) {
+				await settings.click();
+			}
+
+			await expect( settings ).not.toHaveClass( /is-pressed/ );
+			await page.mouse.move( 0, 0 );
+			const unpressedBeforeHover = await readButtonChromeState(
+				settings
+			);
+
+			await settings.hover();
+			const lightUnpressedAfterHover = await readButtonChromeState(
+				settings
+			);
+
+			expect( lightUnpressedAfterHover.backgroundColor ).not.toBe(
+				unpressedBeforeHover.backgroundColor
+			);
+			expect( lightUnpressedAfterHover.color ).not.toBe(
+				unpressedBeforeHover.color
+			);
+			expect( lightUnpressedAfterHover.backgroundColor ).not.toBe(
+				'rgb(30, 30, 30)'
+			);
+
+			await page.mouse.move( 0, 0 );
+			await page.evaluate( () => {
+				document
+					.getElementById( 'cortext-root' )
+					?.setAttribute( 'data-theme', 'dark' );
+			} );
+			const darkUnpressedBeforeHover = await readButtonChromeState(
+				settings
+			);
+
+			await settings.hover();
+			const darkUnpressedAfterHover = await readButtonChromeState(
+				settings
+			);
+
+			expect( darkUnpressedAfterHover.backgroundColor ).not.toBe(
+				darkUnpressedBeforeHover.backgroundColor
+			);
+			expect( darkUnpressedAfterHover.color ).not.toBe(
+				darkUnpressedBeforeHover.color
+			);
+			expect( darkUnpressedAfterHover.backgroundColor ).not.toBe(
+				'rgb(30, 30, 30)'
+			);
+
+			if (
+				await settings.evaluate(
+					( element ) => ! element.classList.contains( 'is-pressed' )
+				)
+			) {
+				await settings.click();
+			}
+
+			await expect( settings ).toHaveClass( /is-pressed/ );
+			await page.mouse.move( 0, 0 );
+			const beforeHover = await readButtonChromeState( settings );
+
+			await settings.hover();
+			const afterHover = await readButtonChromeState( settings );
+
+			expect( afterHover.backgroundColor ).not.toBe(
+				beforeHover.backgroundColor
+			);
+			expect( afterHover.color ).toBe( beforeHover.color );
+			expect( afterHover.backgroundColor ).not.toBe(
+				'rgb(30, 30, 30)'
+			);
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			const title = sidebar.getByRole( 'button', {
+				name: `E2E Cog Chrome ${ suffix }`,
+				exact: true,
+			} );
+			const selectedRow = title.locator(
+				'xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " cortext-sidebar__row ")][1]'
+			);
+
+			await expect( title ).toHaveClass( /is-pressed/ );
+			await expect( selectedRow ).toHaveClass( /is-selected/ );
+
+			const titleBeforeHover = await readButtonChromeState( title );
+			await title.hover();
+			const titleAfterHover = await readButtonChromeState( title );
+
+			expect( titleBeforeHover.backgroundColor ).toBe(
+				'rgba(0, 0, 0, 0)'
+			);
+			expect( titleAfterHover.backgroundColor ).toBe(
+				titleBeforeHover.backgroundColor
+			);
+
+			await title.hover();
+			const menu = sidebar.getByRole( 'button', {
+				name: `Actions for E2E Cog Chrome ${ suffix }`,
+				exact: true,
+			} );
+			await menu.click();
+			await expect( menu ).toHaveClass( /is-pressed/ );
+
+			const menuBeforeHover = await readButtonChromeState( menu );
+			await menu.hover();
+			const menuAfterHover = await readButtonChromeState( menu );
+
+			expect( menuBeforeHover.backgroundColor ).toBe(
+				'rgba(0, 0, 0, 0)'
+			);
+			expect( menuAfterHover.backgroundColor ).toBe(
+				menuBeforeHover.backgroundColor
+			);
 		} finally {
 			await deleteIfCreated(
 				requestUtils,


### PR DESCRIPTION
## What

Part of #140

This makes the sidebar and top bar states easier to read in both light and dark mode. Hover, selected, and toggled states now feel more consistent across page rows, row menus, the collapse button, the theme button, publish state, and the settings cog.

## Why

The old states were hard to see in dark mode, and some buttons behaved differently from others. The settings cog also needed clearer hover feedback without falling back to WordPress’ default button colors.

## How

- Using shared state colors for sidebar and top bar hover/selected states.
- Marking toggled controls with `isPressed` where that state should be visible.
- Keeping row backgrounds owned by the row, so selected rows do not get darker blocks inside them.

## Testing Instructions

1. Open Cortext.
2. Switch between light and dark mode.
3. Hover sidebar rows, selected rows, row menu buttons, and the settings cog.
4. Confirm the hover and active states are visible but subtle.

## Before/After

| Before | After |
| - | - |
| <img width="272" height="934" alt="image" src="https://github.com/user-attachments/assets/a7d779b7-ccf2-46ef-91f1-6941b3e56717" /> | <img width="274" height="936" alt="image" src="https://github.com/user-attachments/assets/63f1a837-d6de-4c2a-890c-3ff6457891b3" /> |
| <img width="271" height="937" alt="image" src="https://github.com/user-attachments/assets/ef09c642-a546-4878-9dde-ca01b90c999a" /> | <img width="270" height="932" alt="image" src="https://github.com/user-attachments/assets/892a8ca3-e346-4d55-b125-a43e5b372433" /> |