### PR TITLE
Add collection row detail views

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -327,3 +327,19 @@ The user-facing placeholder is still Core's generic "Search commands and setting
 **Where.** `src/components/CommandPalette.js`, the `canvasRef` passed from `src/router.js`, `dequeue_core_command_palette` in `includes/Admin/Screen.php`, and the `@wordpress/commands` stylesheet import in `src/index.scss`.
 
 **Solution.** Upstream could make app-owned palettes less ad hoc: a scoped command registry or namespace API, a supported way for full-screen admin apps to opt out of Core's admin palette, a custom input label, and an explicit focus-return target or after-close callback. With those, Cortext could keep registering commands through `@wordpress/commands` and drop most of the shell-specific wiring.
+
+## 39. Row detail relation editing is deferred `[internal]`
+
+**What.** Relation fields look like regular row fields in the detail view, but they are not regular meta. A plain `editPost( { meta } )` save would only update the current row. It would skip `RowsController::update_row_field()` and `Relations::sync_relation_value()`, so the row on the other side of the relation could be left pointing at stale data. For now, row detail shows relations but does not let you edit them.
+
+**Where.** `isRowDetailFieldEditable` in `src/components/RowDetailView.js`.
+
+**Solution.** Reuse the relation picker in row detail and save relation changes through the row-field endpoint, not through generic post meta edits. Once DataViews has a real relation/reference field primitive (#37), there should be less custom wiring here.
+
+## 40. Autosave has to infer in-flight save completion `[upstream, soft]`
+
+**What.** `savePost()` gives us a promise when Cortext starts the save. If a save is already running, though, Gutenberg only tells us about it through selectors like `isSavingPost()` and `didPostSaveRequestFail()`. There is no promise to await. `flushNow()` has to keep its own small list of waiters and release them when `isSaving` flips back to false.
+
+**Where.** `savePromiseRef`, `savingWaitersRef`, and `flushNow` in `src/hooks/useAutosave.js`.
+
+**Solution.** Gutenberg could expose the current save promise, or make `savePost()` return the in-flight promise when one already exists. Then Cortext could drop the waiter bookkeeping.

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -307,7 +307,7 @@ final class CollectionEntries {
 					'rest_base'          => $post_type,
 					'has_archive'        => false,
 					'hierarchical'       => false,
-					'supports'           => array( 'title', 'custom-fields' ),
+					'supports'           => array( 'title', 'editor', 'custom-fields' ),
 					'capability_type'    => 'post',
 					'map_meta_cap'       => true,
 					'can_export'         => true,

--- a/src/blocks/data-view/block.json
+++ b/src/blocks/data-view/block.json
@@ -33,7 +33,8 @@
 				"perPage": 25,
 				"page": 1,
 				"search": "",
-				"layout": {}
+				"layout": {},
+				"rowDetailMode": "side"
 			}
 		}
 	}

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -30,6 +30,7 @@ function createDefaultView() {
 		page: 1,
 		search: '',
 		layout: { density: 'compact' },
+		rowDetailMode: 'side',
 	};
 }
 

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -550,12 +550,13 @@ function CanvasReadyEffect( { postId, onReady } ) {
 	return null;
 }
 
-function VisualCanvas( { postId, onReady } ) {
+function VisualCanvas( { postId, postType, onReady } ) {
 	const styles = useSelect(
 		( select ) => select( editorStore ).getEditorSettings().styles,
 		[]
 	);
 	const [ layout ] = useSettings( 'layout' );
+	const supportsPageIdentity = postType === POST_TYPE;
 
 	// Mirror the post editor's root-container setup so theme.json
 	// constrained layout (max-width, root padding, post-content gap)
@@ -579,8 +580,12 @@ function VisualCanvas( { postId, onReady } ) {
 		<div className="cortext-canvas__visual">
 			<div className="cortext-canvas__block-canvas">
 				<BlockCanvas height="100%" styles={ styles }>
-					<PageIdentityActions postId={ postId } />
-					<EnsureHeaderBlocks postId={ postId } />
+					{ supportsPageIdentity ? (
+						<>
+							<PageIdentityActions postId={ postId } />
+							<EnsureHeaderBlocks postId={ postId } />
+						</>
+					) : null }
 					<div className="cortext-canvas__editor">
 						<BlockList
 							className="wp-block-post-content is-layout-constrained has-global-padding"
@@ -674,12 +679,14 @@ function CanvasEditor( {
 							<Disabled className="cortext-canvas__locked">
 								<VisualCanvas
 									postId={ post.id }
+									postType={ postType }
 									onReady={ onDisplayedPost }
 								/>
 							</Disabled>
 						) : (
 							<VisualCanvas
 								postId={ post.id }
+								postType={ postType }
 								onReady={ onDisplayedPost }
 							/>
 						) }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -30,6 +30,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { cog } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 import {
+	useCallback,
 	useEffect,
 	useLayoutEffect,
 	useRef,
@@ -44,6 +45,7 @@ import {
 	TRASHED_PAGES_QUERY,
 } from './page-queries';
 import PublishToggle from './PublishToggle';
+import { RowDetailSidebarSlot } from './RowDetailSidebarSlot';
 import { TopBarActionsFill } from './WorkspaceTopBar';
 import MediaPicker, { MediaUploadCheck } from './MediaPicker';
 import PageIdentityControls from './PageIdentityControls';
@@ -238,7 +240,7 @@ function PageIdentityActions( { postId } ) {
 	);
 }
 
-function DocumentActions( { isActive } ) {
+function DocumentActions( { isActive, postType, topBarActions } ) {
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
 	const isInspectorOpen = useSelect(
@@ -259,7 +261,8 @@ function DocumentActions( { isActive } ) {
 	return (
 		<TopBarActionsFill>
 			<div className="cortext-document-actions">
-				<PublishToggle />
+				{ topBarActions }
+				{ postType === POST_TYPE ? <PublishToggle /> : null }
 				<Button
 					className="cortext-document-actions__settings"
 					icon={ cog }
@@ -593,13 +596,32 @@ function VisualCanvas( { postId, onReady } ) {
 
 function CanvasEditor( {
 	post,
+	postType,
 	pendingPost,
 	onSwitchPost,
 	onDisplayedPost,
 	isActive,
+	topBarActions,
+	notice,
+	onApi,
+	onSaved,
 } ) {
-	const { flushNow, isDirty, isSaving } = useAutosave();
+	const { status, flushNow, isDirty, isSaving } = useAutosave();
+	const { resetPost } = useDispatch( editorStore );
+	const discard = useCallback( () => resetPost(), [ resetPost ] );
 	const isTrashed = post.status === 'trash';
+	const canRestoreTrash = postType === POST_TYPE;
+
+	useEffect( () => {
+		onApi?.( { flushNow, discard } );
+		return () => onApi?.( null );
+	}, [ discard, flushNow, onApi ] );
+
+	useEffect( () => {
+		if ( status === 'saved' ) {
+			onSaved?.();
+		}
+	}, [ onSaved, status ] );
 
 	useEffect( () => {
 		if ( ! pendingPost || pendingPost.id === post.id ) {
@@ -627,14 +649,21 @@ function CanvasEditor( {
 
 	return (
 		<>
-			<DocumentActions isActive={ isActive } />
+			<DocumentActions
+				isActive={ isActive }
+				postType={ postType }
+				topBarActions={ topBarActions }
+			/>
 			<CortextSnackbars />
 			<HideHeaderBlockKebab />
 			<InterfaceSkeleton
 				className="cortext-canvas"
 				content={
 					<>
-						{ isTrashed && <TrashedNotice postId={ post.id } /> }
+						{ notice }
+						{ isTrashed && canRestoreTrash && (
+							<TrashedNotice postId={ post.id } />
+						) }
 						{ isTrashed ? (
 							<Disabled className="cortext-canvas__locked">
 								<VisualCanvas
@@ -650,28 +679,53 @@ function CanvasEditor( {
 						) }
 					</>
 				}
-				sidebar={ <ComplementaryArea.Slot scope={ SCOPE } /> }
+				sidebar={
+					isActive ? (
+						<RowDetailSidebarSlot
+							fallback={
+								<ComplementaryArea.Slot scope={ SCOPE } />
+							}
+						/>
+					) : (
+						<ComplementaryArea.Slot scope={ SCOPE } />
+					)
+				}
 			/>
 			<InspectorSidebar />
 		</>
 	);
 }
 
-export default function Canvas( { postId, onDisplayedPost, isActive } ) {
+export default function Canvas( {
+	postId,
+	postType = POST_TYPE,
+	onDisplayedPost,
+	isActive,
+	topBarActions = null,
+	notice = null,
+	onApi,
+	onSaved,
+	useSubRegistry = false,
+} ) {
 	const { record: requestedPost } = useEntityRecord(
 		'postType',
-		POST_TYPE,
+		postType,
 		postId
 	);
 	const [ displayedPost, setDisplayedPost ] = useState( null );
-	const renderedPost = displayedPost ?? requestedPost;
+	const renderedPost =
+		displayedPost?.type === postType ? displayedPost : requestedPost;
 
 	useEffect( () => {
 		if ( ! requestedPost ) {
 			return;
 		}
 		setDisplayedPost( ( current ) => {
-			if ( ! current || current.id === requestedPost.id ) {
+			if (
+				! current ||
+				current.type !== requestedPost.type ||
+				current.id === requestedPost.id
+			) {
 				return requestedPost;
 			}
 			return current;
@@ -687,7 +741,9 @@ export default function Canvas( { postId, onDisplayedPost, isActive } ) {
 	}
 
 	const pendingPost =
-		requestedPost && requestedPost.id !== renderedPost.id
+		requestedPost &&
+		( requestedPost.type !== renderedPost.type ||
+			requestedPost.id !== renderedPost.id )
 			? requestedPost
 			: null;
 
@@ -695,14 +751,19 @@ export default function Canvas( { postId, onDisplayedPost, isActive } ) {
 		<EditorProvider
 			post={ renderedPost }
 			settings={ window.cortextEditorSettings ?? {} }
-			useSubRegistry={ false }
+			useSubRegistry={ useSubRegistry }
 		>
 			<CanvasEditor
 				post={ renderedPost }
+				postType={ postType }
 				pendingPost={ pendingPost }
 				onSwitchPost={ setDisplayedPost }
 				onDisplayedPost={ onDisplayedPost }
 				isActive={ isActive }
+				topBarActions={ topBarActions }
+				notice={ notice }
+				onApi={ onApi }
+				onSaved={ onSaved }
 			/>
 		</EditorProvider>
 	);

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -609,6 +609,12 @@ function CanvasEditor( {
 	const { status, flushNow, isDirty, isSaving } = useAutosave();
 	const { resetPost } = useDispatch( editorStore );
 	const discard = useCallback( () => resetPost(), [ resetPost ] );
+	const isInspectorOpen = useSelect(
+		( select ) =>
+			select( interfaceStore ).getActiveComplementaryArea( SCOPE ) ===
+			INSPECTOR,
+		[]
+	);
 	const isTrashed = post.status === 'trash';
 	const canRestoreTrash = postType === POST_TYPE;
 
@@ -685,6 +691,7 @@ function CanvasEditor( {
 							fallback={
 								<ComplementaryArea.Slot scope={ SCOPE } />
 							}
+							isFallbackActive={ isInspectorOpen }
 						/>
 					) : (
 						<ComplementaryArea.Slot scope={ SCOPE } />

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -39,6 +39,10 @@ const DEFAULT_LAYOUTS = { table: { density: 'compact' }, grid: {}, list: {} };
 const TITLE_LABEL = __( 'Title', 'cortext' );
 const ROW_SEARCH_KEY = 'row';
 const ROW_COLLECTION_SEARCH_KEY = 'rowCollection';
+const ROW_DETAIL_SIDE_SURFACE_EXIT_MS = 300;
+const ROW_DETAIL_MODAL_ENTER_MS = 200;
+const ROW_DETAIL_SIDE_TO_MODAL_HANDOFF_MS =
+	ROW_DETAIL_SIDE_SURFACE_EXIT_MS - ROW_DETAIL_MODAL_ENTER_MS;
 
 function parseSearchId( value ) {
 	if ( Array.isArray( value ) ) {
@@ -46,6 +50,13 @@ function parseSearchId( value ) {
 	}
 	const id = Number.parseInt( String( value ).replaceAll( '"', '' ), 10 );
 	return Number.isFinite( id ) && id > 0 ? id : null;
+}
+
+function prefersReducedMotion() {
+	return (
+		typeof window !== 'undefined' &&
+		window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches
+	);
 }
 
 const OpenRowActionContext = createContext( {
@@ -482,9 +493,31 @@ export default function CollectionDataViews( {
 	const [ detailSaveError, setDetailSaveError ] = useState( null );
 	const [ pendingDetailTransition, setPendingDetailTransition ] =
 		useState( null );
+	const [ modeSurfaceTransition, setModeSurfaceTransition ] =
+		useState( null );
+	const modeSurfaceTransitionTimeoutRef = useRef( null );
+	const renderedRowDetailMode =
+		modeSurfaceTransition !== null
+			? modeSurfaceTransition.surfaceMode
+			: rowDetailMode;
 	const setDetailApi = useCallback( ( api ) => {
 		detailApiRef.current = api;
 	}, [] );
+	const clearModeSurfaceTransition = useCallback( () => {
+		if ( modeSurfaceTransitionTimeoutRef.current ) {
+			clearTimeout( modeSurfaceTransitionTimeoutRef.current );
+			modeSurfaceTransitionTimeoutRef.current = null;
+		}
+		setModeSurfaceTransition( null );
+	}, [] );
+	useEffect(
+		() => () => {
+			if ( modeSurfaceTransitionTimeoutRef.current ) {
+				clearTimeout( modeSurfaceTransitionTimeoutRef.current );
+			}
+		},
+		[]
+	);
 	const updateRouteRow = useCallback(
 		( rowId, options = {} ) => {
 			if ( ! collectionId || ! rowId ) {
@@ -570,12 +603,14 @@ export default function CollectionDataViews( {
 			setPendingDetailTransition( null );
 
 			if ( transition.type === 'close' ) {
+				clearModeSurfaceTransition();
 				setOpenRowId( null );
 				setFullRowId( null );
 				if ( transition.syncUrl !== false ) {
 					clearRouteRow( { replace: true } );
 				}
 			} else if ( transition.type === 'row' ) {
+				clearModeSurfaceTransition();
 				setOpenRowId( transition.rowId );
 				setFullRowId( null );
 				if ( transition.syncUrl !== false ) {
@@ -589,6 +624,7 @@ export default function CollectionDataViews( {
 					withRowDetailMode( viewRef.current, transition.mode )
 				);
 			} else if ( transition.type === 'full' ) {
+				clearModeSurfaceTransition();
 				if ( transition.syncUrl !== false ) {
 					updateRouteRow( transition.rowId, {
 						replace: ! transition.pushUrl,
@@ -600,7 +636,13 @@ export default function CollectionDataViews( {
 				refresh();
 			}
 		},
-		[ clearRouteRow, openFullRow, refresh, updateRouteRow ]
+		[
+			clearModeSurfaceTransition,
+			clearRouteRow,
+			openFullRow,
+			refresh,
+			updateRouteRow,
+		]
 	);
 
 	const runDetailTransition = useCallback(
@@ -697,14 +739,51 @@ export default function CollectionDataViews( {
 	);
 
 	const requestDetailMode = useCallback(
-		( mode ) => {
+		async ( mode ) => {
 			if ( mode === 'full' && openRowId ) {
+				clearModeSurfaceTransition();
 				runDetailTransition( { type: 'full', rowId: openRowId } );
 			} else if ( mode !== rowDetailMode ) {
+				if (
+					rowDetailMode === 'side' &&
+					mode === 'modal' &&
+					openRowId &&
+					! prefersReducedMotion()
+				) {
+					setModeSurfaceTransition( {
+						surfaceMode: 'side',
+					} );
+					const didSwitch = await runDetailTransition( {
+						type: 'mode',
+						mode,
+					} );
+					if ( ! didSwitch ) {
+						clearModeSurfaceTransition();
+						return;
+					}
+					setModeSurfaceTransition( {
+						surfaceMode: null,
+					} );
+					modeSurfaceTransitionTimeoutRef.current = setTimeout(
+						() => {
+							modeSurfaceTransitionTimeoutRef.current = null;
+							setModeSurfaceTransition( null );
+						},
+						ROW_DETAIL_SIDE_TO_MODAL_HANDOFF_MS
+					);
+					return;
+				}
+
+				clearModeSurfaceTransition();
 				runDetailTransition( { type: 'mode', mode } );
 			}
 		},
-		[ openRowId, rowDetailMode, runDetailTransition ]
+		[
+			clearModeSurfaceTransition,
+			openRowId,
+			rowDetailMode,
+			runDetailTransition,
+		]
 	);
 
 	const retryPendingDetailTransition = useCallback( () => {
@@ -720,12 +799,13 @@ export default function CollectionDataViews( {
 	}, [ pendingDetailTransition, runDetailTransition ] );
 
 	useEffect( () => {
+		clearModeSurfaceTransition();
 		setOpenRowId( null );
 		setFullRowId( null );
 		setDetailSaveError( null );
 		setPendingDetailTransition( null );
 		detailApiRef.current = null;
-	}, [ collectionId ] );
+	}, [ clearModeSurfaceTransition, collectionId ] );
 
 	useEffect( () => {
 		const routeTargetsThisCollection =
@@ -977,13 +1057,13 @@ export default function CollectionDataViews( {
 	const nextRowId = adjacentRowId( dataFiltered, openRowId, 1 );
 	let detailSurface = null;
 
-	if ( openRowId && postType && ! isFullDetail ) {
+	if ( openRowId && postType && ! isFullDetail && renderedRowDetailMode ) {
 		const detailView = (
 			<RowDetailView
 				canGoNext={ Boolean( nextRowId ) }
 				canGoPrevious={ Boolean( previousRowId ) }
 				fields={ availableFields }
-				mode={ rowDetailMode }
+				mode={ renderedRowDetailMode }
 				onApi={ setDetailApi }
 				onClose={ requestCloseDetail }
 				onDiscardPending={ discardPendingDetailTransition }
@@ -999,7 +1079,7 @@ export default function CollectionDataViews( {
 			/>
 		);
 		detailSurface =
-			rowDetailMode === 'side' ? (
+			renderedRowDetailMode === 'side' ? (
 				<RowDetailSidebar.Fill>{ detailView }</RowDetailSidebar.Fill>
 			) : (
 				detailView

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -2,7 +2,9 @@ import apiFetch from '@wordpress/api-fetch';
 import { Button, Notice } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import {
+	createContext,
 	useCallback,
+	useContext,
 	useEffect,
 	useMemo,
 	useRef,
@@ -10,22 +12,99 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
+import { useNavigate, useSearch } from '@wordpress/route';
 
 import DataViewColumnInteractions from './DataViewColumnInteractions';
 import EditableCell, { RowMutationContext } from './EditableCell';
 import TableCalculationsFooter from './TableCalculationsFooter';
 import ColumnHeaderActions from './fields/ColumnHeaderActions';
+import RowDetailView, { ROW_DETAIL_MODE_ICONS } from './RowDetailView';
+import { RowFullEditorContext } from './RowFullEditorContext';
+import { RowDetailSidebar } from './RowDetailSidebarSlot';
 import {
 	GHOST_FIELD_ID,
 	TITLE_FIELD_ID,
 	normalizeView,
 } from './dataViewColumns';
+import {
+	adjacentRowId,
+	getRowDetailMode,
+	withRowDetailMode,
+} from './rowDetailUtils';
 import useCollectionFields from '../hooks/useCollectionFields';
 import useCollectionRows from '../hooks/useCollectionRows';
 import { elementsFromOptions } from '../hooks/optionElements';
 
 const DEFAULT_LAYOUTS = { table: { density: 'compact' }, grid: {}, list: {} };
 const TITLE_LABEL = __( 'Title', 'cortext' );
+const ROW_SEARCH_KEY = 'row';
+const ROW_COLLECTION_SEARCH_KEY = 'rowCollection';
+
+function parseSearchId( value ) {
+	if ( Array.isArray( value ) ) {
+		return parseSearchId( value[ 0 ] );
+	}
+	const id = Number.parseInt( String( value ).replaceAll( '"', '' ), 10 );
+	return Number.isFinite( id ) && id > 0 ? id : null;
+}
+
+const OpenRowActionContext = createContext( {
+	enabled: false,
+	icon: ROW_DETAIL_MODE_ICONS.side,
+	openRowId: null,
+	requestOpenRow: null,
+} );
+
+function TitleCell( { item } ) {
+	const { enabled, icon, openRowId, requestOpenRow } =
+		useContext( OpenRowActionContext );
+	const canOpenRow = Boolean( enabled && requestOpenRow );
+	const isOpenRow = canOpenRow && String( item?.id ) === String( openRowId );
+	const openRow = useCallback(
+		( event ) => {
+			event.preventDefault();
+			event.stopPropagation();
+			requestOpenRow?.( item );
+		},
+		[ item, requestOpenRow ]
+	);
+	const stopPropagation = useCallback( ( event ) => {
+		event.stopPropagation();
+	}, [] );
+
+	return (
+		<div
+			className={
+				'cortext-title-cell' +
+				( canOpenRow ? ' cortext-title-cell--with-open-action' : '' ) +
+				( isOpenRow ? ' cortext-title-cell--is-open' : '' )
+			}
+		>
+			<EditableCell
+				item={ item }
+				fieldId="title"
+				fieldType="title"
+				label={ TITLE_LABEL }
+				getValue={ ( ctx ) =>
+					ctx.item?.title?.raw ?? ctx.item?.title?.rendered ?? ''
+				}
+			/>
+			{ canOpenRow ? (
+				<Button
+					className="cortext-title-cell__open"
+					icon={ icon }
+					label={ __( 'Open row', 'cortext' ) }
+					size="small"
+					variant="tertiary"
+					onClick={ openRow }
+					onMouseDown={ stopPropagation }
+				>
+					{ __( 'Open', 'cortext' ) }
+				</Button>
+			) : null }
+		</div>
+	);
+}
 
 const TITLE_FIELD = {
 	id: TITLE_FIELD_ID,
@@ -38,17 +117,7 @@ const TITLE_FIELD = {
 	// would otherwise sort under that literal entity). Same reason as
 	// `mapField`'s label fallback in `src/hooks/fieldMapping.js`.
 	getValue: ( { item } ) => item?.title?.raw ?? item?.title?.rendered ?? '',
-	render: ( { item } ) => (
-		<EditableCell
-			item={ item }
-			fieldId="title"
-			fieldType="title"
-			label={ TITLE_LABEL }
-			getValue={ ( ctx ) =>
-				ctx.item?.title?.raw ?? ctx.item?.title?.rendered ?? ''
-			}
-		/>
-	),
+	render: ( { item } ) => <TitleCell item={ item } />,
 	editable: true,
 	cortextType: 'title',
 	enableGlobalSearch: true,
@@ -73,7 +142,9 @@ const GHOST_FIELD = {
 	enableHiding: false,
 	editable: false,
 	getValue: () => '',
-	render: () => null,
+	render: () => (
+		<span className="cortext-data-view__ghost-cell" aria-hidden="true" />
+	),
 	header: (
 		<span
 			className="cortext-column-header-marker cortext-column-header-marker--add"
@@ -187,8 +258,14 @@ export default function CollectionDataViews( {
 	error,
 	onReady,
 } ) {
+	const navigate = useNavigate();
+	const routeSearch = useSearch( { strict: false } );
 	const { fields, collection, slug, isResolving, fieldsResolved } =
 		useCollectionFields( collectionId );
+	const routeRowId = parseSearchId( routeSearch?.[ ROW_SEARCH_KEY ] );
+	const routeRowCollectionId = parseSearchId(
+		routeSearch?.[ ROW_COLLECTION_SEARCH_KEY ]
+	);
 
 	const availableFields = useMemo(
 		() => [ TITLE_FIELD, ...fields ],
@@ -391,6 +468,305 @@ export default function CollectionDataViews( {
 	// for fields the user just created. `null` on first run signals
 	// "saved view, leave it alone."
 	const knownFieldIdsRef = useRef( null );
+	const savedRowDetailMode = getRowDetailMode( view );
+	const rowDetailMode =
+		savedRowDetailMode === 'full' ? 'side' : savedRowDetailMode;
+	const postType = slug ? `crtxt_${ slug }` : null;
+	const { clearSuppressedRouteRow, openRowFull, suppressedRouteRow } =
+		useContext( RowFullEditorContext );
+	const detailApiRef = useRef( null );
+	const [ openRowId, setOpenRowId ] = useState( null );
+	const openRowIdRef = useRef( openRowId );
+	openRowIdRef.current = openRowId;
+	const [ fullRowId, setFullRowId ] = useState( null );
+	const [ detailSaveError, setDetailSaveError ] = useState( null );
+	const [ pendingDetailTransition, setPendingDetailTransition ] =
+		useState( null );
+	const setDetailApi = useCallback( ( api ) => {
+		detailApiRef.current = api;
+	}, [] );
+	const updateRouteRow = useCallback(
+		( rowId, options = {} ) => {
+			if ( ! collectionId || ! rowId ) {
+				return;
+			}
+			navigate( {
+				search: ( current ) => ( {
+					...( current ?? {} ),
+					[ ROW_COLLECTION_SEARCH_KEY ]: collectionId,
+					[ ROW_SEARCH_KEY ]: rowId,
+				} ),
+				replace: options.replace ?? false,
+			} );
+		},
+		[ collectionId, navigate ]
+	);
+	const clearRouteRow = useCallback(
+		( options = {} ) => {
+			navigate( {
+				search: ( current ) => {
+					const next = { ...( current ?? {} ) };
+					delete next[ ROW_COLLECTION_SEARCH_KEY ];
+					delete next[ ROW_SEARCH_KEY ];
+					return next;
+				},
+				replace: options.replace ?? true,
+			} );
+		},
+		[ navigate ]
+	);
+
+	const openRow = useMemo( () => {
+		if ( ! openRowId ) {
+			return null;
+		}
+		const id = String( openRowId );
+		return (
+			dataFiltered.find( ( row ) => String( row.id ) === id ) ??
+			data.find( ( row ) => String( row.id ) === id ) ??
+			null
+		);
+	}, [ data, dataFiltered, openRowId ] );
+
+	const openFullRow = useCallback(
+		( rowId ) => {
+			if ( ! openRowFull || ! postType || ! rowId ) {
+				return false;
+			}
+			setOpenRowId( rowId );
+			setFullRowId( rowId );
+			openRowFull( {
+				collectionId,
+				postType,
+				rowId,
+				onClose: () => {
+					setOpenRowId( null );
+					setFullRowId( null );
+					setDetailSaveError( null );
+					setPendingDetailTransition( null );
+					clearRouteRow( { replace: true } );
+					refresh();
+				},
+				onModeChange: ( mode, nextRowId ) => {
+					setOpenRowId( nextRowId );
+					setFullRowId( null );
+					setDetailSaveError( null );
+					setPendingDetailTransition( null );
+					onChangeViewRef.current(
+						withRowDetailMode( viewRef.current, mode )
+					);
+					refresh();
+				},
+				onSaved: refresh,
+			} );
+			return true;
+		},
+		[ clearRouteRow, collectionId, openRowFull, postType, refresh ]
+	);
+
+	const applyDetailTransition = useCallback(
+		( transition, options = {} ) => {
+			setDetailSaveError( null );
+			setPendingDetailTransition( null );
+
+			if ( transition.type === 'close' ) {
+				setOpenRowId( null );
+				setFullRowId( null );
+				if ( transition.syncUrl !== false ) {
+					clearRouteRow( { replace: true } );
+				}
+			} else if ( transition.type === 'row' ) {
+				setOpenRowId( transition.rowId );
+				setFullRowId( null );
+				if ( transition.syncUrl !== false ) {
+					updateRouteRow( transition.rowId, {
+						replace: ! transition.pushUrl,
+					} );
+				}
+			} else if ( transition.type === 'mode' ) {
+				setFullRowId( null );
+				onChangeViewRef.current(
+					withRowDetailMode( viewRef.current, transition.mode )
+				);
+			} else if ( transition.type === 'full' ) {
+				if ( transition.syncUrl !== false ) {
+					updateRouteRow( transition.rowId, {
+						replace: ! transition.pushUrl,
+					} );
+				}
+				openFullRow( transition.rowId );
+			}
+			if ( options.refreshRows ) {
+				refresh();
+			}
+		},
+		[ clearRouteRow, openFullRow, refresh, updateRouteRow ]
+	);
+
+	const runDetailTransition = useCallback(
+		async ( transition, options = {} ) => {
+			const api = detailApiRef.current;
+			setDetailSaveError( null );
+
+			if ( options.discard ) {
+				api?.discard?.();
+				applyDetailTransition( transition, { refreshRows: true } );
+				return true;
+			}
+
+			let shouldRefreshRows = false;
+			if ( api?.flushNow ) {
+				shouldRefreshRows = api.hasPendingEdits?.() ?? true;
+				const didSave = await api.flushNow();
+				if ( ! didSave ) {
+					setPendingDetailTransition( transition );
+					setDetailSaveError(
+						__(
+							'Row changes could not be saved. Retry or discard the pending edits to continue.',
+							'cortext'
+						)
+					);
+					return false;
+				}
+			}
+
+			applyDetailTransition( transition, {
+				refreshRows: shouldRefreshRows,
+			} );
+			return true;
+		},
+		[ applyDetailTransition ]
+	);
+
+	const requestOpenRow = useCallback(
+		( row ) => {
+			if ( ! row?.id ) {
+				return;
+			}
+			runDetailTransition( {
+				type: rowDetailMode === 'full' ? 'full' : 'row',
+				rowId: row.id,
+				pushUrl: ! openRowId,
+			} );
+		},
+		[ openRowId, rowDetailMode, runDetailTransition ]
+	);
+
+	const openRowActionContext = useMemo(
+		() => ( {
+			enabled: isTableLayout,
+			icon: ROW_DETAIL_MODE_ICONS[ rowDetailMode ],
+			openRowId,
+			requestOpenRow,
+		} ),
+		[ isTableLayout, openRowId, requestOpenRow, rowDetailMode ]
+	);
+
+	const rowActions = useMemo(
+		() => [
+			{
+				id: 'open-row',
+				label: __( 'Open row', 'cortext' ),
+				icon: ROW_DETAIL_MODE_ICONS[ rowDetailMode ],
+				isPrimary: true,
+				context: 'single',
+				callback: ( items ) => requestOpenRow( items?.[ 0 ] ),
+			},
+		],
+		[ requestOpenRow, rowDetailMode ]
+	);
+
+	const dataViewActions = useMemo(
+		() => ( isTableLayout ? undefined : rowActions ),
+		[ isTableLayout, rowActions ]
+	);
+
+	const requestCloseDetail = useCallback(
+		() => runDetailTransition( { type: 'close' } ),
+		[ runDetailTransition ]
+	);
+
+	const requestAdjacentRow = useCallback(
+		( direction ) => {
+			const rowId = adjacentRowId( dataFiltered, openRowId, direction );
+			if ( rowId ) {
+				runDetailTransition( { type: 'row', rowId } );
+			}
+		},
+		[ dataFiltered, openRowId, runDetailTransition ]
+	);
+
+	const requestDetailMode = useCallback(
+		( mode ) => {
+			if ( mode === 'full' && openRowId ) {
+				runDetailTransition( { type: 'full', rowId: openRowId } );
+			} else if ( mode !== rowDetailMode ) {
+				runDetailTransition( { type: 'mode', mode } );
+			}
+		},
+		[ openRowId, rowDetailMode, runDetailTransition ]
+	);
+
+	const retryPendingDetailTransition = useCallback( () => {
+		if ( pendingDetailTransition ) {
+			runDetailTransition( pendingDetailTransition );
+		}
+	}, [ pendingDetailTransition, runDetailTransition ] );
+
+	const discardPendingDetailTransition = useCallback( () => {
+		if ( pendingDetailTransition ) {
+			runDetailTransition( pendingDetailTransition, { discard: true } );
+		}
+	}, [ pendingDetailTransition, runDetailTransition ] );
+
+	useEffect( () => {
+		setOpenRowId( null );
+		setFullRowId( null );
+		setDetailSaveError( null );
+		setPendingDetailTransition( null );
+		detailApiRef.current = null;
+	}, [ collectionId ] );
+
+	useEffect( () => {
+		const routeTargetsThisCollection =
+			routeRowId &&
+			routeRowCollectionId &&
+			String( routeRowCollectionId ) === String( collectionId );
+
+		if ( ! routeTargetsThisCollection ) {
+			clearSuppressedRouteRow?.();
+			if ( openRowIdRef.current ) {
+				runDetailTransition( { type: 'close', syncUrl: false } );
+			}
+			return;
+		}
+
+		if (
+			String( suppressedRouteRow?.collectionId ) ===
+				String( collectionId ) &&
+			String( suppressedRouteRow?.rowId ) === String( routeRowId )
+		) {
+			return;
+		}
+
+		if ( String( openRowIdRef.current ) === String( routeRowId ) ) {
+			return;
+		}
+
+		runDetailTransition( {
+			type: rowDetailMode === 'full' ? 'full' : 'row',
+			rowId: routeRowId,
+			syncUrl: false,
+		} );
+	}, [
+		collectionId,
+		clearSuppressedRouteRow,
+		routeRowCollectionId,
+		routeRowId,
+		rowDetailMode,
+		runDetailTransition,
+		suppressedRouteRow,
+	] );
 
 	// Reconcile saved view state with the live schema whenever the field
 	// set changes: seed defaults on first render, then hand off to
@@ -596,58 +972,107 @@ export default function CollectionDataViews( {
 		);
 	}
 
+	const isFullDetail = Boolean( fullRowId );
+	const previousRowId = adjacentRowId( dataFiltered, openRowId, -1 );
+	const nextRowId = adjacentRowId( dataFiltered, openRowId, 1 );
+	let detailSurface = null;
+
+	if ( openRowId && postType && ! isFullDetail ) {
+		const detailView = (
+			<RowDetailView
+				canGoNext={ Boolean( nextRowId ) }
+				canGoPrevious={ Boolean( previousRowId ) }
+				fields={ availableFields }
+				mode={ rowDetailMode }
+				onApi={ setDetailApi }
+				onClose={ requestCloseDetail }
+				onDiscardPending={ discardPendingDetailTransition }
+				onModeChange={ requestDetailMode }
+				onNext={ () => requestAdjacentRow( 1 ) }
+				onPrevious={ () => requestAdjacentRow( -1 ) }
+				onRetryPending={ retryPendingDetailTransition }
+				onSaved={ refresh }
+				postType={ postType }
+				row={ openRow }
+				rowId={ openRowId }
+				saveError={ detailSaveError }
+			/>
+		);
+		detailSurface =
+			rowDetailMode === 'side' ? (
+				<RowDetailSidebar.Fill>{ detailView }</RowDetailSidebar.Fill>
+			) : (
+				detailView
+			);
+	}
+
 	return (
 		<RowMutationContext.Provider value={ mutationContext }>
-			<div className="cortext-data-view" ref={ tableWrapperRef }>
-				<DataViews
-					data={ dataFiltered }
-					fields={ dataViewFields }
-					view={ view }
-					onChangeView={ onChangeView }
-					paginationInfo={ clientPaginationInfo }
-					defaultLayouts={ DEFAULT_LAYOUTS }
-					getItemId={ ( item ) => String( item.id ) }
-					isLoading={ isLoading }
-					empty={ empty }
-				/>
-				{ isTableLayout && (
-					<TableCalculationsFooter
-						wrapperRef={ tableWrapperRef }
-						view={ view }
-						fields={ availableFields }
-						data={ dataFilteredForCalculations }
-						onChangeView={ onChangeView }
-					/>
-				) }
-				{ isTableLayout && (
-					<DataViewColumnInteractions
-						wrapperRef={ tableWrapperRef }
-						view={ view }
-						fields={ availableFields }
-						onChangeView={ onChangeView }
-					/>
-				) }
-				{ isTableLayout && (
-					<ColumnHeaderActions
-						collectionId={ collectionId }
-						view={ view }
-						onChangeView={ onChangeView }
-						onFieldOptionsSaved={ updateFieldOptions }
-						onRowsChanged={ refresh }
-					/>
-				) }
-				{ /* tech-debt.md#7: DataViews has no footer slot, so the
-				   New-row affordance and its CSS layout sit outside the
-				   component instead of inside its layout chrome. */ }
-				<div className="cortext-data-view__footer">
-					<NewRowButton
-						slug={ slug }
-						view={ view }
-						fields={ fields }
-						onCreated={ onCreated }
-					/>
+			<OpenRowActionContext.Provider value={ openRowActionContext }>
+				<div
+					className="cortext-data-view-shell"
+					data-row-detail-mode={ rowDetailMode }
+					data-row-detail-open={ openRowId ? 'true' : 'false' }
+				>
+					{ ! isFullDetail && (
+						<div
+							className="cortext-data-view"
+							ref={ tableWrapperRef }
+						>
+							<DataViews
+								data={ dataFiltered }
+								fields={ dataViewFields }
+								view={ view }
+								onChangeView={ onChangeView }
+								paginationInfo={ clientPaginationInfo }
+								defaultLayouts={ DEFAULT_LAYOUTS }
+								getItemId={ ( item ) => String( item.id ) }
+								isLoading={ isLoading }
+								empty={ empty }
+								actions={ dataViewActions }
+							/>
+							{ isTableLayout && (
+								<TableCalculationsFooter
+									wrapperRef={ tableWrapperRef }
+									view={ view }
+									fields={ availableFields }
+									data={ dataFilteredForCalculations }
+									onChangeView={ onChangeView }
+								/>
+							) }
+							{ isTableLayout && (
+								<DataViewColumnInteractions
+									wrapperRef={ tableWrapperRef }
+									view={ view }
+									fields={ availableFields }
+									onChangeView={ onChangeView }
+								/>
+							) }
+							{ isTableLayout && (
+								<ColumnHeaderActions
+									collectionId={ collectionId }
+									view={ view }
+									onChangeView={ onChangeView }
+									onFieldOptionsSaved={ updateFieldOptions }
+									onRowsChanged={ refresh }
+								/>
+							) }
+							{ /* tech-debt.md#7: DataViews has no footer slot, so the
+							   New-row affordance and its CSS layout sit outside the
+							   component instead of inside its layout chrome. */ }
+							<div className="cortext-data-view__footer">
+								<NewRowButton
+									slug={ slug }
+									view={ view }
+									fields={ fields }
+									onCreated={ onCreated }
+								/>
+							</div>
+						</div>
+					) }
+					{ detailSurface }
 				</div>
-			</div>
+			</OpenRowActionContext.Provider>
 		</RowMutationContext.Provider>
 	);
 }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -685,10 +685,13 @@ export default function CollectionDataViews( {
 			if ( ! row?.id ) {
 				return;
 			}
+			if ( String( row.id ) === String( openRowId ) ) {
+				return;
+			}
 			runDetailTransition( {
 				type: rowDetailMode === 'full' ? 'full' : 'row',
 				rowId: row.id,
-				pushUrl: ! openRowId,
+				pushUrl: true,
 			} );
 		},
 		[ openRowId, rowDetailMode, runDetailTransition ]
@@ -732,7 +735,7 @@ export default function CollectionDataViews( {
 		( direction ) => {
 			const rowId = adjacentRowId( dataFiltered, openRowId, direction );
 			if ( rowId ) {
-				runDetailTransition( { type: 'row', rowId } );
+				runDetailTransition( { type: 'row', rowId, pushUrl: true } );
 			}
 		},
 		[ dataFiltered, openRowId, runDetailTransition ]

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -394,7 +394,7 @@ export function formatDisplay( value, type, options = {} ) {
 	return String( value );
 }
 
-function CellShell( { children, onActivate, ariaLabel, isEmpty, disabled } ) {
+function CellShell( { children, onActivate, ariaLabel, className, disabled } ) {
 	// Plain-text content gets the ellipsis wrapper so narrow columns
 	// truncate cleanly. JSX content (chips, links, icons) carries its own
 	// truncation/wrap rules and renders directly — putting `white-space:
@@ -405,10 +405,7 @@ function CellShell( { children, onActivate, ariaLabel, isEmpty, disabled } ) {
 		<div
 			role={ disabled ? undefined : 'button' }
 			tabIndex={ disabled ? -1 : 0 }
-			className={
-				'cortext-editable-cell__shell' +
-				( isEmpty ? ' cortext-editable-cell__shell--empty' : '' )
-			}
+			className={ className }
 			onClick={ disabled ? undefined : onActivate }
 			onKeyDown={
 				disabled
@@ -890,6 +887,10 @@ export default function EditableCell( {
 	// Always render the shell so its content sets the column's intrinsic
 	// width. When editing, overlay the editor on top via position:absolute
 	// so the column doesn't reflow to the editor's larger min-content.
+	const shellClassName =
+		'cortext-editable-cell__shell' +
+		( display === '' ? ' cortext-editable-cell__shell--empty' : '' );
+
 	return (
 		<div
 			className={
@@ -899,7 +900,7 @@ export default function EditableCell( {
 		>
 			<CellShell
 				ariaLabel={ label }
-				isEmpty={ display === '' }
+				className={ shellClassName }
 				disabled={ isEditing }
 				onActivate={ () => setIsEditing( true ) }
 			>

--- a/src/components/RowDetailSidebarSlot.js
+++ b/src/components/RowDetailSidebarSlot.js
@@ -1,0 +1,197 @@
+import {
+	createSlotFill,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseSlotFills as useSlotFills,
+} from '@wordpress/components';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+export const RowDetailSidebar = createSlotFill( 'CortextRowDetailSidebar' );
+
+const WIDTH_KEY = 'cortext.rowDetailSidebarWidth';
+const DEFAULT_WIDTH = 560;
+const MIN_WIDTH = 360;
+const MAX_WIDTH = 840;
+const RESIZE_STEP = 24;
+const MAX_VIEWPORT_RATIO = 0.66;
+
+function getMaxWidth() {
+	if ( typeof window === 'undefined' ) {
+		return MAX_WIDTH;
+	}
+	const viewportMax = Math.floor( window.innerWidth * MAX_VIEWPORT_RATIO );
+	return Math.max( MIN_WIDTH, Math.min( MAX_WIDTH, viewportMax ) );
+}
+
+function clampWidth( value ) {
+	const numericValue = Number.isFinite( value ) ? value : DEFAULT_WIDTH;
+	return Math.min(
+		getMaxWidth(),
+		Math.max( MIN_WIDTH, Math.round( numericValue ) )
+	);
+}
+
+function initialWidth() {
+	if ( typeof window === 'undefined' ) {
+		return DEFAULT_WIDTH;
+	}
+	let stored = NaN;
+	try {
+		stored = Number.parseInt(
+			window.localStorage?.getItem( WIDTH_KEY ),
+			10
+		);
+	} catch {
+		// Ignore storage access failures and fall back to the default width.
+	}
+	return clampWidth( Number.isFinite( stored ) ? stored : DEFAULT_WIDTH );
+}
+
+export function RowDetailSidebarSlot( { fallback = null } ) {
+	const fills = useSlotFills( RowDetailSidebar.name );
+	const hasRowDetail = Boolean( fills?.length );
+	const [ width, setWidth ] = useState( initialWidth );
+	const dragRef = useRef( null );
+	const widthRef = useRef( width );
+
+	const commitWidth = useCallback( ( next ) => {
+		const clamped = clampWidth( next );
+		widthRef.current = clamped;
+		setWidth( clamped );
+		if ( typeof window !== 'undefined' ) {
+			try {
+				window.localStorage?.setItem( WIDTH_KEY, String( clamped ) );
+			} catch {
+				// Saving the preference is best-effort; resizing should still work.
+			}
+		}
+	}, [] );
+
+	useEffect( () => {
+		widthRef.current = width;
+	}, [ width ] );
+
+	useEffect( () => {
+		return () => {
+			if ( typeof document !== 'undefined' ) {
+				document.body.classList.remove(
+					'cortext-row-detail-sidebar-resizing'
+				);
+			}
+		};
+	}, [] );
+
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return undefined;
+		}
+
+		const onWindowResize = () => {
+			commitWidth( widthRef.current );
+		};
+
+		window.addEventListener( 'resize', onWindowResize );
+		return () => {
+			window.removeEventListener( 'resize', onWindowResize );
+		};
+	}, [ commitWidth ] );
+
+	const onResizeStart = useCallback( ( event ) => {
+		if ( event.button !== 0 ) {
+			return;
+		}
+		event.preventDefault();
+		event.currentTarget.setPointerCapture?.( event.pointerId );
+		document.body.classList.add( 'cortext-row-detail-sidebar-resizing' );
+		dragRef.current = {
+			pointerId: event.pointerId,
+			startX: event.clientX,
+			startWidth: widthRef.current,
+		};
+	}, [] );
+
+	const onResizeMove = useCallback( ( event ) => {
+		const drag = dragRef.current;
+		if ( ! drag || drag.pointerId !== event.pointerId ) {
+			return;
+		}
+		const next = clampWidth(
+			drag.startWidth + drag.startX - event.clientX
+		);
+		widthRef.current = next;
+		setWidth( next );
+	}, [] );
+
+	const onResizeEnd = useCallback(
+		( event ) => {
+			const drag = dragRef.current;
+			if ( ! drag || drag.pointerId !== event.pointerId ) {
+				return;
+			}
+			if ( event.currentTarget.hasPointerCapture?.( event.pointerId ) ) {
+				event.currentTarget.releasePointerCapture?.( event.pointerId );
+			}
+			document.body.classList.remove(
+				'cortext-row-detail-sidebar-resizing'
+			);
+			dragRef.current = null;
+			commitWidth( widthRef.current );
+		},
+		[ commitWidth ]
+	);
+
+	const onResizeKeyDown = useCallback(
+		( event ) => {
+			if ( event.key === 'ArrowLeft' ) {
+				event.preventDefault();
+				commitWidth( width + RESIZE_STEP );
+			} else if ( event.key === 'ArrowRight' ) {
+				event.preventDefault();
+				commitWidth( width - RESIZE_STEP );
+			} else if ( event.key === 'Home' ) {
+				event.preventDefault();
+				commitWidth( MIN_WIDTH );
+			} else if ( event.key === 'End' ) {
+				event.preventDefault();
+				commitWidth( MAX_WIDTH );
+			}
+		},
+		[ commitWidth, width ]
+	);
+
+	if ( ! hasRowDetail ) {
+		return fallback;
+	}
+
+	const maxWidth = getMaxWidth();
+
+	return (
+		<div
+			className="cortext-row-detail-sidebar-shell"
+			style={ {
+				'--cortext-row-detail-sidebar-width': `${ width }px`,
+			} }
+		>
+			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
+			<div
+				className="cortext-row-detail-sidebar-shell__resize-handle"
+				role="separator"
+				aria-label={ __( 'Resize row detail panel', 'cortext' ) }
+				aria-orientation="vertical"
+				aria-valuemin={ MIN_WIDTH }
+				aria-valuemax={ maxWidth }
+				aria-valuenow={ width }
+				tabIndex={ 0 }
+				onPointerDown={ onResizeStart }
+				onPointerMove={ onResizeMove }
+				onPointerUp={ onResizeEnd }
+				onPointerCancel={ onResizeEnd }
+				onKeyDown={ onResizeKeyDown }
+			/>
+			<RowDetailSidebar.Slot
+				bubblesVirtually
+				className="cortext-row-detail-sidebar"
+			/>
+		</div>
+	);
+}

--- a/src/components/RowDetailSidebarSlot.js
+++ b/src/components/RowDetailSidebarSlot.js
@@ -14,6 +14,15 @@ const MIN_WIDTH = 360;
 const MAX_WIDTH = 840;
 const RESIZE_STEP = 24;
 const MAX_VIEWPORT_RATIO = 0.66;
+const SIDEBAR_ANIMATION_MS = 300;
+const SIDEBAR_ANIMATION_FALLBACK_MS = SIDEBAR_ANIMATION_MS + 100;
+
+function prefersReducedMotion() {
+	return (
+		typeof window !== 'undefined' &&
+		window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches
+	);
+}
 
 function getMaxWidth() {
 	if ( typeof window === 'undefined' ) {
@@ -47,9 +56,13 @@ function initialWidth() {
 	return clampWidth( Number.isFinite( stored ) ? stored : DEFAULT_WIDTH );
 }
 
-export function RowDetailSidebarSlot( { fallback = null } ) {
+export function RowDetailSidebarSlot( {
+	fallback = null,
+	isFallbackActive = false,
+} ) {
 	const fills = useSlotFills( RowDetailSidebar.name );
 	const hasRowDetail = Boolean( fills?.length );
+	const [ isRendered, setIsRendered ] = useState( hasRowDetail );
 	const [ width, setWidth ] = useState( initialWidth );
 	const dragRef = useRef( null );
 	const widthRef = useRef( width );
@@ -70,6 +83,25 @@ export function RowDetailSidebarSlot( { fallback = null } ) {
 	useEffect( () => {
 		widthRef.current = width;
 	}, [ width ] );
+
+	useEffect( () => {
+		if ( hasRowDetail ) {
+			setIsRendered( true );
+			return undefined;
+		}
+		if ( ! isRendered ) {
+			return undefined;
+		}
+		if ( prefersReducedMotion() ) {
+			setIsRendered( false );
+			return undefined;
+		}
+
+		const timeout = setTimeout( () => {
+			setIsRendered( false );
+		}, SIDEBAR_ANIMATION_FALLBACK_MS );
+		return () => clearTimeout( timeout );
+	}, [ hasRowDetail, isRendered ] );
 
 	useEffect( () => {
 		return () => {
@@ -159,39 +191,83 @@ export function RowDetailSidebarSlot( { fallback = null } ) {
 		[ commitWidth, width ]
 	);
 
-	if ( ! hasRowDetail ) {
+	const onShellAnimationEnd = useCallback(
+		( event ) => {
+			if ( hasRowDetail || event.target !== event.currentTarget ) {
+				return;
+			}
+			setIsRendered( false );
+		},
+		[ hasRowDetail ]
+	);
+
+	if ( ! isRendered ) {
 		return fallback;
 	}
 
 	const maxWidth = getMaxWidth();
+	const isClosing = ! hasRowDetail;
+	const shouldReserveFallback = Boolean( fallback && isFallbackActive );
 
-	return (
+	const shell = (
 		<div
-			className="cortext-row-detail-sidebar-shell"
+			className={
+				'cortext-row-detail-sidebar-shell' +
+				( isClosing
+					? ' cortext-row-detail-sidebar-shell--closing'
+					: '' )
+			}
+			aria-hidden={ isClosing ? true : undefined }
+			{ ...( isClosing ? { inert: '' } : {} ) }
 			style={ {
 				'--cortext-row-detail-sidebar-width': `${ width }px`,
 			} }
+			onAnimationEnd={ onShellAnimationEnd }
 		>
-			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
-			<div
-				className="cortext-row-detail-sidebar-shell__resize-handle"
-				role="separator"
-				aria-label={ __( 'Resize row detail panel', 'cortext' ) }
-				aria-orientation="vertical"
-				aria-valuemin={ MIN_WIDTH }
-				aria-valuemax={ maxWidth }
-				aria-valuenow={ width }
-				tabIndex={ 0 }
-				onPointerDown={ onResizeStart }
-				onPointerMove={ onResizeMove }
-				onPointerUp={ onResizeEnd }
-				onPointerCancel={ onResizeEnd }
-				onKeyDown={ onResizeKeyDown }
-			/>
-			<RowDetailSidebar.Slot
-				bubblesVirtually
-				className="cortext-row-detail-sidebar"
-			/>
+			{ ! isClosing ? (
+				<>
+					{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
+					<div
+						className="cortext-row-detail-sidebar-shell__resize-handle"
+						role="separator"
+						aria-label={ __(
+							'Resize row detail panel',
+							'cortext'
+						) }
+						aria-orientation="vertical"
+						aria-valuemin={ MIN_WIDTH }
+						aria-valuemax={ maxWidth }
+						aria-valuenow={ width }
+						tabIndex={ 0 }
+						onPointerDown={ onResizeStart }
+						onPointerMove={ onResizeMove }
+						onPointerUp={ onResizeEnd }
+						onPointerCancel={ onResizeEnd }
+						onKeyDown={ onResizeKeyDown }
+					/>
+					<RowDetailSidebar.Slot
+						bubblesVirtually
+						className="cortext-row-detail-sidebar"
+					/>
+				</>
+			) : null }
 		</div>
 	);
+
+	if ( shouldReserveFallback ) {
+		return (
+			<div className="cortext-row-detail-sidebar-handoff cortext-row-detail-sidebar-handoff--reserve">
+				<div
+					className="cortext-row-detail-sidebar-handoff__fallback"
+					aria-hidden={ hasRowDetail ? true : undefined }
+					{ ...( hasRowDetail ? { inert: '' } : {} ) }
+				>
+					{ fallback }
+				</div>
+				{ shell }
+			</div>
+		);
+	}
+
+	return shell;
 }

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -4,18 +4,18 @@ import {
 	CheckboxControl,
 	DateTimePicker,
 	Dropdown,
-	FormTokenField,
-	MenuGroup,
-	MenuItem,
 	Modal,
 	Notice,
+	Popover,
 	Spinner,
 } from '@wordpress/components';
 import { useEntityRecord } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { EditorProvider, store as editorStore } from '@wordpress/editor';
 import {
+	createPortal,
 	useCallback,
+	useContext,
 	useEffect,
 	useMemo,
 	useRef,
@@ -26,16 +26,28 @@ import {
 	chevronDown,
 	chevronUp,
 	closeSmall,
-	details,
 	drawerRight,
 	fullscreen,
+	seen,
 	square,
+	unseen,
 } from '@wordpress/icons';
 
 import useAutosave from '../hooks/useAutosave';
-import { dateOnlyValue, formatDisplay } from './EditableCell';
+import { toRecordId } from '../hooks/fieldIds';
+import {
+	RowMutationContext,
+	dateOnlyValue,
+	formatDisplay,
+} from './EditableCell';
 import { TITLE_FIELD_ID } from './dataViewColumns';
-import { getRowDetailMode, splitPropertyPatch } from './rowDetailUtils';
+import EditOptionsPopover from './fields/EditOptionsPopover';
+import {
+	getRowDetailMode,
+	isValidNumberDraft,
+	parseNumberPropertyValue,
+	splitPropertyPatch,
+} from './rowDetailUtils';
 
 export const ROW_DETAIL_MODE_ICONS = {
 	side: drawerRight,
@@ -48,6 +60,54 @@ const ROW_DETAIL_MODE_LABELS = {
 	modal: __( 'Center modal', 'cortext' ),
 	full: __( 'Full page', 'cortext' ),
 };
+const ROW_DETAIL_MODAL_CLOSE_MS = 240;
+const ROW_DETAIL_SWITCH_MS = 180;
+const ROW_DETAIL_SWITCH_FALLBACK_MS = ROW_DETAIL_SWITCH_MS + 100;
+
+function delay( duration ) {
+	return new Promise( ( resolve ) => {
+		setTimeout( resolve, duration );
+	} );
+}
+
+function detailKeyFor( detail ) {
+	if ( ! detail ) {
+		return null;
+	}
+	return `${ detail.postType }:${ detail.rowId }`;
+}
+
+function prefersReducedMotion() {
+	return (
+		typeof window !== 'undefined' &&
+		window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches
+	);
+}
+
+function settleDetailPanes( panes ) {
+	const enteringPane = panes.find( ( pane ) => pane.state === 'entering' );
+	if ( enteringPane ) {
+		return panes
+			.filter(
+				( pane ) =>
+					pane.key === enteringPane.key || pane.state === 'preparing'
+			)
+			.map( ( pane ) =>
+				pane.key === enteringPane.key
+					? { ...pane, state: 'active' }
+					: pane
+			);
+	}
+	return panes.filter( ( pane ) => pane.state !== 'covered' );
+}
+
+function DetailReadySignal( { detailKey, onReady } ) {
+	useEffect( () => {
+		onReady( detailKey );
+	}, [ detailKey, onReady ] );
+
+	return null;
+}
 
 const ROW_DETAIL_EDITOR_CSS = `
 	body {
@@ -73,7 +133,7 @@ const ROW_DETAIL_EDITOR_CSS = `
 	}
 `;
 
-function RowAutosaveBridge( { onApi, onSaved } ) {
+function RowAutosaveBridge( { isActive = true, onApi, onSaved } ) {
 	const { status, flushNow, isDirty, isSaving } = useAutosave( {
 		debounceMs: 0,
 		minSaveIntervalMs: 0,
@@ -90,15 +150,18 @@ function RowAutosaveBridge( { onApi, onSaved } ) {
 	);
 
 	useEffect( () => {
+		if ( ! isActive ) {
+			return undefined;
+		}
 		onApi?.( { flushNow, discard, hasPendingEdits } );
 		return () => onApi?.( null );
-	}, [ discard, flushNow, hasPendingEdits, onApi ] );
+	}, [ discard, flushNow, hasPendingEdits, isActive, onApi ] );
 
 	useEffect( () => {
-		if ( status === 'saved' ) {
+		if ( isActive && status === 'saved' ) {
 			onSaved?.();
 		}
-	}, [ onSaved, status ] );
+	}, [ isActive, onSaved, status ] );
 
 	return null;
 }
@@ -144,136 +207,128 @@ function ReadOnlyProperty( { value, type, elements, format } ) {
 	);
 }
 
-function labelForElementValue( elements, value ) {
-	const match = ( elements ?? [] ).find( ( element ) => {
-		return String( element.value ) === String( value );
-	} );
-	return match?.label ?? value;
+function OptionPropertyValue( { value, type, elements } ) {
+	const display = formatDisplay( value, type, { elements } );
+	return display === '' ? emptyLabel() : display;
 }
 
-function SelectPropertyControl( { field, value, elements, onChange } ) {
-	const hasValue = value !== null && value !== undefined && value !== '';
-	const triggerLabel = hasValue
-		? labelForElementValue( elements, value )
-		: __( 'Empty', 'cortext' );
+function SelectPropertyControl( {
+	field,
+	value,
+	elements,
+	onChange,
+	onOptionsSaved,
+	onRowsChanged,
+} ) {
+	const [ anchor, setAnchor ] = useState( null );
+	const [ isOpen, setIsOpen ] = useState( false );
+	const close = useCallback( () => setIsOpen( false ), [] );
+	const recordId = field.cortextRecordId ?? toRecordId( field.id );
 
 	return (
-		<Dropdown
-			popoverProps={ { placement: 'bottom-start' } }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					className="cortext-row-detail__property-trigger"
-					variant="tertiary"
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-					aria-label={ field.label }
+		<>
+			<Button
+				ref={ setAnchor }
+				className="cortext-row-detail__property-trigger"
+				variant="tertiary"
+				onClick={ () => setIsOpen( true ) }
+				aria-expanded={ isOpen }
+				aria-label={ field.label }
+			>
+				<OptionPropertyValue
+					value={ value }
+					type="select"
+					elements={ elements }
+				/>
+			</Button>
+			{ isOpen && anchor ? (
+				<Popover
+					anchor={ anchor }
+					placement="bottom-start"
+					onClose={ close }
+					focusOnMount="firstElement"
 				>
-					{ triggerLabel }
-				</Button>
-			) }
-			renderContent={ ( { onClose } ) => (
-				<MenuGroup>
-					<MenuItem
-						isSelected={ ! hasValue }
-						onClick={ () => {
-							onChange( null );
-							onClose();
+					<EditOptionsPopover
+						recordId={ recordId }
+						fieldType="select"
+						initialOptions={ elements ?? [] }
+						value={ value }
+						onOptionsSaved={ onOptionsSaved }
+						onRowsChanged={ onRowsChanged }
+						onRequestClose={ close }
+						onPick={ async ( next ) => {
+							onChange( next );
+							close();
 						} }
-					>
-						{ __( 'Empty', 'cortext' ) }
-					</MenuItem>
-					{ ( elements ?? [] ).map( ( element ) => (
-						<MenuItem
-							key={ element.value }
-							isSelected={
-								String( element.value ) === String( value )
-							}
-							onClick={ () => {
-								onChange( element.value );
-								onClose();
-							} }
-						>
-							{ element.label }
-						</MenuItem>
-					) ) }
-				</MenuGroup>
-			) }
-		/>
-	);
-}
-
-function MultiselectPropertyControl( { field, value, elements, onChange } ) {
-	const valueToLabel = useMemo( () => {
-		const map = new Map();
-		( elements ?? [] ).forEach( ( element ) =>
-			map.set( element.value, element.label )
-		);
-		return map;
-	}, [ elements ] );
-	const labelToValue = useMemo( () => {
-		const map = new Map();
-		( elements ?? [] ).forEach( ( element ) =>
-			map.set( element.label, element.value )
-		);
-		return map;
-	}, [ elements ] );
-	const tokens = useMemo(
-		() =>
-			( Array.isArray( value ) ? value : [] ).map(
-				( item ) => valueToLabel.get( item ) ?? String( item )
-			),
-		[ value, valueToLabel ]
-	);
-	const suggestions = useMemo(
-		() => ( elements ?? [] ).map( ( element ) => element.label ),
-		[ elements ]
-	);
-	const triggerLabel = tokens.length
-		? tokens.join( ', ' )
-		: __( 'Empty', 'cortext' );
-
-	return (
-		<Dropdown
-			popoverProps={ { placement: 'bottom-start' } }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					className="cortext-row-detail__property-trigger"
-					variant="tertiary"
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-					aria-label={ field.label }
-				>
-					{ triggerLabel }
-				</Button>
-			) }
-			renderContent={ () => (
-				<div className="cortext-row-detail__tokens-popover">
-					<FormTokenField
-						value={ tokens }
-						suggestions={ suggestions }
-						onChange={ ( nextTokens ) => {
-							onChange(
-								nextTokens
-									.map(
-										( token ) =>
-											labelToValue.get( token ) ?? token
-									)
-									.filter(
-										( next ) =>
-											next !== '' &&
-											next !== null &&
-											next !== undefined
-									)
-							);
-						} }
-						label={ field.label }
-						__experimentalExpandOnFocus
-						__experimentalShowHowTo={ false }
-						__nextHasNoMarginBottom
 					/>
-				</div>
-			) }
-		/>
+				</Popover>
+			) : null }
+		</>
+	);
+}
+
+function MultiselectPropertyControl( {
+	field,
+	value,
+	elements,
+	onChange,
+	onOptionsSaved,
+	onRowsChanged,
+} ) {
+	const [ anchor, setAnchor ] = useState( null );
+	const [ isOpen, setIsOpen ] = useState( false );
+	const close = useCallback( () => setIsOpen( false ), [] );
+	const recordId = field.cortextRecordId ?? toRecordId( field.id );
+	const current = useMemo(
+		() => ( Array.isArray( value ) ? value : [] ),
+		[ value ]
+	);
+	const handlePick = useCallback(
+		( optionValue ) => {
+			const next = current.includes( optionValue )
+				? current.filter( ( item ) => item !== optionValue )
+				: [ ...current, optionValue ];
+			onChange( next );
+		},
+		[ current, onChange ]
+	);
+
+	return (
+		<>
+			<Button
+				ref={ setAnchor }
+				className="cortext-row-detail__property-trigger"
+				variant="tertiary"
+				onClick={ () => setIsOpen( true ) }
+				aria-expanded={ isOpen }
+				aria-label={ field.label }
+			>
+				<OptionPropertyValue
+					value={ current }
+					type="multiselect"
+					elements={ elements }
+				/>
+			</Button>
+			{ isOpen && anchor ? (
+				<Popover
+					anchor={ anchor }
+					placement="bottom-start"
+					onClose={ close }
+					focusOnMount="firstElement"
+				>
+					<EditOptionsPopover
+						recordId={ recordId }
+						fieldType="multiselect"
+						initialOptions={ elements ?? [] }
+						value={ current }
+						onOptionsSaved={ onOptionsSaved }
+						onRowsChanged={ onRowsChanged }
+						onRequestClose={ close }
+						onPick={ handlePick }
+					/>
+				</Popover>
+			) : null }
+		</>
 	);
 }
 
@@ -332,51 +387,112 @@ function valueForField( field, data ) {
 }
 
 function EditablePropertyText( { label, inputMode, value, onChange } ) {
-	const ref = useRef( null );
 	const textValue =
 		value === null || value === undefined ? '' : String( value );
+	const [ draft, setDraft ] = useState( textValue );
+	const [ isFocused, setIsFocused ] = useState( false );
 
 	useEffect( () => {
-		const ownerDocument = ref.current?.ownerDocument;
-		if (
-			ref.current &&
-			ownerDocument?.activeElement !== ref.current &&
-			ref.current.textContent !== textValue
-		) {
-			ref.current.textContent = textValue;
+		if ( ! isFocused ) {
+			setDraft( textValue );
 		}
-	}, [ textValue ] );
+	}, [ isFocused, textValue ] );
 
 	return (
-		<div
-			ref={ ref }
+		<input
 			aria-label={ label }
 			className="cortext-row-detail__property-editable-text"
-			contentEditable
-			data-placeholder={ __( 'Empty', 'cortext' ) }
 			inputMode={ inputMode }
-			role="textbox"
-			suppressContentEditableWarning
-			tabIndex={ 0 }
-			onInput={ ( event ) =>
-				onChange( event.currentTarget.textContent ?? '' )
-			}
-			onKeyDown={ ( event ) => {
-				if ( event.key === 'Enter' ) {
-					event.preventDefault();
-					event.currentTarget.blur();
-				}
+			placeholder={ isFocused ? '' : __( 'Empty', 'cortext' ) }
+			type="text"
+			value={ draft }
+			onBlur={ () => setIsFocused( false ) }
+			onChange={ ( event ) => {
+				const next = event.currentTarget.value;
+				setDraft( next );
+				onChange( next );
 			} }
-		>
-			{ textValue }
-		</div>
+			onFocus={ () => setIsFocused( true ) }
+		/>
 	);
 }
 
-function PropertyControl( { field, value, onChange } ) {
+function EditableNumberPropertyText( { label, value, onChange } ) {
+	const textValue =
+		value === null || value === undefined ? '' : String( value );
+	const committedTextRef = useRef( textValue );
+	const committedValueRef = useRef( value ?? null );
+	const [ draft, setDraft ] = useState( textValue );
+	const [ isFocused, setIsFocused ] = useState( false );
+
+	useEffect( () => {
+		committedTextRef.current = textValue;
+		committedValueRef.current = value ?? null;
+
+		if ( ! isFocused ) {
+			setDraft( textValue );
+		}
+	}, [ isFocused, textValue, value ] );
+
+	const commitDraft = useCallback(
+		( nextDraft ) => {
+			if ( ! isValidNumberDraft( nextDraft ) ) {
+				return;
+			}
+
+			setDraft( nextDraft );
+			const parsed = parseNumberPropertyValue( nextDraft );
+
+			if ( parsed.complete ) {
+				const normalized =
+					parsed.value === null ? '' : String( parsed.value );
+				if ( ! Object.is( parsed.value, committedValueRef.current ) ) {
+					onChange( parsed.value );
+				}
+				committedValueRef.current = parsed.value;
+				committedTextRef.current = normalized;
+			}
+		},
+		[ onChange ]
+	);
+
+	return (
+		<input
+			aria-label={ label }
+			className="cortext-row-detail__property-editable-text"
+			inputMode="decimal"
+			placeholder={ isFocused ? '' : __( 'Empty', 'cortext' ) }
+			type="text"
+			value={ draft }
+			onBlur={ () => {
+				setIsFocused( false );
+				const parsed = parseNumberPropertyValue( draft );
+
+				if ( parsed.valid && parsed.complete ) {
+					setDraft(
+						parsed.value === null ? '' : String( parsed.value )
+					);
+					return;
+				}
+
+				setDraft( committedTextRef.current );
+			} }
+			onChange={ ( event ) => commitDraft( event.currentTarget.value ) }
+			onFocus={ () => setIsFocused( true ) }
+		/>
+	);
+}
+
+function PropertyControl( {
+	field,
+	value,
+	elements,
+	onChange,
+	onOptionsSaved,
+	onRowsChanged,
+} ) {
 	const type = fieldType( field );
 	const label = field.label;
-	const elements = field.cortextElements ?? field.elements ?? [];
 
 	if ( type === 'checkbox' ) {
 		return (
@@ -392,17 +508,10 @@ function PropertyControl( { field, value, onChange } ) {
 
 	if ( type === 'number' ) {
 		return (
-			<EditablePropertyText
+			<EditableNumberPropertyText
 				label={ label }
-				inputMode="decimal"
-				value={ value ?? '' }
-				onChange={ ( next ) =>
-					onChange(
-						next === '' || next === null || next === undefined
-							? null
-							: Number( next )
-					)
-				}
+				value={ value }
+				onChange={ onChange }
 			/>
 		);
 	}
@@ -414,6 +523,8 @@ function PropertyControl( { field, value, onChange } ) {
 				value={ value }
 				elements={ elements }
 				onChange={ onChange }
+				onOptionsSaved={ onOptionsSaved }
+				onRowsChanged={ onRowsChanged }
 			/>
 		);
 	}
@@ -425,6 +536,8 @@ function PropertyControl( { field, value, onChange } ) {
 				value={ value }
 				elements={ elements }
 				onChange={ onChange }
+				onOptionsSaved={ onOptionsSaved }
+				onRowsChanged={ onRowsChanged }
 			/>
 		);
 	}
@@ -457,8 +570,65 @@ function PropertyControl( { field, value, onChange } ) {
 	);
 }
 
-function RowPropertyForm( { fields, row } ) {
+function PropertyValueMount( { fieldId, onMount } ) {
+	const setRef = useCallback(
+		( node ) => onMount( fieldId, node ),
+		[ fieldId, onMount ]
+	);
+
+	return (
+		<div
+			className="cortext-row-detail__property-value-stack"
+			ref={ setRef }
+		/>
+	);
+}
+
+function RowPropertyRows( { fields, onValueMount } ) {
+	return (
+		<div className="cortext-row-detail__properties cortext-row-detail__properties--rows">
+			{ fields.map( ( field ) => {
+				const isEditable =
+					field.id === TITLE_FIELD_ID ||
+					( field.editable && field.id?.startsWith?.( 'field-' ) );
+
+				return (
+					<div
+						key={ field.id }
+						className={
+							'cortext-row-detail__property' +
+							( isEditable
+								? ' cortext-row-detail__property--editable'
+								: ' cortext-row-detail__property--readonly' )
+						}
+					>
+						<div className="cortext-row-detail__property-label">
+							{ field.label }
+						</div>
+						<div className="cortext-row-detail__property-value">
+							<PropertyValueMount
+								fieldId={ field.id }
+								onMount={ onValueMount }
+							/>
+						</div>
+					</div>
+				);
+			} ) }
+		</div>
+	);
+}
+
+function RowPropertyValues( {
+	fields,
+	mountNodes,
+	row,
+	state,
+	isActive,
+	isHidden,
+} ) {
 	const { editPost } = useDispatch( editorStore );
+	const { optionOverrides, updateFieldOptions, refreshRows } =
+		useContext( RowMutationContext );
 	const { title, meta } = useSelect(
 		( select ) => ( {
 			title: select( editorStore ).getEditedPostAttribute( 'title' ),
@@ -497,51 +667,83 @@ function RowPropertyForm( { fields, row } ) {
 	);
 
 	return (
-		<div className="cortext-row-detail__properties">
+		<>
 			{ fields.map( ( field ) => {
+				const mountNode = mountNodes?.[ field.id ];
+				if ( ! mountNode ) {
+					return null;
+				}
+
 				const value = valueForField( field, data );
 				const type = fieldType( field );
+				const elements =
+					optionOverrides?.[ field.id ] ??
+					field.cortextElements ??
+					field.elements ??
+					[];
 				const isEditable =
 					field.id === TITLE_FIELD_ID ||
 					( field.editable && field.id?.startsWith?.( 'field-' ) );
 
-				return (
+				return createPortal(
 					<div
 						key={ field.id }
-						className={
-							'cortext-row-detail__property' +
-							( isEditable
-								? ' cortext-row-detail__property--editable'
-								: ' cortext-row-detail__property--readonly' )
-						}
+						className="cortext-row-detail__property-value-pane"
+						data-state={ state }
+						data-interactive={ isActive ? 'true' : 'false' }
+						aria-hidden={ isHidden ? true : undefined }
+						{ ...( isHidden ? { inert: '' } : {} ) }
 					>
-						<div className="cortext-row-detail__property-label">
-							{ field.label }
-						</div>
-						<div className="cortext-row-detail__property-value">
-							{ isEditable ? (
-								<PropertyControl
-									field={ field }
-									value={ value }
-									onChange={ ( next ) =>
-										update( { [ field.id ]: next } )
-									}
-								/>
-							) : (
-								<ReadOnlyProperty
-									value={ value }
-									type={ type }
-									elements={
-										field.cortextElements ?? field.elements
-									}
-									format={ field.cortextFormat }
-								/>
-							) }
-						</div>
-					</div>
+						{ isEditable ? (
+							<PropertyControl
+								field={ field }
+								value={ value }
+								elements={ elements }
+								onChange={ ( next ) =>
+									update( { [ field.id ]: next } )
+								}
+								onOptionsSaved={ ( nextOptions ) =>
+									updateFieldOptions?.(
+										field.cortextRecordId ??
+											toRecordId( field.id ),
+										nextOptions
+									)
+								}
+								onRowsChanged={ refreshRows }
+							/>
+						) : (
+							<ReadOnlyProperty
+								value={ value }
+								type={ type }
+								elements={ elements }
+								format={ field.cortextFormat }
+							/>
+						) }
+					</div>,
+					mountNode
 				);
 			} ) }
-		</div>
+		</>
+	);
+}
+
+function RowPropertyValuesPortal( {
+	fields,
+	isActive,
+	isHidden,
+	mountNodes,
+	row,
+	state,
+} ) {
+	return (
+		<RowPropertyValues
+			fields={ fields }
+			isActive={ isActive }
+			isHidden={ isHidden }
+			mountNodes={ mountNodes }
+			row={ row }
+			state={ state }
+		/>
 	);
 }
 
@@ -569,31 +771,154 @@ export function ModeControl( { mode, onChangeMode } ) {
 	);
 }
 
-function DetailFrame( {
+function titleFromRow( row ) {
+	const title = row?.title;
+	if ( typeof title === 'string' ) {
+		return title;
+	}
+	return title?.raw ?? title?.rendered ?? '';
+}
+
+function titleFromDetail( detail ) {
+	if ( ! detail ) {
+		return '';
+	}
+	return titleFromRow( detail.record ) || titleFromRow( detail.row );
+}
+
+function DetailTitleSignal( { isActive, onTitle, row } ) {
+	const editedTitle = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'title' ),
+		[]
+	);
+	const title =
+		typeof editedTitle === 'string' ? editedTitle : titleFromRow( row );
+
+	useEffect( () => {
+		if ( isActive ) {
+			onTitle?.( title );
+		}
+	}, [ isActive, onTitle, title ] );
+
+	return null;
+}
+
+function DetailBody( {
+	arePropertiesVisible,
+	children,
+	fields,
+	fieldCountLabel,
+	onValueMount,
+} ) {
+	return (
+		<div className="cortext-row-detail__body">
+			<div
+				className="cortext-row-detail__properties-region"
+				aria-hidden={ arePropertiesVisible ? undefined : true }
+				{ ...( arePropertiesVisible ? {} : { inert: '' } ) }
+			>
+				<div className="cortext-row-detail__properties-region-inner">
+					<div className="cortext-row-detail__properties-shell">
+						<RowPropertyRows
+							fields={ fields }
+							onValueMount={ onValueMount }
+						/>
+					</div>
+				</div>
+			</div>
+			<div
+				className="cortext-row-detail__fields-indicator-wrap"
+				aria-hidden={ arePropertiesVisible ? true : undefined }
+				{ ...( arePropertiesVisible ? { inert: '' } : {} ) }
+			>
+				<div className="cortext-row-detail__fields-indicator-inner">
+					<div
+						className="cortext-row-detail__fields-indicator"
+						aria-label={ sprintf(
+							/* translators: %s: Number of hidden fields. */
+							__( '%s hidden', 'cortext' ),
+							fieldCountLabel
+						) }
+					>
+						{ fieldCountLabel }
+					</div>
+				</div>
+			</div>
+			{ children }
+		</div>
+	);
+}
+
+function DetailPaneContent( {
+	fields,
+	isActive,
+	isHidden,
+	onApi,
+	onSaved,
+	onTitle,
+	propertyValueMounts,
+	row,
+	state,
+} ) {
+	return (
+		<>
+			<RowAutosaveBridge
+				isActive={ isActive }
+				onApi={ onApi }
+				onSaved={ onSaved }
+			/>
+			<DetailTitleSignal
+				isActive={ isActive }
+				onTitle={ onTitle }
+				row={ row }
+			/>
+			<RowPropertyValuesPortal
+				fields={ fields }
+				isActive={ isActive }
+				isHidden={ isHidden }
+				mountNodes={ propertyValueMounts }
+				row={ row }
+				state={ state }
+			/>
+			<RowContentEditor />
+		</>
+	);
+}
+
+function DetailShell( {
+	arePropertiesVisible,
+	children,
 	fields,
 	mode,
-	onApi,
 	onClose,
 	onDiscardPending,
 	onModeChange,
 	onNext,
 	onPrevious,
 	onRetryPending,
-	onSaved,
-	row,
 	saveError,
 	canGoNext,
 	canGoPrevious,
+	setArePropertiesVisible,
+	title,
 } ) {
-	const editedTitle = useSelect(
-		( select ) => select( editorStore ).getEditedPostAttribute( 'title' ),
-		[]
-	);
-	const title =
-		typeof editedTitle === 'string'
-			? editedTitle
-			: row?.title?.raw ?? row?.title?.rendered ?? '';
-	const [ arePropertiesVisible, setArePropertiesVisible ] = useState( true );
+	const [ propertyValueMounts, setPropertyValueMounts ] = useState( {} );
+	const setPropertyValueMount = useCallback( ( fieldId, node ) => {
+		setPropertyValueMounts( ( current ) => {
+			if ( node ) {
+				if ( current[ fieldId ] === node ) {
+					return current;
+				}
+				return { ...current, [ fieldId ]: node };
+			}
+			if ( ! current[ fieldId ] ) {
+				return current;
+			}
+			const next = { ...current };
+			delete next[ fieldId ];
+			return next;
+		} );
+	}, [] );
 	const fieldCountLabel = sprintf(
 		/* translators: %d: Number of row fields. */
 		_n( '%d field', '%d fields', fields.length, 'cortext' ),
@@ -606,7 +931,6 @@ function DetailFrame( {
 			data-properties-visible={ arePropertiesVisible ? 'true' : 'false' }
 		>
 			<div className="cortext-row-detail__header">
-				<RowAutosaveBridge onApi={ onApi } onSaved={ onSaved } />
 				<div
 					className="cortext-row-detail__toolbar"
 					role="toolbar"
@@ -615,7 +939,7 @@ function DetailFrame( {
 					<div className="cortext-row-detail__toolbar-group">
 						<Button
 							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--icon"
-							icon={ details }
+							icon={ arePropertiesVisible ? unseen : seen }
 							label={
 								arePropertiesVisible
 									? __( 'Hide fields', 'cortext' )
@@ -686,39 +1010,14 @@ function DetailFrame( {
 					{ saveError }
 				</Notice>
 			) : null }
-			<div className="cortext-row-detail__body">
-				<div
-					className="cortext-row-detail__properties-region"
-					aria-hidden={ arePropertiesVisible ? undefined : true }
-					{ ...( arePropertiesVisible ? {} : { inert: '' } ) }
-				>
-					<div className="cortext-row-detail__properties-region-inner">
-						<RowPropertyForm fields={ fields } row={ row } />
-					</div>
-				</div>
-				<div
-					className="cortext-row-detail__fields-indicator-wrap"
-					aria-hidden={ arePropertiesVisible ? true : undefined }
-					{ ...( arePropertiesVisible ? { inert: '' } : {} ) }
-				>
-					<div className="cortext-row-detail__fields-indicator-inner">
-						<Button
-							className="cortext-row-detail__fields-indicator"
-							icon={ details }
-							label={ sprintf(
-								/* translators: %s: Number of hidden fields. */
-								__( 'Show %s', 'cortext' ),
-								fieldCountLabel
-							) }
-							variant="tertiary"
-							onClick={ () => setArePropertiesVisible( true ) }
-						>
-							{ fieldCountLabel }
-						</Button>
-					</div>
-				</div>
-				<RowContentEditor />
-			</div>
+			<DetailBody
+				arePropertiesVisible={ arePropertiesVisible }
+				fields={ fields }
+				fieldCountLabel={ fieldCountLabel }
+				onValueMount={ setPropertyValueMount }
+			>
+				{ children( { propertyValueMounts } ) }
+			</DetailBody>
 		</div>
 	);
 }
@@ -761,8 +1060,14 @@ export default function RowDetailView( {
 		enabled: Boolean( postType && rowId ),
 	} );
 	const normalizedMode = getRowDetailMode( { rowDetailMode: mode } );
+	const [ isModalClosing, setIsModalClosing ] = useState( false );
 	const targetDetail = useMemo( () => {
-		if ( ! record || ! postType || ! rowId ) {
+		if (
+			! record ||
+			! postType ||
+			! rowId ||
+			String( record.id ) !== String( rowId )
+		) {
 			return null;
 		}
 		return { postType, record, row, rowId };
@@ -775,54 +1080,278 @@ export default function RowDetailView( {
 		}
 	}, [ targetDetail ] );
 
+	useEffect( () => {
+		if ( normalizedMode !== 'modal' ) {
+			setIsModalClosing( false );
+		}
+	}, [ normalizedMode ] );
+
 	const activeDetail =
 		targetDetail ??
 		( resolvedDetail?.postType === postType ? resolvedDetail : null );
-	const isSwitchingRows = Boolean(
-		activeDetail && String( activeDetail.rowId ) !== String( rowId )
+	const activeDetailKey = detailKeyFor( activeDetail );
+	const [ arePropertiesVisible, setArePropertiesVisible ] = useState( true );
+	const [ displayTitle, setDisplayTitle ] = useState( () =>
+		titleFromDetail( activeDetail )
+	);
+	const [ detailPanes, setDetailPanes ] = useState( () =>
+		activeDetail && activeDetailKey
+			? [
+					{
+						key: activeDetailKey,
+						detail: activeDetail,
+						state: 'active',
+					},
+			  ]
+			: []
 	);
 
-	const content = ! activeDetail ? (
-		<LoadingDetail onClose={ onClose } />
-	) : (
-		<EditorProvider
-			key={ `${ activeDetail.postType }:${ activeDetail.rowId }` }
-			post={ activeDetail.record }
-			settings={ window.cortextEditorSettings ?? {} }
-		>
-			<DetailFrame
-				canGoNext={ ! isSwitchingRows && canGoNext }
-				canGoPrevious={ ! isSwitchingRows && canGoPrevious }
+	useEffect( () => {
+		if ( activeDetail ) {
+			setDisplayTitle( titleFromDetail( activeDetail ) );
+		}
+	}, [ activeDetail ] );
+
+	useEffect( () => {
+		if ( ! activeDetail || ! activeDetailKey ) {
+			setDetailPanes( [] );
+			return;
+		}
+
+		setDetailPanes( ( current ) => {
+			if ( current.some( ( pane ) => pane.key === activeDetailKey ) ) {
+				return current
+					.filter(
+						( pane ) =>
+							pane.key === activeDetailKey ||
+							pane.state !== 'preparing'
+					)
+					.map( ( pane ) => {
+						if ( pane.key !== activeDetailKey ) {
+							return pane;
+						}
+						return {
+							...pane,
+							detail: activeDetail,
+							state:
+								pane.state === 'covered'
+									? 'entering'
+									: pane.state,
+						};
+					} );
+			}
+
+			const visiblePanes = current
+				.filter(
+					( pane ) =>
+						pane.state === 'active' || pane.state === 'entering'
+				)
+				.map( ( pane ) => ( { ...pane, state: 'active' } ) );
+
+			return [
+				...visiblePanes,
+				{
+					key: activeDetailKey,
+					detail: activeDetail,
+					state: visiblePanes.length ? 'preparing' : 'active',
+				},
+			];
+		} );
+	}, [ activeDetail, activeDetailKey ] );
+
+	const onPaneReady = useCallback( ( readyKey ) => {
+		setDetailPanes( ( current ) => {
+			const readyPane = current.find( ( pane ) => pane.key === readyKey );
+			if ( ! readyPane || readyPane.state !== 'preparing' ) {
+				return current;
+			}
+
+			return current
+				.filter(
+					( pane ) =>
+						pane.key === readyKey || pane.state !== 'preparing'
+				)
+				.map( ( pane ) => {
+					if ( pane.key === readyKey ) {
+						return { ...pane, state: 'entering' };
+					}
+					if (
+						pane.state === 'active' ||
+						pane.state === 'entering'
+					) {
+						return { ...pane, state: 'covered' };
+					}
+					return pane;
+				} );
+		} );
+	}, [] );
+
+	const onPaneAnimationEnd = useCallback( ( event ) => {
+		if ( event.target !== event.currentTarget ) {
+			return;
+		}
+		setDetailPanes( settleDetailPanes );
+	}, [] );
+
+	useEffect( () => {
+		const isTransitioning = detailPanes.some(
+			( pane ) => pane.state === 'entering'
+		);
+		if ( ! isTransitioning ) {
+			return undefined;
+		}
+		if ( prefersReducedMotion() ) {
+			setDetailPanes( settleDetailPanes );
+			return undefined;
+		}
+
+		const timeout = setTimeout( () => {
+			setDetailPanes( settleDetailPanes );
+		}, ROW_DETAIL_SWITCH_FALLBACK_MS );
+		return () => clearTimeout( timeout );
+	}, [ detailPanes ] );
+
+	const requestClose = useCallback( async () => {
+		if ( normalizedMode !== 'modal' ) {
+			return onClose?.();
+		}
+		if ( isModalClosing ) {
+			return false;
+		}
+		if ( prefersReducedMotion() ) {
+			return onClose?.();
+		}
+
+		setIsModalClosing( true );
+		await delay( ROW_DETAIL_MODAL_CLOSE_MS );
+		const didClose = await onClose?.();
+		if ( didClose === false ) {
+			setIsModalClosing( false );
+		}
+		return didClose;
+	}, [ isModalClosing, normalizedMode, onClose ] );
+	const requestNativeModalClose = useCallback(
+		() => onClose?.(),
+		[ onClose ]
+	);
+	const activePane = detailPanes.find(
+		( pane ) => pane.key === activeDetailKey
+	);
+	const canUseRowControls = Boolean(
+		activeDetail &&
+			activePane &&
+			activePane.state !== 'preparing' &&
+			activePane.state !== 'covered' &&
+			String( activeDetail.rowId ) === String( rowId )
+	);
+
+	const content =
+		! activeDetail && detailPanes.length === 0 ? (
+			<LoadingDetail onClose={ requestClose } />
+		) : (
+			<DetailShell
+				arePropertiesVisible={ arePropertiesVisible }
+				canGoNext={ canUseRowControls && canGoNext }
+				canGoPrevious={ canUseRowControls && canGoPrevious }
 				fields={ fields }
 				mode={ normalizedMode }
-				onApi={ onApi }
-				onClose={ onClose }
+				onClose={ requestClose }
 				onDiscardPending={ onDiscardPending }
 				onModeChange={ onModeChange }
 				onNext={ onNext }
 				onPrevious={ onPrevious }
 				onRetryPending={ onRetryPending }
-				onSaved={ onSaved }
-				row={ {
-					...( activeDetail.row ?? {} ),
-					...activeDetail.record,
-					title: activeDetail.record.title ?? activeDetail.row?.title,
-					meta: activeDetail.record.meta ?? activeDetail.row?.meta,
-				} }
-				saveError={ saveError }
-			/>
-		</EditorProvider>
-	);
+				saveError={ canUseRowControls ? saveError : null }
+				setArePropertiesVisible={ setArePropertiesVisible }
+				title={ displayTitle }
+			>
+				{ ( { propertyValueMounts } ) => (
+					<div className="cortext-row-detail__pane-stack">
+						{ detailPanes.map( ( pane ) => {
+							const isCurrentPane =
+								pane.key === activeDetailKey &&
+								( pane.state === 'active' ||
+									pane.state === 'entering' );
+							const isHiddenPane =
+								pane.state === 'preparing' ||
+								pane.state === 'covered';
+							const isApiActive = isCurrentPane && ! isHiddenPane;
+							const paneRow = {
+								...( pane.detail.row ?? {} ),
+								...pane.detail.record,
+								title:
+									pane.detail.record.title ??
+									pane.detail.row?.title,
+								meta:
+									pane.detail.record.meta ??
+									pane.detail.row?.meta,
+							};
+
+							return (
+								<div
+									key={ pane.key }
+									className="cortext-row-detail__pane"
+									data-state={ pane.state }
+									data-interactive={
+										isApiActive ? 'true' : 'false'
+									}
+									aria-hidden={
+										isHiddenPane ? true : undefined
+									}
+									{ ...( isHiddenPane ? { inert: '' } : {} ) }
+									onAnimationEnd={ onPaneAnimationEnd }
+								>
+									<EditorProvider
+										post={ pane.detail.record }
+										settings={
+											window.cortextEditorSettings ?? {}
+										}
+									>
+										<DetailReadySignal
+											detailKey={ pane.key }
+											onReady={ onPaneReady }
+										/>
+										<DetailPaneContent
+											fields={ fields }
+											isActive={ isApiActive }
+											isHidden={ isHiddenPane }
+											onApi={ onApi }
+											onSaved={ onSaved }
+											onTitle={ setDisplayTitle }
+											propertyValueMounts={
+												propertyValueMounts
+											}
+											row={ paneRow }
+											state={ pane.state }
+										/>
+									</EditorProvider>
+								</div>
+							);
+						} ) }
+					</div>
+				) }
+			</DetailShell>
+		);
 
 	if ( normalizedMode === 'modal' ) {
 		return (
 			<Modal
-				className="cortext-row-detail-modal"
+				className={
+					'cortext-row-detail-modal' +
+					( isModalClosing
+						? ' cortext-row-detail-modal--closing'
+						: '' )
+				}
 				title={ __( 'Row detail', 'cortext' ) }
-				onRequestClose={ onClose }
+				overlayClassName={
+					isModalClosing ? 'is-animating-out' : undefined
+				}
+				onRequestClose={ requestNativeModalClose }
 				__experimentalHideHeader
 			>
-				{ content }
+				<div className="cortext-row-detail cortext-row-detail--modal">
+					{ content }
+				</div>
 			</Modal>
 		);
 	}

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -432,6 +432,47 @@ function EditablePropertyText( { label, inputMode, value, onChange } ) {
 	);
 }
 
+function EditableRowTitle( { onTitle, row } ) {
+	const { editPost } = useDispatch( editorStore );
+	const editedTitle = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'title' ),
+		[]
+	);
+	const title =
+		typeof editedTitle === 'string' ? editedTitle : titleFromRow( row );
+	const [ draft, setDraft ] = useState( title );
+	const [ isFocused, setIsFocused ] = useState( false );
+
+	useEffect( () => {
+		onTitle?.( title );
+	}, [ onTitle, title ] );
+
+	useEffect( () => {
+		if ( ! isFocused ) {
+			setDraft( title );
+		}
+	}, [ isFocused, title ] );
+
+	return (
+		<h2 className="cortext-row-detail__title">
+			<input
+				aria-label={ __( 'Title', 'cortext' ) }
+				className="cortext-row-detail__title-input"
+				placeholder={ __( 'Untitled', 'cortext' ) }
+				type="text"
+				value={ draft }
+				onBlur={ () => setIsFocused( false ) }
+				onChange={ ( event ) => {
+					const next = event.currentTarget.value;
+					setDraft( next );
+					editPost( { title: next } );
+				} }
+				onFocus={ () => setIsFocused( true ) }
+			/>
+		</h2>
+	);
+}
+
 function EditableNumberPropertyText( { label, value, onChange } ) {
 	const textValue =
 		value === null || value === undefined ? '' : String( value );
@@ -797,21 +838,15 @@ function titleFromDetail( detail ) {
 	return titleFromRow( detail.record ) || titleFromRow( detail.row );
 }
 
-function DetailTitleSignal( { isActive, onTitle, row } ) {
-	const editedTitle = useSelect(
-		( select ) => select( editorStore ).getEditedPostAttribute( 'title' ),
-		[]
+function RowTitlePortal( { isActive, mountNode, onTitle, row } ) {
+	if ( ! isActive || ! mountNode ) {
+		return null;
+	}
+
+	return createPortal(
+		<EditableRowTitle onTitle={ onTitle } row={ row } />,
+		mountNode
 	);
-	const title =
-		typeof editedTitle === 'string' ? editedTitle : titleFromRow( row );
-
-	useEffect( () => {
-		if ( isActive ) {
-			onTitle?.( title );
-		}
-	}, [ isActive, onTitle, title ] );
-
-	return null;
 }
 
 function DetailBody( {
@@ -864,12 +899,14 @@ function DetailPaneContent( {
 	fields,
 	isActive,
 	isHidden,
+	isTitleActive,
 	onApi,
 	onSaved,
 	onTitle,
 	propertyValueMounts,
 	row,
 	state,
+	titleMountNode,
 } ) {
 	return (
 		<>
@@ -878,8 +915,9 @@ function DetailPaneContent( {
 				onApi={ onApi }
 				onSaved={ onSaved }
 			/>
-			<DetailTitleSignal
-				isActive={ isActive }
+			<RowTitlePortal
+				isActive={ isTitleActive }
+				mountNode={ titleMountNode }
 				onTitle={ onTitle }
 				row={ row }
 			/>
@@ -914,6 +952,7 @@ function DetailShell( {
 	title,
 } ) {
 	const [ propertyValueMounts, setPropertyValueMounts ] = useState( {} );
+	const [ titleMountNode, setTitleMountNode ] = useState( null );
 	const setPropertyValueMount = useCallback( ( fieldId, node ) => {
 		setPropertyValueMounts( ( current ) => {
 			if ( node ) {
@@ -995,9 +1034,16 @@ function DetailShell( {
 					</div>
 				</div>
 				<div className="cortext-row-detail__identity">
-					<h2 className="cortext-row-detail__title">
-						{ title || __( 'Untitled', 'cortext' ) }
-					</h2>
+					<div
+						className="cortext-row-detail__title-slot"
+						ref={ setTitleMountNode }
+					>
+						{ ! titleMountNode ? (
+							<h2 className="cortext-row-detail__title">
+								{ title || __( 'Untitled', 'cortext' ) }
+							</h2>
+						) : null }
+					</div>
 				</div>
 			</div>
 			{ saveError ? (
@@ -1027,7 +1073,7 @@ function DetailShell( {
 				fieldCountLabel={ fieldCountLabel }
 				onValueMount={ setPropertyValueMount }
 			>
-				{ children( { propertyValueMounts } ) }
+				{ children( { propertyValueMounts, titleMountNode } ) }
 			</DetailBody>
 		</div>
 	);
@@ -1115,6 +1161,10 @@ export default function RowDetailView( {
 					},
 			  ]
 			: []
+	);
+	const propertyFields = useMemo(
+		() => fields.filter( ( field ) => field.id !== TITLE_FIELD_ID ),
+		[ fields ]
 	);
 
 	useEffect( () => {
@@ -1264,7 +1314,7 @@ export default function RowDetailView( {
 				arePropertiesVisible={ arePropertiesVisible }
 				canGoNext={ canUseRowControls && canGoNext }
 				canGoPrevious={ canUseRowControls && canGoPrevious }
-				fields={ fields }
+				fields={ propertyFields }
 				mode={ normalizedMode }
 				onClose={ requestClose }
 				onDiscardPending={ onDiscardPending }
@@ -1276,7 +1326,7 @@ export default function RowDetailView( {
 				setArePropertiesVisible={ setArePropertiesVisible }
 				title={ displayTitle }
 			>
-				{ ( { propertyValueMounts } ) => (
+				{ ( { propertyValueMounts, titleMountNode } ) => (
 					<div className="cortext-row-detail__pane-stack">
 						{ detailPanes.map( ( pane ) => {
 							const isCurrentPane =
@@ -1287,6 +1337,10 @@ export default function RowDetailView( {
 								pane.state === 'preparing' ||
 								pane.state === 'covered';
 							const isApiActive = isCurrentPane && ! isHiddenPane;
+							const isTitleActive =
+								! isHiddenPane &&
+								( pane.state === 'active' ||
+									pane.state === 'entering' );
 							const paneRow = {
 								...( pane.detail.row ?? {} ),
 								...pane.detail.record,
@@ -1323,9 +1377,10 @@ export default function RowDetailView( {
 											onReady={ onPaneReady }
 										/>
 										<DetailPaneContent
-											fields={ fields }
+											fields={ propertyFields }
 											isActive={ isApiActive }
 											isHidden={ isHiddenPane }
+											isTitleActive={ isTitleActive }
 											onApi={ onApi }
 											onSaved={ onSaved }
 											onTitle={ setDisplayTitle }
@@ -1334,6 +1389,7 @@ export default function RowDetailView( {
 											}
 											row={ paneRow }
 											state={ pane.state }
+											titleMountNode={ titleMountNode }
 										/>
 									</EditorProvider>
 								</div>

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -195,7 +195,11 @@ function RowContentEditor() {
 }
 
 function emptyLabel() {
-	return <span className="cortext-row-detail__empty-value">Empty</span>;
+	return (
+		<span className="cortext-row-detail__empty-value">
+			{ __( 'Empty', 'cortext' ) }
+		</span>
+	);
 }
 
 function ReadOnlyProperty( { value, type, elements, format } ) {
@@ -374,6 +378,17 @@ function fieldType( field ) {
 		return 'text';
 	}
 	return field.cortextFieldType ?? field.type ?? 'text';
+}
+
+function isRowDetailFieldEditable( field ) {
+	if ( fieldType( field ) === 'relation' ) {
+		return false;
+	}
+
+	return (
+		field.id === TITLE_FIELD_ID ||
+		( field.editable && field.id?.startsWith?.( 'field-' ) )
+	);
 }
 
 function valueForField( field, data ) {
@@ -588,9 +603,7 @@ function RowPropertyRows( { fields, onValueMount } ) {
 	return (
 		<div className="cortext-row-detail__properties cortext-row-detail__properties--rows">
 			{ fields.map( ( field ) => {
-				const isEditable =
-					field.id === TITLE_FIELD_ID ||
-					( field.editable && field.id?.startsWith?.( 'field-' ) );
+				const isEditable = isRowDetailFieldEditable( field );
 
 				return (
 					<div
@@ -681,9 +694,7 @@ function RowPropertyValues( {
 					field.cortextElements ??
 					field.elements ??
 					[];
-				const isEditable =
-					field.id === TITLE_FIELD_ID ||
-					( field.editable && field.id?.startsWith?.( 'field-' ) );
+				const isEditable = isRowDetailFieldEditable( field );
 
 				return createPortal(
 					<div

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -1,0 +1,839 @@
+import { BlockCanvas, BlockList, useSettings } from '@wordpress/block-editor';
+import {
+	Button,
+	CheckboxControl,
+	DateTimePicker,
+	Dropdown,
+	FormTokenField,
+	MenuGroup,
+	MenuItem,
+	Modal,
+	Notice,
+	Spinner,
+} from '@wordpress/components';
+import { useEntityRecord } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { EditorProvider, store as editorStore } from '@wordpress/editor';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+	chevronDown,
+	chevronUp,
+	closeSmall,
+	details,
+	drawerRight,
+	fullscreen,
+	square,
+} from '@wordpress/icons';
+
+import useAutosave from '../hooks/useAutosave';
+import { dateOnlyValue, formatDisplay } from './EditableCell';
+import { TITLE_FIELD_ID } from './dataViewColumns';
+import { getRowDetailMode, splitPropertyPatch } from './rowDetailUtils';
+
+export const ROW_DETAIL_MODE_ICONS = {
+	side: drawerRight,
+	modal: square,
+	full: fullscreen,
+};
+
+const ROW_DETAIL_MODE_LABELS = {
+	side: __( 'Side peek', 'cortext' ),
+	modal: __( 'Center modal', 'cortext' ),
+	full: __( 'Full page', 'cortext' ),
+};
+
+const ROW_DETAIL_EDITOR_CSS = `
+	body {
+		background: #fff;
+	}
+
+	.editor-styles-wrapper {
+		box-sizing: border-box;
+		min-height: 100%;
+		padding: 24px 32px 48px;
+	}
+
+	.editor-styles-wrapper .wp-block-post-content {
+		margin-block-start: 0;
+	}
+
+	.editor-styles-wrapper .block-editor-block-list__layout {
+		min-height: 180px;
+	}
+
+	.editor-styles-wrapper .block-list-appender {
+		margin-top: 12px;
+	}
+`;
+
+function RowAutosaveBridge( { onApi, onSaved } ) {
+	const { status, flushNow, isDirty, isSaving } = useAutosave( {
+		debounceMs: 0,
+		minSaveIntervalMs: 0,
+	} );
+	const { resetPost } = useDispatch( editorStore );
+	const discard = useCallback( () => resetPost(), [ resetPost ] );
+	const autosaveStateRef = useRef( { isDirty, isSaving } );
+	autosaveStateRef.current = { isDirty, isSaving };
+	const hasPendingEdits = useCallback(
+		() =>
+			autosaveStateRef.current.isDirty ||
+			autosaveStateRef.current.isSaving,
+		[]
+	);
+
+	useEffect( () => {
+		onApi?.( { flushNow, discard, hasPendingEdits } );
+		return () => onApi?.( null );
+	}, [ discard, flushNow, hasPendingEdits, onApi ] );
+
+	useEffect( () => {
+		if ( status === 'saved' ) {
+			onSaved?.();
+		}
+	}, [ onSaved, status ] );
+
+	return null;
+}
+
+function RowContentEditor() {
+	const styles = useSelect(
+		( select ) => select( editorStore ).getEditorSettings().styles,
+		[]
+	);
+	const editorStyles = useMemo(
+		() => [
+			...Object.values( styles ?? [] ),
+			{
+				css: ROW_DETAIL_EDITOR_CSS,
+			},
+		],
+		[ styles ]
+	);
+	const [ layout ] = useSettings( 'layout' );
+
+	return (
+		<div className="cortext-row-detail__content-editor">
+			<BlockCanvas height="100%" styles={ editorStyles }>
+				<BlockList
+					className="wp-block-post-content is-layout-constrained has-global-padding"
+					layout={ { type: 'constrained', ...layout } }
+				/>
+			</BlockCanvas>
+		</div>
+	);
+}
+
+function emptyLabel() {
+	return <span className="cortext-row-detail__empty-value">Empty</span>;
+}
+
+function ReadOnlyProperty( { value, type, elements, format } ) {
+	const display = formatDisplay( value, type, { elements, format } );
+	return (
+		<div className="cortext-row-detail__readonly">
+			{ display === '' ? emptyLabel() : display }
+		</div>
+	);
+}
+
+function labelForElementValue( elements, value ) {
+	const match = ( elements ?? [] ).find( ( element ) => {
+		return String( element.value ) === String( value );
+	} );
+	return match?.label ?? value;
+}
+
+function SelectPropertyControl( { field, value, elements, onChange } ) {
+	const hasValue = value !== null && value !== undefined && value !== '';
+	const triggerLabel = hasValue
+		? labelForElementValue( elements, value )
+		: __( 'Empty', 'cortext' );
+
+	return (
+		<Dropdown
+			popoverProps={ { placement: 'bottom-start' } }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					className="cortext-row-detail__property-trigger"
+					variant="tertiary"
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+					aria-label={ field.label }
+				>
+					{ triggerLabel }
+				</Button>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<MenuGroup>
+					<MenuItem
+						isSelected={ ! hasValue }
+						onClick={ () => {
+							onChange( null );
+							onClose();
+						} }
+					>
+						{ __( 'Empty', 'cortext' ) }
+					</MenuItem>
+					{ ( elements ?? [] ).map( ( element ) => (
+						<MenuItem
+							key={ element.value }
+							isSelected={
+								String( element.value ) === String( value )
+							}
+							onClick={ () => {
+								onChange( element.value );
+								onClose();
+							} }
+						>
+							{ element.label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			) }
+		/>
+	);
+}
+
+function MultiselectPropertyControl( { field, value, elements, onChange } ) {
+	const valueToLabel = useMemo( () => {
+		const map = new Map();
+		( elements ?? [] ).forEach( ( element ) =>
+			map.set( element.value, element.label )
+		);
+		return map;
+	}, [ elements ] );
+	const labelToValue = useMemo( () => {
+		const map = new Map();
+		( elements ?? [] ).forEach( ( element ) =>
+			map.set( element.label, element.value )
+		);
+		return map;
+	}, [ elements ] );
+	const tokens = useMemo(
+		() =>
+			( Array.isArray( value ) ? value : [] ).map(
+				( item ) => valueToLabel.get( item ) ?? String( item )
+			),
+		[ value, valueToLabel ]
+	);
+	const suggestions = useMemo(
+		() => ( elements ?? [] ).map( ( element ) => element.label ),
+		[ elements ]
+	);
+	const triggerLabel = tokens.length
+		? tokens.join( ', ' )
+		: __( 'Empty', 'cortext' );
+
+	return (
+		<Dropdown
+			popoverProps={ { placement: 'bottom-start' } }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					className="cortext-row-detail__property-trigger"
+					variant="tertiary"
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+					aria-label={ field.label }
+				>
+					{ triggerLabel }
+				</Button>
+			) }
+			renderContent={ () => (
+				<div className="cortext-row-detail__tokens-popover">
+					<FormTokenField
+						value={ tokens }
+						suggestions={ suggestions }
+						onChange={ ( nextTokens ) => {
+							onChange(
+								nextTokens
+									.map(
+										( token ) =>
+											labelToValue.get( token ) ?? token
+									)
+									.filter(
+										( next ) =>
+											next !== '' &&
+											next !== null &&
+											next !== undefined
+									)
+							);
+						} }
+						label={ field.label }
+						__experimentalExpandOnFocus
+						__experimentalShowHowTo={ false }
+						__nextHasNoMarginBottom
+					/>
+				</div>
+			) }
+		/>
+	);
+}
+
+function DatePropertyControl( { field, value, type, onChange } ) {
+	const display = value
+		? formatDisplay( value, type, { format: field.cortextFormat } )
+		: __( 'Empty', 'cortext' );
+
+	return (
+		<Dropdown
+			popoverProps={ { placement: 'bottom-start' } }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					className="cortext-row-detail__property-trigger"
+					variant="tertiary"
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+					aria-label={ field.label }
+				>
+					{ display }
+				</Button>
+			) }
+			renderContent={ () => (
+				<div className="cortext-row-detail__date-popover">
+					<DateTimePicker
+						currentDate={ value || null }
+						onChange={ ( next ) =>
+							onChange(
+								type === 'date' ? dateOnlyValue( next ) : next
+							)
+						}
+						is12Hour={ field.cortextFormat?.hour12 ?? true }
+						aria-label={ field.label }
+					/>
+				</div>
+			) }
+		/>
+	);
+}
+
+function fieldType( field ) {
+	if ( field.id === TITLE_FIELD_ID ) {
+		return 'text';
+	}
+	return field.cortextFieldType ?? field.type ?? 'text';
+}
+
+function valueForField( field, data ) {
+	if ( field.id === TITLE_FIELD_ID ) {
+		return data.title ?? '';
+	}
+	if ( field.id?.startsWith?.( 'field-' ) ) {
+		return data.meta?.[ field.id ] ?? null;
+	}
+	return field.getValue?.( { item: data.row } ) ?? null;
+}
+
+function EditablePropertyText( { label, inputMode, value, onChange } ) {
+	const ref = useRef( null );
+	const textValue =
+		value === null || value === undefined ? '' : String( value );
+
+	useEffect( () => {
+		const ownerDocument = ref.current?.ownerDocument;
+		if (
+			ref.current &&
+			ownerDocument?.activeElement !== ref.current &&
+			ref.current.textContent !== textValue
+		) {
+			ref.current.textContent = textValue;
+		}
+	}, [ textValue ] );
+
+	return (
+		<div
+			ref={ ref }
+			aria-label={ label }
+			className="cortext-row-detail__property-editable-text"
+			contentEditable
+			data-placeholder={ __( 'Empty', 'cortext' ) }
+			inputMode={ inputMode }
+			role="textbox"
+			suppressContentEditableWarning
+			tabIndex={ 0 }
+			onInput={ ( event ) =>
+				onChange( event.currentTarget.textContent ?? '' )
+			}
+			onKeyDown={ ( event ) => {
+				if ( event.key === 'Enter' ) {
+					event.preventDefault();
+					event.currentTarget.blur();
+				}
+			} }
+		>
+			{ textValue }
+		</div>
+	);
+}
+
+function PropertyControl( { field, value, onChange } ) {
+	const type = fieldType( field );
+	const label = field.label;
+	const elements = field.cortextElements ?? field.elements ?? [];
+
+	if ( type === 'checkbox' ) {
+		return (
+			<CheckboxControl
+				label=""
+				aria-label={ label }
+				checked={ Boolean( value ) }
+				onChange={ ( next ) => onChange( next ) }
+				__nextHasNoMarginBottom
+			/>
+		);
+	}
+
+	if ( type === 'number' ) {
+		return (
+			<EditablePropertyText
+				label={ label }
+				inputMode="decimal"
+				value={ value ?? '' }
+				onChange={ ( next ) =>
+					onChange(
+						next === '' || next === null || next === undefined
+							? null
+							: Number( next )
+					)
+				}
+			/>
+		);
+	}
+
+	if ( type === 'select' ) {
+		return (
+			<SelectPropertyControl
+				field={ field }
+				value={ value }
+				elements={ elements }
+				onChange={ onChange }
+			/>
+		);
+	}
+
+	if ( type === 'multiselect' ) {
+		return (
+			<MultiselectPropertyControl
+				field={ field }
+				value={ value }
+				elements={ elements }
+				onChange={ onChange }
+			/>
+		);
+	}
+
+	if ( type === 'date' || type === 'datetime' ) {
+		return (
+			<DatePropertyControl
+				field={ field }
+				value={ value }
+				type={ type }
+				onChange={ onChange }
+			/>
+		);
+	}
+
+	let textInputMode;
+	if ( type === 'email' ) {
+		textInputMode = 'email';
+	} else if ( type === 'url' ) {
+		textInputMode = 'url';
+	}
+
+	return (
+		<EditablePropertyText
+			label={ label }
+			inputMode={ textInputMode }
+			value={ value ?? '' }
+			onChange={ onChange }
+		/>
+	);
+}
+
+function RowPropertyForm( { fields, row } ) {
+	const { editPost } = useDispatch( editorStore );
+	const { title, meta } = useSelect(
+		( select ) => ( {
+			title: select( editorStore ).getEditedPostAttribute( 'title' ),
+			meta: select( editorStore ).getEditedPostAttribute( 'meta' ) ?? {},
+		} ),
+		[]
+	);
+
+	const data = useMemo(
+		() => ( {
+			row,
+			title:
+				typeof title === 'string'
+					? title
+					: row?.title?.raw ?? row?.title?.rendered ?? '',
+			meta: meta ?? {},
+		} ),
+		[ meta, row, title ]
+	);
+
+	const update = useCallback(
+		( patch ) => {
+			const split = splitPropertyPatch( patch, meta );
+			const next = {};
+			if ( split.title !== undefined ) {
+				next.title = split.title;
+			}
+			if ( split.meta ) {
+				next.meta = split.meta;
+			}
+			if ( Object.keys( next ).length > 0 ) {
+				editPost( next );
+			}
+		},
+		[ editPost, meta ]
+	);
+
+	return (
+		<div className="cortext-row-detail__properties">
+			{ fields.map( ( field ) => {
+				const value = valueForField( field, data );
+				const type = fieldType( field );
+				const isEditable =
+					field.id === TITLE_FIELD_ID ||
+					( field.editable && field.id?.startsWith?.( 'field-' ) );
+
+				return (
+					<div
+						key={ field.id }
+						className={
+							'cortext-row-detail__property' +
+							( isEditable
+								? ' cortext-row-detail__property--editable'
+								: ' cortext-row-detail__property--readonly' )
+						}
+					>
+						<div className="cortext-row-detail__property-label">
+							{ field.label }
+						</div>
+						<div className="cortext-row-detail__property-value">
+							{ isEditable ? (
+								<PropertyControl
+									field={ field }
+									value={ value }
+									onChange={ ( next ) =>
+										update( { [ field.id ]: next } )
+									}
+								/>
+							) : (
+								<ReadOnlyProperty
+									value={ value }
+									type={ type }
+									elements={
+										field.cortextElements ?? field.elements
+									}
+									format={ field.cortextFormat }
+								/>
+							) }
+						</div>
+					</div>
+				);
+			} ) }
+		</div>
+	);
+}
+
+export function ModeControl( { mode, onChangeMode } ) {
+	const modes = Object.keys( ROW_DETAIL_MODE_LABELS ).filter(
+		( nextMode ) => nextMode !== mode
+	);
+
+	return (
+		<>
+			{ modes.map( ( nextMode ) => (
+				<Button
+					key={ nextMode }
+					className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--icon"
+					icon={ ROW_DETAIL_MODE_ICONS[ nextMode ] }
+					label={ ROW_DETAIL_MODE_LABELS[ nextMode ] }
+					onClick={ () => {
+						if ( mode !== nextMode ) {
+							onChangeMode( nextMode );
+						}
+					} }
+				/>
+			) ) }
+		</>
+	);
+}
+
+function DetailFrame( {
+	fields,
+	mode,
+	onApi,
+	onClose,
+	onDiscardPending,
+	onModeChange,
+	onNext,
+	onPrevious,
+	onRetryPending,
+	onSaved,
+	row,
+	saveError,
+	canGoNext,
+	canGoPrevious,
+} ) {
+	const editedTitle = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'title' ),
+		[]
+	);
+	const title =
+		typeof editedTitle === 'string'
+			? editedTitle
+			: row?.title?.raw ?? row?.title?.rendered ?? '';
+	const [ arePropertiesVisible, setArePropertiesVisible ] = useState( true );
+	const fieldCountLabel = sprintf(
+		/* translators: %d: Number of row fields. */
+		_n( '%d field', '%d fields', fields.length, 'cortext' ),
+		fields.length
+	);
+
+	return (
+		<div
+			className="cortext-row-detail__frame"
+			data-properties-visible={ arePropertiesVisible ? 'true' : 'false' }
+		>
+			<div className="cortext-row-detail__header">
+				<RowAutosaveBridge onApi={ onApi } onSaved={ onSaved } />
+				<div
+					className="cortext-row-detail__toolbar"
+					role="toolbar"
+					aria-label={ __( 'Row detail tools', 'cortext' ) }
+				>
+					<div className="cortext-row-detail__toolbar-group">
+						<Button
+							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--icon"
+							icon={ details }
+							label={
+								arePropertiesVisible
+									? __( 'Hide fields', 'cortext' )
+									: __( 'Show fields', 'cortext' )
+							}
+							onClick={ () =>
+								setArePropertiesVisible(
+									( current ) => ! current
+								)
+							}
+						/>
+					</div>
+					<div className="cortext-row-detail__toolbar-group">
+						<Button
+							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--icon"
+							icon={ chevronUp }
+							label={ __( 'Row above', 'cortext' ) }
+							onClick={ onPrevious }
+							disabled={ ! canGoPrevious }
+						/>
+						<Button
+							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--icon"
+							icon={ chevronDown }
+							label={ __( 'Row below', 'cortext' ) }
+							onClick={ onNext }
+							disabled={ ! canGoNext }
+						/>
+					</div>
+					<div className="cortext-row-detail__toolbar-group">
+						<ModeControl
+							mode={ mode }
+							onChangeMode={ onModeChange }
+						/>
+					</div>
+					<div className="cortext-row-detail__toolbar-group cortext-row-detail__toolbar-group--end">
+						<Button
+							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--close"
+							icon={ closeSmall }
+							label={ __( 'Close', 'cortext' ) }
+							onClick={ onClose }
+						/>
+					</div>
+				</div>
+				<div className="cortext-row-detail__identity">
+					<h2 className="cortext-row-detail__title">
+						{ title || __( 'Untitled', 'cortext' ) }
+					</h2>
+				</div>
+			</div>
+			{ saveError ? (
+				<Notice
+					className="cortext-row-detail__notice"
+					status="error"
+					isDismissible={ false }
+					actions={ [
+						{
+							label: __( 'Retry', 'cortext' ),
+							onClick: onRetryPending,
+							variant: 'primary',
+						},
+						{
+							label: __( 'Discard', 'cortext' ),
+							onClick: onDiscardPending,
+							variant: 'tertiary',
+						},
+					] }
+				>
+					{ saveError }
+				</Notice>
+			) : null }
+			<div className="cortext-row-detail__body">
+				<div
+					className="cortext-row-detail__properties-region"
+					aria-hidden={ arePropertiesVisible ? undefined : true }
+					{ ...( arePropertiesVisible ? {} : { inert: '' } ) }
+				>
+					<div className="cortext-row-detail__properties-region-inner">
+						<RowPropertyForm fields={ fields } row={ row } />
+					</div>
+				</div>
+				<div
+					className="cortext-row-detail__fields-indicator-wrap"
+					aria-hidden={ arePropertiesVisible ? true : undefined }
+					{ ...( arePropertiesVisible ? { inert: '' } : {} ) }
+				>
+					<div className="cortext-row-detail__fields-indicator-inner">
+						<Button
+							className="cortext-row-detail__fields-indicator"
+							icon={ details }
+							label={ sprintf(
+								/* translators: %s: Number of hidden fields. */
+								__( 'Show %s', 'cortext' ),
+								fieldCountLabel
+							) }
+							variant="tertiary"
+							onClick={ () => setArePropertiesVisible( true ) }
+						>
+							{ fieldCountLabel }
+						</Button>
+					</div>
+				</div>
+				<RowContentEditor />
+			</div>
+		</div>
+	);
+}
+
+function LoadingDetail( { onClose } ) {
+	return (
+		<div className="cortext-row-detail__frame">
+			<div className="cortext-row-detail__header">
+				<Spinner />
+				<Button
+					icon={ closeSmall }
+					label={ __( 'Close', 'cortext' ) }
+					size="compact"
+					onClick={ onClose }
+				/>
+			</div>
+		</div>
+	);
+}
+
+export default function RowDetailView( {
+	canGoNext,
+	canGoPrevious,
+	fields,
+	mode,
+	onApi,
+	onClose,
+	onDiscardPending,
+	onModeChange,
+	onNext,
+	onPrevious,
+	onRetryPending,
+	onSaved,
+	postType,
+	row,
+	rowId,
+	saveError,
+} ) {
+	const { record } = useEntityRecord( 'postType', postType, rowId ?? 0, {
+		enabled: Boolean( postType && rowId ),
+	} );
+	const normalizedMode = getRowDetailMode( { rowDetailMode: mode } );
+	const targetDetail = useMemo( () => {
+		if ( ! record || ! postType || ! rowId ) {
+			return null;
+		}
+		return { postType, record, row, rowId };
+	}, [ postType, record, row, rowId ] );
+	const [ resolvedDetail, setResolvedDetail ] = useState( targetDetail );
+
+	useEffect( () => {
+		if ( targetDetail ) {
+			setResolvedDetail( targetDetail );
+		}
+	}, [ targetDetail ] );
+
+	const activeDetail =
+		targetDetail ??
+		( resolvedDetail?.postType === postType ? resolvedDetail : null );
+	const isSwitchingRows = Boolean(
+		activeDetail && String( activeDetail.rowId ) !== String( rowId )
+	);
+
+	const content = ! activeDetail ? (
+		<LoadingDetail onClose={ onClose } />
+	) : (
+		<EditorProvider
+			key={ `${ activeDetail.postType }:${ activeDetail.rowId }` }
+			post={ activeDetail.record }
+			settings={ window.cortextEditorSettings ?? {} }
+		>
+			<DetailFrame
+				canGoNext={ ! isSwitchingRows && canGoNext }
+				canGoPrevious={ ! isSwitchingRows && canGoPrevious }
+				fields={ fields }
+				mode={ normalizedMode }
+				onApi={ onApi }
+				onClose={ onClose }
+				onDiscardPending={ onDiscardPending }
+				onModeChange={ onModeChange }
+				onNext={ onNext }
+				onPrevious={ onPrevious }
+				onRetryPending={ onRetryPending }
+				onSaved={ onSaved }
+				row={ {
+					...( activeDetail.row ?? {} ),
+					...activeDetail.record,
+					title: activeDetail.record.title ?? activeDetail.row?.title,
+					meta: activeDetail.record.meta ?? activeDetail.row?.meta,
+				} }
+				saveError={ saveError }
+			/>
+		</EditorProvider>
+	);
+
+	if ( normalizedMode === 'modal' ) {
+		return (
+			<Modal
+				className="cortext-row-detail-modal"
+				title={ __( 'Row detail', 'cortext' ) }
+				onRequestClose={ onClose }
+				__experimentalHideHeader
+			>
+				{ content }
+			</Modal>
+		);
+	}
+
+	return (
+		<div
+			className={ `cortext-row-detail cortext-row-detail--${ normalizedMode }` }
+			role="dialog"
+			aria-label={ __( 'Row detail', 'cortext' ) }
+		>
+			{ content }
+		</div>
+	);
+}

--- a/src/components/RowFullEditorContext.js
+++ b/src/components/RowFullEditorContext.js
@@ -1,0 +1,11 @@
+import { createContext, useContext } from '@wordpress/element';
+
+export const RowFullEditorContext = createContext( {
+	clearSuppressedRouteRow: null,
+	openRowFull: null,
+	suppressedRouteRow: null,
+} );
+
+export function useRowFullEditor() {
+	return useContext( RowFullEditorContext );
+}

--- a/src/components/rowDetailUtils.js
+++ b/src/components/rowDetailUtils.js
@@ -1,0 +1,53 @@
+export const ROW_DETAIL_MODES = [ 'side', 'modal', 'full' ];
+export const DEFAULT_ROW_DETAIL_MODE = 'side';
+
+export function normalizeRowDetailMode( mode ) {
+	return ROW_DETAIL_MODES.includes( mode ) ? mode : DEFAULT_ROW_DETAIL_MODE;
+}
+
+export function getRowDetailMode( view ) {
+	return normalizeRowDetailMode( view?.rowDetailMode );
+}
+
+export function withRowDetailMode( view, mode ) {
+	const nextMode = normalizeRowDetailMode( mode );
+	if ( view?.rowDetailMode === nextMode ) {
+		return view;
+	}
+	return { ...( view ?? {} ), rowDetailMode: nextMode };
+}
+
+export function adjacentRowId( rows, currentRowId, direction ) {
+	if ( ! Array.isArray( rows ) || ! rows.length ) {
+		return null;
+	}
+	const current = String( currentRowId );
+	const index = rows.findIndex( ( row ) => String( row?.id ) === current );
+	if ( index < 0 ) {
+		return null;
+	}
+	const next = rows[ index + direction ];
+	return next?.id ?? null;
+}
+
+export function splitPropertyPatch( patch, currentMeta = {} ) {
+	const next = {
+		title: undefined,
+		meta: null,
+	};
+	const metaPatch = {};
+
+	for ( const [ key, value ] of Object.entries( patch ?? {} ) ) {
+		if ( key === 'title' ) {
+			next.title = value ?? '';
+		} else {
+			metaPatch[ key ] = value;
+		}
+	}
+
+	if ( Object.keys( metaPatch ).length > 0 ) {
+		next.meta = { ...( currentMeta ?? {} ), ...metaPatch };
+	}
+
+	return next;
+}

--- a/src/components/rowDetailUtils.js
+++ b/src/components/rowDetailUtils.js
@@ -51,3 +51,27 @@ export function splitPropertyPatch( patch, currentMeta = {} ) {
 
 	return next;
 }
+
+const NUMBER_DRAFT_PATTERN = /^[+-]?\d*(?:\.\d*)?$/;
+const NUMBER_COMPLETE_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+export function isValidNumberDraft( value ) {
+	return NUMBER_DRAFT_PATTERN.test( String( value ?? '' ) );
+}
+
+export function parseNumberPropertyValue( value ) {
+	const text = String( value ?? '' );
+	if ( text === '' ) {
+		return { valid: true, complete: true, value: null };
+	}
+	if ( ! isValidNumberDraft( text ) ) {
+		return { valid: false, complete: false, value: null };
+	}
+	if ( ! NUMBER_COMPLETE_PATTERN.test( text ) ) {
+		return { valid: true, complete: false, value: null };
+	}
+	const number = Number( text );
+	return Number.isFinite( number )
+		? { valid: true, complete: true, value: number }
+		: { valid: false, complete: false, value: null };
+}

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -208,7 +208,6 @@ export function mapField( field ) {
 		getValue: ( { item } ) => item?.meta?.[ id ] ?? null,
 		render: buildRender( id, type, label, elements, format, relation ),
 		editable: EDITABLE_TYPES.has( type ),
-		cortextFormat: format,
 		enableGlobalSearch: SEARCHABLE_TYPES.has( type ),
 		cortextFieldType: type,
 		cortextElements: elements,

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -210,6 +210,10 @@ export function mapField( field ) {
 		editable: EDITABLE_TYPES.has( type ),
 		cortextFormat: format,
 		enableGlobalSearch: SEARCHABLE_TYPES.has( type ),
+		cortextFieldType: type,
+		cortextElements: elements,
+		cortextFormat: format,
+		cortextRecordId: field.id,
 	};
 
 	// DataViews v6's FieldType union is

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -9,7 +9,9 @@ const DEBOUNCE_MS = 800;
 const MIN_SAVE_INTERVAL_MS = 2000;
 const AUTOSAVE_ERROR_NOTICE_ID = 'cortext-autosave-error';
 
-export default function useAutosave() {
+export default function useAutosave( options = {} ) {
+	const debounceMs = options.debounceMs ?? DEBOUNCE_MS;
+	const minSaveIntervalMs = options.minSaveIntervalMs ?? MIN_SAVE_INTERVAL_MS;
 	const { savePost, editPost } = useDispatch( editorStore );
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
 
@@ -114,7 +116,7 @@ export default function useAutosave() {
 			return undefined;
 		}
 		const elapsed = Date.now() - lastSaveAtRef.current;
-		const wait = Math.max( DEBOUNCE_MS, MIN_SAVE_INTERVAL_MS - elapsed );
+		const wait = Math.max( debounceMs, minSaveIntervalMs - elapsed );
 
 		if ( debounceRef.current ) {
 			clearTimeout( debounceRef.current );
@@ -141,7 +143,15 @@ export default function useAutosave() {
 				debounceRef.current = null;
 			}
 		};
-	}, [ isDirty, isSaveable, editsReference, postStatus ] );
+	}, [
+		debounceMs,
+		editsReference,
+		isDirty,
+		isSaveable,
+		isSaving,
+		minSaveIntervalMs,
+		postStatus,
+	] );
 
 	useEffect( () => {
 		if ( isSaving ) {

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -46,6 +46,8 @@ export default function useAutosave( options = {} ) {
 
 	const debounceRef = useRef( null );
 	const lastSaveAtRef = useRef( 0 );
+	const savePromiseRef = useRef( null );
+	const savingWaitersRef = useRef( [] );
 
 	const stateRef = useRef( {
 		isDirty,
@@ -68,7 +70,7 @@ export default function useAutosave( options = {} ) {
 
 	// Promote draft to private once the user has given the page a real title,
 	// so WP core regenerates post_name from the title on save.
-	const maybePromoteStatus = () => {
+	const maybePromoteStatus = useCallback( () => {
 		const {
 			editPost: edit,
 			postStatus: s,
@@ -77,33 +79,81 @@ export default function useAutosave( options = {} ) {
 		if ( s === 'draft' && typeof t === 'string' && t.trim() !== '' ) {
 			edit( { status: 'private' } );
 		}
-	};
+	}, [] );
 
-	const flushNow = useCallback( () => {
+	const saveCurrentPost = useCallback( () => {
+		const { savePost: save } = stateRef.current;
+
+		maybePromoteStatus();
+		lastSaveAtRef.current = Date.now();
+		const savePromise = Promise.resolve( save() ).then(
+			() => true,
+			() => false
+		);
+		savePromiseRef.current = savePromise;
+		savePromise.finally( () => {
+			if ( savePromiseRef.current === savePromise ) {
+				savePromiseRef.current = null;
+			}
+		} );
+
+		return savePromise;
+	}, [ maybePromoteStatus ] );
+
+	const waitForSavingToFinish = useCallback( () => {
+		if ( ! stateRef.current.isSaving ) {
+			return Promise.resolve( true );
+		}
+
+		return new Promise( ( resolve ) => {
+			savingWaitersRef.current.push( resolve );
+		} );
+	}, [] );
+
+	const flushNow = useCallback( async () => {
 		if ( debounceRef.current ) {
 			clearTimeout( debounceRef.current );
 			debounceRef.current = null;
 		}
+
+		if ( savePromiseRef.current ) {
+			const didSave = await savePromiseRef.current;
+			if ( ! didSave ) {
+				return false;
+			}
+		}
+
+		if ( stateRef.current.isSaving ) {
+			const didSave = await waitForSavingToFinish();
+			if ( ! didSave ) {
+				return false;
+			}
+		}
+
 		const {
 			isDirty: d,
 			isSaveable: s,
 			isSaving: saving,
 			postStatus: ps,
-			savePost: save,
 		} = stateRef.current;
 		if ( ! d || ! s || ps === 'trash' ) {
-			return Promise.resolve( true );
+			return true;
 		}
 		if ( saving ) {
-			return Promise.resolve( false );
+			return waitForSavingToFinish();
 		}
-		maybePromoteStatus();
-		lastSaveAtRef.current = Date.now();
-		return Promise.resolve( save() ).then(
-			() => true,
-			() => false
-		);
-	}, [] );
+		return saveCurrentPost();
+	}, [ saveCurrentPost, waitForSavingToFinish ] );
+
+	useEffect( () => {
+		if ( isSaving || savingWaitersRef.current.length === 0 ) {
+			return;
+		}
+
+		const waiters = savingWaitersRef.current;
+		savingWaitersRef.current = [];
+		waiters.forEach( ( resolve ) => resolve( ! didFail ) );
+	}, [ didFail, isSaving ] );
 
 	useEffect( () => {
 		if ( ! isDirty || ! isSaveable ) {
@@ -128,12 +178,9 @@ export default function useAutosave( options = {} ) {
 				isSaveable: s,
 				isSaving: saving,
 				postStatus: ps,
-				savePost: save,
 			} = stateRef.current;
 			if ( d && s && ! saving && ps !== 'trash' ) {
-				maybePromoteStatus();
-				lastSaveAtRef.current = Date.now();
-				save();
+				saveCurrentPost();
 			}
 		}, wait );
 
@@ -151,6 +198,7 @@ export default function useAutosave( options = {} ) {
 		isSaving,
 		minSaveIntervalMs,
 		postStatus,
+		saveCurrentPost,
 	] );
 
 	useEffect( () => {

--- a/src/hooks/useBreadcrumbSegments.js
+++ b/src/hooks/useBreadcrumbSegments.js
@@ -34,7 +34,16 @@ export default function useBreadcrumbSegments( paintedRoute ) {
 	const navigate = useNavigate();
 	const kind = paintedRoute?.kind ?? 'unresolved';
 	const pageId = kind === 'page' ? paintedRoute.id : null;
-	const collectionId = kind === 'collection' ? paintedRoute.id : null;
+	const rowId = kind === 'row' ? paintedRoute.id : null;
+	const rowPostType = kind === 'row' ? paintedRoute.postType : null;
+	const onNavigateCollection =
+		kind === 'row' ? paintedRoute.onNavigateCollection : null;
+	let collectionId = null;
+	if ( kind === 'collection' ) {
+		collectionId = paintedRoute.id;
+	} else if ( kind === 'row' ) {
+		collectionId = paintedRoute.collectionId;
+	}
 
 	// Pulled from the same store the Sidebar populates, so no extra fetch.
 	const { records: pages } = useEntityRecords(
@@ -59,6 +68,12 @@ export default function useBreadcrumbSegments( paintedRoute ) {
 		'postType',
 		COLLECTION_POST_TYPE,
 		collectionId ?? 0
+	);
+	const { record: currentRow } = useEntityRecord(
+		'postType',
+		rowPostType ?? '',
+		rowId ?? 0,
+		{ enabled: Boolean( rowPostType && rowId ) }
 	);
 
 	const goToPage = useCallback(
@@ -123,6 +138,22 @@ export default function useBreadcrumbSegments( paintedRoute ) {
 			if ( ! collection ) {
 				return [];
 			}
+			if ( rowId ) {
+				return [
+					{
+						key: `collection:${ collection.id }`,
+						label: titleOf( collection ),
+						onClick: onNavigateCollection,
+						isCurrent: false,
+					},
+					{
+						key: `row:${ rowPostType }:${ rowId }`,
+						label: titleOf( currentRow ),
+						onClick: null,
+						isCurrent: true,
+					},
+				];
+			}
 			return [
 				{
 					key: `collection:${ collection.id }`,
@@ -137,10 +168,14 @@ export default function useBreadcrumbSegments( paintedRoute ) {
 	}, [
 		pageId,
 		collectionId,
+		rowId,
+		rowPostType,
+		onNavigateCollection,
 		pages,
 		collections,
 		currentPage,
 		currentCollection,
+		currentRow,
 		goToPage,
 	] );
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1535,7 +1535,7 @@ tbody > tr > td:not(:first-child) {
 	box-sizing: border-box;
 
 	&__shell {
-		cursor: text;
+		cursor: pointer;
 		// 40px matches the height of the editor controls
 		// (TextControl/NumberControl/SelectControl with __next40pxDefaultSize),
 		// so opening a cell doesn't bump the row height.
@@ -2643,6 +2643,10 @@ tr:has(.cortext-title-cell--is-open)
 		min-width: 0;
 	}
 
+	&__title-slot {
+		min-width: 0;
+	}
+
 	&__title {
 		overflow: hidden;
 		margin: 0;
@@ -2652,6 +2656,60 @@ tr:has(.cortext-title-cell--is-open)
 		line-height: 1.3;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	&__title-input {
+		appearance: none;
+		display: block;
+		overflow: hidden;
+		width: 100%;
+		min-width: 0;
+		margin: 0;
+		padding: 0 2px;
+		border: 0;
+		border-radius: 4px;
+		box-sizing: border-box;
+		outline: 0;
+		background: transparent;
+		box-shadow: none;
+		color: inherit;
+		cursor: text;
+		font: inherit;
+		line-height: inherit;
+		text-overflow: ellipsis;
+
+		&::placeholder {
+			color: var(--cortext-row-detail-muted);
+			opacity: 1;
+		}
+
+		&:hover {
+			background: var(--cortext-row-detail-hover-surface);
+		}
+
+		&:focus,
+		&:focus-visible {
+			background: transparent;
+			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
+		}
+	}
+
+	input.cortext-row-detail__title-input,
+	input.cortext-row-detail__title-input:hover,
+	input.cortext-row-detail__title-input:focus,
+	input.cortext-row-detail__title-input:focus-visible {
+		border: 0;
+		outline: 0;
+	}
+
+	input.cortext-row-detail__title-input:hover {
+		background: var(--cortext-row-detail-hover-surface);
+	}
+
+	input.cortext-row-detail__title-input:focus,
+	input.cortext-row-detail__title-input:focus-visible {
+		background: transparent;
+		box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
 	}
 
 	/* stylelint-disable no-descending-specificity */
@@ -2855,6 +2913,7 @@ tr:has(.cortext-title-cell--is-open)
 		overflow: hidden;
 		padding-top: 8px;
 		color: var(--cortext-row-detail-muted);
+		cursor: default;
 		font-size: 12px;
 		font-weight: 400;
 		line-height: 1.3;

--- a/src/index.scss
+++ b/src/index.scss
@@ -738,6 +738,7 @@ body.cortext-sidebar-resizing {
 
 .cortext-collection-pane {
 	position: relative;
+	display: flex;
 	height: 100%;
 	min-height: 0;
 }
@@ -983,8 +984,10 @@ body.cortext-sidebar-resizing {
 		// must have an explicit height or it falls back to 0 + internal
 		// scroll. Fill the canvas column: DataViews already owns the internal
 		// toolbar/table padding.
-		position: absolute;
-		inset: 0;
+		position: relative;
+		flex: 1 1 auto;
+		min-width: 0;
+		height: 100%;
 		overflow: hidden;
 		background: $white;
 		color: $gray-900;
@@ -1439,8 +1442,8 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 // wrapper. Match DataViews' selector specificity so our overrides
 // win, then size the column to the button's natural width with a
 // tight right padding.
-.dataviews-view-table tr th:last-child,
-.dataviews-view-table tr td:last-child {
+.dataviews-view-table tr th:has(.cortext-column-header-marker--add),
+.dataviews-view-table tr td:has(.cortext-data-view__ghost-cell) {
 	width: 0;
 	padding-right: $grid-unit-10;
 
@@ -1480,9 +1483,7 @@ th:has(.cortext-column-header-marker)
 // of `width + padding`, so a td with full padding-left forces the
 // whole column wider than the th. Mirror the th's padding-left on the
 // tds so column widths follow the header.
-.cortext-data-view
-.dataviews-view-table
-tbody > tr > td:not(:first-child) {
+.cortext-data-view .dataviews-view-table tbody > tr > td:not(:first-child) {
 	padding-left: 4px;
 }
 
@@ -1646,6 +1647,58 @@ tbody > tr > td:not(:first-child) {
 		font-size: 12px;
 		margin-top: $grid-unit-05;
 	}
+}
+
+.cortext-title-cell {
+	width: 100%;
+	min-width: 0;
+	max-width: 100%;
+
+	&--with-open-action {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: center;
+		gap: $grid-unit-05;
+
+		.cortext-editable-cell {
+			min-width: 0;
+			max-width: 100%;
+		}
+	}
+
+	&__open.components-button {
+		justify-self: end;
+		width: auto;
+		min-width: 0;
+		height: 28px;
+		min-height: 28px;
+		padding: 0 $grid-unit-10;
+		border: $border-width solid transparent;
+		color: $gray-700;
+		font-size: 12px;
+		line-height: 1;
+		box-sizing: border-box;
+		opacity: 0;
+		pointer-events: none;
+
+		&:hover,
+		&:focus-visible {
+			border-color: $gray-300;
+			color: $gray-900;
+		}
+	}
+}
+
+.cortext-title-cell:focus-within .cortext-title-cell__open.components-button,
+.cortext-data-view .dataviews-view-table tbody tr:hover .cortext-title-cell__open.components-button,
+.cortext-data-view .dataviews-view-table tbody tr:has(.cortext-title-cell--is-open) .cortext-title-cell__open.components-button {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.cortext-data-view .dataviews-view-table tbody tr:has(.cortext-title-cell--is-open),
+.cortext-data-view .dataviews-view-table tbody tr:has(.cortext-title-cell--is-open) .dataviews-view-table__actions-column--sticky {
+	background-color: #f8f8f8;
 }
 
 .cortext-cell-readonly {
@@ -2354,6 +2407,576 @@ tbody > tr > td:not(:first-child) {
 	gap: $grid-unit-10;
 }
 
+.cortext-data-view-shell {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+	background: $white;
+
+	> .cortext-data-view {
+		flex: 1 1 auto;
+		min-width: 0;
+		min-height: 0;
+	}
+}
+
+.cortext-row-detail,
+.cortext-row-detail-modal {
+	--cortext-row-detail-text: #37352f;
+	--cortext-row-detail-muted: #787774;
+	--cortext-row-detail-border: #e9e9e7;
+	--cortext-row-detail-hover-surface: #f7f6f3;
+	--cortext-row-detail-pressed-surface: #ebeae6;
+	--cortext-row-detail-toolbar-button-size: #{$grid-unit-40};
+	--cortext-row-detail-toolbar-button-padding: #{$grid-unit-10};
+
+	font-size: 13px;
+	line-height: 1.4;
+}
+
+.cortext-row-detail {
+	z-index: 2;
+	min-width: 0;
+	min-height: 0;
+	background: $white;
+	color: var(--cortext-row-detail-text);
+
+	&--full {
+		flex: 1 1 auto;
+		width: 100%;
+	}
+
+	&__frame {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+		background: $white;
+		color: var(--cortext-row-detail-text);
+	}
+
+	&__header {
+		display: flex;
+		flex: 0 0 auto;
+		flex-direction: column;
+		align-items: stretch;
+		gap: $grid-unit-10;
+		padding: $grid-unit-15 $grid-unit-20 $grid-unit-10;
+		border-bottom: $border-width solid $gray-200;
+		background: $white;
+	}
+
+	&__identity {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	&__title {
+		overflow: hidden;
+		margin: 0;
+		color: var(--cortext-row-detail-text);
+		font-size: 18px;
+		font-weight: 600;
+		line-height: 1.3;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* stylelint-disable no-descending-specificity */
+	&__toolbar {
+		display: flex;
+		flex: 0 0 auto;
+		align-items: center;
+		gap: $grid-unit-05;
+		flex-wrap: wrap;
+		min-height: $grid-unit-40;
+
+		.components-dropdown {
+			display: flex;
+			min-width: 0;
+		}
+	}
+
+	&__toolbar-group {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		min-width: 0;
+
+		&::after {
+			content: "";
+			display: block;
+			width: $border-width;
+			height: $grid-unit-20;
+			margin-inline: $grid-unit-05 0;
+			background: var(--cortext-row-detail-border);
+		}
+
+		&:last-child::after {
+			display: none;
+		}
+
+		&--end {
+			margin-left: auto;
+		}
+	}
+
+	&__toolbar-button.components-button {
+		display: inline-flex;
+		align-items: center;
+		min-width: var(--cortext-row-detail-toolbar-button-size);
+		height: var(--cortext-row-detail-toolbar-button-size);
+		justify-content: center;
+		gap: $grid-unit-05;
+		padding: 0 var(--cortext-row-detail-toolbar-button-padding);
+		border-radius: 4px;
+		box-shadow: none;
+		color: var(--cortext-row-detail-muted);
+		font-weight: 400;
+		line-height: 1;
+
+		&:focus:not(:focus-visible) {
+			box-shadow: none;
+			outline: none;
+		}
+
+		&:hover:not(:disabled),
+		&:focus-visible:not(:disabled) {
+			background: var(--cortext-row-detail-hover-surface);
+			box-shadow: none;
+			color: var(--cortext-row-detail-text);
+		}
+
+		&.is-pressed {
+			background: transparent;
+			color: var(--cortext-row-detail-muted);
+		}
+
+		&:disabled,
+		&[aria-disabled="true"] {
+			background: transparent;
+			box-shadow: none;
+			color: #b9b7b1;
+			cursor: default;
+			opacity: 0.45;
+		}
+
+		svg {
+			display: block;
+			flex: 0 0 auto;
+			width: 20px;
+			height: 20px;
+			fill: currentcolor;
+		}
+	}
+
+	&__toolbar-button--icon.components-button {
+		width: var(--cortext-row-detail-toolbar-button-size);
+		padding: 0;
+	}
+
+	&__toolbar-button--close.components-button {
+		width: var(--cortext-row-detail-toolbar-button-size);
+		min-width: var(--cortext-row-detail-toolbar-button-size);
+		padding: 0;
+	}
+	/* stylelint-enable no-descending-specificity */
+
+	&__notice {
+		flex: 0 0 auto;
+		margin: $grid-unit-10 $grid-unit-20 0;
+	}
+
+	&__body {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 0;
+		overflow: auto;
+	}
+
+	&__properties-region,
+	&__fields-indicator-wrap {
+		display: grid;
+		flex: 0 0 auto;
+		overflow: hidden;
+		transition:
+			grid-template-rows 180ms ease,
+			opacity 140ms ease;
+	}
+
+	&__properties-region {
+		grid-template-rows: 1fr;
+		opacity: 1;
+	}
+
+	&__properties-region-inner,
+	&__fields-indicator-inner {
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	&__properties {
+		display: flex;
+		flex: 0 0 auto;
+		flex-direction: column;
+		gap: 2px;
+		padding: $grid-unit-20 $grid-unit-30 $grid-unit-10;
+	}
+
+	&__fields-indicator-wrap {
+		grid-template-rows: 0fr;
+		opacity: 0;
+	}
+
+	&__fields-indicator-inner {
+		padding: 0 $grid-unit-30;
+	}
+
+	&__fields-indicator.components-button {
+		height: 30px;
+		min-height: 30px;
+		margin-top: $grid-unit-10;
+		padding: 0 $grid-unit-10;
+		border-radius: 4px;
+		background: transparent;
+		box-shadow: none;
+		color: var(--cortext-row-detail-muted);
+		font-size: 12px;
+		font-weight: 400;
+
+		&:hover:not(:disabled),
+		&:focus-visible:not(:disabled) {
+			background: var(--cortext-row-detail-hover-surface);
+			box-shadow: none;
+			color: var(--cortext-row-detail-text);
+		}
+	}
+
+	&__property {
+		display: grid;
+		grid-template-columns: minmax(104px, 136px) minmax(0, 1fr);
+		align-items: start;
+		gap: $grid-unit-15;
+		min-width: 0;
+		min-height: $grid-unit-40;
+		padding: 2px $grid-unit-05;
+		border-radius: 4px;
+
+		&:hover {
+			background: var(--cortext-row-detail-hover-surface);
+		}
+
+		.components-base-control {
+			width: 100%;
+			margin-bottom: 0;
+		}
+
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
+
+		.components-dropdown {
+			width: 100%;
+		}
+
+		.components-checkbox-control__input-container {
+			margin-top: 7px;
+		}
+	}
+
+	&__property-label {
+		overflow: hidden;
+		padding-top: 8px;
+		color: var(--cortext-row-detail-muted);
+		font-size: 12px;
+		font-weight: 400;
+		line-height: 1.3;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__property-value {
+		min-width: 0;
+		color: var(--cortext-row-detail-text);
+
+		.components-base-control,
+		.components-base-control__field,
+		.components-input-control,
+		.components-input-control__container {
+			min-height: 30px;
+		}
+
+		.components-text-control__input,
+		.components-select-control__input,
+		.components-input-control__input {
+			width: 100%;
+			min-height: 30px;
+			height: 30px;
+			padding: 0;
+			border-color: transparent;
+			border-radius: 4px;
+			background: transparent;
+			box-shadow: none;
+			font: inherit;
+			color: inherit;
+
+			&:hover {
+				background: transparent;
+				border-color: transparent;
+			}
+
+			&:focus {
+				border-color: var(--wp-admin-theme-color);
+				box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+			}
+		}
+
+		.components-input-control__backdrop {
+			border-color: transparent;
+			box-shadow: none;
+		}
+
+		.components-checkbox-control__input-container {
+			margin-right: 0;
+		}
+	}
+
+	&__readonly {
+		display: flex;
+		align-items: center;
+		min-height: 30px;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: var(--cortext-row-detail-text);
+	}
+
+	&__empty-value {
+		color: var(--cortext-row-detail-muted);
+	}
+
+	&__property--readonly {
+		color: var(--cortext-row-detail-muted);
+		cursor: default;
+
+		.cortext-row-detail__property-label,
+		.cortext-row-detail__property-value,
+		.cortext-row-detail__readonly {
+			color: inherit;
+			cursor: inherit;
+		}
+	}
+
+	&__property-editable-text {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		min-height: 30px;
+		margin: 0 0 0 -4px;
+		padding: 0 4px;
+		border: 0;
+		border-radius: 4px;
+		outline: 0;
+		background: transparent;
+		box-shadow: none;
+		color: var(--cortext-row-detail-text);
+		cursor: text;
+		font: inherit;
+		line-height: 1.4;
+		white-space: pre-wrap;
+		word-break: break-word;
+
+		&:empty::before {
+			content: attr(data-placeholder);
+			color: var(--cortext-row-detail-muted);
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+		}
+	}
+
+	&__property-trigger.components-button {
+		justify-content: flex-start;
+		width: 100%;
+		min-height: 30px;
+		padding: 0;
+		border-radius: 4px;
+		background: transparent;
+		box-shadow: none;
+		color: var(--cortext-row-detail-text);
+		font-weight: 400;
+		text-align: left;
+		text-decoration: none;
+		white-space: normal;
+
+		&:hover:not(:disabled),
+		&:focus:not(:disabled) {
+			background: transparent;
+			box-shadow: none;
+			color: var(--cortext-row-detail-text);
+			text-decoration: none;
+		}
+
+		&:focus-visible:not(:disabled) {
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+		}
+	}
+
+	&__tokens-popover,
+	&__date-popover {
+		min-width: 280px;
+		padding: $grid-unit-15;
+	}
+
+	&__content-editor {
+		flex: 1 1 420px;
+		min-height: 360px;
+		margin: $grid-unit-10 0 0;
+		background: $white;
+		box-sizing: border-box;
+		overflow: visible;
+	}
+
+	&__content-editor iframe {
+		border: 0;
+		background: $white;
+	}
+
+	&--side {
+		--cortext-row-detail-toolbar-button-size: 34px;
+		--cortext-row-detail-toolbar-button-padding: #{$grid-unit-05};
+
+		flex: 1 1 auto;
+		width: 100%;
+		height: 100%;
+
+		.cortext-row-detail__header {
+			gap: $grid-unit-10;
+			padding: $grid-unit-15;
+		}
+
+		.cortext-row-detail__toolbar {
+			gap: 2px;
+		}
+
+		.cortext-row-detail__toolbar-group::after {
+			margin-inline: $grid-unit-05;
+		}
+
+		.cortext-row-detail__properties {
+			gap: 2px;
+			padding: $grid-unit-15;
+		}
+
+		.cortext-row-detail__fields-indicator-inner {
+			padding: 0 $grid-unit-15;
+		}
+
+		.cortext-row-detail__property {
+			grid-template-columns: minmax(96px, 116px) minmax(0, 1fr);
+			gap: $grid-unit-10;
+		}
+
+		.cortext-row-detail__content-editor {
+			min-height: 320px;
+			margin-top: $grid-unit-10;
+		}
+	}
+
+	&__frame[data-properties-visible="false"] &__content-editor {
+		margin-top: 0;
+	}
+
+	&__frame[data-properties-visible="false"] &__properties-region {
+		grid-template-rows: 0fr;
+		opacity: 0;
+	}
+
+	&__frame[data-properties-visible="false"] &__fields-indicator-wrap {
+		grid-template-rows: 1fr;
+		opacity: 1;
+	}
+}
+
+.cortext-row-detail-sidebar-shell {
+	position: relative;
+	flex: 0 0 var(--cortext-row-detail-sidebar-width, 560px);
+	width: var(--cortext-row-detail-sidebar-width, 560px);
+	height: 100%;
+	min-width: min(360px, 100vw);
+	min-height: 0;
+	max-width: min(840px, 66vw);
+	background: $white;
+	border-left: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
+
+	&__resize-handle {
+		position: absolute;
+		z-index: 3;
+		top: 0;
+		bottom: 0;
+		left: -5px;
+		width: 10px;
+		cursor: col-resize;
+		touch-action: none;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: 4px;
+			width: $border-width;
+			background: transparent;
+		}
+
+		&:hover::after,
+		&:focus-visible::after {
+			background: var(--wp-admin-theme-color);
+		}
+
+		&:focus-visible {
+			outline: none;
+		}
+	}
+}
+
+.cortext-row-detail-sidebar {
+	width: 100%;
+	height: 100%;
+	min-height: 0;
+}
+
+body.cortext-row-detail-sidebar-resizing {
+	cursor: col-resize;
+	user-select: none;
+}
+
+.cortext-row-detail-modal {
+	width: min(960px, calc(100vw - 48px));
+	height: min(820px, calc(100vh - 48px));
+	border-radius: 6px;
+	box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
+	overflow: hidden;
+
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		margin-top: 0;
+		padding: 0;
+	}
+
+	.cortext-row-detail__header {
+		gap: $grid-unit-15;
+		padding: $grid-unit-20 $grid-unit-30 $grid-unit-15;
+	}
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
 .cortext-data-view {
 	position: relative; // anchor for the column drop indicator
 	display: flex;
@@ -2540,7 +3163,7 @@ tbody > tr > td:not(:first-child) {
 // Per-context heights. The shared rules above stay context-agnostic; each
 // render path provides its own height.
 
-// Standalone pane fills the absolutely-positioned canvas.
+.cortext-canvas__table .cortext-data-view-shell,
 .cortext-canvas__table .cortext-data-view {
 	height: 100%;
 }
@@ -2548,6 +3171,7 @@ tbody > tr > td:not(:first-child) {
 // tech-debt.md#23: embedded block has no per-instance height attribute, so use
 // a fixed viewport height and let DataViews scroll internally. Width comes from
 // Gutenberg's alignment.
+.wp-block-cortext-data-view .cortext-data-view-shell,
 .wp-block-cortext-data-view .cortext-data-view {
 	height: var(--cortext-data-view-block-min-height);
 	min-height: 0;
@@ -2711,6 +3335,7 @@ thead > tr > th {
 .cortext-topbar,
 .cortext-canvas__identity-actions {
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	.components-button {
 		border-radius: var(--cortext-shell-radius);
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -989,7 +989,7 @@ body.cortext-sidebar-resizing {
 		min-width: 0;
 		height: 100%;
 		overflow: hidden;
-		background: $white;
+		background: transparent;
 		color: $gray-900;
 	}
 
@@ -1653,12 +1653,15 @@ tbody > tr > td:not(:first-child) {
 	width: 100%;
 	min-width: 0;
 	max-width: 100%;
+	border-radius: 2px;
+	box-sizing: border-box;
 
 	&--with-open-action {
 		display: grid;
 		grid-template-columns: minmax(0, 1fr) auto;
 		align-items: center;
 		gap: $grid-unit-05;
+		padding-inline-end: $grid-unit-10;
 
 		.cortext-editable-cell {
 			min-width: 0;
@@ -1689,15 +1692,40 @@ tbody > tr > td:not(:first-child) {
 	}
 }
 
+.cortext-title-cell:focus-within,
+.cortext-data-view
+.dataviews-view-table
+tbody
+tr:hover
+.cortext-title-cell--with-open-action,
+.cortext-title-cell--is-open {
+	background: $gray-100;
+}
+
 .cortext-title-cell:focus-within .cortext-title-cell__open.components-button,
-.cortext-data-view .dataviews-view-table tbody tr:hover .cortext-title-cell__open.components-button,
-.cortext-data-view .dataviews-view-table tbody tr:has(.cortext-title-cell--is-open) .cortext-title-cell__open.components-button {
+.cortext-data-view
+.dataviews-view-table
+tbody
+tr:hover
+.cortext-title-cell__open.components-button,
+.cortext-data-view
+.dataviews-view-table
+tbody
+tr:has(.cortext-title-cell--is-open)
+.cortext-title-cell__open.components-button {
 	opacity: 1;
 	pointer-events: auto;
 }
 
-.cortext-data-view .dataviews-view-table tbody tr:has(.cortext-title-cell--is-open),
-.cortext-data-view .dataviews-view-table tbody tr:has(.cortext-title-cell--is-open) .dataviews-view-table__actions-column--sticky {
+.cortext-data-view
+.dataviews-view-table
+tbody
+tr:has(.cortext-title-cell--is-open),
+.cortext-data-view
+.dataviews-view-table
+tbody
+tr:has(.cortext-title-cell--is-open)
+.dataviews-view-table__actions-column--sticky {
 	background-color: #f8f8f8;
 }
 
@@ -1819,7 +1847,7 @@ tbody > tr > td:not(:first-child) {
 		padding: 0 $grid-unit-10;
 		border: $border-width solid $gray-200;
 		border-radius: 4px;
-		background: $white;
+		background: transparent;
 		font-size: 13px;
 		line-height: 20px;
 		width: 100%;
@@ -2429,6 +2457,7 @@ tbody > tr > td:not(:first-child) {
 	--cortext-row-detail-border: #e9e9e7;
 	--cortext-row-detail-hover-surface: #f7f6f3;
 	--cortext-row-detail-pressed-surface: #ebeae6;
+	--cortext-row-detail-field-inset: 56px;
 	--cortext-row-detail-toolbar-button-size: #{$grid-unit-40};
 	--cortext-row-detail-toolbar-button-padding: #{$grid-unit-10};
 
@@ -2457,13 +2486,154 @@ tbody > tr > td:not(:first-child) {
 		color: var(--cortext-row-detail-text);
 	}
 
+	&__pane-stack {
+		position: relative;
+		flex: 1 1 auto;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		overflow: clip;
+		background: $white;
+	}
+
+	&__pane {
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		background: $white;
+		opacity: 1;
+		transform: translateY(0);
+		will-change: opacity, transform;
+
+		&[data-state="active"] {
+			z-index: 2;
+		}
+
+		&[data-state="covered"] {
+			z-index: 2;
+			pointer-events: none;
+		}
+
+		&[data-state="preparing"] {
+			visibility: hidden;
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&[data-interactive="false"] {
+			pointer-events: none;
+		}
+
+		&[data-state="entering"] {
+			z-index: 3;
+			animation:
+				cortext-row-detail-pane-enter 180ms
+				cubic-bezier(0.6, 0, 0.4, 1) both;
+		}
+	}
+
+	&--side,
+	&--modal {
+
+		.cortext-row-detail__pane-stack {
+			flex: 0 0 auto;
+			height: auto;
+			min-height: 320px;
+			overflow: visible;
+		}
+
+		.cortext-row-detail__pane {
+			position: relative;
+			inset: auto;
+			height: auto;
+			min-height: 320px;
+		}
+
+		.cortext-row-detail__pane[data-state="covered"],
+		.cortext-row-detail__pane[data-state="preparing"],
+		.cortext-row-detail__pane[data-state="entering"] {
+			position: absolute;
+			inset: 0;
+			height: 100%;
+			min-height: 100%;
+		}
+	}
+
+	&--modal {
+		width: 100%;
+		height: 100%;
+
+		.cortext-row-detail__pane-stack,
+		.cortext-row-detail__pane {
+			min-height: 420px;
+		}
+	}
+
+	&__properties-shell {
+		position: relative;
+		min-width: 0;
+	}
+
+	&__property-value-stack {
+		position: relative;
+		width: 100%;
+		min-height: 30px;
+	}
+
+	&__property-value-pane {
+		position: relative;
+		z-index: 2;
+		display: flex;
+		align-items: center;
+		width: 100%;
+		min-height: 30px;
+		background: transparent;
+		opacity: 1;
+		transform: translateY(0);
+		will-change: opacity, transform;
+
+		&[data-state="covered"] {
+			position: absolute;
+			inset: 0;
+			z-index: 1;
+			pointer-events: none;
+		}
+
+		&[data-state="preparing"] {
+			position: absolute;
+			inset: 0;
+			visibility: hidden;
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&[data-interactive="false"] {
+			pointer-events: none;
+		}
+
+		&[data-state="entering"] {
+			z-index: 3;
+			animation:
+				cortext-row-detail-pane-enter 180ms
+				cubic-bezier(0.6, 0, 0.4, 1) both;
+		}
+	}
+
 	&__header {
 		display: flex;
 		flex: 0 0 auto;
 		flex-direction: column;
 		align-items: stretch;
 		gap: $grid-unit-10;
-		padding: $grid-unit-15 $grid-unit-20 $grid-unit-10;
+		padding:
+			$grid-unit-15 var(--cortext-row-detail-field-inset)
+			$grid-unit-10;
 		border-bottom: $border-width solid $gray-200;
 		background: $white;
 	}
@@ -2623,7 +2793,7 @@ tbody > tr > td:not(:first-child) {
 		flex: 0 0 auto;
 		flex-direction: column;
 		gap: 2px;
-		padding: $grid-unit-20 $grid-unit-30 $grid-unit-10;
+		padding: $grid-unit-20 var(--cortext-row-detail-field-inset) $grid-unit-10;
 	}
 
 	&__fields-indicator-wrap {
@@ -2632,27 +2802,21 @@ tbody > tr > td:not(:first-child) {
 	}
 
 	&__fields-indicator-inner {
-		padding: 0 $grid-unit-30;
+		padding: 0 var(--cortext-row-detail-field-inset);
 	}
 
-	&__fields-indicator.components-button {
+	&__fields-indicator {
+		display: inline-flex;
+		align-items: center;
+		gap: $grid-unit-05;
 		height: 30px;
 		min-height: 30px;
 		margin-top: $grid-unit-10;
-		padding: 0 $grid-unit-10;
-		border-radius: 4px;
+		padding: 0 2px;
 		background: transparent;
-		box-shadow: none;
 		color: var(--cortext-row-detail-muted);
 		font-size: 12px;
 		font-weight: 400;
-
-		&:hover:not(:disabled),
-		&:focus-visible:not(:disabled) {
-			background: var(--cortext-row-detail-hover-surface);
-			box-shadow: none;
-			color: var(--cortext-row-detail-text);
-		}
 	}
 
 	&__property {
@@ -2699,6 +2863,7 @@ tbody > tr > td:not(:first-child) {
 	}
 
 	&__property-value {
+		position: relative;
 		min-width: 0;
 		color: var(--cortext-row-detail-text);
 
@@ -2742,6 +2907,16 @@ tbody > tr > td:not(:first-child) {
 		.components-checkbox-control__input-container {
 			margin-right: 0;
 		}
+
+		&:has(.cortext-row-detail__property-editable-text:focus)::after,
+		&:has(.cortext-row-detail__property-trigger:focus-visible)::after {
+			content: "";
+			position: absolute;
+			inset: 0 -6px;
+			border-radius: 4px;
+			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
+			pointer-events: none;
+		}
 	}
 
 	&__readonly {
@@ -2771,14 +2946,16 @@ tbody > tr > td:not(:first-child) {
 	}
 
 	&__property-editable-text {
-		display: flex;
-		align-items: center;
+		appearance: none;
+		display: block;
 		width: 100%;
+		height: 30px;
 		min-height: 30px;
-		margin: 0 0 0 -4px;
-		padding: 0 4px;
+		margin: 0;
+		padding: 0;
 		border: 0;
 		border-radius: 4px;
+		box-sizing: border-box;
 		outline: 0;
 		background: transparent;
 		box-shadow: none;
@@ -2786,22 +2963,49 @@ tbody > tr > td:not(:first-child) {
 		cursor: text;
 		font: inherit;
 		line-height: 1.4;
-		white-space: pre-wrap;
-		word-break: break-word;
 
-		&:empty::before {
-			content: attr(data-placeholder);
+		&::placeholder {
 			color: var(--cortext-row-detail-muted);
+			opacity: 1;
+		}
+
+		&:focus::placeholder {
+			opacity: 0;
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+			outline: 0;
 		}
 	}
 
+	input.cortext-row-detail__property-editable-text,
+	input.cortext-row-detail__property-editable-text:hover,
+	input.cortext-row-detail__property-editable-text:focus,
+	input.cortext-row-detail__property-editable-text:focus-visible {
+		appearance: none;
+		width: 100%;
+		height: 30px;
+		min-height: 30px;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		border-radius: 4px;
+		box-sizing: border-box;
+		outline: 0;
+		background: transparent;
+		background-color: transparent;
+		box-shadow: none;
+		color: var(--cortext-row-detail-text);
+		cursor: text;
+		font: inherit;
+		line-height: 1.4;
+	}
+
 	&__property-trigger.components-button {
+		align-items: center;
 		justify-content: flex-start;
 		width: 100%;
+		height: auto;
 		min-height: 30px;
 		padding: 0;
 		border-radius: 4px;
@@ -2822,11 +3026,14 @@ tbody > tr > td:not(:first-child) {
 		}
 
 		&:focus-visible:not(:disabled) {
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+			outline: 0;
+		}
+
+		.cortext-chips {
+			align-items: center;
 		}
 	}
 
-	&__tokens-popover,
 	&__date-popover {
 		min-width: 280px;
 		padding: $grid-unit-15;
@@ -2837,6 +3044,7 @@ tbody > tr > td:not(:first-child) {
 		min-height: 360px;
 		margin: $grid-unit-10 0 0;
 		background: $white;
+		border-top: $border-width solid var(--cortext-row-detail-border);
 		box-sizing: border-box;
 		overflow: visible;
 	}
@@ -2847,6 +3055,7 @@ tbody > tr > td:not(:first-child) {
 	}
 
 	&--side {
+		--cortext-row-detail-field-inset: 48px;
 		--cortext-row-detail-toolbar-button-size: 34px;
 		--cortext-row-detail-toolbar-button-padding: #{$grid-unit-05};
 
@@ -2856,7 +3065,9 @@ tbody > tr > td:not(:first-child) {
 
 		.cortext-row-detail__header {
 			gap: $grid-unit-10;
-			padding: $grid-unit-15;
+			padding:
+				$grid-unit-15 var(--cortext-row-detail-field-inset)
+				$grid-unit-10;
 		}
 
 		.cortext-row-detail__toolbar {
@@ -2869,11 +3080,11 @@ tbody > tr > td:not(:first-child) {
 
 		.cortext-row-detail__properties {
 			gap: 2px;
-			padding: $grid-unit-15;
+			padding: $grid-unit-15 var(--cortext-row-detail-field-inset);
 		}
 
 		.cortext-row-detail__fields-indicator-inner {
-			padding: 0 $grid-unit-15;
+			padding: 0 var(--cortext-row-detail-field-inset);
 		}
 
 		.cortext-row-detail__property {
@@ -2902,16 +3113,40 @@ tbody > tr > td:not(:first-child) {
 	}
 }
 
+@keyframes cortext-row-detail-pane-enter {
+
+	from {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
 .cortext-row-detail-sidebar-shell {
 	position: relative;
 	flex: 0 0 var(--cortext-row-detail-sidebar-width, 560px);
 	width: var(--cortext-row-detail-sidebar-width, 560px);
 	height: 100%;
-	min-width: min(360px, 100vw);
+	min-width: 0;
 	min-height: 0;
 	max-width: min(840px, 66vw);
 	background: $white;
 	border-left: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
+	box-shadow: -18px 0 36px rgba(0, 0, 0, 0.12);
+	overflow: hidden;
+	will-change: width;
+	animation:
+		cortext-row-detail-sidebar-open 300ms
+		cubic-bezier(0.6, 0, 0.4, 1) both;
+
+	&--closing {
+		pointer-events: none;
+		animation-name: cortext-row-detail-sidebar-close;
+	}
 
 	&__resize-handle {
 		position: absolute;
@@ -2944,15 +3179,126 @@ tbody > tr > td:not(:first-child) {
 	}
 }
 
+.cortext-collection-pane > .cortext-row-detail-sidebar-shell {
+	position: absolute;
+	inset-block: 0;
+	inset-inline-end: 0;
+	z-index: 8;
+}
+
+.cortext-row-detail-sidebar-handoff {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	min-width: 0;
+	min-height: 0;
+	overflow: visible;
+
+	&__fallback {
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+	}
+
+	&--reserve > .cortext-row-detail-sidebar-shell {
+		position: absolute;
+		inset-block: 0;
+		inset-inline-end: 0;
+		z-index: 2;
+	}
+}
+
+.cortext-canvas:has(.cortext-row-detail-sidebar-handoff--reserve) {
+
+	.interface-interface-skeleton__sidebar {
+		position: relative;
+		z-index: 8;
+		overflow: visible;
+	}
+}
+
+.cortext-canvas:has(.cortext-row-detail-sidebar-shell):not(
+:has(.cortext-row-detail-sidebar-handoff--reserve)
+) {
+
+	.interface-interface-skeleton__body {
+		position: relative;
+	}
+
+	.interface-interface-skeleton__sidebar {
+		position: absolute;
+		inset-block: 0;
+		inset-inline-end: 0;
+		z-index: 8;
+		width: auto;
+		min-width: 0;
+		max-width: none;
+		overflow: visible;
+		pointer-events: none;
+
+		.cortext-row-detail-sidebar-shell {
+			position: relative;
+			pointer-events: auto;
+		}
+	}
+}
+
 .cortext-row-detail-sidebar {
+	display: flex;
+	flex-direction: column;
 	width: 100%;
 	height: 100%;
 	min-height: 0;
+	overflow: hidden;
+
+	> .cortext-row-detail {
+		flex: 1 1 auto;
+	}
 }
 
 body.cortext-row-detail-sidebar-resizing {
 	cursor: col-resize;
 	user-select: none;
+}
+
+@keyframes cortext-row-detail-sidebar-open {
+
+	from {
+		flex-basis: 0;
+		width: 0;
+	}
+
+	to {
+		flex-basis: var(--cortext-row-detail-sidebar-width, 560px);
+		width: var(--cortext-row-detail-sidebar-width, 560px);
+	}
+}
+
+@keyframes cortext-row-detail-sidebar-close {
+
+	from {
+		flex-basis: var(--cortext-row-detail-sidebar-width, 560px);
+		width: var(--cortext-row-detail-sidebar-width, 560px);
+	}
+
+	to {
+		flex-basis: 0;
+		width: 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.cortext-row-detail__pane[data-state="entering"],
+	.cortext-row-detail__pane[data-state="covered"],
+	.cortext-row-detail__property-value-pane[data-state="entering"],
+	.cortext-row-detail__property-value-pane[data-state="covered"] {
+		animation: none;
+	}
+
+	.cortext-row-detail-sidebar-shell {
+		animation: none;
+	}
 }
 
 .cortext-row-detail-modal {
@@ -2962,17 +3308,31 @@ body.cortext-row-detail-sidebar-resizing {
 	box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
 	overflow: hidden;
 
+	&--closing {
+		pointer-events: none;
+	}
+
 	.components-modal__content {
 		display: flex;
 		flex-direction: column;
+		height: 100%;
 		min-height: 0;
 		margin-top: 0;
 		padding: 0;
+
+		> div {
+			display: flex;
+			flex: 1 1 auto;
+			flex-direction: column;
+			min-height: 0;
+		}
 	}
 
 	.cortext-row-detail__header {
 		gap: $grid-unit-15;
-		padding: $grid-unit-20 $grid-unit-30 $grid-unit-15;
+		padding:
+			$grid-unit-20 var(--cortext-row-detail-field-inset)
+			$grid-unit-15;
 	}
 }
 
@@ -3027,7 +3387,6 @@ body.cortext-row-detail-sidebar-resizing {
 		}
 
 		tfoot.cortext-table-calculations {
-
 			/* stylelint-disable-next-line no-descending-specificity */
 			td {
 				padding: 0;
@@ -3334,7 +3693,6 @@ thead > tr > th {
 .cortext-sidebar,
 .cortext-topbar,
 .cortext-canvas__identity-actions {
-
 	/* stylelint-disable-next-line no-descending-specificity */
 	.components-button {
 		border-radius: var(--cortext-shell-radius);

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -1,7 +1,8 @@
 import { useNavigate, useParams } from '@tanstack/react-router';
-import { Spinner } from '@wordpress/components';
+import { Notice, Spinner } from '@wordpress/components';
 import { useEntityRecords } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
+import { useSearch } from '@wordpress/route';
 import {
 	useCallback,
 	useEffect,
@@ -13,6 +14,8 @@ import {
 
 import Canvas from '../components/Canvas';
 import CollectionDataViews from '../components/CollectionDataViews';
+import { RowFullEditorContext } from '../components/RowFullEditorContext';
+import { RowDetailSidebarSlot } from '../components/RowDetailSidebarSlot';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
 import { ACTIVE_PAGES_QUERY, POST_TYPE } from '../components/page-queries';
 import { firstPageInTree } from '../components/pages-tree';
@@ -36,7 +39,17 @@ const DEFAULT_VIEW = {
 	page: 1,
 	search: '',
 	layout: {},
+	rowDetailMode: 'side',
 };
+const ROW_SEARCH_KEY = 'row';
+
+function parseSearchId( value ) {
+	if ( Array.isArray( value ) ) {
+		return parseSearchId( value[ 0 ] );
+	}
+	const id = Number.parseInt( String( value ).replaceAll( '"', '' ), 10 );
+	return Number.isFinite( id ) && id > 0 ? id : null;
+}
 
 function CollectionView( { collectionId, onReady } ) {
 	const [ view, setView ] = useState( DEFAULT_VIEW );
@@ -70,6 +83,7 @@ function CollectionPane( { collectionId, onReady } ) {
 					onReady={ onReady }
 				/>
 			</div>
+			<RowDetailSidebarSlot />
 		</div>
 	);
 }
@@ -108,9 +122,39 @@ function WorkspacePane( { active, preservePaint = false, children } ) {
 	);
 }
 
+function RowFullSaveNotice( { message, onDiscard, onRetry } ) {
+	if ( ! message ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			className="cortext-canvas__notice"
+			status="error"
+			isDismissible={ false }
+			actions={ [
+				{
+					label: __( 'Retry', 'cortext' ),
+					onClick: onRetry,
+					variant: 'primary',
+				},
+				{
+					label: __( 'Discard', 'cortext' ),
+					onClick: onDiscard,
+					variant: 'tertiary',
+				},
+			] }
+		>
+			{ message }
+		</Notice>
+	);
+}
+
 export default function EntityRoute( { history } ) {
 	const params = useParams( { strict: false } );
 	const navigate = useNavigate();
+	const search = useSearch( { strict: false } );
+	const routeRowId = parseSearchId( search?.[ ROW_SEARCH_KEY ] );
 	const splat = params._splat ?? '';
 	const target = useMemo( () => parseTarget( splat ), [ splat ] );
 	const { home, isResolving: isResolvingHome } = useWorkspaceHome();
@@ -242,6 +286,130 @@ export default function EntityRoute( { history } ) {
 		[ dispatch ]
 	);
 
+	const rowFullApiRef = useRef( null );
+	const [ rowFullTarget, setRowFullTarget ] = useState( null );
+	const rowFullTargetRef = useRef( rowFullTarget );
+	rowFullTargetRef.current = rowFullTarget;
+	const [ rowFullSaveError, setRowFullSaveError ] = useState( null );
+	const [ pendingRowFullTransition, setPendingRowFullTransition ] =
+		useState( null );
+	const [ suppressedRouteRow, setSuppressedRouteRow ] = useState( null );
+
+	const openRowFull = useCallback( ( rowTarget ) => {
+		setSuppressedRouteRow( null );
+		setRowFullSaveError( null );
+		setPendingRowFullTransition( null );
+		withViewTransition( () => setRowFullTarget( rowTarget ) );
+	}, [] );
+
+	const clearSuppressedRouteRow = useCallback( () => {
+		setSuppressedRouteRow( null );
+	}, [] );
+
+	const rowFullContext = useMemo(
+		() => ( {
+			clearSuppressedRouteRow,
+			openRowFull,
+			suppressedRouteRow,
+		} ),
+		[ clearSuppressedRouteRow, openRowFull, suppressedRouteRow ]
+	);
+
+	const setRowFullApi = useCallback( ( api ) => {
+		rowFullApiRef.current = api;
+	}, [] );
+
+	const applyRowFullTransition = useCallback( ( transition ) => {
+		const currentRowTarget = rowFullTargetRef.current;
+		if ( ! currentRowTarget ) {
+			return;
+		}
+
+		setRowFullSaveError( null );
+		setPendingRowFullTransition( null );
+
+		if ( transition.type === 'close' ) {
+			setSuppressedRouteRow( {
+				collectionId: currentRowTarget.collectionId,
+				rowId: currentRowTarget.rowId,
+			} );
+			currentRowTarget.onClose?.();
+			withViewTransition( () => setRowFullTarget( null ) );
+		} else if ( transition.type === 'mode' ) {
+			currentRowTarget.onModeChange?.(
+				transition.mode,
+				currentRowTarget.rowId
+			);
+			withViewTransition( () => setRowFullTarget( null ) );
+		}
+	}, [] );
+
+	const runRowFullTransition = useCallback(
+		async ( transition, options = {} ) => {
+			const api = rowFullApiRef.current;
+			setRowFullSaveError( null );
+
+			if ( options.discard ) {
+				api?.discard?.();
+				applyRowFullTransition( transition );
+				return true;
+			}
+
+			if ( api?.flushNow ) {
+				const didSave = await api.flushNow();
+				if ( ! didSave ) {
+					setPendingRowFullTransition( transition );
+					setRowFullSaveError(
+						__(
+							'Row changes could not be saved. Retry or discard the pending edits to continue.',
+							'cortext'
+						)
+					);
+					return false;
+				}
+			}
+
+			applyRowFullTransition( transition );
+			return true;
+		},
+		[ applyRowFullTransition ]
+	);
+
+	const retryPendingRowFullTransition = useCallback( () => {
+		if ( pendingRowFullTransition ) {
+			runRowFullTransition( pendingRowFullTransition );
+		}
+	}, [ pendingRowFullTransition, runRowFullTransition ] );
+
+	const discardPendingRowFullTransition = useCallback( () => {
+		if ( pendingRowFullTransition ) {
+			runRowFullTransition( pendingRowFullTransition, {
+				discard: true,
+			} );
+		}
+	}, [ pendingRowFullTransition, runRowFullTransition ] );
+
+	useEffect( () => {
+		if ( ! rowFullTarget ) {
+			return;
+		}
+		if ( String( routeRowId ) === String( rowFullTarget.rowId ) ) {
+			return;
+		}
+		runRowFullTransition( { type: 'close' } );
+	}, [ routeRowId, rowFullTarget, runRowFullTransition ] );
+
+	const rowFullNotice = (
+		<RowFullSaveNotice
+			message={ rowFullSaveError }
+			onDiscard={ discardPendingRowFullTransition }
+			onRetry={ retryPendingRowFullTransition }
+		/>
+	);
+	const navigateRowFullToCollection = useCallback( () => {
+		runRowFullTransition( { type: 'close' } );
+	}, [ runRowFullTransition ] );
+
 	// Drives the breadcrumb from the same paint state the document-actions
 	// Fill uses, so both sides of the top bar update together. Use
 	// `displayedPageId` rather than `mountedPageId` for the page case: when
@@ -250,7 +418,15 @@ export default function EntityRoute( { history } ) {
 	// catches up. Reading the mounted id would let the breadcrumb jump to B
 	// while A is still on screen.
 	let paintedRoute = { kind: 'unresolved' };
-	if ( active.kind === 'page' && displayedPageId !== null ) {
+	if ( rowFullTarget ) {
+		paintedRoute = {
+			kind: 'row',
+			collectionId: rowFullTarget.collectionId,
+			id: rowFullTarget.rowId,
+			onNavigateCollection: navigateRowFullToCollection,
+			postType: rowFullTarget.postType,
+		};
+	} else if ( active.kind === 'page' && displayedPageId !== null ) {
 		paintedRoute = { kind: 'page', id: displayedPageId };
 	} else if ( active.kind === 'collection' ) {
 		paintedRoute = { kind: 'collection', id: active.id };
@@ -262,22 +438,29 @@ export default function EntityRoute( { history } ) {
 		paintedRoute = { kind: active.kind };
 	}
 
+	const editorPostId = rowFullTarget?.rowId ?? mountedPageId;
+	const editorPostType = rowFullTarget?.postType;
+	const isEditorActive = Boolean( rowFullTarget ) || active.kind === 'page';
+
 	return (
-		<>
+		<RowFullEditorContext.Provider value={ rowFullContext }>
 			<WorkspaceTopBar
 				history={ history }
 				paintedRoute={ paintedRoute }
 			/>
 			<div className="cortext-workspace">
-				{ mountedPageId !== null && (
-					<WorkspacePane
-						active={ active.kind === 'page' }
-						preservePaint
-					>
+				{ editorPostId !== null && (
+					<WorkspacePane active={ isEditorActive } preservePaint>
 						<Canvas
-							postId={ mountedPageId }
-							onDisplayedPost={ handlePageDisplayed }
-							isActive={ active.kind === 'page' }
+							postId={ editorPostId }
+							postType={ editorPostType }
+							onDisplayedPost={
+								rowFullTarget ? undefined : handlePageDisplayed
+							}
+							isActive={ isEditorActive }
+							notice={ rowFullNotice }
+							onApi={ rowFullTarget ? setRowFullApi : undefined }
+							onSaved={ rowFullTarget?.onSaved }
 						/>
 					</WorkspacePane>
 				) }
@@ -286,7 +469,9 @@ export default function EntityRoute( { history } ) {
 					<WorkspacePane
 						key={ id }
 						active={
-							active.kind === 'collection' && active.id === id
+							! rowFullTarget &&
+							active.kind === 'collection' &&
+							active.id === id
 						}
 					>
 						<CollectionPane
@@ -296,21 +481,32 @@ export default function EntityRoute( { history } ) {
 					</WorkspacePane>
 				) ) }
 
-				<WorkspacePane active={ active.kind === 'empty' }>
+				<WorkspacePane
+					active={ ! rowFullTarget && active.kind === 'empty' }
+				>
 					<EmptyState />
 				</WorkspacePane>
-				<WorkspacePane active={ active.kind === 'page-not-found' }>
+				<WorkspacePane
+					active={
+						! rowFullTarget && active.kind === 'page-not-found'
+					}
+				>
 					<NotFoundPane type="page" />
 				</WorkspacePane>
 				<WorkspacePane
-					active={ active.kind === 'collection-not-found' }
+					active={
+						! rowFullTarget &&
+						active.kind === 'collection-not-found'
+					}
 				>
 					<NotFoundPane type="collection" />
 				</WorkspacePane>
-				<WorkspacePane active={ active.kind === 'loading' }>
+				<WorkspacePane
+					active={ ! rowFullTarget && active.kind === 'loading' }
+				>
 					<LoadingPane />
 				</WorkspacePane>
 			</div>
-		</>
+		</RowFullEditorContext.Provider>
 	);
 }

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -798,6 +798,274 @@ test.describe( 'Collection view block', () => {
 		}
 	} );
 
+	test( 'row detail saves properties and remembers the selected mode', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture( requestUtils )
+			);
+
+			fixture.secondEntry = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_${ fixture.slug }`,
+				data: {
+					title: 'Kindred',
+					status: 'private',
+					meta: {
+						[ `field-${ fixture.field.id }` ]: 'Octavia Butler',
+					},
+				},
+			} );
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Row detail page',
+					status: 'private',
+					content: createDataViewBlockMarkup( fixture.collection.id ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page.frameLocator(
+				'.cortext-canvas__visual iframe[name="editor-canvas"]'
+			);
+			await expect(
+				canvas.locator( '.dataviews-view-table__actions-column' )
+			).toHaveCount( 0 );
+			const firstRow = canvas
+				.locator( '.cortext-data-view tbody tr' )
+				.first();
+			const titleCellOpenButton = canvas
+				.locator( '.cortext-title-cell__open' )
+				.first();
+			await expect( titleCellOpenButton ).toHaveAttribute(
+				'aria-label',
+				'Open row'
+			);
+			await expect( titleCellOpenButton ).toHaveCSS( 'opacity', '0' );
+			await firstRow.hover();
+			await expect( titleCellOpenButton ).toHaveCSS( 'opacity', '1' );
+			await expect( titleCellOpenButton ).toContainText( 'Open' );
+			await titleCellOpenButton.click();
+			await expect
+				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
+				.toBe( String( fixture.entry.id ) );
+			expect(
+				new URL( page.url() ).searchParams.get( 'rowCollection' )
+			).toBe( String( fixture.collection.id ) );
+
+			await expect(
+				canvas.getByRole( 'dialog', {
+					name: 'Row detail',
+				} )
+			).toHaveCount( 0 );
+
+			const detail = page.getByRole( 'dialog', {
+				name: 'Row detail',
+			} );
+			await expect( detail ).toBeVisible();
+			await detail.hover();
+			await expect( firstRow ).toHaveCSS(
+				'background-color',
+				'rgb(248, 248, 248)'
+			);
+			await expect( titleCellOpenButton ).toHaveCSS( 'opacity', '1' );
+			await expect(
+				detail.getByRole( 'heading', {
+					name: 'The Left Hand of Darkness',
+				} )
+			).toBeVisible();
+
+			const delayedSecondRowPattern = new RegExp(
+				`/wp-json/wp/v2/crtxt_${ fixture.slug }/${ fixture.secondEntry.id }(\\?|$)`
+			);
+			const delaySecondRow = async ( route ) => {
+				await page.waitForTimeout( 350 );
+				await route.continue();
+			};
+			await page.route( delayedSecondRowPattern, delaySecondRow );
+			await detail.getByRole( 'button', { name: 'Row below' } ).click();
+			await expect(
+				detail.locator( '.components-spinner' )
+			).toHaveCount( 0 );
+			await expect(
+				detail.getByRole( 'heading', {
+					name: 'The Left Hand of Darkness',
+				} )
+			).toBeVisible();
+			await expect
+				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
+				.toBe( String( fixture.secondEntry.id ) );
+			await expect(
+				detail.getByRole( 'heading', { name: 'Kindred' } )
+			).toBeVisible();
+			await page.unroute( delayedSecondRowPattern, delaySecondRow );
+			await detail.getByRole( 'button', { name: 'Row above' } ).click();
+			await expect(
+				detail.getByRole( 'heading', {
+					name: 'The Left Hand of Darkness',
+				} )
+			).toBeVisible();
+			await expect
+				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
+				.toBe( String( fixture.entry.id ) );
+
+			await detail
+				.getByRole( 'button', { name: 'Hide fields' } )
+				.click();
+			const collapsedFieldsButton = detail.locator(
+				'.cortext-row-detail__fields-indicator'
+			);
+			await expect(
+				detail.getByRole( 'textbox', { name: 'Title', exact: true } )
+			).toBeHidden();
+			await expect( collapsedFieldsButton ).toBeVisible();
+			await expect(
+				detail.locator( '.cortext-row-detail__content-editor' )
+			).toBeVisible();
+			await collapsedFieldsButton.click();
+			await expect(
+				detail.locator( '.cortext-row-detail__properties' )
+			).toBeVisible();
+
+			await detail
+				.getByRole( 'textbox', { name: 'Title', exact: true } )
+				.fill( 'Changed row detail title' );
+			await expect( firstRow.locator( 'td' ).first() ).toContainText(
+				'Changed row detail title'
+			);
+			await detail
+				.getByRole( 'textbox', { name: 'Author', exact: true } )
+				.fill( 'Octavia Butler' );
+			await expect( firstRow.locator( 'td' ).nth( 1 ) ).toContainText(
+				'Octavia Butler'
+			);
+
+			await expect(
+				detail.getByRole( 'button', { name: 'Center modal' } )
+			).toBeVisible();
+			await expect(
+				detail.getByRole( 'button', { name: 'Full page' } )
+			).toBeVisible();
+			await expect(
+				detail.getByRole( 'button', { name: 'Change layout' } )
+			).toHaveCount( 0 );
+			await detail
+				.getByRole( 'button', { name: 'Center modal' } )
+				.click();
+			const modalDetail = page.locator(
+				'.components-modal__frame.cortext-row-detail-modal'
+			);
+			await expect( modalDetail ).toBeVisible();
+			await expect(
+				modalDetail.getByRole( 'button', { name: 'Center modal' } )
+			).toHaveCount( 0 );
+			await expect(
+				modalDetail.getByRole( 'button', { name: 'Side peek' } )
+			).toBeVisible();
+			await expect(
+				modalDetail.getByRole( 'button', { name: 'Full page' } )
+			).toBeVisible();
+			await modalDetail
+				.getByRole( 'button', { name: 'Full page' } )
+				.click();
+			await expect( detail ).toBeHidden();
+			await expect(
+				canvas.getByText( 'Changed row detail title' )
+			).toBeVisible();
+
+			await page
+				.getByRole( 'navigation', { name: 'Breadcrumb' } )
+				.getByRole( 'button', {
+					name: fixture.collection.title.raw,
+					exact: true,
+				} )
+				.click();
+			await expect
+				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
+				.toBeNull();
+			await expect(
+				canvas.getByRole( 'button', { name: 'Open row' } ).first()
+			).toBeVisible();
+
+			await expect
+				.poll( async () => {
+					const row = await requestUtils.rest( {
+						path: `/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`,
+						params: { context: 'edit' },
+					} );
+					return {
+						title: row.title.raw,
+						author: row.meta[ `field-${ fixture.field.id }` ],
+					};
+				} )
+				.toEqual( {
+					title: 'Changed row detail title',
+					author: 'Octavia Butler',
+				} );
+
+			await page.evaluate( async () => {
+				await window.wp.data.dispatch( 'core/editor' ).savePost();
+			} );
+			await page.waitForFunction(
+				() => ! window.wp.data.select( 'core/editor' ).isSavingPost()
+			);
+
+			const saved = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_pages/${ fixture.page.id }`,
+				params: { context: 'edit' },
+			} );
+			expect( saved.content.raw ).not.toContain(
+				'"rowDetailMode":"full"'
+			);
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.secondEntry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.secondEntry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+
 	test( 'renders typed cells for url, checkbox, number, select, and multiselect', async ( {
 		admin,
 		page,

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -811,6 +811,65 @@ test.describe( 'Collection view block', () => {
 				await createCollectionFixture( requestUtils )
 			);
 
+			fixture.tagsField = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_fields',
+				data: {
+					title: 'Tags',
+					status: 'private',
+					meta: {
+						type: 'multiselect',
+						options: JSON.stringify( [
+							{
+								value: 'research',
+								label: 'Research',
+								color: 'blue',
+							},
+							{ value: 'data', label: 'Data', color: 'green' },
+						] ),
+					},
+				},
+			} );
+
+			fixture.yearField = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_fields',
+				data: {
+					title: 'Year',
+					status: 'private',
+					meta: { type: 'number' },
+				},
+			} );
+
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_collections/${ fixture.collection.id }`,
+				data: {
+					meta: {
+						fields: [
+							String( fixture.field.id ),
+							String( fixture.tagsField.id ),
+							String( fixture.yearField.id ),
+						],
+					},
+				},
+			} );
+
+			fixture.entry = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`,
+				data: {
+					meta: {
+						[ `field-${ fixture.field.id }` ]: 'Ursula K. Le Guin',
+						[ `field-${ fixture.tagsField.id }` ]: [
+							'research',
+							'data',
+						],
+						[ `field-${ fixture.yearField.id }` ]: 1969,
+					},
+				},
+			} );
+
 			fixture.secondEntry = await requestUtils.rest( {
 				method: 'POST',
 				path: `/wp/v2/crtxt_${ fixture.slug }`,
@@ -896,6 +955,37 @@ test.describe( 'Collection view block', () => {
 					name: 'The Left Hand of Darkness',
 				} )
 			).toBeVisible();
+			const tagsLabel = detail
+				.locator(
+					'.cortext-row-detail__properties--rows .cortext-row-detail__property-label'
+				)
+				.filter( { hasText: 'Tags' } );
+			await tagsLabel.evaluate( ( node ) =>
+				node.setAttribute( 'data-e2e-stable-label', 'tags' )
+			);
+			const tagsTrigger = detail.getByRole( 'button', {
+				name: 'Tags',
+				exact: true,
+			} );
+			await expect(
+				tagsTrigger.locator( '.cortext-chips > .cortext-chip' )
+			).toHaveText( [ 'Research', 'Data' ] );
+			await tagsTrigger.click();
+			const optionsPopover = page.locator(
+				'.cortext-edit-options-popover'
+			);
+			await expect( optionsPopover ).toBeVisible();
+			await expect(
+				optionsPopover.locator( '.cortext-chip' ).filter( {
+					hasText: 'Research',
+				} )
+			).toHaveCount( 2 );
+			await detail
+				.getByRole( 'heading', {
+					name: 'The Left Hand of Darkness',
+				} )
+				.click();
+			await expect( optionsPopover ).toBeHidden();
 
 			const delayedSecondRowPattern = new RegExp(
 				`/wp-json/wp/v2/crtxt_${ fixture.slug }/${ fixture.secondEntry.id }(\\?|$)`
@@ -906,9 +996,9 @@ test.describe( 'Collection view block', () => {
 			};
 			await page.route( delayedSecondRowPattern, delaySecondRow );
 			await detail.getByRole( 'button', { name: 'Row below' } ).click();
-			await expect(
-				detail.locator( '.components-spinner' )
-			).toHaveCount( 0 );
+			await expect( detail.locator( '.components-spinner' ) ).toHaveCount(
+				0
+			);
 			await expect(
 				detail.getByRole( 'heading', {
 					name: 'The Left Hand of Darkness',
@@ -920,6 +1010,9 @@ test.describe( 'Collection view block', () => {
 			await expect(
 				detail.getByRole( 'heading', { name: 'Kindred' } )
 			).toBeVisible();
+			await expect(
+				detail.locator( '[data-e2e-stable-label="tags"]' )
+			).toHaveText( 'Tags' );
 			await page.unroute( delayedSecondRowPattern, delaySecondRow );
 			await detail.getByRole( 'button', { name: 'Row above' } ).click();
 			await expect(
@@ -931,9 +1024,7 @@ test.describe( 'Collection view block', () => {
 				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
 				.toBe( String( fixture.entry.id ) );
 
-			await detail
-				.getByRole( 'button', { name: 'Hide fields' } )
-				.click();
+			await detail.getByRole( 'button', { name: 'Hide fields' } ).click();
 			const collapsedFieldsButton = detail.locator(
 				'.cortext-row-detail__fields-indicator'
 			);
@@ -944,14 +1035,31 @@ test.describe( 'Collection view block', () => {
 			await expect(
 				detail.locator( '.cortext-row-detail__content-editor' )
 			).toBeVisible();
-			await collapsedFieldsButton.click();
 			await expect(
-				detail.locator( '.cortext-row-detail__properties' )
+				detail.getByRole( 'button', { name: 'Show fields' } )
+			).toBeVisible();
+			await detail.getByRole( 'button', { name: 'Show fields' } ).click();
+			await expect(
+				detail.locator( '.cortext-row-detail__properties--rows' )
 			).toBeVisible();
 
-			await detail
-				.getByRole( 'textbox', { name: 'Title', exact: true } )
-				.fill( 'Changed row detail title' );
+			const titleProperty = detail.getByRole( 'textbox', {
+				name: 'Title',
+				exact: true,
+			} );
+			await titleProperty.click();
+			await expect( titleProperty ).toHaveCSS(
+				'border-top-width',
+				'0px'
+			);
+			await expect( titleProperty ).toHaveCSS( 'box-shadow', 'none' );
+			await expect( titleProperty ).toHaveCSS(
+				'background-color',
+				'rgba(0, 0, 0, 0)'
+			);
+			await page.keyboard.press( 'ControlOrMeta+A' );
+			await page.keyboard.press( 'Backspace' );
+			await page.keyboard.type( 'Changed row detail title' );
 			await expect( firstRow.locator( 'td' ).first() ).toContainText(
 				'Changed row detail title'
 			);
@@ -961,6 +1069,18 @@ test.describe( 'Collection view block', () => {
 			await expect( firstRow.locator( 'td' ).nth( 1 ) ).toContainText(
 				'Octavia Butler'
 			);
+			const yearProperty = detail.getByRole( 'textbox', {
+				name: 'Year',
+				exact: true,
+			} );
+			await yearProperty.click();
+			await page.keyboard.press( 'ControlOrMeta+A' );
+			await page.keyboard.press( 'Backspace' );
+			await page.keyboard.type( '20a6' );
+			await expect( yearProperty ).toHaveValue( '206' );
+			await page.keyboard.press( 'ControlOrMeta+A' );
+			await page.keyboard.press( 'Backspace' );
+			await page.keyboard.type( '2026' );
 
 			await expect(
 				detail.getByRole( 'button', { name: 'Center modal' } )
@@ -1018,11 +1138,13 @@ test.describe( 'Collection view block', () => {
 					return {
 						title: row.title.raw,
 						author: row.meta[ `field-${ fixture.field.id }` ],
+						year: row.meta[ `field-${ fixture.yearField.id }` ],
 					};
 				} )
 				.toEqual( {
 					title: 'Changed row detail title',
 					author: 'Octavia Butler',
+					year: 2026,
 				} );
 
 			await page.evaluate( async () => {
@@ -1057,6 +1179,16 @@ test.describe( 'Collection view block', () => {
 			await deleteIfCreated(
 				requestUtils,
 				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.tagsField &&
+					`/wp/v2/crtxt_fields/${ fixture.tagsField.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.yearField &&
+					`/wp/v2/crtxt_fields/${ fixture.yearField.id }`
 			);
 			await deleteIfCreated(
 				requestUtils,

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -926,6 +926,11 @@ test.describe( 'Collection view block', () => {
 			await firstRow.hover();
 			await expect( titleCellOpenButton ).toHaveCSS( 'opacity', '1' );
 			await expect( titleCellOpenButton ).toContainText( 'Open' );
+			await expect(
+				firstRow
+					.locator( '.cortext-editable-cell__display' )
+					.first()
+			).toHaveCSS( 'cursor', 'pointer' );
 			await titleCellOpenButton.click();
 			await expect
 				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
@@ -950,16 +955,19 @@ test.describe( 'Collection view block', () => {
 				'rgb(248, 248, 248)'
 			);
 			await expect( titleCellOpenButton ).toHaveCSS( 'opacity', '1' );
-			await expect(
-				detail.getByRole( 'heading', {
-					name: 'The Left Hand of Darkness',
-				} )
-			).toBeVisible();
+			const detailTitle = detail.getByRole( 'textbox', {
+				name: 'Title',
+				exact: true,
+			} );
+			await expect( detailTitle ).toHaveValue(
+				'The Left Hand of Darkness'
+			);
 			const tagsLabel = detail
 				.locator(
 					'.cortext-row-detail__properties--rows .cortext-row-detail__property-label'
 				)
 				.filter( { hasText: 'Tags' } );
+			await expect( tagsLabel ).toHaveCSS( 'cursor', 'default' );
 			await tagsLabel.evaluate( ( node ) =>
 				node.setAttribute( 'data-e2e-stable-label', 'tags' )
 			);
@@ -980,11 +988,7 @@ test.describe( 'Collection view block', () => {
 					hasText: 'Research',
 				} )
 			).toHaveCount( 2 );
-			await detail
-				.getByRole( 'heading', {
-					name: 'The Left Hand of Darkness',
-				} )
-				.click();
+			await detailTitle.click();
 			await expect( optionsPopover ).toBeHidden();
 
 			const delayedSecondRowPattern = new RegExp(
@@ -999,30 +1003,55 @@ test.describe( 'Collection view block', () => {
 			await expect( detail.locator( '.components-spinner' ) ).toHaveCount(
 				0
 			);
-			await expect(
-				detail.getByRole( 'heading', {
-					name: 'The Left Hand of Darkness',
-				} )
-			).toBeVisible();
+			await expect( detailTitle ).toHaveValue(
+				'The Left Hand of Darkness'
+			);
 			await expect
 				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
 				.toBe( String( fixture.secondEntry.id ) );
-			await expect(
-				detail.getByRole( 'heading', { name: 'Kindred' } )
-			).toBeVisible();
+			await expect( detailTitle ).toHaveValue( 'Kindred' );
 			await expect(
 				detail.locator( '[data-e2e-stable-label="tags"]' )
 			).toHaveText( 'Tags' );
 			await page.unroute( delayedSecondRowPattern, delaySecondRow );
 			await detail.getByRole( 'button', { name: 'Row above' } ).click();
-			await expect(
-				detail.getByRole( 'heading', {
-					name: 'The Left Hand of Darkness',
-				} )
-			).toBeVisible();
+			await expect( detailTitle ).toHaveValue(
+				'The Left Hand of Darkness'
+			);
 			await expect
 				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
 				.toBe( String( fixture.entry.id ) );
+
+			const goBack = page.getByRole( 'button', { name: 'Go back' } );
+			const goForward = page.getByRole( 'button', {
+				name: 'Go forward',
+			} );
+			await expect( goBack ).toBeEnabled();
+			await goBack.click();
+			await expect
+				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
+				.toBe( String( fixture.secondEntry.id ) );
+			await expect( detailTitle ).toHaveValue( 'Kindred' );
+			await goBack.click();
+			await expect
+				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
+				.toBe( String( fixture.entry.id ) );
+			await expect( detailTitle ).toHaveValue(
+				'The Left Hand of Darkness'
+			);
+			await expect( goForward ).toBeEnabled();
+			await goForward.click();
+			await expect
+				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
+				.toBe( String( fixture.secondEntry.id ) );
+			await expect( detailTitle ).toHaveValue( 'Kindred' );
+			await goForward.click();
+			await expect
+				.poll( () => new URL( page.url() ).searchParams.get( 'row' ) )
+				.toBe( String( fixture.entry.id ) );
+			await expect( detailTitle ).toHaveValue(
+				'The Left Hand of Darkness'
+			);
 
 			await detail.getByRole( 'button', { name: 'Hide fields' } ).click();
 			const collapsedFieldsButton = detail.locator(
@@ -1030,7 +1059,7 @@ test.describe( 'Collection view block', () => {
 			);
 			await expect(
 				detail.getByRole( 'textbox', { name: 'Title', exact: true } )
-			).toBeHidden();
+			).toBeVisible();
 			await expect( collapsedFieldsButton ).toBeVisible();
 			await expect(
 				detail.locator( '.cortext-row-detail__content-editor' )
@@ -1043,17 +1072,9 @@ test.describe( 'Collection view block', () => {
 				detail.locator( '.cortext-row-detail__properties--rows' )
 			).toBeVisible();
 
-			const titleProperty = detail.getByRole( 'textbox', {
-				name: 'Title',
-				exact: true,
-			} );
-			await titleProperty.click();
-			await expect( titleProperty ).toHaveCSS(
-				'border-top-width',
-				'0px'
-			);
-			await expect( titleProperty ).toHaveCSS( 'box-shadow', 'none' );
-			await expect( titleProperty ).toHaveCSS(
+			await detailTitle.click();
+			await expect( detailTitle ).toHaveCSS( 'border-top-width', '0px' );
+			await expect( detailTitle ).toHaveCSS(
 				'background-color',
 				'rgba(0, 0, 0, 0)'
 			);
@@ -1112,7 +1133,9 @@ test.describe( 'Collection view block', () => {
 				.click();
 			await expect( detail ).toBeHidden();
 			await expect(
-				canvas.getByText( 'Changed row detail title' )
+				page
+					.getByRole( 'navigation', { name: 'Breadcrumb' } )
+					.getByText( 'Changed row detail title' )
 			).toBeVisible();
 
 			await page
@@ -1327,9 +1350,16 @@ test.describe( 'Collection view block', () => {
 			// Number: decimal value renders intact.
 			await expect( canvas.getByText( '12.5' ) ).toBeVisible();
 
+			const table = canvas.locator( '.dataviews-view-table' );
+			const firstRow = table.locator( 'tbody > tr' ).first();
+
 			// Select: chip with the option's color (Notion shape parsed).
-			const statusChip = canvas.getByText( 'Open', { exact: true } );
+			const statusChip = firstRow
+				.locator( 'td' )
+				.nth( 4 )
+				.locator( '.cortext-chip', { hasText: 'Open' } );
 			await expect( statusChip ).toBeVisible();
+			await expect( statusChip ).toHaveCSS( 'cursor', 'pointer' );
 			await expect( statusChip ).toHaveClass( /cortext-chip/ );
 			await expect( statusChip ).not.toHaveClass(
 				/cortext-chip--neutral/

--- a/tests/js/components/rowDetailUtils.test.js
+++ b/tests/js/components/rowDetailUtils.test.js
@@ -1,7 +1,9 @@
 import {
 	adjacentRowId,
 	getRowDetailMode,
+	isValidNumberDraft,
 	normalizeRowDetailMode,
+	parseNumberPropertyValue,
 	splitPropertyPatch,
 	withRowDetailMode,
 } from '../../../src/components/rowDetailUtils';
@@ -83,5 +85,41 @@ describe( 'splitPropertyPatch', () => {
 			title: 'Only title',
 			meta: null,
 		} );
+	} );
+} );
+
+describe( 'number property helpers', () => {
+	it( 'allows numeric drafts a user can still finish typing', () => {
+		expect( isValidNumberDraft( '' ) ).toBe( true );
+		expect( isValidNumberDraft( '-' ) ).toBe( true );
+		expect( isValidNumberDraft( '12.' ) ).toBe( true );
+		expect( isValidNumberDraft( '.5' ) ).toBe( true );
+		expect( isValidNumberDraft( '20a6' ) ).toBe( false );
+		expect( isValidNumberDraft( '1.2.3' ) ).toBe( false );
+	} );
+
+	it( 'parses only empty or complete finite numbers for row meta', () => {
+		expect( parseNumberPropertyValue( '' ) ).toEqual( {
+			valid: true,
+			complete: true,
+			value: null,
+		} );
+		expect( parseNumberPropertyValue( '2026' ) ).toEqual( {
+			valid: true,
+			complete: true,
+			value: 2026,
+		} );
+		expect( parseNumberPropertyValue( '12.' ) ).toEqual( {
+			valid: true,
+			complete: true,
+			value: 12,
+		} );
+		expect( parseNumberPropertyValue( '-' ) ).toEqual( {
+			valid: true,
+			complete: false,
+			value: null,
+		} );
+		expect( parseNumberPropertyValue( 'Infinity' ).valid ).toBe( false );
+		expect( parseNumberPropertyValue( '20a6' ).valid ).toBe( false );
 	} );
 } );

--- a/tests/js/components/rowDetailUtils.test.js
+++ b/tests/js/components/rowDetailUtils.test.js
@@ -1,0 +1,87 @@
+import {
+	adjacentRowId,
+	getRowDetailMode,
+	normalizeRowDetailMode,
+	splitPropertyPatch,
+	withRowDetailMode,
+} from '../../../src/components/rowDetailUtils';
+
+describe( 'row detail mode helpers', () => {
+	it( 'defaults missing or invalid modes to side', () => {
+		expect( normalizeRowDetailMode() ).toBe( 'side' );
+		expect( normalizeRowDetailMode( 'drawer' ) ).toBe( 'side' );
+		expect( getRowDetailMode( {} ) ).toBe( 'side' );
+	} );
+
+	it( 'accepts the supported modes', () => {
+		expect( normalizeRowDetailMode( 'side' ) ).toBe( 'side' );
+		expect( normalizeRowDetailMode( 'modal' ) ).toBe( 'modal' );
+		expect( normalizeRowDetailMode( 'full' ) ).toBe( 'full' );
+	} );
+
+	it( 'writes the normalized mode onto the view', () => {
+		const view = { type: 'table', rowDetailMode: 'side' };
+		expect( withRowDetailMode( view, 'side' ) ).toBe( view );
+		expect( withRowDetailMode( view, 'full' ) ).toEqual( {
+			type: 'table',
+			rowDetailMode: 'full',
+		} );
+		expect( withRowDetailMode( view, 'unknown' ) ).toEqual( view );
+	} );
+} );
+
+describe( 'adjacentRowId', () => {
+	const rows = [ { id: 10 }, { id: 20 }, { id: 30 } ];
+
+	it( 'steps through the active row order', () => {
+		expect( adjacentRowId( rows, 20, -1 ) ).toBe( 10 );
+		expect( adjacentRowId( rows, 20, 1 ) ).toBe( 30 );
+	} );
+
+	it( 'returns null at boundaries or for missing rows', () => {
+		expect( adjacentRowId( rows, 10, -1 ) ).toBeNull();
+		expect( adjacentRowId( rows, 30, 1 ) ).toBeNull();
+		expect( adjacentRowId( rows, 99, 1 ) ).toBeNull();
+		expect( adjacentRowId( [], 10, 1 ) ).toBeNull();
+	} );
+
+	it( 'matches row ids by string value', () => {
+		expect( adjacentRowId( rows, '20', 1 ) ).toBe( 30 );
+	} );
+} );
+
+describe( 'splitPropertyPatch', () => {
+	it( 'separates title edits from meta edits', () => {
+		expect(
+			splitPropertyPatch(
+				{
+					title: 'Next title',
+					'field-1': 'Author',
+					'field-2': true,
+				},
+				{ 'field-1': 'Previous', 'field-3': 'Kept' }
+			)
+		).toEqual( {
+			title: 'Next title',
+			meta: {
+				'field-1': 'Author',
+				'field-2': true,
+				'field-3': 'Kept',
+			},
+		} );
+	} );
+
+	it( 'normalizes empty title values to an empty string', () => {
+		expect( splitPropertyPatch( { title: null } ) ).toEqual( {
+			title: '',
+			meta: null,
+		} );
+	} );
+
+	it( 'leaves meta null when only title changes', () => {
+		expect( splitPropertyPatch( { title: 'Only title' } ) ).toEqual( {
+			title: 'Only title',
+			meta: null,
+		} );
+	} );
+} );

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -294,6 +294,105 @@ describe( 'useAutosave: flush triggers', () => {
 		} );
 		expect( savePost ).not.toHaveBeenCalled();
 	} );
+
+	it( 'waits for an in-flight autosave instead of reporting failure', async () => {
+		let resolveSave;
+		const savePost = jest.fn(
+			() =>
+				new Promise( ( resolve ) => {
+					resolveSave = resolve;
+				} )
+		);
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		const { result, rerender } = renderHook( () =>
+			useAutosave( { debounceMs: 0, minSaveIntervalMs: 0 } )
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 0 );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+
+		const flushPromise = result.current.flushNow();
+		act( () => {
+			setStoreState( { isDirty: false } );
+			rerender();
+		} );
+
+		await act( async () => {
+			resolveSave();
+			await expect( flushPromise ).resolves.toBe( true );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'flushes edits made while an autosave is in flight', async () => {
+		let resolveFirstSave;
+		const savePost = jest
+			.fn()
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveFirstSave = resolve;
+					} )
+			)
+			.mockResolvedValueOnce();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true } );
+
+		const { result, rerender } = renderHook( () =>
+			useAutosave( { debounceMs: 0, minSaveIntervalMs: 0 } )
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 0 );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+
+		const flushPromise = result.current.flushNow();
+		act( () => {
+			setStoreState( { isDirty: true, isSaving: false } );
+			rerender();
+		} );
+
+		await act( async () => {
+			resolveFirstSave();
+			await expect( flushPromise ).resolves.toBe( true );
+		} );
+		expect( savePost ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'waits for a store-reported save before flushing remaining edits', async () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true, isSaving: true } );
+
+		const { result, rerender } = renderHook( () =>
+			useAutosave( { debounceMs: 0, minSaveIntervalMs: 0 } )
+		);
+
+		let didResolve = false;
+		const flushPromise = result.current.flushNow().then( ( value ) => {
+			didResolve = true;
+			return value;
+		} );
+
+		await act( async () => {
+			await Promise.resolve();
+		} );
+		expect( didResolve ).toBe( false );
+		expect( savePost ).not.toHaveBeenCalled();
+
+		act( () => {
+			setStoreState( { isDirty: true, isSaving: false } );
+			rerender();
+		} );
+
+		await expect( flushPromise ).resolves.toBe( true );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
+	} );
 } );
 
 describe( 'useAutosave: status', () => {


### PR DESCRIPTION
## What

Closes #106

Adds a real detail view for collection rows. A row can open in a side panel, modal, or full-page editor, with editable row properties at the top and row content below.

The detail view now behaves more like opening a page: row changes save as you edit, the DataView updates immediately, the URL and breadcrumbs follow the open row, and Back/Forward can step through row navigation.

## Why

Rows need more room than inline table editing can provide, especially once they have rich content. This keeps quick table edits intact while giving each row a page-like editing surface when users need it.

## How

- Adds row detail state to collection DataViews.
- Uses an isolated editor instance for row content so row edits do not interfere with the surrounding page editor.
- Saves row fields to row data and block content to the row content.
- Waits for running saves before closing, switching rows, or changing views.
- Keeps relation fields read-only in row detail until they can save through the relation-aware row field endpoint.

## Testing Instructions

1. Open a collection DataView and hover over a row title.
2. Click Open and confirm the row opens in the side panel.
3. Edit the row title and a few fields, then confirm the table updates immediately.
4. Add or edit content in the row editor, close the row, reopen it, and confirm the content is still there.
5. Use Row below and Row above in the side panel or modal, then use the workspace Back and Forward buttons to move through the same rows.
6. Hide and show the fixed fields, and confirm the title and content editor still feel usable.
7. Switch from side panel to modal, then to full page, and confirm the URL and breadcrumbs update for the open row.
8. Return to the collection from the breadcrumb and confirm the row detail view closes cleanly.

## Screen recording

https://github.com/user-attachments/assets/65efe86b-596a-4c74-9b2c-c798e8d6a382