### PR TITLE
Add workspace recents to the sidebar and palette

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -337,13 +337,15 @@ The state is ours too. `view.calculations` lives on the DataViews view object be
 
 ## 38. Command palette embedding needs host glue `[upstream, soft]`
 
-**What.** Cortext uses `@wordpress/commands` for the palette UI; we are not forking it. The rough part is that the package is built for the shared wp-admin command context. On the Cortext screen we need an app palette instead: no global wp-admin commands, no second Core palette competing for cmd+K, and focus returning to the workspace after a command runs. That leaves a few small bits of shell glue in Cortext: a local data registry, a `wp-core-commands` dequeue, a bundled stylesheet import, and a canvas ref for focus return.
+**What.** Cortext uses `@wordpress/commands` for command registration and palette state, but the stock menu is built for wp-admin. On the Cortext screen we need a scoped app palette: keep Core's commands out, avoid a second cmd+K menu, return focus to the workspace after a command runs, and put workspace recents in their own section instead of mixing them into suggestions. That leaves some glue in Cortext: a local data registry, a `wp-core-commands` dequeue, a bundled stylesheet import, a canvas ref for focus return, and a local command-menu renderer.
+
+The awkward bit is `CortextCommandMenu`. `@wordpress/commands` has a built-in "Recent" group, but that means recently used commands, not Cortext workspace history, and there is no public way to add a custom group. So Cortext renders the menu itself while still reading from the upstream command store. That is better than patching `node_modules` or poking the DOM after render, but upgrades need a close look at the upstream menu markup, CSS classes, keyboard behavior, and `cmdk` wiring.
 
 The user-facing placeholder is still Core's generic "Search commands and settings" string too. Fine for this slice, but it will feel off once the palette grows into actual Cortext search.
 
-**Where.** `src/components/CommandPalette.js`, the `canvasRef` passed from `src/router.js`, `dequeue_core_command_palette` in `includes/Admin/Screen.php`, and the `@wordpress/commands` stylesheet import in `src/index.scss`.
+**Where.** `src/components/CommandPalette.js`, `src/components/CortextCommandMenu.js`, the `canvasRef` passed from `src/router.js`, `dequeue_core_command_palette` in `includes/Admin/Screen.php`, and the `@wordpress/commands` stylesheet import and Cortext command-menu overrides in `src/index.scss`.
 
-**Solution.** Upstream could make app-owned palettes less ad hoc: a scoped command registry or namespace API, a supported way for full-screen admin apps to opt out of Core's admin palette, a custom input label, and an explicit focus-return target or after-close callback. With those, Cortext could keep registering commands through `@wordpress/commands` and drop most of the shell-specific wiring.
+**Solution.** Upstream could make app-owned palettes less ad hoc: a scoped command registry or namespace API, a supported way for full-screen admin apps to opt out of Core's admin palette, a custom input label, an explicit focus-return target or after-close callback, and a group/section API for registered commands or command loaders. With those, Cortext could keep registering commands through `@wordpress/commands`, render workspace recents through an upstream extension point, and drop the local menu renderer plus most of this shell-specific wiring.
 
 ## 39. Row detail relation editing is deferred `[internal]`
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -378,3 +378,19 @@ The user-facing placeholder is still Core's generic "Search commands and setting
 **Where.** `RowProperties` in `src/components/RowProperties.js`, mounted from `src/components/Canvas.js` for full-page row documents and `src/components/RowDetailView.js` for side/modal row detail. There is still no `cortext/document-properties` block or PHP render callback.
 
 **Solution.** Build `cortext/document-properties` as a locked dynamic block, in the same family as `cortext/document-cover` and `cortext/document-icon`. Its `edit()` should reuse the row-property form inside the editor iframe. Its `render_callback` should read the row's collection schema and meta, then emit frontend HTML for public themes. The header-block insertion path should place it after cover/icon/title on row documents. The full-page hide/show control then becomes an editor visibility preference, not the source of truth for whether properties exist in the document.
+
+## 43. Row recents still target the parent collection `[internal]`
+
+**What.** Recents stores row identity (`kind: row`, row id, and parent collection id), but the response still sends the parent collection as the clickable path. Row documents now have their own document URLs, so this is only a first-pass fallback: it gets the user back to the right table, but not directly into the row document they touched. The stored identity is enough to improve the target without changing the saved meta shape.
+
+**Where.** Row handling in `includes/Rest/RecentsController.php`, row clicks in `src/components/SidebarRecents.js`, recent row commands in `src/components/CommandPalette.js`, and the row-recents e2e coverage in `tests/e2e/specs/recents.spec.js`.
+
+**Solution.** Have row recents return the row document path, or give recents a route target shape instead of a single path string. That target should use the same document URL helper as row detail and relations, so sidebar recents and palette recents open the row directly instead of stopping at the parent collection.
+
+## 44. Recents tracking is wired at each call site `[internal]`
+
+**What.** There is no workspace activity layer. Each surface that counts as a visit or edit calls `touchRecent` itself: route resolution, page autosave, sidebar rename, row field save, row creation, and relation-created rows. That makes the behavior easy to understand right now, but future write paths can forget to update recents unless the reviewer knows to look for it.
+
+**Where.** `src/router/EntityRoute.js`, `src/hooks/useAutosave.js`, `src/components/Sidebar.js`, `src/components/CollectionDataViews.js`, and `src/components/relations/RelationEditor.js`.
+
+**Solution.** If more activity surfaces appear, move this behind a small workspace activity helper or event. Route visits can stay in the router, but writes should eventually report through the same mutation path instead of each component remembering to call `touchRecent`. If rows move into `core-data` (#2), that would be a natural time to centralize row touches too.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -27,6 +27,7 @@ use Cortext\Rest\DocumentLocatorController;
 use Cortext\Rest\DocumentTrashController;
 use Cortext\Rest\FavoritesController;
 use Cortext\Rest\FieldsController;
+use Cortext\Rest\RecentsController;
 use Cortext\Rest\RowsController;
 use Cortext\Rest\WorkspaceHomeController;
 use Cortext\Theming\Preferences;
@@ -59,6 +60,7 @@ final class Plugin {
 		( new FieldsController() )->register();
 		( new DocumentLocatorController() )->register();
 		( new DocumentTrashController() )->register();
+		( new RecentsController() )->register();
 		( new RowsController() )->register();
 		( new WorkspaceHomeController() )->register();
 		( new Template() )->register();

--- a/includes/Rest/RecentsController.php
+++ b/includes/Rest/RecentsController.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * REST endpoint for the current user's recent Cortext activity.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Page;
+use Cortext\PostType\PageIdentity;
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class RecentsController {
+
+	private const NAMESPACE = 'cortext/v1';
+	private const META_KEY  = 'cortext_recents';
+	private const MAX_ITEMS = 5;
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/recents',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_recents' ),
+					'permission_callback' => array( $this, 'can_read' ),
+				),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'touch_recent' ),
+					'permission_callback' => array( $this, 'can_read' ),
+					'args'                => array(
+						'kind'         => array(
+							'type'     => 'string',
+							'required' => true,
+							'enum'     => array( 'page', 'collection', 'row' ),
+						),
+						'id'           => array(
+							'type'     => 'integer',
+							'required' => true,
+							'minimum'  => 1,
+						),
+						'collectionId' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function can_read(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	public function get_recents(): WP_REST_Response {
+		return new WP_REST_Response(
+			array(
+				'recents' => $this->resolve_stored_recents( get_current_user_id() ),
+			),
+			200
+		);
+	}
+
+	public function touch_recent( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$kind          = (string) $request->get_param( 'kind' );
+		$id            = (int) $request->get_param( 'id' );
+		$collection_id = (int) $request->get_param( 'collectionId' );
+
+		$target = $this->format_target( $kind, $id, $collection_id );
+		if ( is_wp_error( $target ) ) {
+			return $target;
+		}
+
+		$item = array(
+			'kind'      => $kind,
+			'id'        => $id,
+			'updatedAt' => gmdate( DATE_RFC3339 ),
+		);
+		if ( 'row' === $kind ) {
+			$item['collectionId'] = $collection_id;
+		}
+
+		$items = array( $item );
+		$key   = $this->recent_key( $item );
+		foreach ( $this->read_stored_items( get_current_user_id() ) as $stored_item ) {
+			if ( $this->recent_key( $stored_item ) === $key ) {
+				continue;
+			}
+			$items[] = $stored_item;
+			if ( count( $items ) >= self::MAX_ITEMS ) {
+				break;
+			}
+		}
+
+		update_user_meta( get_current_user_id(), self::META_KEY, $items );
+
+		return new WP_REST_Response(
+			array(
+				'recents' => $this->resolve_stored_recents( get_current_user_id() ),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Resolves stored recents and prunes stale entries.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function resolve_stored_recents( int $user_id ): array {
+		$items    = $this->read_stored_items( $user_id );
+		$resolved = array();
+		$valid    = array();
+
+		foreach ( $items as $item ) {
+			$target = $this->format_target(
+				$item['kind'],
+				$item['id'],
+				$item['collectionId'] ?? 0
+			);
+			if ( is_wp_error( $target ) ) {
+				continue;
+			}
+
+			$target['updatedAt'] = $item['updatedAt'];
+			$resolved[]          = $target;
+			$valid[]             = $item;
+		}
+
+		if ( count( $valid ) !== count( $items ) ) {
+			update_user_meta( $user_id, self::META_KEY, $valid );
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * Reads normalized stored recent items.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array<int,array{kind:string,id:int,updatedAt:string,collectionId?:int}>
+	 */
+	private function read_stored_items( int $user_id ): array {
+		$raw = get_user_meta( $user_id, self::META_KEY, true );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $raw as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			$kind = isset( $item['kind'] ) ? (string) $item['kind'] : '';
+			$id   = isset( $item['id'] ) ? (int) $item['id'] : 0;
+			if ( ! in_array( $kind, array( 'page', 'collection', 'row' ), true ) || $id < 1 ) {
+				continue;
+			}
+
+			$stored = array(
+				'kind'      => $kind,
+				'id'        => $id,
+				'updatedAt' => isset( $item['updatedAt'] ) && is_string( $item['updatedAt'] )
+					? $item['updatedAt']
+					: gmdate( DATE_RFC3339 ),
+			);
+			if ( 'row' === $kind ) {
+				$collection_id = isset( $item['collectionId'] ) ? (int) $item['collectionId'] : 0;
+				if ( $collection_id < 1 ) {
+					continue;
+				}
+				$stored['collectionId'] = $collection_id;
+			}
+			$items[] = $stored;
+		}
+
+		return array_slice( $items, 0, self::MAX_ITEMS );
+	}
+
+	/**
+	 * Formats a supported Cortext target into the recents response contract.
+	 *
+	 * @param string $kind Target kind.
+	 * @param int    $id Target post ID.
+	 * @param int    $collection_id Parent collection ID for row targets.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private function format_target( string $kind, int $id, int $collection_id = 0 ) {
+		if ( ! in_array( $kind, array( 'page', 'collection', 'row' ), true ) || $id < 1 ) {
+			return new WP_Error(
+				'cortext_recents_invalid_target',
+				__( 'Recent target is invalid.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( 'row' === $kind ) {
+			return $this->format_row_target( $id, $collection_id );
+		}
+
+		$post = get_post( $id );
+		$type = 'page' === $kind ? Page::POST_TYPE : Collection::POST_TYPE;
+		if ( ! $post instanceof WP_Post || $type !== $post->post_type || 'trash' === $post->post_status ) {
+			return new WP_Error(
+				'cortext_recents_not_found',
+				__( 'Recent target was not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_post', $id ) ) {
+			return new WP_Error(
+				'cortext_recents_forbidden',
+				__( 'You are not allowed to use this target as a recent item.', 'cortext' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$target = array(
+			'kind'  => $kind,
+			'id'    => $id,
+			'title' => $this->post_title( $post ),
+			'path'  => $this->target_path( $post, $kind ),
+		);
+		if ( 'page' === $kind ) {
+			$icon = get_post_meta( $id, PageIdentity::META_KEY, true );
+			if ( is_string( $icon ) && '' !== $icon ) {
+				$target['icon'] = $icon;
+			}
+		}
+
+		return $target;
+	}
+
+	/**
+	 * Formats a collection row target.
+	 *
+	 * @param int $row_id Row post ID.
+	 * @param int $collection_id Parent collection post ID.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private function format_row_target( int $row_id, int $collection_id ) {
+		if ( $collection_id < 1 ) {
+			return new WP_Error(
+				'cortext_recents_row_collection_required',
+				__( 'Recent row target requires a collection.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$collection = get_post( $collection_id );
+		if (
+			! $collection instanceof WP_Post ||
+			Collection::POST_TYPE !== $collection->post_type ||
+			'trash' === $collection->post_status
+		) {
+			return new WP_Error(
+				'cortext_recents_collection_not_found',
+				__( 'Recent row collection was not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$slug = get_post_meta( $collection_id, 'slug', true );
+		$slug = is_string( $slug ) ? trim( $slug ) : '';
+		$row  = get_post( $row_id );
+		if (
+			'' === $slug ||
+			! $row instanceof WP_Post ||
+			CollectionEntries::CPT_PREFIX . $slug !== $row->post_type ||
+			'trash' === $row->post_status
+		) {
+			return new WP_Error(
+				'cortext_recents_not_found',
+				__( 'Recent target was not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_post', $collection_id ) || ! current_user_can( 'edit_post', $row_id ) ) {
+			return new WP_Error(
+				'cortext_recents_forbidden',
+				__( 'You are not allowed to use this target as a recent item.', 'cortext' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$collection_path = $this->target_path( $collection, 'collection' );
+
+		return array(
+			'kind'       => 'row',
+			'id'         => $row_id,
+			'title'      => $this->post_title( $row ),
+			'path'       => $collection_path,
+			'collection' => array(
+				'id'    => $collection_id,
+				'title' => $this->post_title( $collection ),
+				'path'  => $collection_path,
+			),
+		);
+	}
+
+	private function post_title( WP_Post $post ): string {
+		$title = trim( $post->post_title );
+		return '' === $title ? __( '(untitled)', 'cortext' ) : $title;
+	}
+
+	private function target_path( WP_Post $post, string $kind ): string {
+		if ( 'collection' === $kind ) {
+			$slug = get_post_meta( (int) $post->ID, 'slug', true );
+			$slug = is_string( $slug ) ? trim( $slug ) : '';
+		} else {
+			$slug = trim( $post->post_name );
+		}
+
+		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
+		return "{$kind}/{$tail}";
+	}
+
+	/**
+	 * Builds the stable dedupe key for a stored recent item.
+	 *
+	 * @param array{kind:string,id:int} $item Recent item.
+	 */
+	private function recent_key( array $item ): string {
+		return "{$item['kind']}:{$item['id']}";
+	}
+}

--- a/includes/Rest/RecentsController.php
+++ b/includes/Rest/RecentsController.php
@@ -11,8 +11,8 @@ namespace Cortext\Rest;
 
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Page;
-use Cortext\PostType\PageIdentity;
 use WP_Error;
 use WP_Post;
 use WP_REST_Request;
@@ -239,7 +239,7 @@ final class RecentsController {
 			'path'  => $this->target_path( $post, $kind ),
 		);
 		if ( 'page' === $kind ) {
-			$icon = get_post_meta( $id, PageIdentity::META_KEY, true );
+			$icon = get_post_meta( $id, DocumentIdentity::META_KEY, true );
 			if ( is_string( $icon ) && '' !== $icon ) {
 				$target['icon'] = $icon;
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
 				"@wordpress/private-apis": "^1.44.0",
 				"@wordpress/route": "^0.10.0",
 				"@wordpress/url": "^4.44.0",
+				"cmdk": "^1.1.1",
 				"emoji-mart": "^5.6.0"
 			},
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"@wordpress/private-apis": "^1.44.0",
 		"@wordpress/route": "^0.10.0",
 		"@wordpress/url": "^4.44.0",
+		"cmdk": "^1.1.1",
 		"emoji-mart": "^5.6.0"
 	}
 }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -176,8 +176,16 @@ function CanvasEditor( {
 	onApi,
 	onSaved,
 	onRestored,
+	recentTarget,
 } ) {
-	const { status, flushNow, isDirty, isSaving } = useAutosave();
+	const autosaveRecentTarget =
+		recentTarget ??
+		( postType === POST_TYPE && post?.id
+			? { kind: 'page', id: post.id }
+			: null );
+	const { status, flushNow, isDirty, isSaving } = useAutosave( {
+		recentTarget: autosaveRecentTarget,
+	} );
 	const { resetPost } = useDispatch( editorStore );
 	const discard = useCallback( () => resetPost(), [ resetPost ] );
 	const isInspectorOpen = useSelect(
@@ -330,6 +338,7 @@ export default function Canvas( {
 	onApi,
 	onSaved,
 	onRestored,
+	recentTarget,
 	useSubRegistry = false,
 } ) {
 	const { record: requestedPost } = useEntityRecord(
@@ -401,6 +410,7 @@ export default function Canvas( {
 				onApi={ onApi }
 				onSaved={ onSaved }
 				onRestored={ onRestored }
+				recentTarget={ recentTarget }
 			/>
 		</EditorProvider>
 	);

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -34,6 +34,7 @@ import {
 } from './rowDetailUtils';
 import { useCollectionFieldsContext } from './CollectionFieldsContext';
 import useCollectionRows from '../hooks/useCollectionRows';
+import { useRecents } from '../hooks/useRecents';
 import { elementsFromOptions } from '../hooks/optionElements';
 import { computeDocumentUri } from '../router/useResolveEntity';
 
@@ -282,6 +283,7 @@ export default function CollectionDataViews( {
 	const navigate = useNavigate();
 	const { fields, collection, slug, isResolving, fieldsResolved } =
 		useCollectionFieldsContext();
+	const { touchRecent } = useRecents();
 
 	const availableFields = useMemo(
 		() => [ TITLE_FIELD, ...fields ],
@@ -440,10 +442,15 @@ export default function CollectionDataViews( {
 					value,
 				},
 			} );
+			touchRecent( {
+				kind: 'row',
+				id: updated?.id ?? rowId,
+				collectionId,
+			} );
 			refresh();
 			return updated;
 		},
-		[ collectionId, refresh ]
+		[ collectionId, refresh, touchRecent ]
 	);
 
 	const mutationContext = useMemo(
@@ -496,10 +503,22 @@ export default function CollectionDataViews( {
 				refresh();
 			}
 			if ( created?.id ) {
+				touchRecent( {
+					kind: 'row',
+					id: created.id,
+					collectionId,
+				} );
 				setEditRequest( { rowId: created.id, fieldId: 'title' } );
 			}
 		},
-		[ refresh, view, activePaginationInfo, onChangeView ]
+		[
+			refresh,
+			view,
+			activePaginationInfo,
+			onChangeView,
+			touchRecent,
+			collectionId,
+		]
 	);
 
 	const viewRef = useRef( view );

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1019,6 +1019,7 @@ export default function CollectionDataViews( {
 			<RowDetailView
 				canGoNext={ Boolean( nextRowId ) }
 				canGoPrevious={ Boolean( previousRowId ) }
+				collectionId={ collectionId }
 				fields={ availableFields }
 				mode={ renderedRowDetailMode }
 				onApi={ setDetailApi }

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -1,19 +1,18 @@
 // tech-debt.md#38: use WordPress' palette UI, but keep it on a local
 // registry so core/wp-admin commands do not show up in Cortext.
 
-import {
-	CommandMenu,
-	store as commandsStore,
-	useCommand,
-} from '@wordpress/commands';
+import { store as commandsStore, useCommand } from '@wordpress/commands';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { createRegistry, RegistryProvider, useDispatch } from '@wordpress/data';
 import { useNavigate } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
-import { home as homeIcon } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { home as homeIcon, listItem, table } from '@wordpress/icons';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
 
+import CortextCommandMenu from './CortextCommandMenu';
+import PageIcon from './PageIcon';
+import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHomePath } from '../hooks/useWorkspaceHomePath';
 
 const OPEN_COMMAND_PALETTE_EVENT = 'cortext:open-command-palette';
@@ -47,6 +46,29 @@ function focusCanvasAfterPaletteCloses( canvasRef ) {
 	window.setTimeout( () => {
 		canvasRef?.current?.focus( { preventScroll: true } );
 	}, 0 );
+}
+
+function recentCommandIcon( recent ) {
+	if ( recent?.kind === 'collection' ) {
+		return table;
+	}
+	if ( recent?.kind === 'row' ) {
+		return listItem;
+	}
+	return <PageIcon icon={ recent?.icon ?? '' } size={ 16 } />;
+}
+
+function recentTitle( recent ) {
+	const title = recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
+	if ( recent?.kind === 'row' && recent?.collection?.title ) {
+		return sprintf(
+			/* translators: 1: row title, 2: collection title */
+			__( '%1$s in %2$s', 'cortext' ),
+			title,
+			recent.collection.title
+		);
+	}
+	return title;
 }
 
 function HomeCommandRegistration( {
@@ -83,11 +105,46 @@ function HomeCommandRegistration( {
 	return null;
 }
 
+function RecentCommandRegistration( { canvasRef, recent } ) {
+	const navigate = useNavigate();
+	const goToRecent = useCallback(
+		( { close } ) => {
+			if ( recent?.path ) {
+				navigate( {
+					to: '/$',
+					params: { _splat: recent.path },
+				} );
+			}
+			close();
+			focusCanvasAfterPaletteCloses( canvasRef );
+		},
+		[ canvasRef, navigate, recent?.path ]
+	);
+
+	useCommand( {
+		name: `cortext/recent/${ recent.kind }-${ recent.id }`,
+		label: recentTitle( recent ),
+		searchLabel: sprintf(
+			/* translators: %s: recent item title */
+			__( 'Open recent: %s', 'cortext' ),
+			recentTitle( recent )
+		),
+		context: DEFAULT_COMMAND_CONTEXT,
+		icon: recentCommandIcon( recent ),
+		keywords: [ __( 'recent', 'cortext' ), recent.kind ],
+		disabled: ! recent.path,
+		callback: goToRecent,
+	} );
+	return null;
+}
+
 function CommandPaletteContents( {
 	canvasRef,
 	homePath,
 	isResolvingHomePath,
 } ) {
+	const { recents } = useRecents();
+
 	return (
 		<>
 			<CommandPaletteOpenBridge />
@@ -96,7 +153,14 @@ function CommandPaletteContents( {
 				homePath={ homePath }
 				isResolvingHomePath={ isResolvingHomePath }
 			/>
-			<CommandMenu />
+			{ recents.map( ( recent ) => (
+				<RecentCommandRegistration
+					key={ `${ recent.kind }:${ recent.id }` }
+					canvasRef={ canvasRef }
+					recent={ recent }
+				/>
+			) ) }
+			<CortextCommandMenu />
 		</>
 	);
 }

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -4,7 +4,12 @@
 import { store as commandsStore, useCommand } from '@wordpress/commands';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { createRegistry, RegistryProvider, useDispatch } from '@wordpress/data';
+import {
+	createRegistry,
+	RegistryProvider,
+	useDispatch,
+	useRegistry,
+} from '@wordpress/data';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import { home as homeIcon, listItem, table } from '@wordpress/icons';
@@ -22,8 +27,8 @@ export function openCommandPalette() {
 	window.dispatchEvent( new Event( OPEN_COMMAND_PALETTE_EVENT ) );
 }
 
-function createCommandPaletteRegistry() {
-	const registry = createRegistry();
+function createCommandPaletteRegistry( parentRegistry ) {
+	const registry = createRegistry( {}, parentRegistry );
 	registry.register( commandsStore );
 	registry.register( keyboardShortcutsStore );
 	registry.register( preferencesStore );
@@ -167,7 +172,11 @@ function CommandPaletteContents( {
 
 export default function CommandPalette( { canvasRef } ) {
 	const { homePath, isResolvingHomePath } = useWorkspaceHomePath();
-	const registry = useMemo( createCommandPaletteRegistry, [] );
+	const parentRegistry = useRegistry();
+	const registry = useMemo(
+		() => createCommandPaletteRegistry( parentRegistry ),
+		[ parentRegistry ]
+	);
 
 	return (
 		<RegistryProvider value={ registry }>

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -1,0 +1,278 @@
+import { Command, useCommandState } from 'cmdk';
+
+import { Modal, TextHighlight } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import {
+	useEffect,
+	useRef,
+	useState,
+	isValidElement,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Icon, search as inputIcon } from '@wordpress/icons';
+import {
+	store as keyboardShortcutsStore,
+	useShortcut,
+} from '@wordpress/keyboard-shortcuts';
+import { store as commandsStore } from '@wordpress/commands';
+
+// tech-debt.md#38: @wordpress/commands has no custom group API. Keep the
+// upstream store/hooks, but render the menu locally so workspace recents
+// can live in their own section.
+const ITEM_ID_PREFIX = 'command-palette-item-';
+const RECENT_COMMAND_PREFIX = 'cortext/recent/';
+const inputLabel = __( 'Search commands and settings' );
+
+const CATEGORY_LABELS = {
+	command: __( 'Command' ),
+	view: __( 'View' ),
+	edit: __( 'Edit' ),
+	action: __( 'Action' ),
+	workflow: __( 'Workflow' ),
+};
+
+function isRecentCommand( command ) {
+	return command?.name?.startsWith( RECENT_COMMAND_PREFIX );
+}
+
+export function splitPaletteCommands( commands ) {
+	return commands.reduce(
+		( groups, command ) => {
+			if ( isRecentCommand( command ) ) {
+				groups.recentCommands.push( command );
+			} else {
+				groups.commands.push( command );
+			}
+			return groups;
+		},
+		{ recentCommands: [], commands: [] }
+	);
+}
+
+function isRawSvgIconElement( icon ) {
+	return (
+		isValidElement( icon ) &&
+		icon.props?.xmlns === 'http://www.w3.org/2000/svg' &&
+		!! icon.props?.viewBox
+	);
+}
+
+export function CommandIcon( { icon } ) {
+	if ( ! icon ) {
+		return null;
+	}
+	if ( isRawSvgIconElement( icon ) ) {
+		return <Icon icon={ icon } size={ 16 } />;
+	}
+	if ( isValidElement( icon ) ) {
+		return icon;
+	}
+	return <Icon icon={ icon } size={ 16 } />;
+}
+
+function CommandItem( {
+	command,
+	search,
+	showCategory = true,
+	valuePrefix = '',
+} ) {
+	const { close } = useDispatch( commandsStore );
+	const label = command.searchLabel ?? command.label;
+	const value = valuePrefix ? `${ valuePrefix }${ command.name }` : label;
+	const itemId = `${ ITEM_ID_PREFIX }${ value.toLowerCase() }`;
+
+	return (
+		<Command.Item
+			key={ command.name }
+			id={ itemId }
+			value={ value }
+			keywords={
+				valuePrefix
+					? [ ...( command.keywords ?? [] ), label ]
+					: command.keywords
+			}
+			onSelect={ () => command.callback( { close } ) }
+		>
+			<div
+				className={ [
+					'commands-command-menu__item',
+					command.icon ? 'has-icon' : null,
+				]
+					.filter( Boolean )
+					.join( ' ' ) }
+			>
+				<CommandIcon icon={ command.icon } />
+				<span className="commands-command-menu__item-label">
+					<TextHighlight
+						text={ command.label }
+						highlight={ search }
+					/>
+				</span>
+				{ showCategory && CATEGORY_LABELS[ command.category ] && (
+					<span className="commands-command-menu__item-category">
+						{ CATEGORY_LABELS[ command.category ] }
+					</span>
+				) }
+			</div>
+		</Command.Item>
+	);
+}
+
+function CommandList( { commands, search, showCategory, valuePrefix } ) {
+	return commands.map( ( command ) => (
+		<CommandItem
+			key={ command.name }
+			command={ command }
+			search={ search }
+			showCategory={ showCategory }
+			valuePrefix={ valuePrefix }
+		/>
+	) );
+}
+
+function CommandInput( { search, setSearch } ) {
+	const commandMenuInput = useRef();
+	const selectedValue = useCommandState( ( state ) => state.value );
+	const selectedItemId = selectedValue
+		? `${ ITEM_ID_PREFIX }${ selectedValue.toLowerCase() }`
+		: null;
+
+	useEffect( () => {
+		commandMenuInput.current?.focus();
+	}, [] );
+
+	return (
+		<Command.Input
+			ref={ commandMenuInput }
+			value={ search }
+			onValueChange={ setSearch }
+			placeholder={ inputLabel }
+			aria-activedescendant={ selectedItemId }
+		/>
+	);
+}
+
+function PaletteGroups( { search } ) {
+	const { contextualCommands, allCommands } = useSelect( ( select ) => {
+		const { getCommands } = select( commandsStore );
+		return {
+			contextualCommands: getCommands( true ),
+			allCommands: [ ...getCommands( false ), ...getCommands( true ) ],
+		};
+	}, [] );
+	const { recentCommands, commands } = splitPaletteCommands(
+		search ? allCommands : contextualCommands
+	);
+
+	return (
+		<>
+			{ recentCommands.length > 0 && (
+				<Command.Group
+					className="cortext-command-palette__group cortext-command-palette__group--recent"
+					heading={ __( 'Recent', 'cortext' ) }
+				>
+					<CommandList
+						commands={ recentCommands }
+						search={ search }
+						showCategory={ false }
+						valuePrefix="recent-"
+					/>
+				</Command.Group>
+			) }
+			{ commands.length > 0 && (
+				<Command.Group
+					className="cortext-command-palette__group"
+					heading={
+						search
+							? __( 'Results', 'cortext' )
+							: __( 'Suggestions', 'cortext' )
+					}
+				>
+					<CommandList commands={ commands } search={ search } />
+				</Command.Group>
+			) }
+		</>
+	);
+}
+
+export default function CortextCommandMenu() {
+	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
+	const { open, close } = useDispatch( commandsStore );
+	const [ search, setSearch ] = useState( '' );
+	const paletteIsOpen = useSelect(
+		( select ) => select( commandsStore ).isOpen(),
+		[]
+	);
+
+	useEffect( () => {
+		registerShortcut( {
+			name: 'core/commands',
+			category: 'global',
+			description: __( 'Open the command palette.' ),
+			keyCombination: {
+				modifier: 'primary',
+				character: 'k',
+			},
+		} );
+	}, [ registerShortcut ] );
+
+	useShortcut(
+		'core/commands',
+		( event ) => {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			event.preventDefault();
+			if ( paletteIsOpen ) {
+				close();
+			} else {
+				open();
+			}
+		},
+		{ bindGlobal: true }
+	);
+
+	const closeAndReset = () => {
+		setSearch( '' );
+		close();
+	};
+
+	if ( ! paletteIsOpen ) {
+		return false;
+	}
+
+	return (
+		<Modal
+			className="commands-command-menu"
+			overlayClassName="commands-command-menu__overlay"
+			onRequestClose={ closeAndReset }
+			__experimentalHideHeader
+			size="medium"
+			contentLabel={ __( 'Command palette' ) }
+		>
+			<div className="commands-command-menu__container">
+				<Command label={ inputLabel } loop>
+					<div className="commands-command-menu__header">
+						<Icon
+							className="commands-command-menu__header-search-icon"
+							icon={ inputIcon }
+						/>
+						<CommandInput
+							search={ search }
+							setSearch={ setSearch }
+						/>
+					</div>
+					<Command.List label={ __( 'Command suggestions' ) }>
+						{ search && (
+							<Command.Empty>
+								{ __( 'No results found.' ) }
+							</Command.Empty>
+						) }
+						<PaletteGroups search={ search } />
+					</Command.List>
+				</Command>
+			</div>
+		</Modal>
+	);
+}

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -4,6 +4,7 @@ import { Modal, TextHighlight } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 	isValidElement,
@@ -153,13 +154,17 @@ function CommandInput( { search, setSearch } ) {
 }
 
 function PaletteGroups( { search } ) {
-	const { contextualCommands, allCommands } = useSelect( ( select ) => {
+	const { contextualCommands, staticCommands } = useSelect( ( select ) => {
 		const { getCommands } = select( commandsStore );
 		return {
 			contextualCommands: getCommands( true ),
-			allCommands: [ ...getCommands( false ), ...getCommands( true ) ],
+			staticCommands: getCommands( false ),
 		};
 	}, [] );
+	const allCommands = useMemo(
+		() => [ ...staticCommands, ...contextualCommands ],
+		[ staticCommands, contextualCommands ]
+	);
 	const { recentCommands, commands } = splitPaletteCommands(
 		search ? allCommands : contextualCommands
 	);

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -146,10 +146,16 @@ function titleFromDetail( detail ) {
 	return titleFromRow( detail.record ) || titleFromRow( detail.row );
 }
 
-function RowAutosaveBridge( { isActive = true, onApi, onSaved } ) {
+function RowAutosaveBridge( {
+	isActive = true,
+	onApi,
+	onSaved,
+	recentTarget,
+} ) {
 	const { status, lastSavedAt, flushNow, isDirty, isSaving } = useAutosave( {
 		debounceMs: 0,
 		minSaveIntervalMs: 0,
+		recentTarget,
 	} );
 	const { resetPost } = useDispatch( editorStore );
 	const discard = useCallback( () => resetPost(), [ resetPost ] );
@@ -212,6 +218,7 @@ export function ModeControl( { mode, onChangeMode } ) {
 }
 
 function DetailPaneContent( {
+	collectionId,
 	fields,
 	isActive,
 	isHidden,
@@ -223,6 +230,7 @@ function DetailPaneContent( {
 	postType,
 	propertiesVisible,
 	row,
+	rowId,
 } ) {
 	const fallbackTitle = useMemo( () => titleFromRow( row ), [ row ] );
 	return (
@@ -231,6 +239,11 @@ function DetailPaneContent( {
 				isActive={ isActive }
 				onApi={ onApi }
 				onSaved={ onSaved }
+				recentTarget={
+					rowId && collectionId
+						? { kind: 'row', id: rowId, collectionId }
+						: null
+				}
 			/>
 			<RowTitleBridge
 				isActive={ isTitleActive }
@@ -391,6 +404,7 @@ function LoadingDetail( { onClose } ) {
 export default function RowDetailView( {
 	canGoNext,
 	canGoPrevious,
+	collectionId,
 	fields,
 	mode,
 	onApi,
@@ -680,7 +694,9 @@ export default function RowDetailView( {
 										propertiesVisible={
 											arePropertiesVisible
 										}
+										collectionId={ collectionId }
 										row={ paneRow }
+										rowId={ pane.detail.rowId }
 									/>
 								</EditorProvider>
 							</div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -63,6 +63,7 @@ import SidebarFavorites, {
 	filterFavoritesForTrashedPage,
 } from './SidebarFavorites';
 import SidebarResizeHandle from './SidebarResizeHandle';
+import SidebarRecents from './SidebarRecents';
 import SidebarTrash from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
 import {
@@ -688,6 +689,7 @@ const {
 						}
 						onReorder={ reorderFavorites }
 					/>
+					<SidebarRecents />
 
 					<div className="cortext-sidebar__section-header">
 						<h2 className="cortext-sidebar__section-title">

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -85,6 +85,7 @@ import {
 } from '../router/useResolveEntity';
 import { COLLECTION_QUERY } from '../collections';
 import { useFavorites } from '../hooks/useFavorites';
+import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHomePath } from '../hooks/useWorkspaceHomePath';
 
 const AUTO_EXPAND_DELAY = 700;
@@ -118,16 +119,17 @@ export default function Sidebar( {
 		homePath,
 		home,
 		setHome,
-		isResolvingHomePath,
-		isResolvingPages,
-		isUpdating: isHomeUpdating,
-	} = useWorkspaceHomePath();
-	const {
-		favorites,
-		setFavorites,
+	isResolvingHomePath,
+	isResolvingPages,
+	isUpdating: isHomeUpdating,
+} = useWorkspaceHomePath();
+const {
+	favorites,
+	setFavorites,
 		isResolving: isResolvingFavorites,
 		isUpdating: isUpdatingFavorites,
 	} = useFavorites();
+	const { touchRecent } = useRecents();
 	const { saveEntityRecord, invalidateResolution, receiveEntityRecords } =
 		useDispatch( 'core' );
 	const navigate = useNavigate();
@@ -429,8 +431,9 @@ export default function Sidebar( {
 				payload.status = 'private';
 			}
 			await saveEntityRecord( 'postType', POST_TYPE, payload );
+			await touchRecent( { kind: 'page', id } );
 		},
-		[ saveEntityRecord, getRecordById ]
+		[ saveEntityRecord, getRecordById, touchRecent ]
 	);
 
 	const duplicatePage = useCallback(

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -120,13 +120,13 @@ export default function Sidebar( {
 		homePath,
 		home,
 		setHome,
-	isResolvingHomePath,
-	isResolvingPages,
-	isUpdating: isHomeUpdating,
-} = useWorkspaceHomePath();
-const {
-	favorites,
-	setFavorites,
+		isResolvingHomePath,
+		isResolvingPages,
+		isUpdating: isHomeUpdating,
+	} = useWorkspaceHomePath();
+	const {
+		favorites,
+		setFavorites,
 		isResolving: isResolvingFavorites,
 		isUpdating: isUpdatingFavorites,
 	} = useFavorites();

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -1,0 +1,217 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Button, Icon, Spinner } from '@wordpress/components';
+import { useCallback, useLayoutEffect, useRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { listItem, table } from '@wordpress/icons';
+
+import PageIcon from './PageIcon';
+import { useRecents } from '../hooks/useRecents';
+
+const RECENT_REPOSITION_OPTIONS = {
+	duration: 180,
+	easing: 'cubic-bezier(0.2, 0, 0, 1)',
+};
+
+const RECENT_APPEARANCE_OPTIONS = {
+	duration: 140,
+	easing: 'ease-out',
+};
+
+function recentKey( recent ) {
+	return `${ recent.kind }:${ recent.id }`;
+}
+
+function shouldAnimateRecents() {
+	return (
+		typeof window !== 'undefined' &&
+		! window.matchMedia?.( '(prefers-reduced-motion: reduce)' )?.matches &&
+		typeof window.Element !== 'undefined' &&
+		typeof window.Element.prototype.animate === 'function'
+	);
+}
+
+function collectRects( nodesByKey ) {
+	const rects = new Map();
+	nodesByKey.forEach( ( node, key ) => {
+		rects.set( key, node.getBoundingClientRect() );
+	} );
+	return rects;
+}
+
+function runNodeAnimation( node, keyframes, options ) {
+	node.getAnimations?.().forEach( ( animation ) => animation.cancel() );
+	node.animate( keyframes, options );
+}
+
+function kindLabel( kind ) {
+	if ( kind === 'collection' ) {
+		return __( 'Collection', 'cortext' );
+	}
+	if ( kind === 'row' ) {
+		return __( 'Row', 'cortext' );
+	}
+	return __( 'Page', 'cortext' );
+}
+
+function recentTitle( recent ) {
+	const title = recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
+	if ( recent?.kind === 'row' && recent?.collection?.title ) {
+		return sprintf(
+			/* translators: 1: row title, 2: collection title */
+			__( '%1$s in %2$s', 'cortext' ),
+			title,
+			recent.collection.title
+		);
+	}
+	return title;
+}
+
+function recentAriaLabel( recent ) {
+	const title = recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
+	if ( recent?.kind === 'row' && recent?.collection?.title ) {
+		return sprintf(
+			/* translators: 1: row title, 2: collection title */
+			__( 'Recent row: %1$s in %2$s', 'cortext' ),
+			title,
+			recent.collection.title
+		);
+	}
+	return sprintf(
+		/* translators: 1: recent item type, 2: recent item title */
+		__( 'Recent %1$s: %2$s', 'cortext' ),
+		kindLabel( recent?.kind ).toLowerCase(),
+		title
+	);
+}
+
+function RecentIcon( { recent } ) {
+	if ( recent?.kind === 'page' ) {
+		return <PageIcon icon={ recent.icon ?? '' } size={ 16 } />;
+	}
+	const icon = recent?.kind === 'row' ? listItem : table;
+	return <Icon icon={ icon } size={ 16 } />;
+}
+
+export default function SidebarRecents() {
+	const navigate = useNavigate();
+	const { recents, isResolving } = useRecents();
+	const recentNodes = useRef( new Map() );
+	const previousRects = useRef( new Map() );
+	const hasCompletedInitialLoad = useRef( false );
+	const setRecentNodeRef = useCallback(
+		( key ) => ( node ) => {
+			if ( node ) {
+				recentNodes.current.set( key, node );
+			} else {
+				recentNodes.current.delete( key );
+			}
+		},
+		[]
+	);
+
+	useLayoutEffect( () => {
+		const nextRects = collectRects( recentNodes.current );
+
+		if ( hasCompletedInitialLoad.current && shouldAnimateRecents() ) {
+			nextRects.forEach( ( rect, key ) => {
+				const node = recentNodes.current.get( key );
+				if ( ! node ) {
+					return;
+				}
+
+				const previousRect = previousRects.current.get( key );
+				if ( previousRect ) {
+					const deltaY = previousRect.top - rect.top;
+					if ( Math.abs( deltaY ) > 0.5 ) {
+						runNodeAnimation(
+							node,
+							[
+								{ transform: `translateY(${ deltaY }px)` },
+								{ transform: 'translateY(0)' },
+							],
+							RECENT_REPOSITION_OPTIONS
+						);
+					}
+					return;
+				}
+
+				runNodeAnimation(
+					node,
+					[
+						{ opacity: 0, transform: 'translateY(-4px)' },
+						{ opacity: 1, transform: 'translateY(0)' },
+					],
+					RECENT_APPEARANCE_OPTIONS
+				);
+			} );
+		}
+
+		previousRects.current = nextRects;
+		if ( ! isResolving ) {
+			hasCompletedInitialLoad.current = true;
+		}
+	}, [ isResolving, recents ] );
+
+	return (
+		<>
+			<div className="cortext-sidebar__section-header cortext-sidebar__section-header--recents">
+				<h2 className="cortext-sidebar__section-title">
+					{ __( 'Recents', 'cortext' ) }
+				</h2>
+			</div>
+			{ isResolving && recents.length === 0 && (
+				<div className="cortext-sidebar__loading">
+					<Spinner />
+				</div>
+			) }
+			{ ! isResolving && recents.length === 0 && (
+				<p className="cortext-sidebar__empty">
+					{ __( 'No recent activity yet.', 'cortext' ) }
+				</p>
+			) }
+			{ recents.length > 0 && (
+				<ul className="cortext-sidebar__list cortext-sidebar__recents-list">
+					{ recents.map( ( recent ) => {
+						const key = recentKey( recent );
+						return (
+							<li
+								key={ key }
+								ref={ setRecentNodeRef( key ) }
+								className="cortext-sidebar__node cortext-sidebar__recent-node"
+							>
+								<div className="cortext-sidebar__row">
+									<span
+										className="cortext-sidebar__recent-icon"
+										aria-hidden="true"
+									>
+										<RecentIcon recent={ recent } />
+									</span>
+									<Button
+										className="cortext-sidebar__title cortext-sidebar__recent-title"
+										size="compact"
+										variant="tertiary"
+										onClick={ ( event ) => {
+											event.currentTarget.blur();
+											if ( ! recent.path ) {
+												return;
+											}
+											navigate( {
+												to: '/$',
+												params: {
+													_splat: recent.path,
+												},
+											} );
+										} }
+										aria-label={ recentAriaLabel( recent ) }
+									>
+										{ recentTitle( recent ) }
+									</Button>
+								</div>
+							</li>
+						);
+					} ) }
+				</ul>
+			) }
+		</>
+	);
+}

--- a/src/components/relations/RelationEditor.js
+++ b/src/components/relations/RelationEditor.js
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { Icon, closeSmall, plus } from '@wordpress/icons';
 
 import useCollectionRows from '../../hooks/useCollectionRows';
+import { useRecents } from '../../hooks/useRecents';
 import { relationIds, relationTitle } from './relationUtils';
 
 const RELATION_PICKER_VIEW = {
@@ -29,6 +30,7 @@ export default function RelationEditor( {
 	const [ isCreating, setIsCreating ] = useState( false );
 	const [ createError, setCreateError ] = useState( '' );
 	const searchRef = useRef( null );
+	const { touchRecent } = useRecents();
 	const selectedIds = useMemo( () => relationIds( value ), [ value ] );
 	const targetCollectionId = Number( relation?.targetCollectionId );
 	const isMultiple = relation?.multiple !== false;
@@ -121,6 +123,11 @@ export default function RelationEditor( {
 					__( 'Related row could not be created.', 'cortext' )
 				);
 			}
+			touchRecent( {
+				kind: 'row',
+				id: createdId,
+				collectionId: targetCollectionId,
+			} );
 			const nextIds = isMultiple
 				? [
 						...selectedIds.filter( ( id ) => id !== createdId ),

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -5,6 +5,8 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
 
+import { useRecents } from './useRecents';
+
 const DEBOUNCE_MS = 800;
 const MIN_SAVE_INTERVAL_MS = 2000;
 const AUTOSAVE_ERROR_NOTICE_ID = 'cortext-autosave-error';
@@ -14,6 +16,7 @@ export default function useAutosave( options = {} ) {
 	const minSaveIntervalMs = options.minSaveIntervalMs ?? MIN_SAVE_INTERVAL_MS;
 	const { savePost, editPost } = useDispatch( editorStore );
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
+	const { touchRecent } = useRecents();
 
 	const {
 		isDirty,
@@ -217,8 +220,19 @@ export default function useAutosave( options = {} ) {
 			setStatus( 'saved' );
 			setLastSavedAt( Date.now() );
 			removeNotice( AUTOSAVE_ERROR_NOTICE_ID );
+			if ( currentPostId ) {
+				touchRecent( { kind: 'page', id: currentPostId } );
+			}
 		}
-	}, [ isSaving, didSucceed, didFail, createErrorNotice, removeNotice ] );
+	}, [
+		isSaving,
+		didSucceed,
+		didFail,
+		currentPostId,
+		createErrorNotice,
+		removeNotice,
+		touchRecent,
+	] );
 
 	// CanvasEditor stays mounted across post switches so the iframe survives,
 	// which means our local status would otherwise carry a stale "Failed to

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -14,6 +14,9 @@ const AUTOSAVE_ERROR_NOTICE_ID = 'cortext-autosave-error';
 export default function useAutosave( options = {} ) {
 	const debounceMs = options.debounceMs ?? DEBOUNCE_MS;
 	const minSaveIntervalMs = options.minSaveIntervalMs ?? MIN_SAVE_INTERVAL_MS;
+	const recentKind = options.recentTarget?.kind ?? null;
+	const recentId = options.recentTarget?.id ?? null;
+	const recentCollectionId = options.recentTarget?.collectionId ?? null;
 	const { savePost, editPost } = useDispatch( editorStore );
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
 	const { touchRecent } = useRecents();
@@ -220,17 +223,23 @@ export default function useAutosave( options = {} ) {
 			setStatus( 'saved' );
 			setLastSavedAt( Date.now() );
 			removeNotice( AUTOSAVE_ERROR_NOTICE_ID );
-			if ( currentPostId ) {
-				touchRecent( { kind: 'page', id: currentPostId } );
+			if ( recentKind && recentId ) {
+				const target = { kind: recentKind, id: recentId };
+				if ( recentCollectionId ) {
+					target.collectionId = recentCollectionId;
+				}
+				touchRecent( target );
 			}
 		}
 	}, [
 		isSaving,
 		didSucceed,
 		didFail,
-		currentPostId,
 		createErrorNotice,
 		removeNotice,
+		recentKind,
+		recentId,
+		recentCollectionId,
 		touchRecent,
 	] );
 

--- a/src/hooks/useRecents.js
+++ b/src/hooks/useRecents.js
@@ -50,6 +50,8 @@ export function RecentsProvider( { children } ) {
 	const [ isUpdating, setIsUpdating ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const latestTouchRequest = useRef( 0 );
+	const pendingTouchCount = useRef( 0 );
+	const touchQueue = useRef( Promise.resolve() );
 
 	useEffect( () => {
 		let cancelled = false;
@@ -72,6 +74,10 @@ export function RecentsProvider( { children } ) {
 				if ( cancelled ) {
 					return;
 				}
+				if ( latestTouchRequest.current > 0 ) {
+					setIsResolving( false );
+					return;
+				}
 				setRecents( [] );
 				setError( nextError );
 				setIsResolving( false );
@@ -88,31 +94,44 @@ export function RecentsProvider( { children } ) {
 		}
 		const requestId = latestTouchRequest.current + 1;
 		latestTouchRequest.current = requestId;
+		pendingTouchCount.current += 1;
 		setIsUpdating( true );
 		setError( null );
-		try {
-			const response = await apiFetch( {
-				path: '/cortext/v1/recents',
-				method: 'POST',
-				data: target,
-			} );
-			const nextRecents = recentsFromResponse( response );
-			if ( requestId === latestTouchRequest.current ) {
-				applyRecents( setRecents, nextRecents );
-				setIsResolving( false );
+
+		const runTouch = async () => {
+			try {
+				const response = await apiFetch( {
+					path: '/cortext/v1/recents',
+					method: 'POST',
+					data: target,
+				} );
+				const nextRecents = recentsFromResponse( response );
+				if ( requestId === latestTouchRequest.current ) {
+					applyRecents( setRecents, nextRecents );
+					setIsResolving( false );
+				}
+				return nextRecents;
+			} catch ( nextError ) {
+				if ( requestId === latestTouchRequest.current ) {
+					setError( nextError );
+					setIsResolving( false );
+				}
+				return null;
+			} finally {
+				pendingTouchCount.current = Math.max(
+					0,
+					pendingTouchCount.current - 1
+				);
+				if ( pendingTouchCount.current === 0 ) {
+					setIsUpdating( false );
+				}
 			}
-			return nextRecents;
-		} catch ( nextError ) {
-			if ( requestId === latestTouchRequest.current ) {
-				setError( nextError );
-				setIsResolving( false );
-			}
-			return null;
-		} finally {
-			if ( requestId === latestTouchRequest.current ) {
-				setIsUpdating( false );
-			}
-		}
+		};
+
+		// Keep server-side user meta in the same order as local touch calls.
+		const queuedTouch = touchQueue.current.then( runTouch, runTouch );
+		touchQueue.current = queuedTouch.catch( () => null );
+		return queuedTouch;
 	}, [] );
 
 	const value = useMemo(

--- a/src/hooks/useRecents.js
+++ b/src/hooks/useRecents.js
@@ -1,0 +1,136 @@
+import apiFetch from '@wordpress/api-fetch';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+
+const RecentsContext = createContext( null );
+
+function recentFingerprint( recent ) {
+	return JSON.stringify( [
+		recent?.kind,
+		recent?.id,
+		recent?.title,
+		recent?.path,
+		recent?.icon,
+		recent?.collection?.id,
+		recent?.collection?.title,
+		recent?.collection?.path,
+	] );
+}
+
+function areEquivalentRecents( current, next ) {
+	if ( current.length !== next.length ) {
+		return false;
+	}
+	return current.every(
+		( recent, index ) =>
+			recentFingerprint( recent ) === recentFingerprint( next[ index ] )
+	);
+}
+
+function applyRecents( setRecents, nextRecents ) {
+	setRecents( ( current ) =>
+		areEquivalentRecents( current, nextRecents ) ? current : nextRecents
+	);
+}
+
+function recentsFromResponse( response ) {
+	return Array.isArray( response?.recents ) ? response.recents : [];
+}
+
+export function RecentsProvider( { children } ) {
+	const [ recents, setRecents ] = useState( [] );
+	const [ isResolving, setIsResolving ] = useState( true );
+	const [ isUpdating, setIsUpdating ] = useState( false );
+	const [ error, setError ] = useState( null );
+	const latestTouchRequest = useRef( 0 );
+
+	useEffect( () => {
+		let cancelled = false;
+		setIsResolving( true );
+		setError( null );
+
+		apiFetch( { path: '/cortext/v1/recents' } )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				if ( latestTouchRequest.current > 0 ) {
+					setIsResolving( false );
+					return;
+				}
+				applyRecents( setRecents, recentsFromResponse( response ) );
+				setIsResolving( false );
+			} )
+			.catch( ( nextError ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setRecents( [] );
+				setError( nextError );
+				setIsResolving( false );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const touchRecent = useCallback( async ( target ) => {
+		if ( ! target?.kind || ! target?.id ) {
+			return null;
+		}
+		const requestId = latestTouchRequest.current + 1;
+		latestTouchRequest.current = requestId;
+		setIsUpdating( true );
+		setError( null );
+		try {
+			const response = await apiFetch( {
+				path: '/cortext/v1/recents',
+				method: 'POST',
+				data: target,
+			} );
+			const nextRecents = recentsFromResponse( response );
+			if ( requestId === latestTouchRequest.current ) {
+				applyRecents( setRecents, nextRecents );
+				setIsResolving( false );
+			}
+			return nextRecents;
+		} catch ( nextError ) {
+			if ( requestId === latestTouchRequest.current ) {
+				setError( nextError );
+				setIsResolving( false );
+			}
+			return null;
+		} finally {
+			if ( requestId === latestTouchRequest.current ) {
+				setIsUpdating( false );
+			}
+		}
+	}, [] );
+
+	const value = useMemo(
+		() => ( { recents, isResolving, isUpdating, error, touchRecent } ),
+		[ recents, isResolving, isUpdating, error, touchRecent ]
+	);
+
+	return (
+		<RecentsContext.Provider value={ value }>
+			{ children }
+		</RecentsContext.Provider>
+	);
+}
+
+export function useRecents() {
+	const value = useContext( RecentsContext );
+	if ( ! value ) {
+		throw new Error( 'useRecents must be used inside RecentsProvider' );
+	}
+	return value;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -16,6 +16,20 @@
 // sass-loader side-steps that.
 @use "../node_modules/@wordpress/dataviews/build-style/style.css" as dataviews;
 
+.commands-command-menu__container {
+
+	.commands-command-menu__item {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+		width: 100%;
+	}
+
+	.cortext-command-palette__group + .cortext-command-palette__group [cmdk-group-heading] {
+		border-top: var(--cortext-shell-border-width, 1px) solid var(--cortext-chrome-border, #e0e0e0);
+	}
+}
+
 // Hide wp-admin chrome on the Cortext screen. The React shell is
 // `position: fixed; inset: 0`, so admin scaffolding (toolbar, sidebar,
 // footer) would only matter where it has its own `position: fixed` and a

--- a/src/index.scss
+++ b/src/index.scss
@@ -419,6 +419,20 @@ body.cortext-fullscreen {
 		white-space: nowrap;
 	}
 
+	&__recent-icon {
+		flex: 0 0 $grid-unit-30;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: $grid-unit-30;
+		height: $grid-unit-30;
+		color: var(--cortext-text-muted);
+	}
+
+	&__recent-node {
+		will-change: transform, opacity;
+	}
+
 	&__icon.components-button {
 		flex: 0 0 auto;
 		display: inline-flex;

--- a/src/router.js
+++ b/src/router.js
@@ -16,6 +16,7 @@ import AlphaNoticeModal from './components/AlphaNoticeModal';
 import useSidebarLayout from './hooks/useSidebarLayout';
 import useAlphaNotice from './hooks/useAlphaNotice';
 import { FavoritesProvider } from './hooks/useFavorites';
+import { RecentsProvider } from './hooks/useRecents';
 import { WorkspaceHomeProvider } from './hooks/useWorkspaceHome';
 import { unlock } from './lock-unlock';
 
@@ -68,27 +69,29 @@ function RootLayout() {
 		<SlotFillProvider>
 			<WorkspaceHomeProvider>
 				<FavoritesProvider>
-					<div className="cortext-shell">
-						<Sidebar
-							collapsed={ collapsed }
-							width={ width }
-							onToggleCollapsed={ toggleCollapsed }
-							onWidthChange={ setWidth }
-						/>
-						<main
-							ref={ canvasRef }
-							className="cortext-shell__canvas"
-							tabIndex={ -1 }
-						>
-							<EntityRoute history={ router.history } />
-						</main>
-					</div>
-					<CommandPalette canvasRef={ canvasRef } />
-					{ alphaNotice.isOpen && (
-						<AlphaNoticeModal
-							onAcknowledge={ alphaNotice.acknowledge }
-						/>
-					) }
+					<RecentsProvider>
+						<div className="cortext-shell">
+							<Sidebar
+								collapsed={ collapsed }
+								width={ width }
+								onToggleCollapsed={ toggleCollapsed }
+								onWidthChange={ setWidth }
+							/>
+							<main
+								ref={ canvasRef }
+								className="cortext-shell__canvas"
+								tabIndex={ -1 }
+							>
+								<EntityRoute history={ router.history } />
+							</main>
+						</div>
+						<CommandPalette canvasRef={ canvasRef } />
+						{ alphaNotice.isOpen && (
+							<AlphaNoticeModal
+								onAcknowledge={ alphaNotice.acknowledge }
+							/>
+						) }
+					</RecentsProvider>
 				</FavoritesProvider>
 			</WorkspaceHomeProvider>
 		</SlotFillProvider>

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -26,6 +26,7 @@ import {
 import { firstPageInTree } from '../components/pages-tree';
 import { COLLECTION_QUERY } from '../collections';
 import { withViewTransition } from '../hooks/viewTransition';
+import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 import useCollectionFields from '../hooks/useCollectionFields';
 import EmptyState from './EmptyState';
@@ -139,6 +140,7 @@ export default function EntityRoute( { history } ) {
 	const splat = params._splat ?? '';
 	const target = useMemo( () => parseTarget( splat ), [ splat ] );
 	const { home, isResolving: isResolvingHome } = useWorkspaceHome();
+	const { touchRecent } = useRecents();
 	const { records: pages, isResolving: isResolvingPages } = useEntityRecords(
 		'postType',
 		POST_TYPE,
@@ -291,12 +293,39 @@ export default function EntityRoute( { history } ) {
 				id: entity.id,
 				postType: entity.type,
 			} );
+			if ( entity.type === POST_TYPE ) {
+				touchRecent( { kind: 'page', id: entity.id } );
+			}
 			return;
 		}
 		if ( ! isResolving && notFound ) {
 			dispatch( { type: 'DOCUMENT_NOT_FOUND' } );
 		}
-	}, [ target, documentResolution, dispatch ] );
+	}, [ target, documentResolution, dispatch, touchRecent ] );
+
+	useEffect( () => {
+		if (
+			target.kind !== 'document' ||
+			target.id === null ||
+			mountedDocumentId !== target.id ||
+			mountedDocumentType === POST_TYPE ||
+			! rowParentCollectionId
+		) {
+			return;
+		}
+		touchRecent( {
+			kind: 'row',
+			id: target.id,
+			collectionId: rowParentCollectionId,
+		} );
+	}, [
+		target.kind,
+		target.id,
+		mountedDocumentId,
+		mountedDocumentType,
+		rowParentCollectionId,
+		touchRecent,
+	] );
 
 	useEffect( () => {
 		if ( target.kind !== 'collection' || target.id === null ) {
@@ -313,12 +342,13 @@ export default function EntityRoute( { history } ) {
 		}
 		if ( entity?.id === target.id ) {
 			dispatch( { type: 'COLLECTION_RESOLVED', id: entity.id } );
+			touchRecent( { kind: 'collection', id: entity.id } );
 			return;
 		}
 		if ( ! isResolving && notFound ) {
 			dispatch( { type: 'COLLECTION_NOT_FOUND' } );
 		}
-	}, [ target, collectionResolution, dispatch ] );
+	}, [ target, collectionResolution, dispatch, touchRecent ] );
 
 	const handleDocumentDisplayed = useCallback(
 		( id ) => {

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -429,6 +429,14 @@ export default function EntityRoute( { history } ) {
 		[ invalidateResolution, receiveEntityRecords ]
 	);
 
+	const editorRecentTarget =
+		isRow && editorPostId !== null && rowParentCollectionId
+			? {
+					kind: 'row',
+					id: editorPostId,
+					collectionId: rowParentCollectionId,
+			  }
+			: null;
 	const editorCanvas =
 		editorPostId !== null && editorPostType ? (
 			<Canvas
@@ -441,6 +449,7 @@ export default function EntityRoute( { history } ) {
 				onDisplayedPost={ handleDocumentDisplayed }
 				isActive={ isDocumentActive }
 				onRestored={ onRestoreDocument }
+				recentTarget={ editorRecentTarget }
 			/>
 		) : null;
 

--- a/tests/e2e/specs/recents.spec.js
+++ b/tests/e2e/specs/recents.spec.js
@@ -1,0 +1,291 @@
+/**
+ * E2E coverage for the per-user sidebar Recents list.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+async function waitForEditorPost( page, postId ) {
+	await page.waitForFunction(
+		( expectedPostId ) =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ===
+			expectedPostId,
+		postId,
+		{ timeout: 15_000 }
+	);
+}
+
+async function appPath( page ) {
+	return page.evaluate(
+		() => new URL( window.location.href ).searchParams.get( 'p' ) || '/'
+	);
+}
+
+async function readRecentsPlacement( page ) {
+	return page.evaluate( () => {
+		const titles = Array.from(
+			document.querySelectorAll( '.cortext-sidebar__section-title' )
+		).map( ( title ) => title.textContent.trim() );
+		return {
+			recents: titles.indexOf( 'Recents' ),
+			pages: titles.indexOf( 'Pages' ),
+		};
+	} );
+}
+
+async function createCollectionFixture( requestUtils ) {
+	const suffix = Date.now().toString( 36 ).slice( -4 );
+	const slug = `e2erec${ suffix }`;
+	const collectionTitle = `E2E Recent Rows ${ suffix }`;
+
+	const collection = await requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_collections',
+		data: {
+			title: collectionTitle,
+			status: 'private',
+			meta: { slug },
+		},
+	} );
+
+	const field = await requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_fields',
+		data: {
+			title: 'Author',
+			status: 'private',
+			meta: { type: 'text' },
+		},
+	} );
+
+	await requestUtils.rest( {
+		method: 'POST',
+		path: `/wp/v2/crtxt_collections/${ collection.id }`,
+		data: {
+			meta: { fields: [ String( field.id ) ] },
+		},
+	} );
+
+	const entry = await requestUtils.rest( {
+		method: 'POST',
+		path: `/wp/v2/crtxt_${ slug }`,
+		data: {
+			title: 'The Left Hand of Darkness',
+			status: 'private',
+			meta: {
+				[ `field-${ field.id }` ]: 'Ursula K. Le Guin',
+			},
+		},
+	} );
+
+	return { collection, collectionTitle, field, entry, slug };
+}
+
+function createDataViewBlockMarkup( collectionId ) {
+	const attributes = {
+		collectionId,
+		view: {
+			type: 'table',
+			fields: [],
+			sort: null,
+			filters: [],
+			calculations: {},
+			perPage: 25,
+			page: 1,
+			search: '',
+			layout: {},
+		},
+	};
+
+	return `<!-- wp:cortext/data-view ${ JSON.stringify( attributes ) } /-->`;
+}
+
+test.describe( 'Sidebar recents', () => {
+	test( 'records page and collection visits above Pages and persists after reload', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const pageTitle = `E2E Recent Page ${ suffix }`;
+		const collectionTitle = `E2E Recent Collection ${ suffix }`;
+		let recentPage;
+		let collection;
+
+		try {
+			recentPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: pageTitle,
+					status: 'private',
+				},
+			} );
+			collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/cortext/v1/collections',
+				data: { title: collectionTitle },
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ recentPage.id }`
+			);
+			await waitForEditorPost( page, recentPage.id );
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			await expect(
+				sidebar.getByRole( 'button', {
+					name: `Recent page: ${ pageTitle }`,
+				} )
+			).toBeVisible();
+
+			const placement = await readRecentsPlacement( page );
+			expect( placement.recents ).toBeGreaterThanOrEqual( 0 );
+			expect( placement.pages ).toBeGreaterThan( placement.recents );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/collection/${ collection.slug }-${ collection.id }`
+			);
+			await expect(
+				page.locator(
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+				)
+			).toBeVisible( { timeout: 15_000 } );
+			await expect(
+				sidebar.getByRole( 'button', {
+					name: `Recent collection: ${ collectionTitle }`,
+				} )
+			).toBeVisible();
+
+			await page.reload();
+			await expect(
+				sidebar.getByRole( 'button', {
+					name: `Recent collection: ${ collectionTitle }`,
+				} )
+			).toBeVisible();
+			await expect(
+				sidebar.getByRole( 'button', {
+					name: `Recent page: ${ pageTitle }`,
+				} )
+			).toBeVisible();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				collection && `/wp/v2/crtxt_collections/${ collection.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				recentPage && `/wp/v2/crtxt_pages/${ recentPage.id }`
+			);
+		}
+	} );
+
+	test( 'records row edits and row recents open the parent collection', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture( requestUtils )
+			);
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Row recent test page',
+					status: 'private',
+					content: createDataViewBlockMarkup( fixture.collection.id ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ fixture.page.id }`
+			);
+			await waitForEditorPost( page, fixture.page.id );
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			const cell = canvas.getByText( 'Ursula K. Le Guin', {
+				exact: true,
+			} );
+			await expect( cell ).toBeVisible();
+			await cell.click();
+
+			const input = canvas.getByRole( 'textbox', {
+				name: 'Author',
+				exact: true,
+			} );
+			await input.fill( 'U. K. Le Guin' );
+			await input.press( 'Enter' );
+
+			await expect
+				.poll( async () => {
+					const row = await requestUtils.rest( {
+						path: `/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`,
+						params: { context: 'edit' },
+					} );
+					return row.meta[ `field-${ fixture.field.id }` ];
+				} )
+				.toBe( 'U. K. Le Guin' );
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			const recentRow = sidebar.getByRole( 'button', {
+				name: `Recent row: The Left Hand of Darkness in ${ fixture.collectionTitle }`,
+			} );
+			await expect( recentRow ).toBeVisible( { timeout: 15_000 } );
+
+			await recentRow.click();
+
+			await expect
+				.poll( () => appPath( page ) )
+				.toContain(
+					`/collection/${ fixture.slug }-${ fixture.collection.id }`
+				);
+			await expect(
+				page.locator(
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+				)
+			).toBeVisible( { timeout: 15_000 } );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+} );

--- a/tests/js/components/CommandPalette.test.js
+++ b/tests/js/components/CommandPalette.test.js
@@ -1,0 +1,130 @@
+import { render } from '@testing-library/react';
+
+const mockUseCommand = jest.fn();
+const mockOpen = jest.fn();
+const mockNavigate = jest.fn();
+let mockRecents = [];
+
+jest.mock( '@wordpress/commands', () => ( {
+	store: { name: 'core/commands' },
+	useCommand: ( command ) => mockUseCommand( command ),
+} ) );
+
+jest.mock( '@wordpress/keyboard-shortcuts', () => ( {
+	store: { name: 'core/keyboard-shortcuts' },
+} ) );
+
+jest.mock( '@wordpress/preferences', () => ( {
+	store: { name: 'core/preferences' },
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	createRegistry: () => ( { register: jest.fn() } ),
+	RegistryProvider: ( { children } ) => children,
+	useDispatch: () => ( { open: mockOpen } ),
+} ) );
+
+jest.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
+
+jest.mock( '../../../src/hooks/useWorkspaceHomePath', () => ( {
+	useWorkspaceHomePath: () => ( {
+		homePath: 'page/home-1',
+		isResolvingHomePath: false,
+	} ),
+} ) );
+
+jest.mock( '../../../src/hooks/useRecents', () => ( {
+	useRecents: () => ( { recents: mockRecents } ),
+} ) );
+
+jest.mock( '../../../src/components/CortextCommandMenu', () => () => null );
+
+jest.mock( '../../../src/components/PageIcon', () => () => null );
+
+import CommandPalette from '../../../src/components/CommandPalette';
+
+beforeEach( () => {
+	jest.useFakeTimers();
+	mockUseCommand.mockReset();
+	mockOpen.mockReset();
+	mockNavigate.mockReset();
+	mockRecents = [];
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
+describe( 'CommandPalette recents', () => {
+	it( 'registers a command for each recent item', () => {
+		mockRecents = [
+			{
+				kind: 'page',
+				id: 7,
+				title: 'Notes',
+				path: 'page/notes-7',
+			},
+			{
+				kind: 'row',
+				id: 12,
+				title: 'Ada Lovelace',
+				path: 'collection/people-9',
+				collection: { title: 'People' },
+			},
+		];
+
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		const commands = mockUseCommand.mock.calls.map(
+			( [ command ] ) => command
+		);
+		expect( commands ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					name: 'cortext/recent/page-7',
+					label: 'Notes',
+					searchLabel: 'Open recent: Notes',
+				} ),
+				expect.objectContaining( {
+					name: 'cortext/recent/row-12',
+					label: 'Ada Lovelace in People',
+					searchLabel: 'Open recent: Ada Lovelace in People',
+				} ),
+			] )
+		);
+	} );
+
+	it( 'navigates to the recent path when a recent command runs', () => {
+		const close = jest.fn();
+		const focus = jest.fn();
+		mockRecents = [
+			{
+				kind: 'collection',
+				id: 9,
+				title: 'People',
+				path: 'collection/people-9',
+			},
+		];
+
+		render( <CommandPalette canvasRef={ { current: { focus } } } /> );
+
+		const command = mockUseCommand.mock.calls
+			.map( ( [ registered ] ) => registered )
+			.find(
+				( registered ) =>
+					registered.name === 'cortext/recent/collection-9'
+			);
+
+		command.callback( { close } );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'collection/people-9' },
+		} );
+		expect( close ).toHaveBeenCalled();
+		jest.runOnlyPendingTimers();
+		expect( focus ).toHaveBeenCalledWith( { preventScroll: true } );
+	} );
+} );

--- a/tests/js/components/CommandPalette.test.js
+++ b/tests/js/components/CommandPalette.test.js
@@ -1,8 +1,10 @@
 import { render } from '@testing-library/react';
 
 const mockUseCommand = jest.fn();
+const mockCreateRegistry = jest.fn( () => ( { register: jest.fn() } ) );
 const mockOpen = jest.fn();
 const mockNavigate = jest.fn();
+const mockParentRegistry = { parent: true };
 let mockRecents = [];
 
 jest.mock( '@wordpress/commands', () => ( {
@@ -19,9 +21,10 @@ jest.mock( '@wordpress/preferences', () => ( {
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {
-	createRegistry: () => ( { register: jest.fn() } ),
+	createRegistry: ( ...args ) => mockCreateRegistry( ...args ),
 	RegistryProvider: ( { children } ) => children,
 	useDispatch: () => ( { open: mockOpen } ),
+	useRegistry: () => mockParentRegistry,
 } ) );
 
 jest.mock( '@tanstack/react-router', () => ( {
@@ -48,6 +51,7 @@ import CommandPalette from '../../../src/components/CommandPalette';
 beforeEach( () => {
 	jest.useFakeTimers();
 	mockUseCommand.mockReset();
+	mockCreateRegistry.mockClear();
 	mockOpen.mockReset();
 	mockNavigate.mockReset();
 	mockRecents = [];
@@ -76,6 +80,11 @@ describe( 'CommandPalette recents', () => {
 		];
 
 		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		expect( mockCreateRegistry ).toHaveBeenCalledWith(
+			{},
+			mockParentRegistry
+		);
 
 		const commands = mockUseCommand.mock.calls.map(
 			( [ command ] ) => command

--- a/tests/js/components/CortextCommandMenu.test.js
+++ b/tests/js/components/CortextCommandMenu.test.js
@@ -1,10 +1,29 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { store as commandsStore } from '@wordpress/commands';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as preferencesStore } from '@wordpress/preferences';
 import { table } from '@wordpress/icons';
 
 import {
 	CommandIcon,
+	default as CortextCommandMenu,
 	splitPaletteCommands,
 } from '../../../src/components/CortextCommandMenu';
+
+class ResizeObserverMock {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+function createCommandPaletteRegistry() {
+	const registry = createRegistry();
+	registry.register( commandsStore );
+	registry.register( keyboardShortcutsStore );
+	registry.register( preferencesStore );
+	return registry;
+}
 
 describe( 'splitPaletteCommands', () => {
 	it( 'separates Cortext recents from the rest of the palette commands', () => {
@@ -29,5 +48,44 @@ describe( 'CommandIcon', () => {
 		const icon = container.querySelector( 'svg' );
 		expect( icon ).toHaveAttribute( 'width', '16' );
 		expect( icon ).toHaveAttribute( 'height', '16' );
+	} );
+} );
+
+describe( 'CortextCommandMenu', () => {
+	it( 'opens from the primary+k keyboard shortcut', async () => {
+		global.ResizeObserver = ResizeObserverMock;
+		Element.prototype.scrollIntoView = jest.fn();
+		const registry = createCommandPaletteRegistry();
+		registry.dispatch( commandsStore ).registerCommand( {
+			name: 'cortext/test',
+			label: 'Test command',
+			context: 'root',
+			callback: jest.fn(),
+		} );
+
+		render(
+			<RegistryProvider value={ registry }>
+				<CortextCommandMenu />
+			</RegistryProvider>
+		);
+
+		await waitFor( () =>
+			expect(
+				registry
+					.select( keyboardShortcutsStore )
+					.getShortcutKeyCombination( 'core/commands' )
+			).toEqual( { modifier: 'primary', character: 'k' } )
+		);
+
+		fireEvent.keyDown( document, {
+			key: 'k',
+			code: 'KeyK',
+			ctrlKey: true,
+		} );
+
+		expect(
+			await screen.findByPlaceholderText( 'Search commands and settings' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Test command' ) ).toBeInTheDocument();
 	} );
 } );

--- a/tests/js/components/CortextCommandMenu.test.js
+++ b/tests/js/components/CortextCommandMenu.test.js
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { table } from '@wordpress/icons';
+
+import {
+	CommandIcon,
+	splitPaletteCommands,
+} from '../../../src/components/CortextCommandMenu';
+
+describe( 'splitPaletteCommands', () => {
+	it( 'separates Cortext recents from the rest of the palette commands', () => {
+		const home = { name: 'cortext/home', label: 'Go to home' };
+		const page = { name: 'cortext/recent/page-7', label: 'Notes' };
+		const row = {
+			name: 'cortext/recent/row-12',
+			label: 'Ada Lovelace in People',
+		};
+
+		expect( splitPaletteCommands( [ home, page, row ] ) ).toEqual( {
+			recentCommands: [ page, row ],
+			commands: [ home ],
+		} );
+	} );
+} );
+
+describe( 'CommandIcon', () => {
+	it( 'sizes raw WordPress icon elements before rendering them', () => {
+		const { container } = render( <CommandIcon icon={ table } /> );
+
+		const icon = container.querySelector( 'svg' );
+		expect( icon ).toHaveAttribute( 'width', '16' );
+		expect( icon ).toHaveAttribute( 'height', '16' );
+	} );
+} );

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+let mockRecents = [];
+let mockIsResolving = false;
+const mockNavigate = jest.fn();
+
+jest.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, onClick, ...props } ) => (
+		<button onClick={ onClick } { ...props }>
+			{ children }
+		</button>
+	),
+	Icon: ( { icon } ) => <span data-testid={ `icon-${ icon }` } />,
+	Spinner: () => <span data-testid="spinner" />,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	listItem: 'list-item',
+	table: 'table',
+} ) );
+
+jest.mock( '../../../src/components/PageIcon', () => () => (
+	<span data-testid="page-icon" />
+) );
+
+jest.mock( '../../../src/hooks/useRecents', () => ( {
+	useRecents: () => ( {
+		recents: mockRecents,
+		isResolving: mockIsResolving,
+	} ),
+} ) );
+
+import SidebarRecents from '../../../src/components/SidebarRecents';
+
+function pageRecent( id, title ) {
+	return {
+		kind: 'page',
+		id,
+		title,
+		path: `page/${ title.toLowerCase() }-${ id }`,
+	};
+}
+
+const rectForIndex = ( index ) => ( {
+	top: index * 32,
+	bottom: index * 32 + 28,
+	left: 0,
+	right: 120,
+	width: 120,
+	height: 28,
+	x: 0,
+	y: index * 32,
+	toJSON: () => {},
+} );
+
+beforeEach( () => {
+	mockNavigate.mockReset();
+	mockRecents = [];
+	mockIsResolving = false;
+	window.Element.prototype.animate = jest.fn();
+	window.Element.prototype.getAnimations = jest.fn( () => [] );
+	window.matchMedia = jest.fn( () => ( { matches: false } ) );
+	window.Element.prototype.getBoundingClientRect = function () {
+		const list = this.parentElement;
+		const index = list ? Array.from( list.children ).indexOf( this ) : 0;
+		return rectForIndex( Math.max( index, 0 ) );
+	};
+} );
+
+describe( 'SidebarRecents animation', () => {
+	it( 'does not animate the initial recents fetch after a reload', () => {
+		mockIsResolving = true;
+		const { rerender } = render( <SidebarRecents /> );
+
+		mockIsResolving = false;
+		mockRecents = [ pageRecent( 1, 'Alpha' ), pageRecent( 2, 'Beta' ) ];
+		rerender( <SidebarRecents /> );
+
+		expect( window.Element.prototype.animate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'animates rows that reposition after initial load', () => {
+		mockRecents = [ pageRecent( 1, 'Alpha' ), pageRecent( 2, 'Beta' ) ];
+		const { rerender } = render( <SidebarRecents /> );
+		window.Element.prototype.animate.mockClear();
+
+		mockRecents = [ pageRecent( 2, 'Beta' ), pageRecent( 1, 'Alpha' ) ];
+		rerender( <SidebarRecents /> );
+
+		expect( window.Element.prototype.animate ).toHaveBeenCalledTimes( 2 );
+		expect( window.Element.prototype.animate ).toHaveBeenCalledWith(
+			[
+				expect.objectContaining( {
+					transform: expect.stringMatching( /^translateY\(/ ),
+				} ),
+				{ transform: 'translateY(0)' },
+			],
+			expect.objectContaining( { duration: 180 } )
+		);
+	} );
+
+	it( 'blurs the clicked recent before navigating', () => {
+		const blurSpy = jest
+			.spyOn( window.HTMLElement.prototype, 'blur' )
+			.mockImplementation( () => {} );
+		mockRecents = [ pageRecent( 1, 'Alpha' ) ];
+
+		render( <SidebarRecents /> );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Recent page: Alpha' } )
+		);
+
+		expect( blurSpy ).toHaveBeenCalled();
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'page/alpha-1' },
+		} );
+		blurSpy.mockRestore();
+	} );
+} );

--- a/tests/js/components/relations/RelationEditor.test.js
+++ b/tests/js/components/relations/RelationEditor.test.js
@@ -5,6 +5,10 @@ jest.mock( '../../../../src/hooks/useCollectionRows', () => ( {
 	__esModule: true,
 	default: jest.fn(),
 } ) );
+const mockTouchRecent = jest.fn();
+jest.mock( '../../../../src/hooks/useRecents', () => ( {
+	useRecents: () => ( { touchRecent: mockTouchRecent } ),
+} ) );
 
 import apiFetch from '@wordpress/api-fetch';
 import RelationEditor from '../../../../src/components/relations/RelationEditor';
@@ -12,6 +16,7 @@ import useCollectionRows from '../../../../src/hooks/useCollectionRows';
 
 beforeEach( () => {
 	apiFetch.mockReset();
+	mockTouchRecent.mockReset();
 	useCollectionRows.mockReturnValue( {
 		data: [],
 		collection: null,
@@ -97,6 +102,11 @@ describe( 'RelationEditor', () => {
 			} )
 		);
 		await waitFor( () => expect( onSave ).toHaveBeenCalledWith( [ 44 ] ) );
+		expect( mockTouchRecent ).toHaveBeenCalledWith( {
+			kind: 'row',
+			id: 44,
+			collectionId: 9,
+		} );
 		expect( refreshTargetRows ).toHaveBeenCalled();
 	} );
 } );

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -424,9 +424,37 @@ describe( 'useAutosave: status', () => {
 
 		expect( result.current.status ).toBe( 'saved' );
 		expect( typeof result.current.lastSavedAt ).toBe( 'number' );
+		expect( mockTouchRecent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'touches the configured page recent after a successful save', () => {
+		setStoreState( { didSucceed: true, currentPostId: 42 } );
+
+		renderHook( () =>
+			useAutosave( {
+				recentTarget: { kind: 'page', id: 42 },
+			} )
+		);
+
 		expect( mockTouchRecent ).toHaveBeenCalledWith( {
 			kind: 'page',
 			id: 42,
+		} );
+	} );
+
+	it( 'touches the configured row recent after a successful save', () => {
+		setStoreState( { didSucceed: true, currentPostId: 42 } );
+
+		renderHook( () =>
+			useAutosave( {
+				recentTarget: { kind: 'row', id: 42, collectionId: 9 },
+			} )
+		);
+
+		expect( mockTouchRecent ).toHaveBeenCalledWith( {
+			kind: 'row',
+			id: 42,
+			collectionId: 9,
 		} );
 	} );
 

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -24,6 +24,11 @@ jest.mock( '@wordpress/notices', () => ( {
 	store: { name: 'core/notices' },
 } ) );
 
+const mockTouchRecent = jest.fn();
+jest.mock( '../../src/hooks/useRecents', () => ( {
+	useRecents: () => ( { touchRecent: mockTouchRecent } ),
+} ) );
+
 import { useSelect, useDispatch } from '@wordpress/data';
 import useAutosave from '../../src/hooks/useAutosave';
 
@@ -89,6 +94,7 @@ beforeEach( () => {
 		createErrorNotice: jest.fn(),
 		removeNotice: jest.fn(),
 	} );
+	mockTouchRecent.mockReset();
 } );
 
 afterEach( () => {
@@ -412,12 +418,16 @@ describe( 'useAutosave: status', () => {
 	} );
 
 	it( 'reports saved and captures lastSavedAt after a successful save', () => {
-		setStoreState( { didSucceed: true } );
+		setStoreState( { didSucceed: true, currentPostId: 42 } );
 
 		const { result } = renderHook( () => useAutosave() );
 
 		expect( result.current.status ).toBe( 'saved' );
 		expect( typeof result.current.lastSavedAt ).toBe( 'number' );
+		expect( mockTouchRecent ).toHaveBeenCalledWith( {
+			kind: 'page',
+			id: 42,
+		} );
 	} );
 
 	it( 'reports error after a failed save', () => {

--- a/tests/js/useRecents.test.js
+++ b/tests/js/useRecents.test.js
@@ -1,0 +1,206 @@
+/**
+ * Tests for `src/hooks/useRecents.js`.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import { RecentsProvider, useRecents } from '../../src/hooks/useRecents';
+
+function wrapper( { children } ) {
+	return <RecentsProvider>{ children }</RecentsProvider>;
+}
+
+function createDeferred() {
+	const deferred = {};
+	deferred.promise = new Promise( ( resolve, reject ) => {
+		deferred.resolve = resolve;
+		deferred.reject = reject;
+	} );
+	return deferred;
+}
+
+beforeEach( () => {
+	apiFetch.mockReset();
+} );
+
+describe( 'useRecents', () => {
+	it( 'fetches recents on mount', async () => {
+		const recent = {
+			kind: 'page',
+			id: 7,
+			title: 'Notes',
+			path: 'page/notes-7',
+			updatedAt: '2026-05-07T12:00:00+00:00',
+		};
+		apiFetch.mockResolvedValueOnce( { recents: [ recent ] } );
+
+		const { result } = renderHook( () => useRecents(), { wrapper } );
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/recents',
+		} );
+		expect( result.current.recents ).toEqual( [ recent ] );
+	} );
+
+	it( 'touches a recent and replaces state from the response', async () => {
+		const recent = {
+			kind: 'collection',
+			id: 9,
+			title: 'Books',
+			path: 'collection/books-9',
+			updatedAt: '2026-05-07T12:00:00+00:00',
+		};
+		apiFetch
+			.mockResolvedValueOnce( { recents: [] } )
+			.mockResolvedValueOnce( { recents: [ recent ] } );
+
+		const { result } = renderHook( () => useRecents(), { wrapper } );
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		await act( async () => {
+			await result.current.touchRecent( {
+				kind: 'collection',
+				id: 9,
+			} );
+		} );
+
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/cortext/v1/recents',
+			method: 'POST',
+			data: { kind: 'collection', id: 9 },
+		} );
+		expect( result.current.recents ).toEqual( [ recent ] );
+	} );
+
+	it( 'swallows touch failures without clearing existing recents', async () => {
+		const recent = {
+			kind: 'page',
+			id: 7,
+			title: 'Notes',
+			path: 'page/notes-7',
+			updatedAt: '2026-05-07T12:00:00+00:00',
+		};
+		apiFetch
+			.mockResolvedValueOnce( { recents: [ recent ] } )
+			.mockRejectedValueOnce( new Error( 'nope' ) );
+
+		const { result } = renderHook( () => useRecents(), { wrapper } );
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		let response;
+		await act( async () => {
+			response = await result.current.touchRecent( {
+				kind: 'page',
+				id: 7,
+			} );
+		} );
+
+		expect( response ).toBeNull();
+		expect( result.current.recents ).toEqual( [ recent ] );
+		expect( result.current.error ).toBeInstanceOf( Error );
+	} );
+
+	it( 'ignores stale touch responses when requests resolve out of order', async () => {
+		const staleTouch = createDeferred();
+		const latestTouch = createDeferred();
+		const firstRecent = {
+			kind: 'page',
+			id: 1,
+			title: 'First',
+			path: 'page/first-1',
+			updatedAt: '2026-05-07T12:00:00+00:00',
+		};
+		const secondRecent = {
+			kind: 'page',
+			id: 2,
+			title: 'Second',
+			path: 'page/second-2',
+			updatedAt: '2026-05-07T12:01:00+00:00',
+		};
+		apiFetch
+			.mockResolvedValueOnce( { recents: [] } )
+			.mockReturnValueOnce( staleTouch.promise )
+			.mockReturnValueOnce( latestTouch.promise );
+
+		const { result } = renderHook( () => useRecents(), { wrapper } );
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		let firstResponse;
+		let secondResponse;
+		act( () => {
+			firstResponse = result.current.touchRecent( {
+				kind: 'page',
+				id: 1,
+			} );
+		} );
+		act( () => {
+			secondResponse = result.current.touchRecent( {
+				kind: 'page',
+				id: 2,
+			} );
+		} );
+
+		await act( async () => {
+			latestTouch.resolve( { recents: [ secondRecent ] } );
+			await secondResponse;
+		} );
+		expect( result.current.recents ).toEqual( [ secondRecent ] );
+
+		await act( async () => {
+			staleTouch.resolve( { recents: [ firstRecent ] } );
+			await firstResponse;
+		} );
+		expect( result.current.recents ).toEqual( [ secondRecent ] );
+	} );
+
+	it( 'keeps equivalent recents state stable when only timestamps change', async () => {
+		const recent = {
+			kind: 'page',
+			id: 7,
+			title: 'Notes',
+			path: 'page/notes-7',
+			updatedAt: '2026-05-07T12:00:00+00:00',
+		};
+		apiFetch
+			.mockResolvedValueOnce( { recents: [ recent ] } )
+			.mockResolvedValueOnce( {
+				recents: [
+					{
+						...recent,
+						updatedAt: '2026-05-07T12:01:00+00:00',
+					},
+				],
+			} );
+
+		const { result } = renderHook( () => useRecents(), { wrapper } );
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+		const recentsBeforeTouch = result.current.recents;
+
+		await act( async () => {
+			await result.current.touchRecent( {
+				kind: 'page',
+				id: 7,
+			} );
+		} );
+
+		expect( result.current.recents ).toBe( recentsBeforeTouch );
+	} );
+} );

--- a/tests/js/useRecents.test.js
+++ b/tests/js/useRecents.test.js
@@ -84,6 +84,49 @@ describe( 'useRecents', () => {
 		expect( result.current.recents ).toEqual( [ recent ] );
 	} );
 
+	it( 'ignores an initial fetch failure after a touch has populated recents', async () => {
+		const initialFetch = createDeferred();
+		const touch = createDeferred();
+		const recent = {
+			kind: 'page',
+			id: 7,
+			title: 'Notes',
+			path: 'page/notes-7',
+			updatedAt: '2026-05-07T12:00:00+00:00',
+		};
+		apiFetch
+			.mockReturnValueOnce( initialFetch.promise )
+			.mockReturnValueOnce( touch.promise );
+
+		const { result } = renderHook( () => useRecents(), { wrapper } );
+
+		let touchResponse;
+		act( () => {
+			touchResponse = result.current.touchRecent( {
+				kind: 'page',
+				id: 7,
+			} );
+		} );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+
+		await act( async () => {
+			touch.resolve( { recents: [ recent ] } );
+			await touchResponse;
+		} );
+		expect( result.current.recents ).toEqual( [ recent ] );
+		expect( result.current.error ).toBeNull();
+
+		await act( async () => {
+			initialFetch.reject( new Error( 'offline' ) );
+			await initialFetch.promise.catch( () => null );
+		} );
+
+		expect( result.current.recents ).toEqual( [ recent ] );
+		expect( result.current.error ).toBeNull();
+		expect( result.current.isResolving ).toBe( false );
+	} );
+
 	it( 'swallows touch failures without clearing existing recents', async () => {
 		const recent = {
 			kind: 'page',
@@ -114,9 +157,9 @@ describe( 'useRecents', () => {
 		expect( result.current.error ).toBeInstanceOf( Error );
 	} );
 
-	it( 'ignores stale touch responses when requests resolve out of order', async () => {
-		const staleTouch = createDeferred();
-		const latestTouch = createDeferred();
+	it( 'serializes touch writes so persisted order follows user action order', async () => {
+		const firstTouch = createDeferred();
+		const secondTouch = createDeferred();
 		const firstRecent = {
 			kind: 'page',
 			id: 1,
@@ -133,8 +176,8 @@ describe( 'useRecents', () => {
 		};
 		apiFetch
 			.mockResolvedValueOnce( { recents: [] } )
-			.mockReturnValueOnce( staleTouch.promise )
-			.mockReturnValueOnce( latestTouch.promise );
+			.mockReturnValueOnce( firstTouch.promise )
+			.mockReturnValueOnce( secondTouch.promise );
 
 		const { result } = renderHook( () => useRecents(), { wrapper } );
 		await waitFor( () =>
@@ -156,17 +199,35 @@ describe( 'useRecents', () => {
 			} );
 		} );
 
-		await act( async () => {
-			latestTouch.resolve( { recents: [ secondRecent ] } );
-			await secondResponse;
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/cortext/v1/recents',
+			method: 'POST',
+			data: { kind: 'page', id: 1 },
 		} );
-		expect( result.current.recents ).toEqual( [ secondRecent ] );
+		expect( result.current.isUpdating ).toBe( true );
 
 		await act( async () => {
-			staleTouch.resolve( { recents: [ firstRecent ] } );
+			firstTouch.resolve( { recents: [ firstRecent ] } );
 			await firstResponse;
 		} );
-		expect( result.current.recents ).toEqual( [ secondRecent ] );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 3 ) );
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/cortext/v1/recents',
+			method: 'POST',
+			data: { kind: 'page', id: 2 },
+		} );
+
+		await act( async () => {
+			secondTouch.resolve( { recents: [ secondRecent, firstRecent ] } );
+			await secondResponse;
+		} );
+		expect( result.current.recents ).toEqual( [
+			secondRecent,
+			firstRecent,
+		] );
+		expect( result.current.isUpdating ).toBe( false );
 	} );
 
 	it( 'keeps equivalent recents state stable when only timestamps change', async () => {

--- a/tests/php/test-rest-recents-controller.php
+++ b/tests/php/test-rest-recents-controller.php
@@ -11,9 +11,9 @@ namespace Cortext\Tests;
 
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
 use Cortext\PostType\Page;
-use Cortext\PostType\PageIdentity;
 use Cortext\Rest\RecentsController;
 use WorDBless\BaseTestCase;
 use WP_REST_Request;
@@ -67,7 +67,7 @@ final class Test_Rest_Recents_Controller extends BaseTestCase {
 			array(
 				'post_name'  => 'notes',
 				'meta_input' => array(
-					PageIdentity::META_KEY => $page_icon,
+					DocumentIdentity::META_KEY => $page_icon,
 				),
 			)
 		);

--- a/tests/php/test-rest-recents-controller.php
+++ b/tests/php/test-rest-recents-controller.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Tests for Cortext\Rest\RecentsController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Field;
+use Cortext\PostType\Page;
+use Cortext\PostType\PageIdentity;
+use Cortext\Rest\RecentsController;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Recents_Controller extends BaseTestCase {
+
+	private const META_KEY = 'cortext_recents';
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->unregister_dynamic_collection_post_types();
+		( new Page() )->register_post_type();
+		( new Collection() )->register_post_type();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new RecentsController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_route_is_registered(): void {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/cortext/v1/recents', $routes );
+	}
+
+	public function test_requires_edit_posts_capability(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$response = $this->get_recents();
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_touches_pages_collections_and_rows(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_icon  = wp_json_encode(
+			array(
+				'type'  => 'wp',
+				'name'  => 'home',
+				'color' => 'blue',
+			)
+		);
+		$page_id    = $this->create_page(
+			array(
+				'post_name'  => 'notes',
+				'meta_input' => array(
+					PageIdentity::META_KEY => $page_icon,
+				),
+			)
+		);
+		$collection = $this->create_collection( 'people', 'People' );
+		$row_id     = $this->create_row( 'crtxt_people', 'Ada Lovelace' );
+
+		$this->touch_recent( 'page', $page_id );
+		$this->touch_recent( 'collection', $collection );
+		$response = $this->touch_recent( 'row', $row_id, $collection );
+
+		$this->assertSame( 200, $response->get_status() );
+		$recents = $this->get_recents()->get_data()['recents'];
+
+		$this->assertCount( 3, $recents );
+		$this->assertSame( 'row', $recents[0]['kind'] );
+		$this->assertSame( $row_id, $recents[0]['id'] );
+		$this->assertSame( 'Ada Lovelace', $recents[0]['title'] );
+		$this->assertSame( "collection/people-{$collection}", $recents[0]['path'] );
+		$this->assertSame( $collection, $recents[0]['collection']['id'] );
+		$this->assertSame( 'People', $recents[0]['collection']['title'] );
+		$this->assertSame( 'collection', $recents[1]['kind'] );
+		$this->assertSame( "collection/people-{$collection}", $recents[1]['path'] );
+		$this->assertSame( 'page', $recents[2]['kind'] );
+		$this->assertSame( "page/notes-{$page_id}", $recents[2]['path'] );
+		$this->assertSame( $page_icon, $recents[2]['icon'] );
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/',
+			$recents[0]['updatedAt']
+		);
+	}
+
+	public function test_recents_are_stored_per_user(): void {
+		$user_a = $this->create_user( 'administrator' );
+		$user_b = $this->create_user( 'administrator' );
+
+		wp_set_current_user( $user_a );
+		$page_id = $this->create_page();
+		$this->touch_recent( 'page', $page_id );
+
+		wp_set_current_user( $user_b );
+		$response = $this->get_recents();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data()['recents'] );
+	}
+
+	public function test_repeated_touch_moves_item_to_top_without_duplicate(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_a = $this->create_page( array( 'post_title' => 'A' ) );
+		$page_b = $this->create_page( array( 'post_title' => 'B' ) );
+
+		$this->touch_recent( 'page', $page_a );
+		$this->touch_recent( 'page', $page_b );
+		$this->touch_recent( 'page', $page_a );
+
+		$recents = $this->get_recents()->get_data()['recents'];
+
+		$this->assertCount( 2, $recents );
+		$this->assertSame( $page_a, $recents[0]['id'] );
+		$this->assertSame( $page_b, $recents[1]['id'] );
+	}
+
+	public function test_rejects_invalid_and_forbidden_targets(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$post_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular post',
+			)
+		);
+
+		$invalid_type           = $this->touch_recent( 'page', $post_id );
+		$row_missing_collection = $this->touch_recent( 'row', 999 );
+
+		$owner_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $owner_id );
+		$private_page = $this->create_page(
+			array(
+				'post_author' => $owner_id,
+				'post_status' => 'private',
+			)
+		);
+
+		wp_set_current_user( $this->create_user( 'contributor' ) );
+		$forbidden = $this->touch_recent( 'page', $private_page );
+
+		$this->assertSame( 404, $invalid_type->get_status() );
+		$this->assertSame( 400, $row_missing_collection->get_status() );
+		$this->assertSame( 403, $forbidden->get_status() );
+	}
+
+	public function test_get_prunes_deleted_and_trashed_targets(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_id = $this->create_page();
+
+		$this->touch_recent( 'page', $page_id );
+		wp_trash_post( $page_id );
+
+		$response = $this->get_recents();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data()['recents'] );
+		$this->assertSame( array(), get_user_meta( get_current_user_id(), self::META_KEY, true ) );
+
+		$page_id = $this->create_page();
+		$this->touch_recent( 'page', $page_id );
+		wp_delete_post( $page_id, true );
+
+		$response = $this->get_recents();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data()['recents'] );
+	}
+
+	public function test_recents_are_capped_at_five_items(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_ids = array();
+
+		for ( $i = 0; $i < 6; $i++ ) {
+			$page_ids[] = $this->create_page(
+				array(
+					'post_title' => "Page {$i}",
+				)
+			);
+			$this->touch_recent( 'page', $page_ids[ $i ] );
+		}
+
+		$recents = $this->get_recents()->get_data()['recents'];
+
+		$this->assertCount( 5, $recents );
+		$this->assertSame( $page_ids[5], $recents[0]['id'] );
+		$this->assertNotContains(
+			$page_ids[0],
+			array_map(
+				static fn ( array $recent ): int => (int) $recent['id'],
+				$recents
+			)
+		);
+	}
+
+	private function get_recents() {
+		$request = new WP_REST_Request( 'GET', '/cortext/v1/recents' );
+		return rest_do_request( $request );
+	}
+
+	private function touch_recent( string $kind, int $id, int $collection_id = 0 ) {
+		$request = new WP_REST_Request( 'POST', '/cortext/v1/recents' );
+		$params  = array(
+			'kind' => $kind,
+			'id'   => $id,
+		);
+		if ( $collection_id > 0 ) {
+			$params['collectionId'] = $collection_id;
+		}
+		$request->set_body_params( $params );
+		return rest_do_request( $request );
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+
+	private function create_page( array $args = array() ): int {
+		$defaults = array(
+			'post_type'   => Page::POST_TYPE,
+			'post_status' => 'private',
+			'post_title'  => 'Test page ' . wp_generate_uuid4(),
+		);
+
+		$id = wp_insert_post( array_merge( $defaults, $args ) );
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+		return (int) $id;
+	}
+
+	private function create_collection( string $slug, string $title = 'Collection' ): int {
+		$id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => array(
+					'slug' => $slug,
+				),
+			)
+		);
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+
+		( new CollectionEntries() )->register_for_collection( get_post( (int) $id ) );
+
+		return (int) $id;
+	}
+
+	private function create_row( string $post_type, string $title ): int {
+		$id = wp_insert_post(
+			array(
+				'post_type'   => $post_type,
+				'post_status' => 'private',
+				'post_title'  => $title,
+			)
+		);
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+
+		return (int) $id;
+	}
+
+	private function unregister_dynamic_collection_post_types(): void {
+		foreach ( get_post_types() as $post_type ) {
+			if (
+				str_starts_with( $post_type, CollectionEntries::CPT_PREFIX ) &&
+				! in_array( $post_type, array( Page::POST_TYPE, Collection::POST_TYPE, Field::POST_TYPE ), true )
+			) {
+				unregister_post_type( $post_type );
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Closes #146, #151

This adds workspace recents so users can get back to the pages, collections, and rows they were just working on.

- Shows the five most recent items above Pages in the sidebar.
- Adds a Recent section to the command palette.
- Tracks visits and edits for pages, collections, and rows.
- Keeps row recents pointed at the parent collection until row routes exist.

## Why

Coming back to a workspace should not require remembering where you left off. Recents gives each user a small, persistent return path into their own recent work.

## How

- Adds a `/cortext/v1/recents` REST controller with server-side target validation.
- Persists recents per user through WordPress user meta.
- Adds a `RecentsProvider` for shell state and stale-response handling.
- Touches recents from route visits, page autosave, sidebar rename, row creation, row edits, and relation-created rows.
- Uses a local command palette renderer because `@wordpress/commands` does not expose custom command groups.

## Testing Instructions

1. Open a Cortext workspace with at least one page and one collection.
2. Visit a page, then visit a collection, and confirm Recents appears above Pages with the newest item first.
3. Reload the workspace and confirm the same recents persist without flashing.
4. Edit a page title or page content and confirm that page moves to the top of Recents.
5. Create or edit a collection row and confirm the row appears in Recents.
6. Click a page or collection recent and confirm it navigates there without leaving the row highlighted.
7. Click a row recent and confirm it opens the parent collection.
8. Open the command palette and confirm it has a Recent section with icons and the same recent items.
9. Add more than five recent items and confirm only five are shown.

## Screen recording

https://github.com/user-attachments/assets/cd5d2d3c-95c2-4223-b47e-1843b6f52431