### PR TITLE
Add rollups for relation fields

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -122,11 +122,13 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 ## 14. Sort on display-value properties is an open architectural decision `[internal]`
 
-**What.** `created_by`, `modified_by`, future Person properties, Relation, value-Rollup, and Files all share the same pattern: stored value is an internal handle (user ID, post ID, attachment ID), useful sort is on the displayed string (display name, related-row title, filename). Sort by stored is meaningless from the UI; sort by display requires a JOIN (or in-memory sort). PR C ships sort only on the timestamp system fields and rejects sort on `_by` keys at the validator. The same problem will hit Relation and Rollup when those types ship (RSM-1468), so the architecture should be settled once.
+**What.** `created_by`, `modified_by`, Person-style fields, Relations, relation-backed Rollups, and Files all share the same problem: the stored value is an internal handle, while the useful sort is the displayed value. Sorting by user ID, row ID, or attachment ID is not what users mean. Sorting by display name, related-row title, filename, or a computed rollup value needs either JOINs, denormalized display values, or an in-memory pass.
 
-**Where.** `validate_sort_field` in `includes/Rest/RowsController.php` (rejects `_by` keys today). `enableSorting: false` for the `_by` system fields in `systemFields` (`src/hooks/fieldMapping.js`).
+Relations and list-style rollups now keep sorting disabled. Scalar rollups can sort in the client while the table has all rows loaded, but the REST query path still cannot order by computed rollup values because they are not stored as row meta. `build_query_args` falls back to the default date ordering if a rollup sort reaches the server.
 
-**Solution.** A single decision shared with the relations/rollups work: JOIN-and-sort in `build_query_args`, in-memory sort after fetch, or a custom REST query path. Pick when picking up RSM-1468; until then, sort UI on display-value properties stays disabled. Tracked in RSM-1793.
+**Where.** `validate_sort_field` and `build_query_args` in `includes/Rest/RowsController.php`; `enableSorting: false` for display-value fields in `systemFields` and `mapField` (`src/hooks/fieldMapping.js`).
+
+**Solution.** Pick one model for display-value sorting: JOIN-and-sort in `build_query_args`, denormalize sortable display values into row meta, or keep fetching all rows and sort in memory. The answer should cover system user fields, Relations, Rollups, Person, and Files at the same time. Tracked in RSM-1793.
 
 ## 15. DataViews table columns lack interaction extension points `[upstream]`
 

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -14,6 +14,7 @@ use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\Field;
 use Cortext\PostType\Page;
 use Cortext\PostType\PageIdentity;
+use Cortext\Relations;
 use WP_CLI;
 use WP_CLI_Command;
 
@@ -655,6 +656,8 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			$collection_ids[ $spec['slug'] ] = $this->seed_collection( $spec );
 		}
 
+		$this->seed_relationship_examples( $collection_ids );
+
 		$workspace_page_id = $this->seed_pages( $collection_ids );
 		$this->seed_workspace_home( $seed_user_id, $workspace_page_id );
 
@@ -1276,6 +1279,409 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		return (int) $collection_id;
+	}
+
+	/**
+	 * Seeds relation and rollup examples after all base collections exist.
+	 *
+	 * @param array<string,int> $collection_ids Collection IDs keyed by slug.
+	 */
+	private function seed_relationship_examples( array $collection_ids ): void {
+		$projects_id = $collection_ids['projects'] ?? 0;
+		$demo_id     = $collection_ids['demo'] ?? 0;
+		$books_id    = $collection_ids['books'] ?? 0;
+
+		if ( $projects_id > 0 && $demo_id > 0 ) {
+			$tasks_relation = $this->ensure_relation_pair(
+				$projects_id,
+				'Tasks',
+				$demo_id,
+				'Project',
+				true,
+				false
+			);
+
+			$demo_fields = $this->attached_fields_by_title( $demo_id );
+			$this->ensure_rollup_field(
+				$projects_id,
+				'Task count',
+				$tasks_relation['source_id'],
+				0,
+				'count'
+			);
+			$this->ensure_rollup_field(
+				$projects_id,
+				'Task effort',
+				$tasks_relation['source_id'],
+				$demo_fields['Quantity'] ?? 0,
+				'sum'
+			);
+			$this->ensure_rollup_field(
+				$projects_id,
+				'Task statuses',
+				$tasks_relation['source_id'],
+				$demo_fields['Status'] ?? 0,
+				'show_unique'
+			);
+			$this->ensure_rollup_field(
+				$projects_id,
+				'Latest task due',
+				$tasks_relation['source_id'],
+				$demo_fields['Due'] ?? 0,
+				'latest'
+			);
+			$this->ensure_rollup_field(
+				$projects_id,
+				'Task due range',
+				$tasks_relation['source_id'],
+				$demo_fields['Due'] ?? 0,
+				'date_range'
+			);
+
+			$this->register_collection_entries( $projects_id );
+			$this->register_collection_entries( $demo_id );
+
+			$this->set_relation_by_titles(
+				'projects',
+				'Seed realistic demo workspace',
+				$tasks_relation['source_id'],
+				array(
+					'Wire up the inline editor',
+					'Document wp-env demo seed',
+				)
+			);
+			$this->set_relation_by_titles(
+				'projects',
+				'Inline table editing polish',
+				$tasks_relation['source_id'],
+				array(
+					'Polish the footer button',
+					'Add keyboard traversal coverage',
+				)
+			);
+		}
+
+		if ( $books_id > 0 && $projects_id > 0 ) {
+			$projects_relation = $this->ensure_relation_pair(
+				$books_id,
+				'Referenced projects',
+				$projects_id,
+				'Reference books',
+				true,
+				true
+			);
+
+			$project_fields = $this->attached_fields_by_title( $projects_id );
+			$this->ensure_rollup_field(
+				$books_id,
+				'Project statuses',
+				$projects_relation['source_id'],
+				$project_fields['Status'] ?? 0,
+				'show_unique'
+			);
+			$this->ensure_rollup_field(
+				$books_id,
+				'Project due range',
+				$projects_relation['source_id'],
+				$project_fields['Due'] ?? 0,
+				'date_range'
+			);
+
+			$this->register_collection_entries( $books_id );
+			$this->register_collection_entries( $projects_id );
+
+			$this->set_relation_by_titles(
+				'books',
+				'The Left Hand of Darkness',
+				$projects_relation['source_id'],
+				array(
+					'Research relation fields',
+				)
+			);
+			$this->set_relation_by_titles(
+				'books',
+				'Invisible Cities',
+				$projects_relation['source_id'],
+				array(
+					'Collection public templates',
+				)
+			);
+			$this->set_relation_by_titles(
+				'books',
+				'The Dispossessed',
+				$projects_relation['source_id'],
+				array(
+					'Seed realistic demo workspace',
+					'DataViews view persistence',
+				)
+			);
+		}
+	}
+
+	/**
+	 * Ensures a bidirectional relation field pair exists.
+	 *
+	 * @param int    $source_collection_id Source collection ID.
+	 * @param string $source_title         Source relation field title.
+	 * @param int    $target_collection_id Target collection ID.
+	 * @param string $reverse_title        Reverse relation field title.
+	 * @param bool   $source_multiple      Whether source accepts multiple rows.
+	 * @param bool   $reverse_multiple     Whether reverse accepts multiple rows.
+	 * @return array{source_id:int,reverse_id:int}
+	 */
+	private function ensure_relation_pair(
+		int $source_collection_id,
+		string $source_title,
+		int $target_collection_id,
+		string $reverse_title,
+		bool $source_multiple,
+		bool $reverse_multiple
+	): array {
+		$source_id  = $this->ensure_field_post( $source_collection_id, $source_title );
+		$reverse_id = (int) get_post_meta( $source_id, 'relation_reverse_field_id', true );
+
+		if ( $reverse_id < 1 || Field::POST_TYPE !== get_post_type( $reverse_id ) ) {
+			$reverse_id = $this->ensure_field_post( $target_collection_id, $reverse_title );
+		}
+
+		$this->update_relation_field_meta(
+			$source_id,
+			$target_collection_id,
+			$reverse_id,
+			$source_multiple
+		);
+		$this->update_relation_field_meta(
+			$reverse_id,
+			$source_collection_id,
+			$source_id,
+			$reverse_multiple
+		);
+
+		WP_CLI::log(
+			sprintf(
+				"Seeded relation '%s' (ID %d) <-> '%s' (ID %d).",
+				$source_title,
+				$source_id,
+				$reverse_title,
+				$reverse_id
+			)
+		);
+
+		return array(
+			'source_id'  => $source_id,
+			'reverse_id' => $reverse_id,
+		);
+	}
+
+	private function update_relation_field_meta(
+		int $field_id,
+		int $related_collection_id,
+		int $reverse_id,
+		bool $multiple
+	): void {
+		update_post_meta( $field_id, 'type', 'relation' );
+		update_post_meta( $field_id, 'related_collection_id', (string) $related_collection_id );
+		update_post_meta( $field_id, 'relation_reverse_field_id', (string) $reverse_id );
+		update_post_meta( $field_id, 'relation_multiple', $multiple ? '1' : '0' );
+	}
+
+	private function ensure_rollup_field(
+		int $collection_id,
+		string $title,
+		int $relation_field_id,
+		int $target_field_id,
+		string $aggregator
+	): int {
+		$field_id = $this->ensure_field_post( $collection_id, $title );
+
+		update_post_meta( $field_id, 'type', 'rollup' );
+		update_post_meta( $field_id, 'rollup_relation_field_id', (string) $relation_field_id );
+		update_post_meta( $field_id, 'rollup_aggregator', $aggregator );
+		$this->delete_rollup_target_meta( $field_id );
+
+		if ( $target_field_id > 0 ) {
+			update_post_meta( $field_id, 'rollup_target_field_id', (string) $target_field_id );
+			foreach ( $this->rollup_target_meta( $target_field_id ) as $key => $value ) {
+				update_post_meta( $field_id, $key, $value );
+			}
+		} else {
+			delete_post_meta( $field_id, 'rollup_target_field_id' );
+		}
+
+		WP_CLI::log(
+			sprintf(
+				"Seeded rollup '%s' (ID %d, aggregator: %s).",
+				$title,
+				$field_id,
+				$aggregator
+			)
+		);
+
+		return $field_id;
+	}
+
+	/**
+	 * Copies target display metadata onto a seeded rollup field.
+	 *
+	 * @param int $target_field_id Target field post ID.
+	 * @return array<string,string>
+	 */
+	private function rollup_target_meta( int $target_field_id ): array {
+		$target_type = (string) get_post_meta( $target_field_id, 'type', true );
+		$meta        = array();
+
+		if ( '' !== $target_type ) {
+			$meta['rollup_target_type'] = $target_type;
+		}
+
+		foreach (
+			array(
+				'options'               => 'rollup_target_options',
+				'number_format'         => 'rollup_target_number_format',
+				'date_format'           => 'rollup_target_date_format',
+				'related_collection_id' => 'rollup_target_related_collection_id',
+				'relation_multiple'     => 'rollup_target_relation_multiple',
+			) as $source_key => $rollup_key
+		) {
+			$value = get_post_meta( $target_field_id, $source_key, true );
+			if ( '' !== $value && null !== $value ) {
+				$meta[ $rollup_key ] = (string) $value;
+			}
+		}
+
+		return $meta;
+	}
+
+	private function delete_rollup_target_meta( int $field_id ): void {
+		foreach (
+			array(
+				'rollup_target_type',
+				'rollup_target_options',
+				'rollup_target_number_format',
+				'rollup_target_date_format',
+				'rollup_target_related_collection_id',
+				'rollup_target_relation_multiple',
+			) as $meta_key
+		) {
+			delete_post_meta( $field_id, $meta_key );
+		}
+	}
+
+	private function ensure_field_post( int $collection_id, string $title ): int {
+		$field_id = $this->find_attached_field(
+			$title,
+			get_post_meta( $collection_id, 'fields', false )
+		);
+
+		if ( $field_id ) {
+			return $field_id;
+		}
+
+		$field_id = wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_title'  => $title,
+				'post_status' => 'private',
+			),
+			true
+		);
+
+		if ( is_wp_error( $field_id ) ) {
+			WP_CLI::error( "Failed to create field '{$title}': " . $field_id->get_error_message() );
+		}
+
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+		WP_CLI::log( "Created field '{$title}' (ID {$field_id})." );
+
+		return (int) $field_id;
+	}
+
+	/**
+	 * Returns attached field IDs keyed by post title.
+	 *
+	 * @param int $collection_id Collection post ID.
+	 * @return array<string,int>
+	 */
+	private function attached_fields_by_title( int $collection_id ): array {
+		$fields = array();
+		foreach ( get_post_meta( $collection_id, 'fields', false ) as $field_id ) {
+			$field = get_post( (int) $field_id );
+			if ( $field && Field::POST_TYPE === $field->post_type ) {
+				$fields[ $field->post_title ] = (int) $field->ID;
+			}
+		}
+		return $fields;
+	}
+
+	/**
+	 * Replaces a seeded relation value by matching row titles.
+	 *
+	 * @param string   $source_slug   Source collection slug.
+	 * @param string   $source_title  Source row title.
+	 * @param int      $field_id      Source relation field ID.
+	 * @param string[] $target_titles Target row titles.
+	 */
+	private function set_relation_by_titles(
+		string $source_slug,
+		string $source_title,
+		int $field_id,
+		array $target_titles
+	): void {
+		$source_id = $this->entry_id_by_title( $source_slug, $source_title );
+		if ( $source_id < 1 ) {
+			WP_CLI::warning( "Could not seed relation for missing row '{$source_title}'." );
+			return;
+		}
+
+		$target_collection_id = (int) get_post_meta( $field_id, 'related_collection_id', true );
+		$target_slug          = (string) get_post_meta( $target_collection_id, 'slug', true );
+		$target_ids           = array();
+
+		foreach ( $target_titles as $target_title ) {
+			$target_id = $this->entry_id_by_title( $target_slug, $target_title );
+			if ( $target_id < 1 ) {
+				WP_CLI::warning( "Could not seed relation target '{$target_title}'." );
+				continue;
+			}
+			$target_ids[] = $target_id;
+		}
+
+		$result = Relations::sync_relation_value( $source_id, $field_id, $target_ids );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::warning(
+				sprintf(
+					"Could not seed relation for '%s': %s",
+					$source_title,
+					$result->get_error_message()
+				)
+			);
+		}
+	}
+
+	private function entry_id_by_title( string $collection_slug, string $title ): int {
+		if ( '' === $collection_slug ) {
+			return 0;
+		}
+
+		$entry_cpt = CollectionEntries::CPT_PREFIX . $collection_slug;
+		$entries   = get_posts(
+			array(
+				'post_type'   => $entry_cpt,
+				'post_status' => array( 'draft', 'private', 'publish' ),
+				'title'       => $title,
+				'numberposts' => 1,
+				'fields'      => 'ids',
+			)
+		);
+
+		return $entries ? (int) $entries[0] : 0;
+	}
+
+	private function register_collection_entries( int $collection_id ): void {
+		$collection = get_post( $collection_id );
+		if ( $collection ) {
+			( new CollectionEntries() )->register_for_collection( $collection );
+		}
 	}
 
 	private function reset(): void {

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -1390,32 +1390,122 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			$this->register_collection_entries( $books_id );
 			$this->register_collection_entries( $projects_id );
 
-			$this->set_relation_by_titles(
-				'books',
-				'The Left Hand of Darkness',
-				$projects_relation['source_id'],
-				array(
-					'Research relation fields',
-				)
-			);
-			$this->set_relation_by_titles(
-				'books',
-				'Invisible Cities',
-				$projects_relation['source_id'],
-				array(
-					'Collection public templates',
-				)
-			);
-			$this->set_relation_by_titles(
-				'books',
-				'The Dispossessed',
-				$projects_relation['source_id'],
-				array(
-					'Seed realistic demo workspace',
-					'DataViews view persistence',
-				)
-			);
+			foreach ( $this->book_project_relations() as $book_title => $project_titles ) {
+				$this->set_relation_by_titles(
+					'books',
+					$book_title,
+					$projects_relation['source_id'],
+					$project_titles
+				);
+			}
 		}
+	}
+
+	/**
+	 * Returns seeded Books -> Projects relation examples.
+	 *
+	 * @return array<string,string[]>
+	 */
+	private function book_project_relations(): array {
+		return array(
+			'Terre des Hommes'                   => array(
+				'Seed realistic demo workspace',
+				'Inline table editing polish',
+			),
+			'Die Welt als Wille und Vorstellung' => array(
+				'Research relation fields',
+			),
+			'Cien Años de Soledad'               => array(
+				'Collection public templates',
+			),
+			'The Left Hand of Darkness'          => array(
+				'Research relation fields',
+			),
+			'Invisible Cities'                   => array(
+				'Collection public templates',
+			),
+			'The Dispossessed'                   => array(
+				'Seed realistic demo workspace',
+				'DataViews view persistence',
+			),
+			'Ficciones'                          => array(
+				'DataViews view persistence',
+			),
+			'The Master and Margarita'           => array(
+				'Inline table editing polish',
+			),
+			'Things Fall Apart'                  => array(
+				'Collection public templates',
+				'Research relation fields',
+			),
+			'The Name of the Rose'               => array(
+				'Seed realistic demo workspace',
+			),
+			'Kindred'                            => array(
+				'Inline table editing polish',
+				'DataViews view persistence',
+			),
+			'The Rings of Saturn'                => array(
+				'Research relation fields',
+			),
+			'Beloved'                            => array(
+				'Collection public templates',
+			),
+			'The Trial'                          => array(
+				'Inline table editing polish',
+			),
+			'Mrs Dalloway'                       => array(
+				'Seed realistic demo workspace',
+			),
+			'Pedro Páramo'                       => array(
+				'DataViews view persistence',
+			),
+			'Season of Migration to the North'   => array(
+				'Research relation fields',
+			),
+			'The Tale of Genji'                  => array(
+				'Collection public templates',
+			),
+			'The Vegetarian'                     => array(
+				'Inline table editing polish',
+				'Research relation fields',
+			),
+			'Pale Fire'                          => array(
+				'DataViews view persistence',
+			),
+			'The Savage Detectives'              => array(
+				'Seed realistic demo workspace',
+				'Research relation fields',
+			),
+			'Austerlitz'                         => array(
+				'DataViews view persistence',
+			),
+			'The Passion According to G.H.'      => array(
+				'Collection public templates',
+			),
+			'Midnight’s Children'                => array(
+				'Inline table editing polish',
+			),
+			'The God of Small Things'            => array(
+				'Seed realistic demo workspace',
+			),
+			'Snow Country'                       => array(
+				'Research relation fields',
+			),
+			'The Invention of Morel'             => array(
+				'DataViews view persistence',
+			),
+			'The Sound and the Fury'             => array(
+				'Inline table editing polish',
+				'Collection public templates',
+			),
+			'The Leopard'                        => array(
+				'Seed realistic demo workspace',
+			),
+			'Parable of the Sower'               => array(
+				'Research relation fields',
+			),
+		);
 	}
 
 	/**

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -116,6 +116,9 @@ final class CollectionEntries {
 					delete_post_meta( $reverse_owner_collection_id, 'fields', (string) $reverse_id );
 				}
 
+				$this->delete_dependent_rollups_in_collection( $post_id, $owner_collection_id );
+				$this->delete_dependent_rollups_in_collection( $reverse_id, $reverse_owner_collection_id );
+
 				self::$deleting_relation_fields[ $post_id ] = true;
 				wp_delete_post( $reverse_id, true );
 				unset( self::$deleting_relation_fields[ $post_id ] );
@@ -154,6 +157,30 @@ final class CollectionEntries {
 				continue;
 			}
 			delete_post_meta( $collection_id, 'fields', $field_id_str );
+		}
+	}
+
+	/**
+	 * Deletes rollup fields in a collection that depend on a relation field.
+	 *
+	 * @param int $field_id      Relation field post ID being deleted.
+	 * @param int $collection_id Collection whose fields should be scanned.
+	 */
+	private function delete_dependent_rollups_in_collection( int $field_id, int $collection_id ): void {
+		if ( $collection_id < 1 ) {
+			return;
+		}
+
+		foreach ( array_map( 'intval', get_post_meta( $collection_id, 'fields', false ) ) as $rollup_id ) {
+			if (
+				$rollup_id !== $field_id &&
+				Field::POST_TYPE === get_post_type( $rollup_id ) &&
+				'rollup' === (string) get_post_meta( $rollup_id, 'type', true ) &&
+				(string) get_post_meta( $rollup_id, 'rollup_relation_field_id', true ) === (string) $field_id
+			) {
+				delete_post_meta( $collection_id, 'fields', (string) $rollup_id );
+				wp_delete_post( $rollup_id, true );
+			}
 		}
 	}
 

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -103,6 +103,8 @@ final class CollectionEntries {
 			return;
 		}
 
+		$this->delete_dependent_rollups_for_field( $post_id );
+
 		$reverse_id = (int) get_post_meta( $post_id, 'relation_reverse_field_id', true );
 		if ( $reverse_id > 0 && empty( self::$deleting_relation_fields[ $reverse_id ] ) ) {
 			$reverse = get_post( $reverse_id );
@@ -161,9 +163,9 @@ final class CollectionEntries {
 	}
 
 	/**
-	 * Deletes rollup fields in a collection that depend on a relation field.
+	 * Deletes rollup fields in one collection that depend on a deleted field.
 	 *
-	 * @param int $field_id      Relation field post ID being deleted.
+	 * @param int $field_id      Field post ID being deleted.
 	 * @param int $collection_id Collection whose fields should be scanned.
 	 */
 	private function delete_dependent_rollups_in_collection( int $field_id, int $collection_id ): void {
@@ -171,16 +173,127 @@ final class CollectionEntries {
 			return;
 		}
 
+		$field_id_str = (string) $field_id;
 		foreach ( array_map( 'intval', get_post_meta( $collection_id, 'fields', false ) ) as $rollup_id ) {
 			if (
 				$rollup_id !== $field_id &&
 				Field::POST_TYPE === get_post_type( $rollup_id ) &&
 				'rollup' === (string) get_post_meta( $rollup_id, 'type', true ) &&
-				(string) get_post_meta( $rollup_id, 'rollup_relation_field_id', true ) === (string) $field_id
+				(
+					(string) get_post_meta( $rollup_id, 'rollup_relation_field_id', true ) === $field_id_str ||
+					(string) get_post_meta( $rollup_id, 'rollup_target_field_id', true ) === $field_id_str
+				)
 			) {
 				delete_post_meta( $collection_id, 'fields', (string) $rollup_id );
 				wp_delete_post( $rollup_id, true );
 			}
+		}
+	}
+
+	/**
+	 * Deletes rollup fields that depend on a deleted relation or target field.
+	 *
+	 * @param int $field_id Field post ID being deleted.
+	 */
+	private function delete_dependent_rollups_for_field( int $field_id ): void {
+		global $wpdb;
+
+		$field_id_str   = (string) $field_id;
+		$rollup_ids     = array();
+		$collection_ids = array_values( self::$entry_collection_ids );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- cleanup by exact field list value.
+		$attached_collection_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s",
+				'fields',
+				$field_id_str
+			)
+		);
+		$collection_ids          = array_merge(
+			$collection_ids,
+			$attached_collection_ids
+		);
+
+		foreach ( array( 'rollup_relation_field_id', 'rollup_target_field_id' ) as $meta_key ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- cleanup by exact rollup dependency meta.
+			$dependent_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s",
+					$meta_key,
+					$field_id_str
+				)
+			);
+			$rollup_ids    = array_merge(
+				$rollup_ids,
+				$dependent_ids
+			);
+		}
+
+		$fields = get_posts(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => array( 'draft', 'private', 'publish' ),
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+		foreach ( array_map( 'intval', $fields ) as $candidate_id ) {
+			if (
+				$candidate_id !== $field_id &&
+				'rollup' === (string) get_post_meta( $candidate_id, 'type', true ) &&
+				(
+					(string) get_post_meta( $candidate_id, 'rollup_relation_field_id', true ) === $field_id_str ||
+					(string) get_post_meta( $candidate_id, 'rollup_target_field_id', true ) === $field_id_str
+				)
+			) {
+				$rollup_ids[] = $candidate_id;
+			}
+		}
+
+		foreach ( array_unique( array_map( 'intval', $collection_ids ) ) as $collection_id ) {
+			if ( Collection::POST_TYPE !== get_post_type( $collection_id ) ) {
+				continue;
+			}
+			foreach ( array_map( 'intval', get_post_meta( $collection_id, 'fields', false ) ) as $rollup_id ) {
+				if (
+					$rollup_id !== $field_id &&
+					Field::POST_TYPE === get_post_type( $rollup_id ) &&
+					'rollup' === (string) get_post_meta( $rollup_id, 'type', true ) &&
+					(
+						(string) get_post_meta( $rollup_id, 'rollup_relation_field_id', true ) === $field_id_str ||
+						(string) get_post_meta( $rollup_id, 'rollup_target_field_id', true ) === $field_id_str
+					)
+				) {
+					$rollup_ids[] = $rollup_id;
+				}
+			}
+		}
+
+		foreach ( array_unique( array_map( 'intval', $rollup_ids ) ) as $rollup_id ) {
+			if (
+				$rollup_id === $field_id ||
+				Field::POST_TYPE !== get_post_type( $rollup_id ) ||
+				'rollup' !== (string) get_post_meta( $rollup_id, 'type', true )
+			) {
+				continue;
+			}
+
+			$rollup_id_str = (string) $rollup_id;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- cleanup by exact field list value.
+			$owner_collection_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s",
+					'fields',
+					$rollup_id_str
+				)
+			);
+			$owner_collection_ids = array_merge( $owner_collection_ids, $collection_ids );
+			foreach ( array_unique( array_map( 'intval', $owner_collection_ids ) ) as $collection_id ) {
+				if ( Collection::POST_TYPE === get_post_type( $collection_id ) ) {
+					delete_post_meta( $collection_id, 'fields', $rollup_id_str );
+				}
+			}
+			wp_delete_post( $rollup_id, true );
 		}
 	}
 

--- a/includes/PostType/Field.php
+++ b/includes/PostType/Field.php
@@ -60,6 +60,10 @@ final class Field {
 			'date_format',
 			'expression',
 			'rollup_aggregator',
+			'rollup_target_type',
+			'rollup_target_options',
+			'rollup_target_number_format',
+			'rollup_target_date_format',
 		);
 
 		foreach ( $string_meta as $key ) {
@@ -89,6 +93,7 @@ final class Field {
 			'relation_reverse_field_id',
 			'rollup_relation_field_id',
 			'rollup_target_field_id',
+			'rollup_target_related_collection_id',
 		);
 
 		foreach ( $integer_meta as $key ) {
@@ -106,6 +111,16 @@ final class Field {
 		register_post_meta(
 			self::POST_TYPE,
 			'relation_multiple',
+			array(
+				'type'         => 'boolean',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
+
+		register_post_meta(
+			self::POST_TYPE,
+			'rollup_target_relation_multiple',
 			array(
 				'type'         => 'boolean',
 				'single'       => true,

--- a/includes/PostType/Field.php
+++ b/includes/PostType/Field.php
@@ -59,6 +59,7 @@ final class Field {
 			'number_format',
 			'date_format',
 			'expression',
+			'rollup_aggregator',
 		);
 
 		foreach ( $string_meta as $key ) {
@@ -86,6 +87,8 @@ final class Field {
 
 		$integer_meta = array(
 			'relation_reverse_field_id',
+			'rollup_relation_field_id',
+			'rollup_target_field_id',
 		);
 
 		foreach ( $integer_meta as $key ) {

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -39,11 +39,38 @@ final class FieldsController {
 
 	private const ROLLUP_AGGREGATORS = array(
 		'count',
+		'show_original',
+		'show_unique',
+		'count_values',
+		'count_unique',
+		'empty',
+		'not_empty',
+		'percent_empty',
+		'percent_not_empty',
 		'sum',
 		'avg',
+		'median',
 		'min',
 		'max',
+		'range',
+		'earliest',
 		'latest',
+		'date_range',
+	);
+
+	private const ROLLUP_NUMERIC_AGGREGATORS = array(
+		'sum',
+		'avg',
+		'median',
+		'min',
+		'max',
+		'range',
+	);
+
+	private const ROLLUP_DATE_AGGREGATORS = array(
+		'earliest',
+		'latest',
+		'date_range',
 	);
 
 	public function register(): void {
@@ -334,6 +361,12 @@ final class FieldsController {
 				'rollup_relation_field_id',
 				'rollup_target_field_id',
 				'rollup_aggregator',
+				'rollup_target_type',
+				'rollup_target_options',
+				'rollup_target_number_format',
+				'rollup_target_date_format',
+				'rollup_target_related_collection_id',
+				'rollup_target_relation_multiple',
 			) as $key
 		) {
 			$value = get_post_meta( $field_id, $key, true );
@@ -625,9 +658,42 @@ final class FieldsController {
 		);
 		if ( $target_field_id > 0 ) {
 			$meta['rollup_target_field_id'] = (string) $target_field_id;
+			$meta                           = array_merge( $meta, $this->rollup_target_meta( $target_field_id ) );
 		}
 
 		return $this->insert_and_attach( $collection_id, $title, $meta, $insert_after_id );
+	}
+
+	/**
+	 * Copies target display metadata onto the rollup field so table rendering
+	 * does not need to fetch the target field later.
+	 *
+	 * @param int $target_field_id Rollup target field post ID.
+	 * @return array<string,string>
+	 */
+	private function rollup_target_meta( int $target_field_id ): array {
+		$target_type = (string) get_post_meta( $target_field_id, 'type', true );
+		$meta        = array();
+		if ( '' !== $target_type ) {
+			$meta['rollup_target_type'] = $target_type;
+		}
+
+		foreach (
+			array(
+				'options'               => 'rollup_target_options',
+				'number_format'         => 'rollup_target_number_format',
+				'date_format'           => 'rollup_target_date_format',
+				'related_collection_id' => 'rollup_target_related_collection_id',
+				'relation_multiple'     => 'rollup_target_relation_multiple',
+			) as $source_key => $rollup_key
+		) {
+			$value = get_post_meta( $target_field_id, $source_key, true );
+			if ( '' !== $value && null !== $value ) {
+				$meta[ $rollup_key ] = (string) $value;
+			}
+		}
+
+		return $meta;
 	}
 
 	private function validate_rollup_config(
@@ -660,7 +726,7 @@ final class FieldsController {
 			);
 		}
 
-		if ( 'count' === $aggregator ) {
+		if ( 'count' === $aggregator && $target_field_id < 1 ) {
 			return true;
 		}
 		if ( $target_field_id < 1 ) {
@@ -690,17 +756,17 @@ final class FieldsController {
 			);
 		}
 
-		if ( in_array( $aggregator, array( 'sum', 'avg', 'min', 'max' ), true ) && 'number' !== $target_type ) {
+		if ( in_array( $aggregator, self::ROLLUP_NUMERIC_AGGREGATORS, true ) && 'number' !== $target_type ) {
 			return new WP_Error(
 				'cortext_rollup_target_must_be_number',
 				__( 'Numeric rollups must target a number field.', 'cortext' ),
 				array( 'status' => 400 )
 			);
 		}
-		if ( 'latest' === $aggregator && ! in_array( $target_type, array( 'date', 'datetime' ), true ) ) {
+		if ( in_array( $aggregator, self::ROLLUP_DATE_AGGREGATORS, true ) && ! in_array( $target_type, array( 'date', 'datetime' ), true ) ) {
 			return new WP_Error(
 				'cortext_rollup_target_must_be_date',
-				__( 'Latest rollups must target a date field.', 'cortext' ),
+				__( 'Date rollups must target a date field.', 'cortext' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -34,6 +34,16 @@ final class FieldsController {
 		'select',
 		'multiselect',
 		'relation',
+		'rollup',
+	);
+
+	private const ROLLUP_AGGREGATORS = array(
+		'count',
+		'sum',
+		'avg',
+		'min',
+		'max',
+		'latest',
 	);
 
 	public function register(): void {
@@ -50,20 +60,20 @@ final class FieldsController {
 					'callback'            => array( $this, 'create' ),
 					'permission_callback' => array( $this, 'can_edit_collection' ),
 					'args'                => array(
-						'collection_id'         => array(
+						'collection_id'            => array(
 							'type'     => 'integer',
 							'required' => true,
 						),
-						'title'                 => array(
+						'title'                    => array(
 							'type'     => 'string',
 							'required' => true,
 						),
-						'type'                  => array(
+						'type'                     => array(
 							'type'     => 'string',
 							'required' => true,
 							'enum'     => self::ALLOWED_TYPES,
 						),
-						'options'               => array(
+						'options'                  => array(
 							'type'     => 'array',
 							'required' => false,
 							'items'    => array(
@@ -75,23 +85,36 @@ final class FieldsController {
 								),
 							),
 						),
-						'related_collection_id' => array(
+						'related_collection_id'    => array(
 							'type'     => 'integer',
 							'required' => false,
 						),
-						'relation_multiple'     => array(
+						'relation_multiple'        => array(
 							'type'     => 'boolean',
 							'required' => false,
 							'default'  => true,
 						),
-						'reverse_title'         => array(
+						'reverse_title'            => array(
 							'type'     => 'string',
 							'required' => false,
 						),
-						'reverse_multiple'      => array(
+						'reverse_multiple'         => array(
 							'type'     => 'boolean',
 							'required' => false,
 							'default'  => true,
+						),
+						'rollup_relation_field_id' => array(
+							'type'     => 'integer',
+							'required' => false,
+						),
+						'rollup_target_field_id'   => array(
+							'type'     => 'integer',
+							'required' => false,
+						),
+						'rollup_aggregator'        => array(
+							'type'     => 'string',
+							'required' => false,
+							'enum'     => self::ROLLUP_AGGREGATORS,
 						),
 					),
 				),
@@ -238,6 +261,10 @@ final class FieldsController {
 			return $this->create_relation( $request, $collection_id, $title );
 		}
 
+		if ( 'rollup' === $type ) {
+			return $this->create_rollup( $request, $collection_id, $title );
+		}
+
 		$meta = array( 'type' => $type );
 		if ( $this->type_supports_options( $type ) && is_array( $options ) ) {
 			$meta['options'] = wp_json_encode( $this->normalize_options( $options ) );
@@ -304,6 +331,9 @@ final class FieldsController {
 				'expression',
 				'related_collection_id',
 				'relation_multiple',
+				'rollup_relation_field_id',
+				'rollup_target_field_id',
+				'rollup_aggregator',
 			) as $key
 		) {
 			$value = get_post_meta( $field_id, $key, true );
@@ -563,6 +593,119 @@ final class FieldsController {
 		}
 
 		return $this->field_response( $source_id, $title, 'relation' );
+	}
+
+	private function create_rollup(
+		WP_REST_Request $request,
+		int $collection_id,
+		string $title,
+		?string $insert_after_id = null
+	): WP_REST_Response|WP_Error {
+		$relation_field_id = (int) $request->get_param( 'rollup_relation_field_id' );
+		$target_field_id   = (int) $request->get_param( 'rollup_target_field_id' );
+		$aggregator        = (string) $request->get_param( 'rollup_aggregator' );
+		if ( '' === $aggregator ) {
+			$aggregator = 'count';
+		}
+
+		$validation = $this->validate_rollup_config(
+			$collection_id,
+			$relation_field_id,
+			$target_field_id,
+			$aggregator
+		);
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
+
+		$meta = array(
+			'type'                     => 'rollup',
+			'rollup_relation_field_id' => (string) $relation_field_id,
+			'rollup_aggregator'        => $aggregator,
+		);
+		if ( $target_field_id > 0 ) {
+			$meta['rollup_target_field_id'] = (string) $target_field_id;
+		}
+
+		return $this->insert_and_attach( $collection_id, $title, $meta, $insert_after_id );
+	}
+
+	private function validate_rollup_config(
+		int $collection_id,
+		int $relation_field_id,
+		int $target_field_id,
+		string $aggregator
+	): bool|WP_Error {
+		if ( ! in_array( $aggregator, self::ROLLUP_AGGREGATORS, true ) ) {
+			return new WP_Error(
+				'cortext_rollup_aggregator_invalid',
+				__( 'Rollup aggregator is invalid.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$collection_fields = $this->collection_field_ids( $collection_id );
+		if ( ! in_array( (string) $relation_field_id, $collection_fields, true ) ) {
+			return new WP_Error(
+				'cortext_rollup_relation_invalid',
+				__( 'Rollup source relation must belong to this collection.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+		if ( 'relation' !== (string) get_post_meta( $relation_field_id, 'type', true ) ) {
+			return new WP_Error(
+				'cortext_rollup_source_not_relation',
+				__( 'Rollup source field must be a relation.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( 'count' === $aggregator ) {
+			return true;
+		}
+		if ( $target_field_id < 1 ) {
+			return new WP_Error(
+				'cortext_rollup_target_required',
+				__( 'Rollup target field is required.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$target_collection_id = (int) get_post_meta( $relation_field_id, 'related_collection_id', true );
+		$target_fields        = $this->collection_field_ids( $target_collection_id );
+		if ( ! in_array( (string) $target_field_id, $target_fields, true ) ) {
+			return new WP_Error(
+				'cortext_rollup_target_invalid',
+				__( 'Rollup target field must belong to the related collection.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$target_type = (string) get_post_meta( $target_field_id, 'type', true );
+		if ( 'rollup' === $target_type ) {
+			return new WP_Error(
+				'cortext_rollup_of_rollup_unsupported',
+				__( 'Rollups cannot target other rollups.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( in_array( $aggregator, array( 'sum', 'avg', 'min', 'max' ), true ) && 'number' !== $target_type ) {
+			return new WP_Error(
+				'cortext_rollup_target_must_be_number',
+				__( 'Numeric rollups must target a number field.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+		if ( 'latest' === $aggregator && ! in_array( $target_type, array( 'date', 'datetime' ), true ) ) {
+			return new WP_Error(
+				'cortext_rollup_target_must_be_date',
+				__( 'Latest rollups must target a date field.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -670,7 +670,7 @@ final class RowsController {
 		return $refs;
 	}
 
-	private function compute_rollup_value( int $row_id, int $field_id ): int|float|string|null {
+	private function compute_rollup_value( int $row_id, int $field_id ): mixed {
 		$relation_field_id = (int) get_post_meta( $field_id, 'rollup_relation_field_id', true );
 		$target_field_id   = (int) get_post_meta( $field_id, 'rollup_target_field_id', true );
 		$aggregator        = (string) get_post_meta( $field_id, 'rollup_aggregator', true );
@@ -683,11 +683,32 @@ final class RowsController {
 			return count( $related_ids );
 		}
 		if ( $target_field_id < 1 || count( $related_ids ) === 0 ) {
-			return in_array( $aggregator, array( 'sum' ), true ) ? 0 : null;
+			return 'sum' === $aggregator ? 0 : null;
 		}
 
-		if ( 'latest' === $aggregator ) {
-			return $this->latest_rollup_value( $related_ids, $target_field_id );
+		if ( in_array( $aggregator, array( 'show_original', 'show_unique' ), true ) ) {
+			$values = $this->rollup_values( $related_ids, $target_field_id );
+			return 'show_unique' === $aggregator ? $this->unique_rollup_values( $values ) : $values;
+		}
+
+		if ( in_array( $aggregator, array( 'count_values', 'count_unique', 'empty', 'not_empty', 'percent_empty', 'percent_not_empty' ), true ) ) {
+			return $this->count_rollup_value( $related_ids, $target_field_id, $aggregator );
+		}
+
+		if ( in_array( $aggregator, array( 'earliest', 'latest' ), true ) ) {
+			return $this->date_extrema_rollup_value( $related_ids, $target_field_id, 'earliest' === $aggregator ? 'min' : 'max' );
+		}
+
+		if ( 'date_range' === $aggregator ) {
+			$start = $this->date_extrema_rollup_value( $related_ids, $target_field_id, 'min' );
+			$end   = $this->date_extrema_rollup_value( $related_ids, $target_field_id, 'max' );
+			if ( null === $start && null === $end ) {
+				return null;
+			}
+			return array(
+				'start' => $start,
+				'end'   => $end,
+			);
 		}
 
 		$numbers = $this->numeric_rollup_values( $related_ids, $target_field_id );
@@ -698,9 +719,108 @@ final class RowsController {
 		return match ( $aggregator ) {
 			'sum' => array_sum( $numbers ),
 			'avg' => array_sum( $numbers ) / count( $numbers ),
+			'median' => $this->median_rollup_value( $numbers ),
 			'min' => min( $numbers ),
 			'max' => max( $numbers ),
+			'range' => max( $numbers ) - min( $numbers ),
 			default => null,
+		};
+	}
+
+	/**
+	 * Returns flattened, non-empty values from related rows for a target field.
+	 *
+	 * @param int[] $row_ids         Related row IDs.
+	 * @param int   $target_field_id Rollup target field post ID.
+	 * @return array<int,mixed>
+	 */
+	private function rollup_values( array $row_ids, int $target_field_id ): array {
+		$values = array();
+		foreach ( $row_ids as $row_id ) {
+			foreach ( $this->rollup_values_for_row( $row_id, $target_field_id ) as $value ) {
+				$values[] = $value;
+			}
+		}
+		return $values;
+	}
+
+	/**
+	 * Returns flattened values for one related row.
+	 *
+	 * @param int $row_id          Related row ID.
+	 * @param int $target_field_id Rollup target field post ID.
+	 * @return array<int,mixed>
+	 */
+	private function rollup_values_for_row( int $row_id, int $target_field_id ): array {
+		$type = (string) get_post_meta( $target_field_id, 'type', true );
+		if ( 'relation' === $type ) {
+			return $this->format_relation_value( $row_id, $target_field_id );
+		}
+
+		$key = Relations::meta_key( $target_field_id );
+		if ( 'multiselect' === $type ) {
+			return array_values(
+				array_filter(
+					get_post_meta( $row_id, $key, false ),
+					static fn( $value ) => '' !== $value && null !== $value
+				)
+			);
+		}
+
+		$value = get_post_meta( $row_id, $key, true );
+		return '' === $value || null === $value ? array() : array( $value );
+	}
+
+	/**
+	 * Returns unique values while preserving relation order.
+	 *
+	 * @param array<int,mixed> $values Values to de-duplicate.
+	 * @return array<int,mixed>
+	 */
+	private function unique_rollup_values( array $values ): array {
+		$seen   = array();
+		$unique = array();
+		foreach ( $values as $value ) {
+			$key = wp_json_encode( $value );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$unique[]     = $value;
+		}
+		return $unique;
+	}
+
+	/**
+	 * Computes count and percent rollups.
+	 *
+	 * @param int[]  $row_ids         Related row IDs.
+	 * @param int    $target_field_id Rollup target field post ID.
+	 * @param string $aggregator      Rollup aggregator.
+	 */
+	private function count_rollup_value( array $row_ids, int $target_field_id, string $aggregator ): int|float {
+		$total = count( $row_ids );
+		if ( 'count_values' === $aggregator ) {
+			return count( $this->rollup_values( $row_ids, $target_field_id ) );
+		}
+		if ( 'count_unique' === $aggregator ) {
+			return count( $this->unique_rollup_values( $this->rollup_values( $row_ids, $target_field_id ) ) );
+		}
+
+		$not_empty = 0;
+		foreach ( $row_ids as $row_id ) {
+			if ( count( $this->rollup_values_for_row( $row_id, $target_field_id ) ) > 0 ) {
+				++$not_empty;
+			}
+		}
+		$empty = $total - $not_empty;
+
+		return match ( $aggregator ) {
+			'empty' => $empty,
+			'not_empty' => $not_empty,
+			'percent_empty' => $total > 0 ? $empty / $total : 0,
+			'percent_not_empty' => $total > 0 ? $not_empty / $total : 0,
+			default => 0,
 		};
 	}
 
@@ -724,15 +844,31 @@ final class RowsController {
 	}
 
 	/**
-	 * Returns the latest date-like value for a rollup target field.
+	 * Returns the median numeric value for a rollup target field.
 	 *
-	 * @param int[] $row_ids Related row IDs.
-	 * @param int   $target_field_id Rollup target field post ID.
+	 * @param float[] $numbers Numeric values.
 	 */
-	private function latest_rollup_value( array $row_ids, int $target_field_id ): ?string {
-		$key         = Relations::meta_key( $target_field_id );
-		$latest_time = null;
-		$latest      = null;
+	private function median_rollup_value( array $numbers ): float {
+		sort( $numbers, SORT_NUMERIC );
+		$count  = count( $numbers );
+		$middle = intdiv( $count, 2 );
+		if ( 1 === $count % 2 ) {
+			return $numbers[ $middle ];
+		}
+		return ( $numbers[ $middle - 1 ] + $numbers[ $middle ] ) / 2;
+	}
+
+	/**
+	 * Returns the earliest or latest date-like value for a rollup target field.
+	 *
+	 * @param int[]  $row_ids         Related row IDs.
+	 * @param int    $target_field_id Rollup target field post ID.
+	 * @param string $direction       Either `min` or `max`.
+	 */
+	private function date_extrema_rollup_value( array $row_ids, int $target_field_id, string $direction ): ?string {
+		$key       = Relations::meta_key( $target_field_id );
+		$best_time = null;
+		$best      = null;
 		foreach ( $row_ids as $row_id ) {
 			$value = (string) get_post_meta( $row_id, $key, true );
 			if ( '' === $value ) {
@@ -742,12 +878,12 @@ final class RowsController {
 			if ( false === $time ) {
 				continue;
 			}
-			if ( null === $latest_time || $time > $latest_time ) {
-				$latest_time = $time;
-				$latest      = $value;
+			if ( null === $best_time || ( 'min' === $direction ? $time < $best_time : $time > $best_time ) ) {
+				$best_time = $time;
+				$best      = $value;
 			}
 		}
-		return $latest;
+		return $best;
 	}
 
 	/**

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -355,6 +355,14 @@ final class RowsController {
 		}
 
 		$field_type = (string) get_post_meta( $field_id, 'type', true );
+		if ( 'rollup' === $field_type ) {
+			return new WP_Error(
+				'cortext_rollup_read_only',
+				__( 'Rollups are read-only.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		if ( 'relation' === $field_type ) {
 			$synced = Relations::sync_relation_value( $row_id, $field_id, $value );
 			if ( is_wp_error( $synced ) ) {
@@ -424,7 +432,7 @@ final class RowsController {
 	 * sortable system field keys (`'created_at'`, `'modified_at'`). Rejects
 	 * the `*_by` system field keys and any other identifier — sort on
 	 * display-value properties is an open architectural decision shared
-	 * with relations (tech-debt.md#14).
+	 * with relations and rollups (tech-debt.md#14).
 	 *
 	 * @param mixed $sort           Sort param from the request.
 	 * @param int[] $field_ids      Valid field IDs for the collection.
@@ -542,11 +550,16 @@ final class RowsController {
 			} else {
 				$field_id   = $this->field_id_from_key( $sort['field'] );
 				$field_type = $field_id ? (string) get_post_meta( $field_id, 'type', true ) : '';
-				$wp_type    = CollectionEntries::wp_meta_type_for( $field_type );
+				if ( 'rollup' === $field_type ) {
+					$args['orderby'] = 'date';
+					$args['order']   = 'ASC';
+				} else {
+					$wp_type = CollectionEntries::wp_meta_type_for( $field_type );
 
-				$args['meta_key'] = $sort['field']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				$args['orderby']  = 'number' === $wp_type ? 'meta_value_num' : 'meta_value';
-				$args['order']    = $direction;
+					$args['meta_key'] = $sort['field']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					$args['orderby']  = 'number' === $wp_type ? 'meta_value_num' : 'meta_value';
+					$args['order']    = $direction;
+				}
 			}
 		}
 
@@ -564,6 +577,10 @@ final class RowsController {
 				$value    = $filter['value'] ?? '';
 
 				if ( '' === $field || ! isset( self::FILTER_OPERATORS[ $operator ] ) ) {
+					continue;
+				}
+				$field_id = $this->field_id_from_key( $field );
+				if ( $field_id && 'rollup' === (string) get_post_meta( $field_id, 'type', true ) ) {
 					continue;
 				}
 
@@ -653,6 +670,86 @@ final class RowsController {
 		return $refs;
 	}
 
+	private function compute_rollup_value( int $row_id, int $field_id ): int|float|string|null {
+		$relation_field_id = (int) get_post_meta( $field_id, 'rollup_relation_field_id', true );
+		$target_field_id   = (int) get_post_meta( $field_id, 'rollup_target_field_id', true );
+		$aggregator        = (string) get_post_meta( $field_id, 'rollup_aggregator', true );
+		if ( '' === $aggregator ) {
+			$aggregator = 'count';
+		}
+
+		$related_ids = Relations::relation_values( $row_id, $relation_field_id );
+		if ( 'count' === $aggregator ) {
+			return count( $related_ids );
+		}
+		if ( $target_field_id < 1 || count( $related_ids ) === 0 ) {
+			return in_array( $aggregator, array( 'sum' ), true ) ? 0 : null;
+		}
+
+		if ( 'latest' === $aggregator ) {
+			return $this->latest_rollup_value( $related_ids, $target_field_id );
+		}
+
+		$numbers = $this->numeric_rollup_values( $related_ids, $target_field_id );
+		if ( count( $numbers ) === 0 ) {
+			return 'sum' === $aggregator ? 0 : null;
+		}
+
+		return match ( $aggregator ) {
+			'sum' => array_sum( $numbers ),
+			'avg' => array_sum( $numbers ) / count( $numbers ),
+			'min' => min( $numbers ),
+			'max' => max( $numbers ),
+			default => null,
+		};
+	}
+
+	/**
+	 * Returns numeric values for a rollup target field.
+	 *
+	 * @param int[] $row_ids Related row IDs.
+	 * @param int   $target_field_id Rollup target field post ID.
+	 * @return float[]
+	 */
+	private function numeric_rollup_values( array $row_ids, int $target_field_id ): array {
+		$key    = Relations::meta_key( $target_field_id );
+		$values = array();
+		foreach ( $row_ids as $row_id ) {
+			$value = get_post_meta( $row_id, $key, true );
+			if ( '' !== $value && null !== $value && is_numeric( $value ) ) {
+				$values[] = (float) $value;
+			}
+		}
+		return $values;
+	}
+
+	/**
+	 * Returns the latest date-like value for a rollup target field.
+	 *
+	 * @param int[] $row_ids Related row IDs.
+	 * @param int   $target_field_id Rollup target field post ID.
+	 */
+	private function latest_rollup_value( array $row_ids, int $target_field_id ): ?string {
+		$key         = Relations::meta_key( $target_field_id );
+		$latest_time = null;
+		$latest      = null;
+		foreach ( $row_ids as $row_id ) {
+			$value = (string) get_post_meta( $row_id, $key, true );
+			if ( '' === $value ) {
+				continue;
+			}
+			$time = strtotime( $value );
+			if ( false === $time ) {
+				continue;
+			}
+			if ( null === $latest_time || $time > $latest_time ) {
+				$latest_time = $time;
+				$latest      = $value;
+			}
+		}
+		return $latest;
+	}
+
 	/**
 	 * Returns the subset of field IDs whose type stores multiple values.
 	 *
@@ -686,6 +783,8 @@ final class RowsController {
 
 			if ( 'relation' === $field_type ) {
 				$meta[ $key ] = $this->format_relation_value( $post->ID, $field_id );
+			} elseif ( 'rollup' === $field_type ) {
+				$meta[ $key ] = $this->compute_rollup_value( $post->ID, $field_id );
 			} else {
 				$meta[ $key ] = isset( $multi_field_ids[ $field_id ] )
 					? get_post_meta( $post->ID, $key, false )

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -18,6 +18,7 @@ import ColumnHeaderActions from './fields/ColumnHeaderActions';
 import {
 	GHOST_FIELD_ID,
 	TITLE_FIELD_ID,
+	isDefaultVisibleField,
 	normalizeView,
 } from './dataViewColumns';
 import useCollectionFields from '../hooks/useCollectionFields';
@@ -122,15 +123,23 @@ function NewRowButton( { slug, view, fields, onCreated, disabled } ) {
 	const [ isCreating, setIsCreating ] = useState( false );
 	const [ error, setError ] = useState( null );
 
-	const fieldIds = useMemo(
-		() => new Set( fields.map( ( f ) => f.id ) ),
+	const prefillableFieldIds = useMemo(
+		() =>
+			new Set(
+				fields
+					.filter(
+						( f ) =>
+							f.editable !== false && f.cortextType !== 'rollup'
+					)
+					.map( ( f ) => f.id )
+			),
 		[ fields ]
 	);
 
 	const onClick = useCallback( async () => {
 		setIsCreating( true );
 		setError( null );
-		const meta = prefillFromFilters( view?.filters, fieldIds );
+		const meta = prefillFromFilters( view?.filters, prefillableFieldIds );
 		try {
 			// FIXME: Consider supporting row creation via /cortext/v1/rows.
 			const created = await apiFetch( {
@@ -150,7 +159,7 @@ function NewRowButton( { slug, view, fields, onCreated, disabled } ) {
 		} finally {
 			setIsCreating( false );
 		}
-	}, [ slug, view, fieldIds, onCreated ] );
+	}, [ slug, view, prefillableFieldIds, onCreated ] );
 
 	return (
 		<>
@@ -220,7 +229,11 @@ export default function CollectionDataViews( {
 		hasResolved: rowsResolved,
 		error: rowError,
 		refresh,
-	} = useCollectionRows( isResolving ? null : collectionId, reconciledView );
+	} = useCollectionRows(
+		isResolving ? null : collectionId,
+		reconciledView,
+		availableFields
+	);
 
 	const isTableLayout = view?.type === 'table';
 	const dataViewFields = useMemo(
@@ -416,12 +429,12 @@ export default function CollectionDataViews( {
 
 		let seededView = currentView;
 		if ( currentFields.length === 0 ) {
-			// Default to editable columns only: read-only types like formula
-			// do not accept inline saves and can be enabled via the View config.
+			// Default to user-created collection fields. System fields stay
+			// hidden until enabled from the View config.
 			seededView = {
 				...currentView,
 				fields: availableFields
-					.filter( ( f ) => f.editable )
+					.filter( isDefaultVisibleField )
 					.map( ( f ) => f.id ),
 			};
 		}
@@ -450,7 +463,7 @@ export default function CollectionDataViews( {
 			) {
 				const f = availableFields[ schemaIdx ];
 				if (
-					! f.editable ||
+					! isDefaultVisibleField( f ) ||
 					previouslyKnown.has( f.id ) ||
 					next.includes( f.id )
 				) {

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -301,6 +301,24 @@ export function formatDisplay( value, type, options = {} ) {
 		return '';
 	}
 
+	if ( type === 'rollup-date-range' ) {
+		if ( ! value || typeof value !== 'object' ) {
+			return '';
+		}
+		const dateType =
+			format?.rollup_target_type === 'datetime' ? 'datetime' : 'date';
+		const start = value.start
+			? formatDateValue( value.start, dateType, format )
+			: '';
+		const end = value.end
+			? formatDateValue( value.end, dateType, format )
+			: '';
+		if ( start && end && start !== end ) {
+			return `${ start } - ${ end }`;
+		}
+		return start || end;
+	}
+
 	if ( type === 'checkbox' ) {
 		// `false` is a meaningful value but renders as a blank cell.
 		// Reaching this branch is rare in practice (interactive checkbox
@@ -373,10 +391,22 @@ export function formatDisplay( value, type, options = {} ) {
 	}
 
 	if ( type === 'date' || type === 'datetime' ) {
+		if ( Array.isArray( value ) ) {
+			return value
+				.map( ( item ) => formatDateValue( item, type, format ) )
+				.filter( Boolean )
+				.join( ', ' );
+		}
 		return formatDateValue( value, type, format );
 	}
 
 	if ( type === 'number' ) {
+		if ( Array.isArray( value ) ) {
+			return value
+				.map( ( item ) => formatNumberValue( item, format ) )
+				.filter( Boolean )
+				.join( ', ' );
+		}
 		const text = formatNumberValue( value, format );
 		if ( format?.display === 'bar' ) {
 			return (

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -421,6 +421,14 @@ export function formatDisplay( value, type, options = {} ) {
 		return text;
 	}
 
+	if ( Array.isArray( value ) ) {
+		return value
+			.filter(
+				( item ) => item !== null && item !== undefined && item !== ''
+			)
+			.map( ( item ) => String( item ) )
+			.join( ', ' );
+	}
 	return String( value );
 }
 

--- a/src/components/dataViewColumns.js
+++ b/src/components/dataViewColumns.js
@@ -23,6 +23,13 @@ export const MIN_WIDTHS = {
 };
 export const DEFAULT_MIN_WIDTH = 32;
 
+// Default view seeding should show user-created collection fields even
+// when a field is read-only, as with rollups. System fields stay hidden
+// because they have no backing `crtxt_field` record.
+export function isDefaultVisibleField( field ) {
+	return Boolean( field?.editable || field?.recordId );
+}
+
 export function getMinWidth( fieldType ) {
 	return MIN_WIDTHS[ fieldType ] ?? DEFAULT_MIN_WIDTH;
 }

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -100,12 +100,30 @@ const RELATION_LIMIT_OPTIONS = [
 ];
 
 const ROLLUP_AGGREGATORS = [
-	{ value: 'count', label: __( 'Count', 'cortext' ) },
+	{ value: 'show_original', label: __( 'Show original', 'cortext' ) },
+	{ value: 'show_unique', label: __( 'Show unique values', 'cortext' ) },
+	{ value: 'count', label: __( 'Count all', 'cortext' ) },
+	{ value: 'count_values', label: __( 'Count values', 'cortext' ) },
+	{ value: 'count_unique', label: __( 'Count unique values', 'cortext' ) },
+	{ value: 'empty', label: __( 'Count empty', 'cortext' ) },
+	{ value: 'not_empty', label: __( 'Count not empty', 'cortext' ) },
+	{ value: 'percent_empty', label: __( 'Percent empty', 'cortext' ) },
+	{ value: 'percent_not_empty', label: __( 'Percent not empty', 'cortext' ) },
+];
+
+const ROLLUP_NUMBER_AGGREGATORS = [
 	{ value: 'sum', label: __( 'Sum', 'cortext' ) },
 	{ value: 'avg', label: __( 'Average', 'cortext' ) },
+	{ value: 'median', label: __( 'Median', 'cortext' ) },
 	{ value: 'min', label: __( 'Min', 'cortext' ) },
 	{ value: 'max', label: __( 'Max', 'cortext' ) },
+	{ value: 'range', label: __( 'Range', 'cortext' ) },
+];
+
+const ROLLUP_DATE_AGGREGATORS = [
+	{ value: 'earliest', label: __( 'Earliest date', 'cortext' ) },
 	{ value: 'latest', label: __( 'Latest date', 'cortext' ) },
+	{ value: 'date_range', label: __( 'Date range', 'cortext' ) },
 ];
 
 function titleOf( record ) {
@@ -118,9 +136,23 @@ function fieldTypeLabel( type ) {
 
 function rollupAggregatorLabel( aggregator ) {
 	return (
-		ROLLUP_AGGREGATORS.find( ( option ) => option.value === aggregator )
-			?.label ?? aggregator
+		[
+			...ROLLUP_AGGREGATORS,
+			...ROLLUP_NUMBER_AGGREGATORS,
+			...ROLLUP_DATE_AGGREGATORS,
+		].find( ( option ) => option.value === aggregator )?.label ?? aggregator
 	);
+}
+
+function rollupAggregatorOptionsForTarget( type ) {
+	const options = [ ...ROLLUP_AGGREGATORS ];
+	if ( type === 'number' ) {
+		options.push( ...ROLLUP_NUMBER_AGGREGATORS );
+	}
+	if ( type === 'date' || type === 'datetime' ) {
+		options.push( ...ROLLUP_DATE_AGGREGATORS );
+	}
+	return options;
 }
 
 function RelationConfig( {
@@ -271,7 +303,7 @@ function RollupConfig( {
 		( field ) => field.cortextType === 'relation'
 	);
 	const [ relationFieldId, setRelationFieldId ] = useState( '' );
-	const [ aggregator, setAggregator ] = useState( 'count' );
+	const [ aggregator, setAggregator ] = useState( 'show_original' );
 	const [ targetFieldId, setTargetFieldId ] = useState( '' );
 
 	const selectedRelation = relationFields.find(
@@ -299,24 +331,23 @@ function RollupConfig( {
 		( field ) => String( field.id ) === targetFieldId
 	);
 
-	const targetTypeAllowed = ( type ) => {
-		if ( [ 'sum', 'avg', 'min', 'max' ].includes( aggregator ) ) {
-			return type === 'number';
-		}
-		if ( aggregator === 'latest' ) {
-			return type === 'date' || type === 'datetime';
-		}
-		return false;
-	};
-	const targetOptions = [
-		{ value: '', label: __( 'Choose field…', 'cortext' ) },
-		...( targetFields ?? [] )
-			.filter( ( field ) => targetTypeAllowed( field.meta?.type ) )
-			.map( ( field ) => ( {
-				value: String( field.id ),
-				label: titleOf( field ),
-			} ) ),
-	];
+	const targetOptions = useMemo(
+		() => [
+			{ value: '', label: __( 'Choose field…', 'cortext' ) },
+			...( targetFields ?? [] )
+				.filter( ( field ) => field.meta?.type !== 'rollup' )
+				.map( ( field ) => ( {
+					value: String( field.id ),
+					label: titleOf( field ),
+				} ) ),
+		],
+		[ targetFields ]
+	);
+	const aggregatorOptions = useMemo(
+		() =>
+			rollupAggregatorOptionsForTarget( selectedTargetField?.meta?.type ),
+		[ selectedTargetField ]
+	);
 	const relationOptions = [
 		{ value: '', label: __( 'Choose relation…', 'cortext' ) },
 		...relationFields.map( ( field ) => ( {
@@ -324,7 +355,6 @@ function RollupConfig( {
 			label: field.label,
 		} ) ),
 	];
-	const needsTarget = aggregator !== 'count';
 	const defaultRollupTitle = useMemo( () => {
 		const collectionLabel = targetCollection
 			? titleOf( targetCollection )
@@ -333,7 +363,7 @@ function RollupConfig( {
 			return fallbackTitle;
 		}
 		const aggregatorLabel = rollupAggregatorLabel( aggregator );
-		if ( needsTarget && selectedTargetField ) {
+		if ( selectedTargetField ) {
 			return sprintf(
 				/* translators: 1: collection title, 2: field title, 3: rollup aggregation label */
 				__( '%1$s / %2$s (%3$s)', 'cortext' ),
@@ -351,7 +381,6 @@ function RollupConfig( {
 	}, [
 		aggregator,
 		fallbackTitle,
-		needsTarget,
 		selectedRelation,
 		selectedTargetField,
 		targetCollection,
@@ -364,23 +393,27 @@ function RollupConfig( {
 	}, [ relationFields, relationFieldId ] );
 
 	useEffect( () => {
-		if ( ! needsTarget || targetFieldId ) {
+		if ( targetFieldId ) {
 			return;
 		}
-		const compatibleTargets = targetOptions
-			.slice( 1 )
-			.filter( ( option ) => option.value );
+		const compatibleTargets = targetOptions.slice( 1 );
 		if ( compatibleTargets.length === 1 ) {
 			setTargetFieldId( compatibleTargets[ 0 ].value );
 		}
-	}, [ needsTarget, targetFieldId, targetOptions ] );
+	}, [ targetFieldId, targetOptions ] );
+
+	useEffect( () => {
+		if (
+			! aggregatorOptions.some(
+				( option ) => option.value === aggregator
+			)
+		) {
+			setAggregator( 'show_original' );
+		}
+	}, [ aggregator, aggregatorOptions ] );
 
 	const submit = async () => {
-		if (
-			! relationFieldId ||
-			( needsTarget && ! targetFieldId ) ||
-			isBusy
-		) {
+		if ( ! relationFieldId || ! targetFieldId || isBusy ) {
 			return;
 		}
 		try {
@@ -388,9 +421,7 @@ function RollupConfig( {
 				title: title.trim() || defaultRollupTitle,
 				type: 'rollup',
 				rollup_relation_field_id: Number( relationFieldId ),
-				rollup_target_field_id: targetFieldId
-					? Number( targetFieldId )
-					: undefined,
+				rollup_target_field_id: Number( targetFieldId ),
 				rollup_aggregator: aggregator,
 			} );
 			onCreate?.( created );
@@ -419,36 +450,35 @@ function RollupConfig( {
 				onChange={ ( next ) => {
 					setRelationFieldId( next );
 					setTargetFieldId( '' );
+					setAggregator( 'show_original' );
 				} }
 				disabled={ isBusy || relationFields.length === 0 }
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
 			<SelectControl
-				label={ __( 'Calculate', 'cortext' ) }
-				value={ aggregator }
-				options={ ROLLUP_AGGREGATORS }
+				label={ __( 'Target property', 'cortext' ) }
+				value={ targetFieldId }
+				options={ targetOptions }
 				onChange={ ( next ) => {
-					setAggregator( next );
-					setTargetFieldId( '' );
+					setTargetFieldId( next );
+					setAggregator( 'show_original' );
 				} }
-				disabled={ isBusy || relationFields.length === 0 }
+				disabled={
+					isBusy || ! relationFieldId || targetOptions.length <= 1
+				}
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
-			{ needsTarget ? (
-				<SelectControl
-					label={ __( 'Target field', 'cortext' ) }
-					value={ targetFieldId }
-					options={ targetOptions }
-					onChange={ setTargetFieldId }
-					disabled={
-						isBusy || ! relationFieldId || targetOptions.length <= 1
-					}
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			) : null }
+			<SelectControl
+				label={ __( 'Calculate', 'cortext' ) }
+				value={ aggregator }
+				options={ aggregatorOptions }
+				onChange={ setAggregator }
+				disabled={ isBusy || ! targetFieldId }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
 			<div className="cortext-add-field-popover__actions">
 				<Button
 					variant="tertiary"
@@ -461,11 +491,7 @@ function RollupConfig( {
 					variant="primary"
 					onClick={ submit }
 					isBusy={ isBusy }
-					disabled={
-						isBusy ||
-						! relationFieldId ||
-						( needsTarget && ! targetFieldId )
-					}
+					disabled={ isBusy || ! relationFieldId || ! targetFieldId }
 				>
 					{ __( 'Create rollup', 'cortext' ) }
 				</Button>

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -7,10 +7,11 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { useEntityRecords } from '@wordpress/core-data';
-import { useMemo, useState } from '@wordpress/element';
+import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import {
 	atSymbol,
+	backup,
 	calendar,
 	check,
 	formatListBullets,
@@ -21,6 +22,9 @@ import {
 } from '@wordpress/icons';
 
 import { COLLECTION_QUERY } from '../../collections';
+import useCollectionFields, {
+	buildFieldListQuery,
+} from '../../hooks/useCollectionFields';
 import { useCreateField } from '../../hooks/useFieldMutations';
 
 // Inline SVG for the "number" type. `@wordpress/icons` doesn't ship a
@@ -85,6 +89,7 @@ const FIELD_TYPES = [
 	},
 	{ value: 'checkbox', label: __( 'Checkbox', 'cortext' ), icon: check },
 	{ value: 'relation', label: __( 'Relation', 'cortext' ), icon: link },
+	{ value: 'rollup', label: __( 'Rollup', 'cortext' ), icon: backup },
 	{ value: 'url', label: __( 'URL', 'cortext' ), icon: globe },
 	{ value: 'email', label: __( 'Email', 'cortext' ), icon: atSymbol },
 ];
@@ -94,12 +99,28 @@ const RELATION_LIMIT_OPTIONS = [
 	{ value: 'one', label: __( '1 page', 'cortext' ) },
 ];
 
+const ROLLUP_AGGREGATORS = [
+	{ value: 'count', label: __( 'Count', 'cortext' ) },
+	{ value: 'sum', label: __( 'Sum', 'cortext' ) },
+	{ value: 'avg', label: __( 'Average', 'cortext' ) },
+	{ value: 'min', label: __( 'Min', 'cortext' ) },
+	{ value: 'max', label: __( 'Max', 'cortext' ) },
+	{ value: 'latest', label: __( 'Latest date', 'cortext' ) },
+];
+
 function titleOf( record ) {
 	return record?.title?.raw || record?.title?.rendered || `#${ record?.id }`;
 }
 
 function fieldTypeLabel( type ) {
 	return FIELD_TYPES.find( ( fieldType ) => fieldType.value === type )?.label;
+}
+
+function rollupAggregatorLabel( aggregator ) {
+	return (
+		ROLLUP_AGGREGATORS.find( ( option ) => option.value === aggregator )
+			?.label ?? aggregator
+	);
 }
 
 function RelationConfig( {
@@ -235,6 +256,224 @@ function RelationConfig( {
 	);
 }
 
+function RollupConfig( {
+	collectionId,
+	title,
+	fallbackTitle,
+	isBusy,
+	onCreate,
+	onBack,
+	onError,
+	run,
+} ) {
+	const { fields } = useCollectionFields( collectionId );
+	const relationFields = fields.filter(
+		( field ) => field.cortextType === 'relation'
+	);
+	const [ relationFieldId, setRelationFieldId ] = useState( '' );
+	const [ aggregator, setAggregator ] = useState( 'count' );
+	const [ targetFieldId, setTargetFieldId ] = useState( '' );
+
+	const selectedRelation = relationFields.find(
+		( field ) => String( field.recordId ) === relationFieldId
+	);
+	const targetCollectionId = selectedRelation?.relatedCollectionId;
+	const { record: targetCollection } = useEntityRecord(
+		'postType',
+		'crtxt_collection',
+		targetCollectionId ?? 0
+	);
+	const targetFieldIds = useMemo( () => {
+		const raw = targetCollection?.meta?.fields;
+		return Array.isArray( raw )
+			? raw.map( ( id ) => Number( id ) ).filter( Boolean )
+			: [];
+	}, [ targetCollection ] );
+	const { records: targetFields } = useEntityRecords(
+		'postType',
+		'crtxt_field',
+		buildFieldListQuery( targetFieldIds ),
+		{ enabled: targetFieldIds.length > 0 }
+	);
+	const selectedTargetField = targetFields?.find(
+		( field ) => String( field.id ) === targetFieldId
+	);
+
+	const targetTypeAllowed = ( type ) => {
+		if ( [ 'sum', 'avg', 'min', 'max' ].includes( aggregator ) ) {
+			return type === 'number';
+		}
+		if ( aggregator === 'latest' ) {
+			return type === 'date' || type === 'datetime';
+		}
+		return false;
+	};
+	const targetOptions = [
+		{ value: '', label: __( 'Choose field…', 'cortext' ) },
+		...( targetFields ?? [] )
+			.filter( ( field ) => targetTypeAllowed( field.meta?.type ) )
+			.map( ( field ) => ( {
+				value: String( field.id ),
+				label: titleOf( field ),
+			} ) ),
+	];
+	const relationOptions = [
+		{ value: '', label: __( 'Choose relation…', 'cortext' ) },
+		...relationFields.map( ( field ) => ( {
+			value: String( field.recordId ),
+			label: field.label,
+		} ) ),
+	];
+	const needsTarget = aggregator !== 'count';
+	const defaultRollupTitle = useMemo( () => {
+		const collectionLabel = targetCollection
+			? titleOf( targetCollection )
+			: selectedRelation?.label;
+		if ( ! collectionLabel ) {
+			return fallbackTitle;
+		}
+		const aggregatorLabel = rollupAggregatorLabel( aggregator );
+		if ( needsTarget && selectedTargetField ) {
+			return sprintf(
+				/* translators: 1: collection title, 2: field title, 3: rollup aggregation label */
+				__( '%1$s / %2$s (%3$s)', 'cortext' ),
+				collectionLabel,
+				titleOf( selectedTargetField ),
+				aggregatorLabel
+			);
+		}
+		return sprintf(
+			/* translators: 1: collection title, 2: rollup aggregation label */
+			__( '%1$s (%2$s)', 'cortext' ),
+			collectionLabel,
+			aggregatorLabel
+		);
+	}, [
+		aggregator,
+		fallbackTitle,
+		needsTarget,
+		selectedRelation,
+		selectedTargetField,
+		targetCollection,
+	] );
+
+	useEffect( () => {
+		if ( relationFields.length === 1 && ! relationFieldId ) {
+			setRelationFieldId( String( relationFields[ 0 ].recordId ) );
+		}
+	}, [ relationFields, relationFieldId ] );
+
+	useEffect( () => {
+		if ( ! needsTarget || targetFieldId ) {
+			return;
+		}
+		const compatibleTargets = targetOptions
+			.slice( 1 )
+			.filter( ( option ) => option.value );
+		if ( compatibleTargets.length === 1 ) {
+			setTargetFieldId( compatibleTargets[ 0 ].value );
+		}
+	}, [ needsTarget, targetFieldId, targetOptions ] );
+
+	const submit = async () => {
+		if (
+			! relationFieldId ||
+			( needsTarget && ! targetFieldId ) ||
+			isBusy
+		) {
+			return;
+		}
+		try {
+			const created = await run( {
+				title: title.trim() || defaultRollupTitle,
+				type: 'rollup',
+				rollup_relation_field_id: Number( relationFieldId ),
+				rollup_target_field_id: targetFieldId
+					? Number( targetFieldId )
+					: undefined,
+				rollup_aggregator: aggregator,
+			} );
+			onCreate?.( created );
+		} catch ( apiError ) {
+			onError(
+				apiError?.message ||
+					__( 'Rollup could not be created.', 'cortext' )
+			);
+		}
+	};
+
+	return (
+		<div className="cortext-add-field-popover__config">
+			{ relationFields.length === 0 ? (
+				<Notice status="warning" isDismissible={ false }>
+					{ __(
+						'Create a relation before adding a rollup.',
+						'cortext'
+					) }
+				</Notice>
+			) : null }
+			<SelectControl
+				label={ __( 'Relation', 'cortext' ) }
+				value={ relationFieldId }
+				options={ relationOptions }
+				onChange={ ( next ) => {
+					setRelationFieldId( next );
+					setTargetFieldId( '' );
+				} }
+				disabled={ isBusy || relationFields.length === 0 }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			<SelectControl
+				label={ __( 'Calculate', 'cortext' ) }
+				value={ aggregator }
+				options={ ROLLUP_AGGREGATORS }
+				onChange={ ( next ) => {
+					setAggregator( next );
+					setTargetFieldId( '' );
+				} }
+				disabled={ isBusy || relationFields.length === 0 }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			{ needsTarget ? (
+				<SelectControl
+					label={ __( 'Target field', 'cortext' ) }
+					value={ targetFieldId }
+					options={ targetOptions }
+					onChange={ setTargetFieldId }
+					disabled={
+						isBusy || ! relationFieldId || targetOptions.length <= 1
+					}
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) : null }
+			<div className="cortext-add-field-popover__actions">
+				<Button
+					variant="tertiary"
+					onClick={ onBack }
+					disabled={ isBusy }
+				>
+					{ __( 'Back', 'cortext' ) }
+				</Button>
+				<Button
+					variant="primary"
+					onClick={ submit }
+					isBusy={ isBusy }
+					disabled={
+						isBusy ||
+						! relationFieldId ||
+						( needsTarget && ! targetFieldId )
+					}
+				>
+					{ __( 'Create rollup', 'cortext' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}
+
 export default function AddFieldPopover( { collectionId, onCreate } ) {
 	const [ title, setTitle ] = useState( '' );
 	const [ submitError, setSubmitError ] = useState( '' );
@@ -252,7 +491,7 @@ export default function AddFieldPopover( { collectionId, onCreate } ) {
 			return;
 		}
 		setSubmitError( '' );
-		if ( chosenType === 'relation' ) {
+		if ( chosenType === 'relation' || chosenType === 'rollup' ) {
 			setConfigType( chosenType );
 			return;
 		}
@@ -288,6 +527,15 @@ export default function AddFieldPopover( { collectionId, onCreate } ) {
 	const fallbackTitle = configuredType
 		? configuredType.label
 		: fieldTypeLabel( 'text' );
+	let nameLabel = __( 'Name', 'cortext' );
+	let namePlaceholder = __( 'Type property name…', 'cortext' );
+	if ( configType === 'relation' ) {
+		nameLabel = __( 'Relation name', 'cortext' );
+		namePlaceholder = __( 'Relation name', 'cortext' );
+	} else if ( configType === 'rollup' ) {
+		nameLabel = __( 'Rollup name', 'cortext' );
+		namePlaceholder = __( 'Rollup name', 'cortext' );
+	}
 
 	let configuration = null;
 	if ( configType === 'relation' ) {
@@ -295,6 +543,19 @@ export default function AddFieldPopover( { collectionId, onCreate } ) {
 			<RelationConfig
 				collectionId={ collectionId }
 				collections={ collections ?? [] }
+				title={ title }
+				fallbackTitle={ fallbackTitle }
+				isBusy={ isBusy }
+				run={ run }
+				onCreate={ onCreate }
+				onBack={ () => setConfigType( null ) }
+				onError={ setSubmitError }
+			/>
+		);
+	} else if ( configType === 'rollup' ) {
+		configuration = (
+			<RollupConfig
+				collectionId={ collectionId }
 				title={ title }
 				fallbackTitle={ fallbackTitle }
 				isBusy={ isBusy }
@@ -314,16 +575,8 @@ export default function AddFieldPopover( { collectionId, onCreate } ) {
 				</Notice>
 			) : null }
 			<TextControl
-				label={
-					configType
-						? __( 'Relation name', 'cortext' )
-						: __( 'Name', 'cortext' )
-				}
-				placeholder={
-					configType
-						? __( 'Relation name', 'cortext' )
-						: __( 'Type property name…', 'cortext' )
-				}
+				label={ nameLabel }
+				placeholder={ namePlaceholder }
 				value={ title }
 				onChange={ setTitle }
 				onKeyDown={ ( event ) => {

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -303,7 +303,7 @@ function RollupConfig( {
 		( field ) => field.cortextType === 'relation'
 	);
 	const [ relationFieldId, setRelationFieldId ] = useState( '' );
-	const [ aggregator, setAggregator ] = useState( 'show_original' );
+	const [ aggregator, setAggregator ] = useState( 'count' );
 	const [ targetFieldId, setTargetFieldId ] = useState( '' );
 
 	const selectedRelation = relationFields.find(
@@ -348,6 +348,7 @@ function RollupConfig( {
 			rollupAggregatorOptionsForTarget( selectedTargetField?.meta?.type ),
 		[ selectedTargetField ]
 	);
+	const targetRequired = aggregator !== 'count';
 	const relationOptions = [
 		{ value: '', label: __( 'Choose relation…', 'cortext' ) },
 		...relationFields.map( ( field ) => ( {
@@ -399,10 +400,14 @@ function RollupConfig( {
 		const compatibleTargets = targetOptions.slice( 1 );
 		if ( compatibleTargets.length === 1 ) {
 			setTargetFieldId( compatibleTargets[ 0 ].value );
+			setAggregator( 'show_original' );
 		}
 	}, [ targetFieldId, targetOptions ] );
 
 	useEffect( () => {
+		if ( ! targetFieldId ) {
+			return;
+		}
 		if (
 			! aggregatorOptions.some(
 				( option ) => option.value === aggregator
@@ -410,20 +415,27 @@ function RollupConfig( {
 		) {
 			setAggregator( 'show_original' );
 		}
-	}, [ aggregator, aggregatorOptions ] );
+	}, [ aggregator, aggregatorOptions, targetFieldId ] );
 
 	const submit = async () => {
-		if ( ! relationFieldId || ! targetFieldId || isBusy ) {
+		if (
+			! relationFieldId ||
+			( targetRequired && ! targetFieldId ) ||
+			isBusy
+		) {
 			return;
 		}
 		try {
-			const created = await run( {
+			const payload = {
 				title: title.trim() || defaultRollupTitle,
 				type: 'rollup',
 				rollup_relation_field_id: Number( relationFieldId ),
-				rollup_target_field_id: Number( targetFieldId ),
 				rollup_aggregator: aggregator,
-			} );
+			};
+			if ( targetFieldId ) {
+				payload.rollup_target_field_id = Number( targetFieldId );
+			}
+			const created = await run( payload );
 			onCreate?.( created );
 		} catch ( apiError ) {
 			onError(
@@ -450,7 +462,7 @@ function RollupConfig( {
 				onChange={ ( next ) => {
 					setRelationFieldId( next );
 					setTargetFieldId( '' );
-					setAggregator( 'show_original' );
+					setAggregator( 'count' );
 				} }
 				disabled={ isBusy || relationFields.length === 0 }
 				__next40pxDefaultSize
@@ -475,7 +487,7 @@ function RollupConfig( {
 				value={ aggregator }
 				options={ aggregatorOptions }
 				onChange={ setAggregator }
-				disabled={ isBusy || ! targetFieldId }
+				disabled={ isBusy || ! relationFieldId }
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
@@ -491,7 +503,11 @@ function RollupConfig( {
 					variant="primary"
 					onClick={ submit }
 					isBusy={ isBusy }
-					disabled={ isBusy || ! relationFieldId || ! targetFieldId }
+					disabled={
+						isBusy ||
+						! relationFieldId ||
+						( targetRequired && ! targetFieldId )
+					}
 				>
 					{ __( 'Create rollup', 'cortext' ) }
 				</Button>

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -164,7 +164,7 @@ export default function ColumnHeaderActions( {
 				return createPortal(
 					<AddFieldTrigger collectionId={ collectionId } />,
 					target.th,
-					target.key
+					`${ target.key }-${ collectionId }`
 				);
 			} ) }
 		</>

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -1,5 +1,5 @@
 /* global MutationObserver */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	Dropdown,
@@ -34,6 +34,7 @@ import AddFieldPopover from './AddFieldPopover';
 import EditOptionsPopover from './EditOptionsPopover';
 import FieldFormatPopover from './FieldFormatPopover';
 import RenameFieldInline from './RenameFieldInline';
+import useCollectionFields from '../../hooks/useCollectionFields';
 import { elementsFromOptions } from '../../hooks/fieldMapping';
 import { TableCalculationPopover } from '../TableCalculationMenu';
 import {
@@ -194,6 +195,7 @@ function FieldActions( {
 	const optionsAnchorRef = useRef( null );
 	const duplicate = useDuplicateField( collectionId );
 	const remove = useDeleteField( collectionId );
+	const { fields } = useCollectionFields( collectionId );
 	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
 	const fieldType = record?.meta?.type;
 	const canFormat = FORMATTABLE_TYPES.has( fieldType );
@@ -391,6 +393,16 @@ function FieldActions( {
 	const sortField = view?.sort?.field ?? null;
 	const sortDirection = view?.sort?.direction ?? null;
 	const isSorted = sortField === dataViewId;
+	const dependentRollups = useMemo(
+		() =>
+			fields.filter(
+				( field ) =>
+					field.cortextType === 'rollup' &&
+					( field.rollupRelationFieldId === recordId ||
+						field.rollupTargetFieldId === recordId )
+			),
+		[ fields, recordId ]
+	);
 
 	// Title is pinned at index 0 (PR A's normalizeView) and the ghost
 	// column at the end. Move only operates on the data-field region in
@@ -679,10 +691,32 @@ function FieldActions( {
 					onCancel={ () => setConfirmDelete( false ) }
 					confirmButtonText={ __( 'Delete', 'cortext' ) }
 				>
-					{ __(
-						'Delete this field? Existing values for this field will be removed from every entry.',
-						'cortext'
-					) }
+					<p>
+						{ __(
+							'Delete this field? Existing values for this field will be removed from every entry.',
+							'cortext'
+						) }
+					</p>
+					{ dependentRollups.length > 0 ? (
+						<p>
+							{ dependentRollups.length === 1
+								? __(
+										'This will also delete 1 rollup that depends on it:',
+										'cortext'
+								  )
+								: sprintf(
+										/* translators: %d: number of dependent rollup fields */
+										__(
+											'This will also delete %d rollups that depend on it:',
+											'cortext'
+										),
+										dependentRollups.length
+								  ) }{ ' ' }
+							{ dependentRollups
+								.map( ( field ) => field.label )
+								.join( ', ' ) }
+						</p>
+					) : null }
 				</ConfirmDialog>
 			) : null }
 			{ isEditingOptions && supportsOptions ? (

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -83,7 +83,8 @@ function rollupDisplayType( meta ) {
 		return 'rollup-date-range';
 	}
 	if ( ROLLUP_VALUE_AGGREGATORS.has( aggregator ) ) {
-		return meta?.rollup_target_type ?? 'text';
+		const targetType = meta?.rollup_target_type ?? 'text';
+		return targetType === 'select' ? 'multiselect' : targetType;
 	}
 	if ( ! ROLLUP_SCALAR_DATE_AGGREGATORS.has( aggregator ) ) {
 		return 'number';

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -47,6 +47,23 @@ export const EDITABLE_TYPES = new Set( [
 ] );
 
 const SEARCHABLE_TYPES = new Set( [ 'text', 'email', 'url' ] );
+const ROLLUP_VALUE_AGGREGATORS = new Set( [ 'show_original', 'show_unique' ] );
+const ROLLUP_NUMERIC_AGGREGATORS = new Set( [
+	'count',
+	'count_values',
+	'count_unique',
+	'empty',
+	'not_empty',
+	'percent_empty',
+	'percent_not_empty',
+	'sum',
+	'avg',
+	'median',
+	'min',
+	'max',
+	'range',
+] );
+const ROLLUP_SCALAR_DATE_AGGREGATORS = new Set( [ 'earliest', 'latest' ] );
 
 function parseBooleanMeta( raw, fallback = false ) {
 	if ( raw === undefined || raw === null || raw === '' ) {
@@ -61,7 +78,21 @@ function parseBooleanMeta( raw, fallback = false ) {
 }
 
 function rollupDisplayType( meta ) {
-	return meta?.rollup_aggregator === 'latest' ? 'datetime' : 'number';
+	const aggregator = meta?.rollup_aggregator ?? 'count';
+	if ( aggregator === 'date_range' ) {
+		return 'rollup-date-range';
+	}
+	if ( ROLLUP_VALUE_AGGREGATORS.has( aggregator ) ) {
+		return meta?.rollup_target_type ?? 'text';
+	}
+	if ( ! ROLLUP_SCALAR_DATE_AGGREGATORS.has( aggregator ) ) {
+		return 'number';
+	}
+	// Preserve the target field's date/datetime distinction so
+	// `formatDateValue` can take its timezone-safe `date` path on
+	// `YYYY-MM-DD` values. Defaults to `date` when unknown — that's the
+	// branch that won't shift west of UTC.
+	return meta?.rollup_target_type === 'datetime' ? 'datetime' : 'date';
 }
 
 function buildRender( id, type, label, elements, format, relation ) {
@@ -83,6 +114,40 @@ function buildRender( id, type, label, elements, format, relation ) {
 
 function HeaderLabel( { children } ) {
 	return <span className="cortext-column-header-label">{ children }</span>;
+}
+
+function rollupTargetFormat( meta ) {
+	if ( meta?.rollup_target_type === 'number' ) {
+		return parseFormat( meta?.rollup_target_number_format );
+	}
+	if (
+		meta?.rollup_target_type === 'date' ||
+		meta?.rollup_target_type === 'datetime'
+	) {
+		return parseFormat( meta?.rollup_target_date_format );
+	}
+	return undefined;
+}
+
+function fieldRelationConfig( field, type, rollupTargetType ) {
+	if ( type === 'relation' ) {
+		return {
+			targetCollectionId: Number( field.meta?.related_collection_id ),
+			multiple: parseBooleanMeta( field.meta?.relation_multiple, true ),
+		};
+	}
+	if ( type === 'rollup' && rollupTargetType === 'relation' ) {
+		return {
+			targetCollectionId: Number(
+				field.meta?.rollup_target_related_collection_id
+			),
+			multiple: parseBooleanMeta(
+				field.meta?.rollup_target_relation_multiple,
+				true
+			),
+		};
+	}
+	return undefined;
 }
 
 // Returns the four read-only system fields surfaced alongside each
@@ -170,29 +235,33 @@ export function mapField( field ) {
 	// (auto-escaped by React), so the entity layer is unwanted noise.
 	const label = field.title?.raw || field.title?.rendered || `#${ field.id }`;
 	const type = field.meta?.type ?? 'text';
-	const elements = elementsFromOptions( field.meta?.options );
+	const rollupTargetType = field.meta?.rollup_target_type;
+	const elements = elementsFromOptions(
+		type === 'rollup'
+			? field.meta?.rollup_target_options
+			: field.meta?.options
+	);
 	let format;
 	if ( type === 'number' ) {
 		format = parseFormat( field.meta?.number_format );
 	} else if ( type === 'date' || type === 'datetime' ) {
 		format = parseFormat( field.meta?.date_format );
 	} else if ( type === 'rollup' ) {
+		const aggregator = field.meta?.rollup_aggregator ?? 'count';
 		format = {
-			rollup_aggregator: field.meta?.rollup_aggregator ?? 'count',
+			...( rollupTargetFormat( field.meta ) ?? {} ),
+			rollup_aggregator: aggregator,
+			rollup_target_type: rollupTargetType,
 		};
+		if (
+			aggregator === 'percent_empty' ||
+			aggregator === 'percent_not_empty'
+		) {
+			format.style = 'percent';
+			format.decimals = format.decimals ?? 0;
+		}
 	}
-	const relation =
-		type === 'relation'
-			? {
-					targetCollectionId: Number(
-						field.meta?.related_collection_id
-					),
-					multiple: parseBooleanMeta(
-						field.meta?.relation_multiple,
-						true
-					),
-			  }
-			: undefined;
+	const relation = fieldRelationConfig( field, type, rollupTargetType );
 	const base = {
 		id,
 		label,
@@ -201,6 +270,8 @@ export function mapField( field ) {
 		relatedCollectionId: relation?.targetCollectionId,
 		relationMultiple: relation?.multiple,
 		rollupAggregator: field.meta?.rollup_aggregator,
+		rollupRelationFieldId: Number( field.meta?.rollup_relation_field_id ),
+		rollupTargetFieldId: Number( field.meta?.rollup_target_field_id ),
 		// Header content is just an aria-hidden marker.
 		// `ColumnHeaderActions` queries the DOM for it and portals our
 		// combined-dropdown trigger into the owning <th>; DataViews'
@@ -250,25 +321,39 @@ export function mapField( field ) {
 				filterBy: false,
 			};
 		case 'rollup': {
-			if ( rollupDisplayType( field.meta ) === 'datetime' ) {
+			const aggregator = field.meta?.rollup_aggregator ?? 'count';
+			const display = rollupDisplayType( field.meta );
+			if ( ROLLUP_SCALAR_DATE_AGGREGATORS.has( aggregator ) ) {
 				return {
 					...base,
-					type: 'datetime',
+					type: display,
 					editable: false,
 					enableSorting: true,
 				};
 			}
+			if ( ROLLUP_NUMERIC_AGGREGATORS.has( aggregator ) ) {
+				return {
+					...base,
+					type: 'integer',
+					editable: false,
+					enableSorting: true,
+					isValid: { custom: () => null },
+					sort: ( a, b, direction ) => {
+						const av = Number( base.getValue( { item: a } ) ?? 0 );
+						const bv = Number( base.getValue( { item: b } ) ?? 0 );
+						return direction === 'asc' ? av - bv : bv - av;
+					},
+				};
+			}
 			return {
 				...base,
-				type: 'integer',
+				type:
+					display === 'relation' || display === 'multiselect'
+						? 'array'
+						: 'text',
 				editable: false,
-				enableSorting: true,
-				isValid: { custom: () => null },
-				sort: ( a, b, direction ) => {
-					const av = Number( base.getValue( { item: a } ) ?? 0 );
-					const bv = Number( base.getValue( { item: b } ) ?? 0 );
-					return direction === 'asc' ? av - bv : bv - av;
-				},
+				enableSorting: false,
+				filterBy: false,
 			};
 		}
 		case 'date':

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -31,7 +31,7 @@ export function parseFormat( raw ) {
 }
 
 // Cortext field types that this client knows how to edit inline. Anything
-// outside this set (formula, …) renders read-only — see
+// outside this set (formula, rollup, …) renders read-only — see
 // `EditableCell`'s `readOnly` branch.
 export const EDITABLE_TYPES = new Set( [
 	'text',
@@ -60,13 +60,18 @@ function parseBooleanMeta( raw, fallback = false ) {
 	);
 }
 
+function rollupDisplayType( meta ) {
+	return meta?.rollup_aggregator === 'latest' ? 'datetime' : 'number';
+}
+
 function buildRender( id, type, label, elements, format, relation ) {
 	const readOnly = ! EDITABLE_TYPES.has( type );
+	const displayType = type === 'rollup' ? rollupDisplayType( format ) : type;
 	return ( { item } ) => (
 		<EditableCell
 			item={ item }
 			fieldId={ id }
-			fieldType={ type }
+			fieldType={ displayType }
 			elements={ elements }
 			format={ format }
 			relation={ relation }
@@ -89,8 +94,9 @@ function HeaderLabel( { children } ) {
 // `editable: false` and no `recordId` keeps them out of the default
 // `view.fields` seed, so they appear in the column visibility menu
 // default-hidden, addable like any other field. Sort is enabled only on
-// the timestamps. Sort on display-value properties such as Person and
-// Relation is an open architectural decision (tech-debt.md#14).
+// the timestamps — sort on display-value
+// properties (Person, Relation, Rollup) is an open architectural
+// decision shared with relations and rollups (tech-debt.md#14).
 export function systemFields() {
 	const formatDate = ( value ) =>
 		value ? dateI18n( 'M j, Y g:i a', value ) : '';
@@ -170,6 +176,10 @@ export function mapField( field ) {
 		format = parseFormat( field.meta?.number_format );
 	} else if ( type === 'date' || type === 'datetime' ) {
 		format = parseFormat( field.meta?.date_format );
+	} else if ( type === 'rollup' ) {
+		format = {
+			rollup_aggregator: field.meta?.rollup_aggregator ?? 'count',
+		};
 	}
 	const relation =
 		type === 'relation'
@@ -190,6 +200,7 @@ export function mapField( field ) {
 		cortextType: type,
 		relatedCollectionId: relation?.targetCollectionId,
 		relationMultiple: relation?.multiple,
+		rollupAggregator: field.meta?.rollup_aggregator,
 		// Header content is just an aria-hidden marker.
 		// `ColumnHeaderActions` queries the DOM for it and portals our
 		// combined-dropdown trigger into the owning <th>; DataViews'
@@ -238,6 +249,28 @@ export function mapField( field ) {
 				enableSorting: false,
 				filterBy: false,
 			};
+		case 'rollup': {
+			if ( rollupDisplayType( field.meta ) === 'datetime' ) {
+				return {
+					...base,
+					type: 'datetime',
+					editable: false,
+					enableSorting: true,
+				};
+			}
+			return {
+				...base,
+				type: 'integer',
+				editable: false,
+				enableSorting: true,
+				isValid: { custom: () => null },
+				sort: ( a, b, direction ) => {
+					const av = Number( base.getValue( { item: a } ) ?? 0 );
+					const bv = Number( base.getValue( { item: b } ) ?? 0 );
+					return direction === 'asc' ? av - bv : bv - av;
+				},
+			};
+		}
 		case 'date':
 		case 'datetime':
 			return { ...base, type: 'datetime' };

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -7,17 +7,24 @@ import apiFetch from '@wordpress/api-fetch';
 
 const SERVER_OPERATORS = new Set( [ 'is', 'isNot', 'isAny', 'isNone' ] );
 
-function buildQueryArgs( collectionId, view ) {
+function buildQueryArgs( collectionId, view, fields = [] ) {
 	const args = {
 		collection: collectionId,
 		per_page: -1,
 	};
+	const fieldTypes = new Map(
+		fields.map( ( f ) => [ f.id, f.cortextType ] )
+	);
 
 	// Ignore filters that the server isn't equipped to honor, otherwise
 	// changes in `view` will result in a new query to be requested from the
 	// server, even though the results will be the same.
 	const serverFilters = ( view?.filters ?? [] ).filter(
-		( f ) => f.field && f.operator && SERVER_OPERATORS.has( f.operator )
+		( f ) =>
+			f.field &&
+			f.operator &&
+			SERVER_OPERATORS.has( f.operator ) &&
+			fieldTypes.get( f.field ) !== 'rollup'
 	);
 	serverFilters.forEach( ( filter, i ) => {
 		args[ `filters[${ i }][field]` ] = filter.field;
@@ -34,7 +41,18 @@ function buildQueryArgs( collectionId, view ) {
 	return args;
 }
 
-export default function useCollectionRows( collectionId, view ) {
+function schemaSignature( fields = [] ) {
+	return fields
+		.map(
+			( field ) =>
+				`${ field.id }:${ field.recordId ?? '' }:${
+					field.cortextType ?? ''
+				}`
+		)
+		.join( '|' );
+}
+
+export default function useCollectionRows( collectionId, view, fields = [] ) {
 	const [ state, setState ] = useState( {
 		data: [],
 		collection: null,
@@ -47,7 +65,10 @@ export default function useCollectionRows( collectionId, view ) {
 
 	const requestIdRef = useRef( 0 );
 	const queryKey = collectionId
-		? JSON.stringify( buildQueryArgs( collectionId, view ) )
+		? JSON.stringify( {
+				args: buildQueryArgs( collectionId, view, fields ),
+				schema: schemaSignature( fields ),
+		  } )
 		: null;
 
 	// tech-debt.md#2: callers POST via apiFetch and bump refresh() to
@@ -72,7 +93,7 @@ export default function useCollectionRows( collectionId, view ) {
 		const requestId = ++requestIdRef.current;
 		const path = addQueryArgs(
 			'/cortext/v1/rows',
-			buildQueryArgs( collectionId, view )
+			buildQueryArgs( collectionId, view, fields )
 		);
 
 		setState( ( prev ) => ( {

--- a/tests/js/components/EditableCell.test.js
+++ b/tests/js/components/EditableCell.test.js
@@ -27,6 +27,14 @@ describe( 'formatDisplay', () => {
 		);
 	} );
 
+	describe( 'plain values', () => {
+		it( 'joins array values with comma-space', () => {
+			expect( formatDisplay( [ 'Alpha', 'Beta' ], 'text' ) ).toBe(
+				'Alpha, Beta'
+			);
+		} );
+	} );
+
 	describe( 'date / datetime', () => {
 		it( 'formats date-only values per the chosen locale', () => {
 			expect(

--- a/tests/js/components/dataViewColumns.test.js
+++ b/tests/js/components/dataViewColumns.test.js
@@ -5,6 +5,7 @@ import {
 	TITLE_FIELD_ID,
 	clampWidth,
 	getMinWidth,
+	isDefaultVisibleField,
 	normalizeView,
 	withColumnOrder,
 	withColumnWidth,
@@ -51,6 +52,31 @@ describe( 'clampWidth', () => {
 
 	it( 'uses the default floor when no type is provided', () => {
 		expect( clampWidth( 10 ) ).toBe( DEFAULT_MIN_WIDTH );
+	} );
+} );
+
+describe( 'isDefaultVisibleField', () => {
+	it( 'shows editable fields and user-created read-only fields', () => {
+		expect( isDefaultVisibleField( { id: 'title', editable: true } ) ).toBe(
+			true
+		);
+		expect(
+			isDefaultVisibleField( {
+				id: 'field-10',
+				recordId: 10,
+				editable: false,
+				cortextType: 'rollup',
+			} )
+		).toBe( true );
+	} );
+
+	it( 'keeps system fields hidden by default', () => {
+		expect(
+			isDefaultVisibleField( {
+				id: 'created_at',
+				editable: false,
+			} )
+		).toBe( false );
 	} );
 } );
 

--- a/tests/js/components/fields/AddFieldPopover.test.js
+++ b/tests/js/components/fields/AddFieldPopover.test.js
@@ -141,6 +141,32 @@ describe( 'AddFieldPopover rollup config', () => {
 		);
 	} );
 
+	it( 'creates Count all rollups without a target property', async () => {
+		targetFields = [];
+		render( <AddFieldPopover collectionId={ 5 } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Rollup' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByLabelText( 'Calculate' ) ).toHaveValue(
+				'count'
+			)
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Create rollup' } )
+		);
+
+		await waitFor( () =>
+			expect( run ).toHaveBeenCalledWith( {
+				title: 'Invoices (Count all)',
+				type: 'rollup',
+				rollup_relation_field_id: 77,
+				rollup_aggregator: 'count',
+			} )
+		);
+	} );
+
 	it( 'adds number calculations only after selecting a number target', async () => {
 		targetFields = [
 			{

--- a/tests/js/components/fields/AddFieldPopover.test.js
+++ b/tests/js/components/fields/AddFieldPopover.test.js
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityRecord: jest.fn(),
+	useEntityRecords: jest.fn(),
+} ) );
+
+jest.mock( '../../../../src/hooks/useCollectionFields', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	buildFieldListQuery: jest.fn( ( ids ) => ( { include: ids } ) ),
+} ) );
+
+jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
+	useCreateField: jest.fn(),
+} ) );
+
+import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import AddFieldPopover from '../../../../src/components/fields/AddFieldPopover';
+import useCollectionFields from '../../../../src/hooks/useCollectionFields';
+import { useCreateField } from '../../../../src/hooks/useFieldMutations';
+
+const run = jest.fn();
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	run.mockResolvedValue( { id: 100, type: 'rollup' } );
+	useCreateField.mockReturnValue( {
+		run,
+		isBusy: false,
+		error: null,
+	} );
+	useCollectionFields.mockReturnValue( {
+		fields: [
+			{
+				id: 'field-77',
+				recordId: 77,
+				cortextType: 'relation',
+				label: 'Invoices',
+				relatedCollectionId: 9,
+			},
+		],
+	} );
+	useEntityRecord.mockImplementation( ( kind, name, id ) => ( {
+		record:
+			kind === 'postType' && name === 'crtxt_collection' && id === 9
+				? {
+						id: 9,
+						title: { raw: 'Invoices', rendered: 'Invoices' },
+						meta: { fields: [ 88 ] },
+				  }
+				: null,
+	} ) );
+	useEntityRecords.mockImplementation( ( kind, name ) => {
+		if ( kind === 'postType' && name === 'crtxt_field' ) {
+			return {
+				records: [
+					{
+						id: 88,
+						title: { raw: 'Amount', rendered: 'Amount' },
+						meta: { type: 'number' },
+					},
+				],
+			};
+		}
+		return { records: [] };
+	} );
+} );
+
+describe( 'AddFieldPopover rollup config', () => {
+	it( 'defaults count rollup names to the related collection and aggregator', async () => {
+		render( <AddFieldPopover collectionId={ 5 } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Rollup' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByLabelText( 'Relation' ) ).toHaveValue( '77' )
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Create rollup' } )
+		);
+
+		await waitFor( () =>
+			expect( run ).toHaveBeenCalledWith( {
+				title: 'Invoices (Count)',
+				type: 'rollup',
+				rollup_relation_field_id: 77,
+				rollup_target_field_id: undefined,
+				rollup_aggregator: 'count',
+			} )
+		);
+	} );
+
+	it( 'preselects the only relation and only compatible target field', async () => {
+		render( <AddFieldPopover collectionId={ 5 } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Rollup' } ) );
+
+		await waitFor( () =>
+			expect( screen.getByLabelText( 'Relation' ) ).toHaveValue( '77' )
+		);
+
+		fireEvent.change( screen.getByLabelText( 'Calculate' ), {
+			target: { value: 'sum' },
+		} );
+
+		await waitFor( () =>
+			expect( screen.getByLabelText( 'Target field' ) ).toHaveValue(
+				'88'
+			)
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Create rollup' } )
+		);
+
+		await waitFor( () =>
+			expect( run ).toHaveBeenCalledWith( {
+				title: 'Invoices / Amount (Sum)',
+				type: 'rollup',
+				rollup_relation_field_id: 77,
+				rollup_target_field_id: 88,
+				rollup_aggregator: 'sum',
+			} )
+		);
+	} );
+} );

--- a/tests/js/components/fields/AddFieldPopover.test.js
+++ b/tests/js/components/fields/AddFieldPopover.test.js
@@ -21,9 +21,17 @@ import useCollectionFields from '../../../../src/hooks/useCollectionFields';
 import { useCreateField } from '../../../../src/hooks/useFieldMutations';
 
 const run = jest.fn();
+let targetFields;
 
 beforeEach( () => {
 	jest.clearAllMocks();
+	targetFields = [
+		{
+			id: 88,
+			title: { raw: 'Amount', rendered: 'Amount' },
+			meta: { type: 'number' },
+		},
+	];
 	run.mockResolvedValue( { id: 100, type: 'rollup' } );
 	useCreateField.mockReturnValue( {
 		run,
@@ -47,34 +55,45 @@ beforeEach( () => {
 				? {
 						id: 9,
 						title: { raw: 'Invoices', rendered: 'Invoices' },
-						meta: { fields: [ 88 ] },
+						meta: {
+							fields: targetFields.map( ( field ) => field.id ),
+						},
 				  }
 				: null,
 	} ) );
 	useEntityRecords.mockImplementation( ( kind, name ) => {
 		if ( kind === 'postType' && name === 'crtxt_field' ) {
-			return {
-				records: [
-					{
-						id: 88,
-						title: { raw: 'Amount', rendered: 'Amount' },
-						meta: { type: 'number' },
-					},
-				],
-			};
+			return { records: targetFields };
 		}
 		return { records: [] };
 	} );
 } );
 
 describe( 'AddFieldPopover rollup config', () => {
-	it( 'defaults count rollup names to the related collection and aggregator', async () => {
+	it( 'orders rollup controls as relation, target property, then calculate', async () => {
+		render( <AddFieldPopover collectionId={ 5 } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Rollup' } ) );
+
+		const relation = await screen.findByLabelText( 'Relation' );
+		const target = screen.getByLabelText( 'Target property' );
+		const calculate = screen.getByLabelText( 'Calculate' );
+		const controls = screen.getAllByRole( 'combobox' );
+
+		expect( controls[ 0 ] ).toBe( relation );
+		expect( controls[ 1 ] ).toBe( target );
+		expect( controls[ 2 ] ).toBe( calculate );
+	} );
+
+	it( 'defaults value rollup names to the related collection, target, and aggregator', async () => {
 		render( <AddFieldPopover collectionId={ 5 } /> );
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Rollup' } ) );
 
 		await waitFor( () =>
-			expect( screen.getByLabelText( 'Relation' ) ).toHaveValue( '77' )
+			expect( screen.getByLabelText( 'Target property' ) ).toHaveValue(
+				'88'
+			)
 		);
 
 		fireEvent.click(
@@ -83,33 +102,29 @@ describe( 'AddFieldPopover rollup config', () => {
 
 		await waitFor( () =>
 			expect( run ).toHaveBeenCalledWith( {
-				title: 'Invoices (Count)',
+				title: 'Invoices / Amount (Show original)',
 				type: 'rollup',
 				rollup_relation_field_id: 77,
-				rollup_target_field_id: undefined,
-				rollup_aggregator: 'count',
+				rollup_target_field_id: 88,
+				rollup_aggregator: 'show_original',
 			} )
 		);
 	} );
 
-	it( 'preselects the only relation and only compatible target field', async () => {
+	it( 'preselects the only relation and only target field', async () => {
 		render( <AddFieldPopover collectionId={ 5 } /> );
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Rollup' } ) );
 
 		await waitFor( () =>
-			expect( screen.getByLabelText( 'Relation' ) ).toHaveValue( '77' )
+			expect( screen.getByLabelText( 'Target property' ) ).toHaveValue(
+				'88'
+			)
 		);
 
 		fireEvent.change( screen.getByLabelText( 'Calculate' ), {
 			target: { value: 'sum' },
 		} );
-
-		await waitFor( () =>
-			expect( screen.getByLabelText( 'Target field' ) ).toHaveValue(
-				'88'
-			)
-		);
 
 		fireEvent.click(
 			screen.getByRole( 'button', { name: 'Create rollup' } )
@@ -124,5 +139,76 @@ describe( 'AddFieldPopover rollup config', () => {
 				rollup_aggregator: 'sum',
 			} )
 		);
+	} );
+
+	it( 'adds number calculations only after selecting a number target', async () => {
+		targetFields = [
+			{
+				id: 88,
+				title: { raw: 'Amount', rendered: 'Amount' },
+				meta: { type: 'number' },
+			},
+			{
+				id: 89,
+				title: { raw: 'Due', rendered: 'Due' },
+				meta: { type: 'date' },
+			},
+		];
+		render( <AddFieldPopover collectionId={ 5 } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Rollup' } ) );
+
+		await screen.findByLabelText( 'Target property' );
+		expect( screen.queryByRole( 'option', { name: 'Sum' } ) ).toBeNull();
+		expect(
+			screen.queryByRole( 'option', { name: 'Latest date' } )
+		).toBeNull();
+
+		fireEvent.change( screen.getByLabelText( 'Target property' ), {
+			target: { value: '88' },
+		} );
+
+		expect( screen.getByRole( 'option', { name: 'Sum' } ) ).toBeTruthy();
+		expect(
+			screen.queryByRole( 'option', { name: 'Latest date' } )
+		).toBeNull();
+	} );
+
+	it( 'adds date calculations only after selecting a date target', async () => {
+		targetFields = [
+			{
+				id: 88,
+				title: { raw: 'Amount', rendered: 'Amount' },
+				meta: { type: 'number' },
+			},
+			{
+				id: 89,
+				title: { raw: 'Due', rendered: 'Due' },
+				meta: { type: 'date' },
+			},
+		];
+		render( <AddFieldPopover collectionId={ 5 } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Rollup' } ) );
+
+		await screen.findByLabelText( 'Target property' );
+		expect(
+			screen.queryByRole( 'option', { name: 'Earliest date' } )
+		).toBeNull();
+
+		fireEvent.change( screen.getByLabelText( 'Target property' ), {
+			target: { value: '89' },
+		} );
+
+		expect(
+			screen.getByRole( 'option', { name: 'Earliest date' } )
+		).toBeTruthy();
+		expect(
+			screen.getByRole( 'option', { name: 'Latest date' } )
+		).toBeTruthy();
+		expect(
+			screen.getByRole( 'option', { name: 'Date range' } )
+		).toBeTruthy();
+		expect( screen.queryByRole( 'option', { name: 'Sum' } ) ).toBeNull();
 	} );
 } );

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -11,12 +11,12 @@ jest.mock( '@wordpress/components', () => {
 		(
 			{
 				children,
-				icon, // eslint-disable-line no-unused-vars
+				icon,
 				isPressed,
 				label,
 				onClick,
-				size, // eslint-disable-line no-unused-vars
-				variant, // eslint-disable-line no-unused-vars
+				size,
+				variant,
 				...rest
 			},
 			ref
@@ -74,10 +74,13 @@ jest.mock( '@wordpress/core-data', () => ( {
 } ) );
 
 jest.mock( '../../../../src/lock-unlock', () => {
-	const { createElement } = require( '@wordpress/element' );
+	const { createElement, forwardRef } = require( '@wordpress/element' );
 	const Menu = ( { children } ) => createElement( 'div', null, children );
 	Menu.Group = ( { children } ) => createElement( 'div', null, children );
-	Menu.Item = ( { children } ) => createElement( 'button', null, children );
+	Menu.Item = forwardRef( ( { children, onClick }, ref ) =>
+		createElement( 'button', { ref, onClick }, children )
+	);
+	Menu.Item.displayName = 'MenuItem';
 	Menu.ItemLabel = ( { children } ) =>
 		createElement( 'span', null, children );
 	Menu.Popover = ( { children } ) => createElement( 'div', null, children );
@@ -97,6 +100,11 @@ jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
 	useDuplicateField: () => ( { run: jest.fn() } ),
 } ) );
 
+jest.mock( '../../../../src/hooks/useCollectionFields', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
 jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
 	__esModule: true,
 	default: ( { collectionId } ) => (
@@ -105,13 +113,20 @@ jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
 } ) );
 
 import ColumnHeaderActions from '../../../../src/components/fields/ColumnHeaderActions';
+import { useEntityRecord } from '@wordpress/core-data';
+import useCollectionFields from '../../../../src/hooks/useCollectionFields';
 
-function Harness( { collectionId } ) {
+function Harness( { collectionId, recordId } ) {
 	return (
 		<div className="cortext-data-view">
 			<table>
 				<thead>
 					<tr>
+						{ recordId ? (
+							<th>
+								<span data-cortext-field-marker={ recordId } />
+							</th>
+						) : null }
 						<th>
 							<span data-cortext-add-field-marker="true" />
 						</th>
@@ -128,6 +143,17 @@ function Harness( { collectionId } ) {
 }
 
 describe( 'ColumnHeaderActions', () => {
+	beforeEach( () => {
+		useCollectionFields.mockReturnValue( { fields: [] } );
+		useEntityRecord.mockReturnValue( {
+			record: {
+				id: 77,
+				title: { raw: 'Invoices', rendered: 'Invoices' },
+				meta: { type: 'relation' },
+			},
+		} );
+	} );
+
 	it( 'closes the add-field dropdown when the collection changes', async () => {
 		const { rerender } = render( <Harness collectionId={ 5 } /> );
 
@@ -144,5 +170,40 @@ describe( 'ColumnHeaderActions', () => {
 		await waitFor( () =>
 			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
 		);
+	} );
+
+	it( 'warns when deleting a field will also delete dependent rollups', async () => {
+		useCollectionFields.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Invoices',
+					cortextType: 'relation',
+				},
+				{
+					id: 'field-88',
+					recordId: 88,
+					label: 'Invoice total',
+					cortextType: 'rollup',
+					rollupRelationFieldId: 77,
+					rollupTargetFieldId: 99,
+				},
+			],
+		} );
+
+		render( <Harness collectionId={ 5 } recordId={ 77 } /> );
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Delete' } )
+		);
+
+		expect(
+			screen.getByText(
+				'This will also delete 1 rollup that depends on it:',
+				{ exact: false }
+			)
+		).toBeInTheDocument();
+		expect( screen.getByText( /Invoice total/ ) ).toBeInTheDocument();
 	} );
 } );

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/components', () => {
+	const {
+		createElement,
+		forwardRef,
+		useState,
+	} = require( '@wordpress/element' );
+
+	const Button = forwardRef(
+		(
+			{
+				children,
+				icon, // eslint-disable-line no-unused-vars
+				isPressed,
+				label,
+				onClick,
+				size, // eslint-disable-line no-unused-vars
+				variant, // eslint-disable-line no-unused-vars
+				...rest
+			},
+			ref
+		) =>
+			createElement(
+				'button',
+				{
+					...rest,
+					ref,
+					type: 'button',
+					'aria-label': label,
+					'aria-pressed': isPressed ? 'true' : 'false',
+					onClick,
+				},
+				children ?? label
+			)
+	);
+	Button.displayName = 'Button';
+
+	const Dropdown = ( { renderToggle, renderContent } ) => {
+		const [ isOpen, setIsOpen ] = useState( false );
+		const onClose = () => setIsOpen( false );
+		const onToggle = () => setIsOpen( ( current ) => ! current );
+
+		return createElement(
+			'div',
+			null,
+			renderToggle( { isOpen, onClose, onToggle } ),
+			isOpen
+				? createElement(
+						'div',
+						{ role: 'dialog' },
+						renderContent( { onClose } )
+				  )
+				: null
+		);
+	};
+
+	const Passthrough = ( { children } ) =>
+		createElement( 'div', null, children );
+
+	return {
+		__esModule: true,
+		Button,
+		Dropdown,
+		Icon: () => null,
+		Popover: Passthrough,
+		privateApis: {},
+		__experimentalConfirmDialog: Passthrough,
+	};
+} );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityRecord: jest.fn(),
+} ) );
+
+jest.mock( '../../../../src/lock-unlock', () => {
+	const { createElement } = require( '@wordpress/element' );
+	const Menu = ( { children } ) => createElement( 'div', null, children );
+	Menu.Group = ( { children } ) => createElement( 'div', null, children );
+	Menu.Item = ( { children } ) => createElement( 'button', null, children );
+	Menu.ItemLabel = ( { children } ) =>
+		createElement( 'span', null, children );
+	Menu.Popover = ( { children } ) => createElement( 'div', null, children );
+	Menu.RadioItem = ( { children } ) =>
+		createElement( 'button', null, children );
+	Menu.Separator = () => createElement( 'hr' );
+	Menu.TriggerButton = ( { children } ) =>
+		createElement( 'button', null, children );
+
+	return {
+		unlock: () => ( { Menu } ),
+	};
+} );
+
+jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
+	useDeleteField: () => ( { run: jest.fn() } ),
+	useDuplicateField: () => ( { run: jest.fn() } ),
+} ) );
+
+jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
+	__esModule: true,
+	default: ( { collectionId } ) => (
+		<div>{ `Add field for collection ${ collectionId }` }</div>
+	),
+} ) );
+
+import ColumnHeaderActions from '../../../../src/components/fields/ColumnHeaderActions';
+
+function Harness( { collectionId } ) {
+	return (
+		<div className="cortext-data-view">
+			<table>
+				<thead>
+					<tr>
+						<th>
+							<span data-cortext-add-field-marker="true" />
+						</th>
+					</tr>
+				</thead>
+			</table>
+			<ColumnHeaderActions
+				collectionId={ collectionId }
+				view={ { fields: [] } }
+				onChangeView={ jest.fn() }
+			/>
+		</div>
+	);
+}
+
+describe( 'ColumnHeaderActions', () => {
+	it( 'closes the add-field dropdown when the collection changes', async () => {
+		const { rerender } = render( <Harness collectionId={ 5 } /> );
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Add field' } )
+		);
+
+		expect( screen.getByRole( 'dialog' ) ).toHaveTextContent(
+			'Add field for collection 5'
+		);
+
+		rerender( <Harness collectionId={ 6 } /> );
+
+		await waitFor( () =>
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
+		);
+	} );
+} );

--- a/tests/js/hooks/fieldMapping.test.js
+++ b/tests/js/hooks/fieldMapping.test.js
@@ -124,6 +124,32 @@ describe( 'mapField', () => {
 		expect( mapped.relationMultiple ).toBe( false );
 	} );
 
+	it( "maps numeric rollups to read-only DataViews 'integer' fields with numeric sorting", () => {
+		const mapped = mapField(
+			baseField( { type: 'rollup', rollup_aggregator: 'sum' } )
+		);
+		expect( mapped.type ).toBe( 'integer' );
+		expect( mapped.editable ).toBe( false );
+		expect( mapped.enableSorting ).toBe( true );
+		expect( mapped.rollupAggregator ).toBe( 'sum' );
+		expect(
+			mapped.sort(
+				{ meta: { 'field-5': 2 } },
+				{ meta: { 'field-5': 10 } },
+				'asc'
+			)
+		).toBeLessThan( 0 );
+	} );
+
+	it( "maps latest rollups to read-only DataViews 'datetime' fields", () => {
+		const mapped = mapField(
+			baseField( { type: 'rollup', rollup_aggregator: 'latest' } )
+		);
+		expect( mapped.type ).toBe( 'datetime' );
+		expect( mapped.editable ).toBe( false );
+		expect( mapped.enableSorting ).toBe( true );
+	} );
+
 	it( "maps email to DataViews 'email'", () => {
 		expect( mapField( baseField( { type: 'email' } ) ).type ).toBe(
 			'email'

--- a/tests/js/hooks/fieldMapping.test.js
+++ b/tests/js/hooks/fieldMapping.test.js
@@ -141,13 +141,85 @@ describe( 'mapField', () => {
 		).toBeLessThan( 0 );
 	} );
 
-	it( "maps latest rollups to read-only DataViews 'datetime' fields", () => {
+	it( "maps latest rollups against a date target to read-only DataViews 'date' fields", () => {
 		const mapped = mapField(
-			baseField( { type: 'rollup', rollup_aggregator: 'latest' } )
+			baseField( {
+				type: 'rollup',
+				rollup_aggregator: 'latest',
+				rollup_target_type: 'date',
+			} )
+		);
+		expect( mapped.type ).toBe( 'date' );
+		expect( mapped.editable ).toBe( false );
+		expect( mapped.enableSorting ).toBe( true );
+	} );
+
+	it( "maps latest rollups against a datetime target to read-only DataViews 'datetime' fields", () => {
+		const mapped = mapField(
+			baseField( {
+				type: 'rollup',
+				rollup_aggregator: 'latest',
+				rollup_target_type: 'datetime',
+			} )
 		);
 		expect( mapped.type ).toBe( 'datetime' );
 		expect( mapped.editable ).toBe( false );
 		expect( mapped.enableSorting ).toBe( true );
+	} );
+
+	it( 'maps value-list rollups to read-only non-sortable fields', () => {
+		const mapped = mapField(
+			baseField( {
+				type: 'rollup',
+				rollup_aggregator: 'show_unique',
+				rollup_target_type: 'select',
+				rollup_target_options:
+					'[{"value":"paid","label":"Paid","color":"green"}]',
+			} )
+		);
+		expect( mapped.type ).toBe( 'text' );
+		expect( mapped.editable ).toBe( false );
+		expect( mapped.enableSorting ).toBe( false );
+		expect( mapped.filterBy ).toBe( false );
+	} );
+
+	it( 'maps date range rollups to read-only non-sortable text fields', () => {
+		const mapped = mapField(
+			baseField( {
+				type: 'rollup',
+				rollup_aggregator: 'date_range',
+				rollup_target_type: 'date',
+			} )
+		);
+		expect( mapped.type ).toBe( 'text' );
+		expect( mapped.editable ).toBe( false );
+		expect( mapped.enableSorting ).toBe( false );
+		expect( mapped.filterBy ).toBe( false );
+	} );
+
+	it( 'renders date range rollups as start and end text', () => {
+		const mapped = mapField(
+			baseField( {
+				type: 'rollup',
+				rollup_aggregator: 'date_range',
+				rollup_target_type: 'date',
+				rollup_target_date_format: '{"style":"us"}',
+			} )
+		);
+		const { container } = render(
+			mapped.render( {
+				item: {
+					meta: {
+						'field-5': {
+							start: '2026-05-01',
+							end: '2026-05-03',
+						},
+					},
+				},
+			} )
+		);
+
+		expect( container.textContent ).toContain( '05/01/2026 - 05/03/2026' );
 	} );
 
 	it( "maps email to DataViews 'email'", () => {

--- a/tests/js/hooks/fieldMapping.test.js
+++ b/tests/js/hooks/fieldMapping.test.js
@@ -177,10 +177,34 @@ describe( 'mapField', () => {
 					'[{"value":"paid","label":"Paid","color":"green"}]',
 			} )
 		);
-		expect( mapped.type ).toBe( 'text' );
+		expect( mapped.type ).toBe( 'array' );
 		expect( mapped.editable ).toBe( false );
 		expect( mapped.enableSorting ).toBe( false );
 		expect( mapped.filterBy ).toBe( false );
+	} );
+
+	it( 'renders select value-list rollups as multiple chips', () => {
+		const mapped = mapField(
+			baseField( {
+				type: 'rollup',
+				rollup_aggregator: 'show_original',
+				rollup_target_type: 'select',
+				rollup_target_options:
+					'[{"value":"paid","label":"Paid","color":"green"},{"value":"draft","label":"Draft","color":"gray"}]',
+			} )
+		);
+		const { container } = render(
+			mapped.render( {
+				item: {
+					meta: {
+						'field-5': [ 'paid', 'draft' ],
+					},
+				},
+			} )
+		);
+
+		expect( container.textContent ).toContain( 'Paid' );
+		expect( container.textContent ).toContain( 'Draft' );
 	} );
 
 	it( 'maps date range rollups to read-only non-sortable text fields', () => {

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -1,0 +1,49 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import useCollectionRows from '../../../src/hooks/useCollectionRows';
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	apiFetch.mockResolvedValue( {
+		rows: [],
+		collection: null,
+		total: 0,
+		totalPages: 1,
+	} );
+} );
+
+describe( 'useCollectionRows', () => {
+	it( 'refetches rows when the visible schema gains a rollup field', async () => {
+		const view = { type: 'table', filters: [] };
+		const initialFields = [
+			{ id: 'title', cortextType: 'title' },
+			{ id: 'field-10', recordId: 10, cortextType: 'relation' },
+		];
+		const nextFields = [
+			...initialFields,
+			{ id: 'field-20', recordId: 20, cortextType: 'rollup' },
+		];
+
+		const { rerender } = renderHook(
+			( { fields } ) => useCollectionRows( 7, view, fields ),
+			{ initialProps: { fields: initialFields } }
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+
+		rerender( { fields: nextFields } );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		expect( apiFetch ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( 'collection=7' ),
+			} )
+		);
+	} );
+} );

--- a/tests/js/hooks/useFieldMutations.test.js
+++ b/tests/js/hooks/useFieldMutations.test.js
@@ -99,7 +99,7 @@ describe( 'useCreateField', () => {
 		} );
 	} );
 
-	it( 'forwards relation config fields on the request body', async () => {
+	it( 'forwards relation and rollup config fields on the request body', async () => {
 		apiFetch.mockResolvedValueOnce( { id: 101 } );
 		const { result } = renderHook( () => useCreateField( 5 ) );
 		await act( async () => {
@@ -123,6 +123,29 @@ describe( 'useCreateField', () => {
 				relation_multiple: true,
 				reverse_title: 'Projects',
 				reverse_multiple: false,
+			},
+		} );
+
+		apiFetch.mockResolvedValueOnce( { id: 102 } );
+		await act( async () => {
+			await result.current.run( {
+				title: 'Total',
+				type: 'rollup',
+				rollup_relation_field_id: 77,
+				rollup_target_field_id: 88,
+				rollup_aggregator: 'sum',
+			} );
+		} );
+
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/cortext/v1/collections/5/fields',
+			method: 'POST',
+			data: {
+				title: 'Total',
+				type: 'rollup',
+				rollup_relation_field_id: 77,
+				rollup_target_field_id: 88,
+				rollup_aggregator: 'sum',
 			},
 		} );
 	} );

--- a/tests/php/test-collection-entries.php
+++ b/tests/php/test-collection-entries.php
@@ -613,6 +613,39 @@ final class Test_Collection_Entries extends BaseTestCase {
 		);
 	}
 
+	public function test_target_field_delete_deletes_dependent_rollups(): void {
+		$entries     = new CollectionEntries();
+		$projects_id = $this->create_collection_with_slug( 'Projects', 'prj-target' );
+		$invoices_id = $this->create_collection_with_slug( 'Invoices', 'inv-target' );
+		$relation_id = $this->create_relation_field( $projects_id, $invoices_id, 'Invoices' );
+		$reverse_id  = $this->create_relation_field( $invoices_id, $projects_id, 'Projects' );
+		$amount_id   = $this->create_field( $invoices_id, 'Amount', 'number' );
+		$rollup_id   = $this->create_field(
+			$projects_id,
+			'Total',
+			'rollup',
+			array(
+				'rollup_relation_field_id' => (string) $relation_id,
+				'rollup_target_field_id'   => (string) $amount_id,
+				'rollup_aggregator'        => 'sum',
+			)
+		);
+		update_post_meta( $relation_id, 'relation_reverse_field_id', (string) $reverse_id );
+		update_post_meta( $reverse_id, 'relation_reverse_field_id', (string) $relation_id );
+
+		$entries->register_for_collection( get_post( $projects_id ) );
+		$entries->register_for_collection( get_post( $invoices_id ) );
+		$entries->register();
+
+		wp_delete_post( $amount_id, true );
+
+		$this->assertNull( get_post( $rollup_id ) );
+		$this->assertNotContains(
+			(string) $rollup_id,
+			get_post_meta( $projects_id, 'fields', false )
+		);
+	}
+
 	public function test_entry_delete_removes_stale_reverse_relation_references(): void {
 		$entries       = new CollectionEntries();
 		$tasks_id      = $this->create_collection_with_slug( 'Tasks', 'tasks-rdel' );

--- a/tests/php/test-collection-entries.php
+++ b/tests/php/test-collection-entries.php
@@ -580,6 +580,39 @@ final class Test_Collection_Entries extends BaseTestCase {
 		);
 	}
 
+	public function test_field_delete_deletes_dependent_rollups(): void {
+		$entries     = new CollectionEntries();
+		$projects_id = $this->create_collection_with_slug( 'Projects', 'projects-roll-del' );
+		$invoices_id = $this->create_collection_with_slug( 'Invoices', 'invoices-roll-del' );
+		$relation_id = $this->create_relation_field( $projects_id, $invoices_id, 'Invoices' );
+		$reverse_id  = $this->create_relation_field( $invoices_id, $projects_id, 'Projects' );
+		$amount_id   = $this->create_field( $invoices_id, 'Amount', 'number' );
+		$rollup_id   = $this->create_field(
+			$projects_id,
+			'Total',
+			'rollup',
+			array(
+				'rollup_relation_field_id' => (string) $relation_id,
+				'rollup_target_field_id'   => (string) $amount_id,
+				'rollup_aggregator'        => 'sum',
+			)
+		);
+		update_post_meta( $relation_id, 'relation_reverse_field_id', (string) $reverse_id );
+		update_post_meta( $reverse_id, 'relation_reverse_field_id', (string) $relation_id );
+
+		$entries->register_for_collection( get_post( $projects_id ) );
+		$entries->register_for_collection( get_post( $invoices_id ) );
+		$entries->register();
+
+		wp_delete_post( $relation_id, true );
+
+		$this->assertNull( get_post( $rollup_id ) );
+		$this->assertNotContains(
+			(string) $rollup_id,
+			get_post_meta( $projects_id, 'fields', false )
+		);
+	}
+
 	public function test_entry_delete_removes_stale_reverse_relation_references(): void {
 		$entries       = new CollectionEntries();
 		$tasks_id      = $this->create_collection_with_slug( 'Tasks', 'tasks-rdel' );
@@ -674,16 +707,24 @@ final class Test_Collection_Entries extends BaseTestCase {
 	}
 
 	private function create_relation_field( int $collection_id, int $target_collection_id, string $title ): int {
+		return $this->create_field(
+			$collection_id,
+			$title,
+			'relation',
+			array(
+				'related_collection_id' => (string) $target_collection_id,
+				'relation_multiple'     => '1',
+			)
+		);
+	}
+
+	private function create_field( int $collection_id, string $title, string $type, array $meta = array() ): int {
 		$field_id = (int) wp_insert_post(
 			array(
 				'post_type'   => Field::POST_TYPE,
 				'post_status' => 'private',
 				'post_title'  => $title,
-				'meta_input'  => array(
-					'type'                  => 'relation',
-					'related_collection_id' => (string) $target_collection_id,
-					'relation_multiple'     => '1',
-				),
+				'meta_input'  => array_merge( array( 'type' => $type ), $meta ),
 			)
 		);
 		add_post_meta( $collection_id, 'fields', (string) $field_id );

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -359,6 +359,14 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 				'type'  => 'number',
 			)
 		)->get_data()['id'];
+		$number_format = wp_json_encode(
+			array(
+				'style'    => 'currency',
+				'decimals' => 2,
+				'currency' => 'USD',
+			)
+		);
+		update_post_meta( $amount_id, 'number_format', $number_format );
 
 		$response = $this->create_field(
 			$source_collection_id,
@@ -378,6 +386,46 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$this->assertSame( $relation_id, (int) get_post_meta( $rollup_id, 'rollup_relation_field_id', true ) );
 		$this->assertSame( $amount_id, (int) get_post_meta( $rollup_id, 'rollup_target_field_id', true ) );
 		$this->assertSame( 'sum', get_post_meta( $rollup_id, 'rollup_aggregator', true ) );
+		$this->assertSame( 'number', get_post_meta( $rollup_id, 'rollup_target_type', true ) );
+		$this->assertSame( $number_format, get_post_meta( $rollup_id, 'rollup_target_number_format', true ) );
+	}
+
+	public function test_create_rollup_accepts_date_range_for_date_targets(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$source_collection_id = $this->create_collection_with_slug( 'Projects', 'projects-date-roll' );
+		$target_collection_id = $this->create_collection_with_slug( 'Invoices', 'invoices-date-roll' );
+
+		$relation_id = (int) $this->create_field(
+			$source_collection_id,
+			array(
+				'title'                 => 'Invoices',
+				'type'                  => 'relation',
+				'related_collection_id' => $target_collection_id,
+			)
+		)->get_data()['id'];
+		$date_id     = (int) $this->create_field(
+			$target_collection_id,
+			array(
+				'title' => 'Due',
+				'type'  => 'date',
+			)
+		)->get_data()['id'];
+
+		$response = $this->create_field(
+			$source_collection_id,
+			array(
+				'title'                    => 'Due range',
+				'type'                     => 'rollup',
+				'rollup_relation_field_id' => $relation_id,
+				'rollup_target_field_id'   => $date_id,
+				'rollup_aggregator'        => 'date_range',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$rollup_id = (int) $response->get_data()['id'];
+		$this->assertSame( 'date_range', get_post_meta( $rollup_id, 'rollup_aggregator', true ) );
+		$this->assertSame( 'date', get_post_meta( $rollup_id, 'rollup_target_type', true ) );
 	}
 
 	public function test_create_rollup_rejects_rollup_of_rollup(): void {
@@ -547,6 +595,43 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 			$date_format,
 			get_post_meta( $copy_id, 'date_format', true )
 		);
+	}
+
+	public function test_duplicate_clones_rollup_target_display_meta(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Rollup Clone', 'rollup-clone' );
+		$options       = wp_json_encode(
+			array(
+				array(
+					'value' => 'paid',
+					'label' => 'Paid',
+					'color' => 'green',
+				),
+			)
+		);
+
+		$source_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Statuses',
+				'meta_input'  => array(
+					'type'                  => 'rollup',
+					'rollup_aggregator'     => 'show_unique',
+					'rollup_target_type'    => 'select',
+					'rollup_target_options' => $options,
+				),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $source_id );
+
+		$copy_id = (int) $this->duplicate_field( $collection_id, $source_id )
+			->get_data()['id'];
+
+		$this->assertSame( 'rollup', get_post_meta( $copy_id, 'type', true ) );
+		$this->assertSame( 'show_unique', get_post_meta( $copy_id, 'rollup_aggregator', true ) );
+		$this->assertSame( 'select', get_post_meta( $copy_id, 'rollup_target_type', true ) );
+		$this->assertSame( $options, get_post_meta( $copy_id, 'rollup_target_options', true ) );
 	}
 
 	public function test_duplicate_preserves_related_collection_id(): void {

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -339,6 +339,97 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$this->assertSame( array(), get_post_meta( $target_collection_id, 'fields', false ) );
 	}
 
+	public function test_create_rollup_validates_and_stores_config(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$source_collection_id = $this->create_collection_with_slug( 'Projects', 'projects-roll' );
+		$target_collection_id = $this->create_collection_with_slug( 'Invoices', 'invoices-roll' );
+
+		$relation_id = (int) $this->create_field(
+			$source_collection_id,
+			array(
+				'title'                 => 'Invoices',
+				'type'                  => 'relation',
+				'related_collection_id' => $target_collection_id,
+			)
+		)->get_data()['id'];
+		$amount_id   = (int) $this->create_field(
+			$target_collection_id,
+			array(
+				'title' => 'Amount',
+				'type'  => 'number',
+			)
+		)->get_data()['id'];
+
+		$response = $this->create_field(
+			$source_collection_id,
+			array(
+				'title'                    => 'Total',
+				'type'                     => 'rollup',
+				'rollup_relation_field_id' => $relation_id,
+				'rollup_target_field_id'   => $amount_id,
+				'rollup_aggregator'        => 'sum',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$rollup_id = (int) $response->get_data()['id'];
+		$this->assertSame( 'rollup', get_post_meta( $rollup_id, 'type', true ) );
+		$this->assertSame( $relation_id, (int) get_post_meta( $rollup_id, 'rollup_relation_field_id', true ) );
+		$this->assertSame( $amount_id, (int) get_post_meta( $rollup_id, 'rollup_target_field_id', true ) );
+		$this->assertSame( 'sum', get_post_meta( $rollup_id, 'rollup_aggregator', true ) );
+	}
+
+	public function test_create_rollup_rejects_rollup_of_rollup(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$source_collection_id = $this->create_collection_with_slug( 'Projects', 'projects-ror' );
+		$target_collection_id = $this->create_collection_with_slug( 'Invoices', 'invoices-ror' );
+
+		$relation_id = (int) $this->create_field(
+			$source_collection_id,
+			array(
+				'title'                 => 'Invoices',
+				'type'                  => 'relation',
+				'related_collection_id' => $target_collection_id,
+			)
+		)->get_data()['id'];
+		$reverse_id  = (int) get_post_meta( $relation_id, 'relation_reverse_field_id', true );
+		$amount_id   = (int) $this->create_field(
+			$source_collection_id,
+			array(
+				'title' => 'Budget',
+				'type'  => 'number',
+			)
+		)->get_data()['id'];
+		$rollup_id   = (int) $this->create_field(
+			$target_collection_id,
+			array(
+				'title'                    => 'Project budget',
+				'type'                     => 'rollup',
+				'rollup_relation_field_id' => $reverse_id,
+				'rollup_target_field_id'   => $amount_id,
+				'rollup_aggregator'        => 'sum',
+			)
+		)->get_data()['id'];
+
+		$response = $this->create_field(
+			$source_collection_id,
+			array(
+				'title'                    => 'Nested',
+				'type'                     => 'rollup',
+				'rollup_relation_field_id' => $relation_id,
+				'rollup_target_field_id'   => $rollup_id,
+				'rollup_aggregator'        => 'sum',
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame(
+			'cortext_rollup_of_rollup_unsupported',
+			$response->get_data()['code']
+		);
+	}
+
 	public function test_duplicate_inserts_after_source_with_copy_title(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		$collection_id = $this->create_collection_with_slug( 'Schemas', 'schemas' );

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -665,40 +665,97 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$relation = $this->create_relation_pair( $projects_id, $invoices_id );
 		$amount_id = $this->create_collection_field( $invoices_id, 'Amount', 'number' );
 		$date_id = $this->create_collection_field( $invoices_id, 'Due', 'date' );
+		$status_id = $this->create_collection_field(
+			$invoices_id,
+			'Status',
+			'select',
+			array(
+				'options' => wp_json_encode(
+					array(
+						array(
+							'value' => 'paid',
+							'label' => 'Paid',
+						),
+					)
+				),
+			)
+		);
 		$count_id = $this->create_rollup_field( $projects_id, 'Invoice count', $relation['source_id'], 0, 'count' );
 		$sum_id = $this->create_rollup_field( $projects_id, 'Total', $relation['source_id'], $amount_id, 'sum' );
 		$avg_id = $this->create_rollup_field( $projects_id, 'Average', $relation['source_id'], $amount_id, 'avg' );
+		$median_id = $this->create_rollup_field( $projects_id, 'Median', $relation['source_id'], $amount_id, 'median' );
 		$min_id = $this->create_rollup_field( $projects_id, 'Minimum', $relation['source_id'], $amount_id, 'min' );
 		$max_id = $this->create_rollup_field( $projects_id, 'Maximum', $relation['source_id'], $amount_id, 'max' );
+		$range_id = $this->create_rollup_field( $projects_id, 'Range', $relation['source_id'], $amount_id, 'range' );
+		$earliest_id = $this->create_rollup_field( $projects_id, 'Earliest due', $relation['source_id'], $date_id, 'earliest' );
 		$latest_id = $this->create_rollup_field( $projects_id, 'Latest due', $relation['source_id'], $date_id, 'latest' );
+		$date_range_id = $this->create_rollup_field( $projects_id, 'Due range', $relation['source_id'], $date_id, 'date_range' );
+		$original_status_id = $this->create_rollup_field( $projects_id, 'Statuses', $relation['source_id'], $status_id, 'show_original' );
+		$unique_status_id = $this->create_rollup_field( $projects_id, 'Unique statuses', $relation['source_id'], $status_id, 'show_unique' );
+		$count_values_id = $this->create_rollup_field( $projects_id, 'Status values', $relation['source_id'], $status_id, 'count_values' );
+		$count_unique_id = $this->create_rollup_field( $projects_id, 'Unique status count', $relation['source_id'], $status_id, 'count_unique' );
+		$empty_id = $this->create_rollup_field( $projects_id, 'Empty statuses', $relation['source_id'], $status_id, 'empty' );
+		$not_empty_id = $this->create_rollup_field( $projects_id, 'Filled statuses', $relation['source_id'], $status_id, 'not_empty' );
+		$percent_empty_id = $this->create_rollup_field( $projects_id, 'Empty percent', $relation['source_id'], $status_id, 'percent_empty' );
 
 		$project_id = $this->create_entry( 'crtxt_projects-calc', 'Liberation' );
 		$invoice_a = $this->create_entry( 'crtxt_invoices-calc', 'Invoice A' );
 		$invoice_b = $this->create_entry( 'crtxt_invoices-calc', 'Invoice B' );
+		$invoice_c = $this->create_entry( 'crtxt_invoices-calc', 'Invoice C' );
 		update_post_meta( $invoice_a, "field-{$amount_id}", '10' );
 		update_post_meta( $invoice_a, "field-{$date_id}", '2026-05-01' );
+		update_post_meta( $invoice_a, "field-{$status_id}", 'paid' );
 		update_post_meta( $invoice_b, "field-{$amount_id}", '5' );
 		update_post_meta( $invoice_b, "field-{$date_id}", '2026-05-03' );
+		update_post_meta( $invoice_b, "field-{$status_id}", 'paid' );
 
-		Relations::sync_relation_value( $project_id, $relation['source_id'], array( $invoice_a, $invoice_b ) );
+		Relations::sync_relation_value( $project_id, $relation['source_id'], array( $invoice_a, $invoice_b, $invoice_c ) );
 
 		$field_ids = array(
 			$relation['source_id'],
 			$count_id,
 			$sum_id,
 			$avg_id,
+			$median_id,
 			$min_id,
 			$max_id,
+			$range_id,
+			$earliest_id,
 			$latest_id,
+			$date_range_id,
+			$original_status_id,
+			$unique_status_id,
+			$count_values_id,
+			$count_unique_id,
+			$empty_id,
+			$not_empty_id,
+			$percent_empty_id,
 		);
 		$row       = $this->invoke_format_row_with_fields( $project_id, $field_ids );
 
-		$this->assertSame( 2, $row['meta']["field-{$count_id}"] );
+		$this->assertSame( 3, $row['meta']["field-{$count_id}"] );
 		$this->assertSame( 15.0, $row['meta']["field-{$sum_id}"] );
 		$this->assertSame( 7.5, $row['meta']["field-{$avg_id}"] );
+		$this->assertSame( 7.5, $row['meta']["field-{$median_id}"] );
 		$this->assertSame( 5.0, $row['meta']["field-{$min_id}"] );
 		$this->assertSame( 10.0, $row['meta']["field-{$max_id}"] );
+		$this->assertSame( 5.0, $row['meta']["field-{$range_id}"] );
+		$this->assertSame( '2026-05-01', $row['meta']["field-{$earliest_id}"] );
 		$this->assertSame( '2026-05-03', $row['meta']["field-{$latest_id}"] );
+		$this->assertSame(
+			array(
+				'start' => '2026-05-01',
+				'end'   => '2026-05-03',
+			),
+			$row['meta']["field-{$date_range_id}"]
+		);
+		$this->assertSame( array( 'paid', 'paid' ), $row['meta']["field-{$original_status_id}"] );
+		$this->assertSame( array( 'paid' ), $row['meta']["field-{$unique_status_id}"] );
+		$this->assertSame( 2, $row['meta']["field-{$count_values_id}"] );
+		$this->assertSame( 1, $row['meta']["field-{$count_unique_id}"] );
+		$this->assertSame( 1, $row['meta']["field-{$empty_id}"] );
+		$this->assertSame( 2, $row['meta']["field-{$not_empty_id}"] );
+		$this->assertEqualsWithDelta( 1 / 3, $row['meta']["field-{$percent_empty_id}"], 0.000001 );
 		$this->assertSame( 'Invoice A', $row['meta']["field-{$relation['source_id']}"][0]['title']['raw'] );
 
 		update_post_meta( $invoice_b, "field-{$amount_id}", '20' );

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -494,7 +494,49 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertSame( array( 'blue', 'green' ), $args['meta_query'][1]['value'] );
 	}
 
-	// -- Relation tests -------------------------------------------------
+	public function test_build_query_args_skips_rollup_sort_and_filter_meta_query(): void {
+		$fixture = $this->create_collection_fixture( 'bqaroll', 'rollup' );
+
+		$request = new WP_REST_Request( 'GET', '/cortext/v1/rows' );
+		$request->set_query_params(
+			array(
+				'collection' => $fixture['collection_id'],
+				'sort'       => array(
+					'field'     => "field-{$fixture['field_id']}",
+					'direction' => 'desc',
+				),
+				'filters'    => array(
+					array(
+						'field'    => "field-{$fixture['field_id']}",
+						'operator' => 'is',
+						'value'    => '2',
+					),
+				),
+			)
+		);
+		$request->set_default_params(
+			array(
+				'per_page' => 25,
+				'page'     => 1,
+				'search'   => '',
+				'sort'     => null,
+				'filters'  => array(),
+			)
+		);
+
+		$controller = new RowsController();
+		$method     = new \ReflectionMethod( $controller, 'build_query_args' );
+		$method->setAccessible( true );
+
+		$args = $method->invoke( $controller, $request, 'bqaroll' );
+
+		$this->assertSame( 'date', $args['orderby'] );
+		$this->assertSame( 'ASC', $args['order'] );
+		$this->assertArrayNotHasKey( 'meta_key', $args );
+		$this->assertArrayNotHasKey( 'meta_query', $args );
+	}
+
+	// -- Relation and rollup tests --------------------------------------
 
 	public function test_update_row_field_syncs_relation_from_source_and_reverse(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
@@ -614,6 +656,58 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 			'tasks-self',
 			$data['meta']["field-{$relation['source_id']}"][0]['collectionSlug']
 		);
+	}
+
+	public function test_rollups_compute_from_related_rows_and_update_on_read(): void {
+		$projects_id = $this->create_collection_with_slug( 'Projects', 'projects-calc' );
+		$invoices_id = $this->create_collection_with_slug( 'Invoices', 'invoices-calc' );
+
+		$relation = $this->create_relation_pair( $projects_id, $invoices_id );
+		$amount_id = $this->create_collection_field( $invoices_id, 'Amount', 'number' );
+		$date_id = $this->create_collection_field( $invoices_id, 'Due', 'date' );
+		$count_id = $this->create_rollup_field( $projects_id, 'Invoice count', $relation['source_id'], 0, 'count' );
+		$sum_id = $this->create_rollup_field( $projects_id, 'Total', $relation['source_id'], $amount_id, 'sum' );
+		$avg_id = $this->create_rollup_field( $projects_id, 'Average', $relation['source_id'], $amount_id, 'avg' );
+		$min_id = $this->create_rollup_field( $projects_id, 'Minimum', $relation['source_id'], $amount_id, 'min' );
+		$max_id = $this->create_rollup_field( $projects_id, 'Maximum', $relation['source_id'], $amount_id, 'max' );
+		$latest_id = $this->create_rollup_field( $projects_id, 'Latest due', $relation['source_id'], $date_id, 'latest' );
+
+		$project_id = $this->create_entry( 'crtxt_projects-calc', 'Liberation' );
+		$invoice_a = $this->create_entry( 'crtxt_invoices-calc', 'Invoice A' );
+		$invoice_b = $this->create_entry( 'crtxt_invoices-calc', 'Invoice B' );
+		update_post_meta( $invoice_a, "field-{$amount_id}", '10' );
+		update_post_meta( $invoice_a, "field-{$date_id}", '2026-05-01' );
+		update_post_meta( $invoice_b, "field-{$amount_id}", '5' );
+		update_post_meta( $invoice_b, "field-{$date_id}", '2026-05-03' );
+
+		Relations::sync_relation_value( $project_id, $relation['source_id'], array( $invoice_a, $invoice_b ) );
+
+		$field_ids = array(
+			$relation['source_id'],
+			$count_id,
+			$sum_id,
+			$avg_id,
+			$min_id,
+			$max_id,
+			$latest_id,
+		);
+		$row       = $this->invoke_format_row_with_fields( $project_id, $field_ids );
+
+		$this->assertSame( 2, $row['meta']["field-{$count_id}"] );
+		$this->assertSame( 15.0, $row['meta']["field-{$sum_id}"] );
+		$this->assertSame( 7.5, $row['meta']["field-{$avg_id}"] );
+		$this->assertSame( 5.0, $row['meta']["field-{$min_id}"] );
+		$this->assertSame( 10.0, $row['meta']["field-{$max_id}"] );
+		$this->assertSame( '2026-05-03', $row['meta']["field-{$latest_id}"] );
+		$this->assertSame( 'Invoice A', $row['meta']["field-{$relation['source_id']}"][0]['title']['raw'] );
+
+		update_post_meta( $invoice_b, "field-{$amount_id}", '20' );
+		update_post_meta( $invoice_a, "field-{$date_id}", '2026-05-04' );
+
+		$updated = $this->invoke_format_row_with_fields( $project_id, $field_ids );
+
+		$this->assertSame( 30.0, $updated['meta']["field-{$sum_id}"] );
+		$this->assertSame( '2026-05-04', $updated['meta']["field-{$latest_id}"] );
 	}
 
 	// -- System field tests ---------------------------------------------
@@ -1030,6 +1124,24 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 			'source_id'  => $source_id,
 			'reverse_id' => $reverse_id,
 		);
+	}
+
+	private function create_rollup_field(
+		int $collection_id,
+		string $title,
+		int $relation_field_id,
+		int $target_field_id,
+		string $aggregator
+	): int {
+		$meta = array(
+			'rollup_relation_field_id' => (string) $relation_field_id,
+			'rollup_aggregator'        => $aggregator,
+		);
+		if ( $target_field_id > 0 ) {
+			$meta['rollup_target_field_id'] = (string) $target_field_id;
+		}
+
+		return $this->create_collection_field( $collection_id, $title, 'rollup', $meta );
 	}
 
 	private function create_entry( string $post_type, string $title ): int {


### PR DESCRIPTION
## What

Part of #109

This adds rollups to relation fields. You can connect rows with a relation, then show useful information from those related rows in the current table: counts, related values, number totals, dates, and date ranges.

The setup follows the shape of the data: pick a relation, pick a property from the related collection, then pick the calculation. Once the target property is known, the menu only shows calculations that make sense for that type.

- Adds rollup fields for relations.
- Supports value lists, counts, percentages, number calculations, dates, and date ranges.
- Shows rollups as read-only table values.
- Warns when deleting a relation will also delete rollups that depend on it.
- Adds seeded examples so the feature is visible after a reset seed.

## Why

Relations are useful, but they are much more useful when a table can summarize what is on the other side. This PR makes that possible without copying data around manually.

It also makes the local demo easier to review. After a reset seed, Books, Projects, and Demo include populated relation and rollup examples instead of empty placeholder columns.

## How

- Stores the selected relation, target property, calculation, and target display metadata on rollup fields.
- Validates rollup setup against the selected relation and target property type.
- Computes rollup values when rows are returned.
- Maps rollups to the right table display type based on the calculation.
- Deletes dependent rollups when their source relation is deleted.
- Seeds relation pairs and example rollup data after the base demo collections are created.

## Testing Instructions

1. Run a reset seed for the local Cortext environment.
2. Open the seeded Books collection and confirm `Referenced projects`, `Project statuses`, and `Project due range` are populated.
3. Open the seeded Projects collection and confirm task rollups show counts, totals, statuses, latest due dates, and due ranges.
4. Create a rollup field in a collection with a relation.
5. Confirm the setup asks for Relation, then Target property, then Calculate.
6. Select a number target and confirm number calculations appear.
7. Select a date or datetime target and confirm date calculations appear.
8. Delete a relation field that has dependent rollups and confirm the warning lists the rollups that will also be deleted.

## Screen recording

https://github.com/user-attachments/assets/75cfe48d-cb96-4c9a-81ad-8cc6e27c54ce