### PR TITLE
 Add sidebar favorites

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -327,3 +327,11 @@ The user-facing placeholder is still Core's generic "Search commands and setting
 **Where.** `src/components/CommandPalette.js`, the `canvasRef` passed from `src/router.js`, `dequeue_core_command_palette` in `includes/Admin/Screen.php`, and the `@wordpress/commands` stylesheet import in `src/index.scss`.
 
 **Solution.** Upstream could make app-owned palettes less ad hoc: a scoped command registry or namespace API, a supported way for full-screen admin apps to opt out of Core's admin palette, a custom input label, and an explicit focus-return target or after-close callback. With those, Cortext could keep registering commands through `@wordpress/commands` and drop most of the shell-specific wiring.
+
+## 39. Favorite rows have their own sidebar-row shape `[internal, soft]`
+
+**What.** Favorites look like sidebar rows, but they are not normal page-tree rows. They are shortcuts, they should never show the active selection state, and they are sortable only inside the Favorites section. Sharing the whole row as both a navigation button and a dnd-kit sortable handle made clicks repaint the hover state and feel like a flash. The current row splits those jobs: the icon is the drag handle, the title is a plain navigation button, and the star is the remove action. It works, but it means Favorites carry a small custom row shape alongside `PageRow` and `CollectionRow`.
+
+**Where.** `src/components/SidebarFavorites.js`, plus the `.cortext-sidebar__favorite-*` rules in `src/index.scss`.
+
+**Solution.** Extract a shared sidebar-row primitive with explicit slots for title navigation, drag handle, menu/actions, selected state, and shortcut-only rows. Then `PageRow`, `CollectionRow`, and `SidebarFavorites` can share the same interaction contract without reusing the wrong DOM shape for Favorites.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -23,6 +23,7 @@ use Cortext\PostType\Page;
 use Cortext\PostType\PageIdentity;
 use Cortext\PostType\PageTrashCascade;
 use Cortext\Rest\CollectionsController;
+use Cortext\Rest\FavoritesController;
 use Cortext\Rest\FieldsController;
 use Cortext\Rest\PageTrashController;
 use Cortext\Rest\RowsController;
@@ -53,6 +54,7 @@ final class Plugin {
 		( new PageCoverBlock() )->register();
 		( new PageHeaderActionsBlock() )->register();
 		( new CollectionsController() )->register();
+		( new FavoritesController() )->register();
 		( new FieldsController() )->register();
 		( new PageTrashController() )->register();
 		( new RowsController() )->register();

--- a/includes/Rest/FavoritesController.php
+++ b/includes/Rest/FavoritesController.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * REST endpoint for the current user's sidebar favorites.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\Page;
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class FavoritesController {
+
+	private const NAMESPACE = 'cortext/v1';
+	private const META_KEY  = 'cortext_favorites';
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/favorites',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_favorites' ),
+					'permission_callback' => array( $this, 'can_read' ),
+				),
+				array(
+					'methods'             => 'PUT',
+					'callback'            => array( $this, 'update_favorites' ),
+					'permission_callback' => array( $this, 'can_read' ),
+					'args'                => array(
+						'favorites' => array(
+							'type'     => 'array',
+							'required' => true,
+							'items'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'kind' => array(
+										'type' => 'string',
+										'enum' => array( 'page', 'collection' ),
+									),
+									'id'   => array(
+										'type'    => 'integer',
+										'minimum' => 1,
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function can_read(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	public function get_favorites(): WP_REST_Response {
+		return new WP_REST_Response(
+			array(
+				'favorites' => $this->resolve_stored_favorites( get_current_user_id() ),
+			),
+			200
+		);
+	}
+
+	public function update_favorites( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$favorites = $request->get_param( 'favorites' );
+		if ( ! is_array( $favorites ) ) {
+			return new WP_Error(
+				'cortext_favorites_invalid_payload',
+				__( 'Favorites must be an ordered list.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$formatted = array();
+		$stored    = array();
+		$seen      = array();
+
+		foreach ( $favorites as $favorite ) {
+			if ( ! is_array( $favorite ) ) {
+				return $this->invalid_target_error();
+			}
+
+			$kind = isset( $favorite['kind'] ) ? (string) $favorite['kind'] : '';
+			$id   = isset( $favorite['id'] ) ? (int) $favorite['id'] : 0;
+			$key  = "{$kind}:{$id}";
+
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$target = $this->format_target( $kind, $id, true );
+			if ( is_wp_error( $target ) ) {
+				return $target;
+			}
+
+			$seen[ $key ] = true;
+			$stored[]     = $key;
+			$formatted[]  = $target;
+		}
+
+		update_user_meta( get_current_user_id(), self::META_KEY, $stored );
+
+		return new WP_REST_Response(
+			array(
+				'favorites' => $formatted,
+			),
+			200
+		);
+	}
+
+	private function resolve_stored_favorites( int $user_id ): array {
+		$raw = get_user_meta( $user_id, self::META_KEY, true );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$out  = array();
+		$seen = array();
+		foreach ( $raw as $entry ) {
+			$parsed = $this->parse_stored_entry( $entry );
+			if ( ! $parsed ) {
+				continue;
+			}
+
+			$key = "{$parsed['kind']}:{$parsed['id']}";
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$target = $this->format_target( $parsed['kind'], $parsed['id'], true );
+			if ( is_wp_error( $target ) ) {
+				continue;
+			}
+
+			$seen[ $key ] = true;
+			$out[]        = $target;
+		}
+
+		return $out;
+	}
+
+	private function parse_stored_entry( mixed $entry ): ?array {
+		if ( is_string( $entry ) ) {
+			$parts = explode( ':', $entry, 2 );
+			if ( 2 !== count( $parts ) ) {
+				return null;
+			}
+			return array(
+				'kind' => $parts[0],
+				'id'   => (int) $parts[1],
+			);
+		}
+
+		if ( is_array( $entry ) ) {
+			return array(
+				'kind' => isset( $entry['kind'] ) ? (string) $entry['kind'] : '',
+				'id'   => isset( $entry['id'] ) ? (int) $entry['id'] : 0,
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Formats a page or collection target into the shell route contract.
+	 *
+	 * @param string $kind Target kind.
+	 * @param int    $id Target post ID.
+	 * @param bool   $require_edit Whether to enforce edit_post capability.
+	 * @return array{kind:string,id:int,path:string}|WP_Error
+	 */
+	private function format_target( string $kind, int $id, bool $require_edit ) {
+		if ( ! in_array( $kind, array( 'page', 'collection' ), true ) || $id < 1 ) {
+			return $this->invalid_target_error();
+		}
+
+		$post = get_post( $id );
+		if ( ! $this->is_supported_target( $post, $kind ) ) {
+			return new WP_Error(
+				'cortext_favorites_not_found',
+				__( 'Favorite target was not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( $require_edit && ! current_user_can( 'edit_post', $id ) ) {
+			return new WP_Error(
+				'cortext_favorites_forbidden',
+				__( 'You are not allowed to favorite this target.', 'cortext' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return array(
+			'kind' => $kind,
+			'id'   => $id,
+			'path' => $this->target_path( $post, $kind ),
+		);
+	}
+
+	private function invalid_target_error(): WP_Error {
+		return new WP_Error(
+			'cortext_favorites_invalid_target',
+			__( 'Favorite target is invalid.', 'cortext' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	private function is_supported_target( ?WP_Post $post, string $kind ): bool {
+		if ( ! $post || 'trash' === $post->post_status ) {
+			return false;
+		}
+
+		$type = 'page' === $kind ? Page::POST_TYPE : Collection::POST_TYPE;
+		return $type === $post->post_type;
+	}
+
+	private function target_path( WP_Post $post, string $kind ): string {
+		if ( 'collection' === $kind ) {
+			$slug = get_post_meta( (int) $post->ID, 'slug', true );
+			$slug = is_string( $slug ) ? trim( $slug ) : '';
+		} else {
+			$slug = trim( $post->post_name );
+		}
+
+		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
+		return "{$kind}/{$tail}";
+	}
+}

--- a/src/components/CollectionRow.js
+++ b/src/components/CollectionRow.js
@@ -1,0 +1,97 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	home as homeIcon,
+	moreVertical,
+	starEmpty,
+	starFilled,
+} from '@wordpress/icons';
+
+export function collectionTitle( collection ) {
+	return (
+		collection.title?.rendered?.trim() ||
+		collection.title?.raw?.trim() ||
+		collection.title?.trim?.() ||
+		__( '(untitled)', 'cortext' )
+	);
+}
+
+export default function CollectionRow( {
+	collection,
+	isSelected,
+	isFavorite = false,
+	isHome,
+	isHomeUpdating,
+	onSelect,
+	onToggleFavorite,
+	onSetHome,
+} ) {
+	const title = collectionTitle( collection );
+	const rowClasses = [ 'cortext-sidebar__row' ];
+	if ( isSelected ) {
+		rowClasses.push( 'is-selected' );
+	}
+
+	return (
+		<li className="cortext-sidebar__node">
+			<div className={ rowClasses.join( ' ' ) }>
+				<Button
+					className="cortext-sidebar__title"
+					size="compact"
+					variant="tertiary"
+					onClick={ onSelect }
+					isPressed={ isSelected }
+				>
+					{ title }
+				</Button>
+				<Dropdown
+					popoverProps={ { placement: 'bottom-end' } }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							className={
+								'cortext-sidebar__menu' +
+								( isOpen ? ' is-opened' : '' )
+							}
+							icon={ moreVertical }
+							size="small"
+							label={ sprintf(
+								/* translators: %s: collection title */
+								__( 'Actions for %s', 'cortext' ),
+								title
+							) }
+							onClick={ onToggle }
+							aria-expanded={ isOpen }
+						/>
+					) }
+					renderContent={ ( { onClose } ) => (
+						<MenuGroup>
+							<MenuItem
+								icon={ isFavorite ? starFilled : starEmpty }
+								onClick={ () => {
+									onToggleFavorite?.( collection.id );
+									onClose();
+								} }
+							>
+								{ isFavorite
+									? __( 'Remove from favorites', 'cortext' )
+									: __( 'Add to favorites', 'cortext' ) }
+							</MenuItem>
+							<MenuItem
+								icon={ homeIcon }
+								disabled={ isHome || isHomeUpdating }
+								onClick={ () => {
+									onSetHome( collection.id );
+									onClose();
+								} }
+							>
+								{ isHome
+									? __( 'Home', 'cortext' )
+									: __( 'Set as home', 'cortext' ) }
+							</MenuItem>
+						</MenuGroup>
+					) }
+				/>
+			</div>
+		</li>
+	);
+}

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -12,6 +12,8 @@ import {
 	home as homeIcon,
 	moreVertical,
 	plus,
+	starEmpty,
+	starFilled,
 } from '@wordpress/icons';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 
@@ -38,6 +40,8 @@ export default function PageRow( {
 	onRename,
 	onDuplicate,
 	onDelete,
+	isFavorite = false,
+	onToggleFavorite,
 	onSetHome,
 	home,
 	isHomeUpdating = false,
@@ -53,6 +57,8 @@ export default function PageRow( {
 	const hasChildren = children.length > 0;
 	const isExpanded = expandedIds.has( page.id );
 	const isSelected = page.id === selectedId;
+	const pageIsFavorite =
+		typeof isFavorite === 'function' ? isFavorite( page.id ) : isFavorite;
 	const isHome = home?.kind === 'page' && home.id === page.id;
 	const isBeingDragged = draggedId === page.id;
 
@@ -263,6 +269,22 @@ export default function PageRow( {
 						renderContent={ ( { onClose } ) => (
 							<MenuGroup>
 								<MenuItem
+									icon={
+										pageIsFavorite ? starFilled : starEmpty
+									}
+									onClick={ () => {
+										onToggleFavorite?.( page.id );
+										onClose();
+									} }
+								>
+									{ pageIsFavorite
+										? __(
+												'Remove from favorites',
+												'cortext'
+										  )
+										: __( 'Add to favorites', 'cortext' ) }
+								</MenuItem>
+								<MenuItem
 									icon={ homeIcon }
 									disabled={ isHome || isHomeUpdating }
 									onClick={ () => {
@@ -350,6 +372,8 @@ export default function PageRow( {
 								onRename={ onRename }
 								onDuplicate={ onDuplicate }
 								onDelete={ onDelete }
+								isFavorite={ isFavorite }
+								onToggleFavorite={ onToggleFavorite }
 								onSetHome={ onSetHome }
 								home={ home }
 								isHomeUpdating={ isHomeUpdating }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,21 +9,8 @@ import {
 	useCallback,
 	useEffect,
 } from '@wordpress/element';
-import {
-	Button,
-	Dropdown,
-	Icon,
-	MenuGroup,
-	MenuItem,
-	Spinner,
-} from '@wordpress/components';
-import {
-	home as homeIcon,
-	moreVertical,
-	plus,
-	search,
-	wordpress,
-} from '@wordpress/icons';
+import { Button, Icon, Spinner } from '@wordpress/components';
+import { home as homeIcon, plus, search, wordpress } from '@wordpress/icons';
 
 // Notion-style sidebar toggle: panel outline with a vertical accent on
 // the left side. Same icon for both states; the aria-label tells the
@@ -68,8 +55,10 @@ import {
 } from '@dnd-kit/core';
 import { useNavigate, useParams } from '@tanstack/react-router';
 
+import CollectionRow from './CollectionRow';
 import PageRow from './PageRow';
 import { openCommandPalette } from './CommandPalette';
+import SidebarFavorites, { favoriteKey } from './SidebarFavorites';
 import SidebarResizeHandle from './SidebarResizeHandle';
 import SidebarTrash from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
@@ -91,6 +80,7 @@ import {
 	parseSplatUri,
 } from '../router/useResolveEntity';
 import { COLLECTION_QUERY } from '../collections';
+import { useFavorites } from '../hooks/useFavorites';
 import { useWorkspaceHomePath } from '../hooks/useWorkspaceHomePath';
 
 const AUTO_EXPAND_DELAY = 700;
@@ -105,82 +95,6 @@ function parseDropId( id ) {
 		return null;
 	}
 	return { zone, targetId: pageId };
-}
-
-function collectionTitle( collection ) {
-	return (
-		collection.title?.rendered?.trim() ||
-		collection.title?.raw?.trim() ||
-		collection.title?.trim?.() ||
-		__( '(untitled)', 'cortext' )
-	);
-}
-
-function CollectionRow( {
-	collection,
-	isSelected,
-	isHome,
-	isHomeUpdating,
-	onSelect,
-	onSetHome,
-} ) {
-	const title = collectionTitle( collection );
-	const rowClasses = [ 'cortext-sidebar__row' ];
-	if ( isSelected ) {
-		rowClasses.push( 'is-selected' );
-	}
-
-	return (
-		<li className="cortext-sidebar__node">
-			<div className={ rowClasses.join( ' ' ) }>
-				<Button
-					className="cortext-sidebar__title"
-					size="compact"
-					variant="tertiary"
-					onClick={ onSelect }
-					isPressed={ isSelected }
-				>
-					{ title }
-				</Button>
-				<Dropdown
-					popoverProps={ { placement: 'bottom-end' } }
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<Button
-							className={
-								'cortext-sidebar__menu' +
-								( isOpen ? ' is-opened' : '' )
-							}
-							icon={ moreVertical }
-							size="small"
-							label={ sprintf(
-								/* translators: %s: collection title */
-								__( 'Actions for %s', 'cortext' ),
-								title
-							) }
-							onClick={ onToggle }
-							aria-expanded={ isOpen }
-						/>
-					) }
-					renderContent={ ( { onClose } ) => (
-						<MenuGroup>
-							<MenuItem
-								icon={ homeIcon }
-								disabled={ isHome || isHomeUpdating }
-								onClick={ () => {
-									onSetHome( collection.id );
-									onClose();
-								} }
-							>
-								{ isHome
-									? __( 'Home', 'cortext' )
-									: __( 'Set as home', 'cortext' ) }
-							</MenuItem>
-						</MenuGroup>
-					) }
-				/>
-			</div>
-		</li>
-	);
 }
 
 export default function Sidebar( {
@@ -204,6 +118,11 @@ export default function Sidebar( {
 		isResolvingPages,
 		isUpdating: isHomeUpdating,
 	} = useWorkspaceHomePath();
+	const {
+		favorites,
+		setFavorites,
+		isResolving: isResolvingFavorites,
+	} = useFavorites();
 	const { saveEntityRecord, invalidateResolution, receiveEntityRecords } =
 		useDispatch( 'core' );
 	const navigate = useNavigate();
@@ -303,6 +222,60 @@ export default function Sidebar( {
 			} catch {}
 		},
 		[ setHome ]
+	);
+
+	const favoriteKeys = useMemo(
+		() =>
+			new Set( favorites.map( ( favorite ) => favoriteKey( favorite ) ) ),
+		[ favorites ]
+	);
+	const isPageFavorite = useCallback(
+		( id ) => favoriteKeys.has( favoriteKey( { kind: 'page', id } ) ),
+		[ favoriteKeys ]
+	);
+	const isCollectionFavorite = useCallback(
+		( id ) => favoriteKeys.has( favoriteKey( { kind: 'collection', id } ) ),
+		[ favoriteKeys ]
+	);
+	const toggleFavorite = useCallback(
+		async ( kind, id ) => {
+			const key = favoriteKey( { kind, id } );
+			const exists = favoriteKeys.has( key );
+			const next = exists
+				? favorites.filter(
+						( favorite ) => favoriteKey( favorite ) !== key
+				  )
+				: [ ...favorites, { kind, id } ];
+			try {
+				await setFavorites( next );
+			} catch {}
+		},
+		[ favoriteKeys, favorites, setFavorites ]
+	);
+	const reorderFavorites = useCallback(
+		async ( next ) => {
+			try {
+				await setFavorites( next );
+			} catch {}
+		},
+		[ setFavorites ]
+	);
+	const selectFavorite = useCallback(
+		( favorite ) => {
+			if (
+				( favorite.kind === 'page' && favorite.id === selectedId ) ||
+				( favorite.kind === 'collection' &&
+					favorite.id === selectedCollectionId )
+			) {
+				return false;
+			}
+			navigate( {
+				to: '/$',
+				params: { _splat: favorite.path },
+			} );
+			return true;
+		},
+		[ navigate, selectedCollectionId, selectedId ]
 	);
 
 	const tree = useMemo( () => buildTree( pages ), [ pages ] );
@@ -647,6 +620,21 @@ export default function Sidebar( {
 			</div>
 			{ ! collapsed && (
 				<div className="cortext-sidebar__content">
+					<SidebarFavorites
+						favorites={ favorites }
+						pages={ pages }
+						collections={ collections ?? [] }
+						isResolving={ isResolvingFavorites }
+						isResolvingItems={
+							isResolvingPages || isResolvingCollections
+						}
+						onSelect={ selectFavorite }
+						onRemove={ ( favorite ) =>
+							toggleFavorite( favorite.kind, favorite.id )
+						}
+						onReorder={ reorderFavorites }
+					/>
+
 					<div className="cortext-sidebar__section-header">
 						<h2 className="cortext-sidebar__section-title">
 							{ __( 'Pages', 'cortext' ) }
@@ -694,6 +682,10 @@ export default function Sidebar( {
 									onRename={ renamePage }
 									onDuplicate={ duplicatePage }
 									onDelete={ trashPage }
+									isFavorite={ isPageFavorite }
+									onToggleFavorite={ ( id ) =>
+										toggleFavorite( 'page', id )
+									}
 									onSetHome={ setPageHome }
 									home={ home }
 									isHomeUpdating={ isHomeUpdating }
@@ -750,7 +742,13 @@ export default function Sidebar( {
 										home?.kind === 'collection' &&
 										home.id === collection.id
 									}
+									isFavorite={ isCollectionFavorite(
+										collection.id
+									) }
 									isHomeUpdating={ isHomeUpdating }
+									onToggleFavorite={ ( id ) =>
+										toggleFavorite( 'collection', id )
+									}
 									onSetHome={ setCollectionHome }
 									onSelect={ () =>
 										navigate( {

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -1,0 +1,382 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Icon, Spinner } from '@wordpress/components';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { customPostType, starFilled } from '@wordpress/icons';
+import {
+	DndContext,
+	PointerSensor,
+	closestCenter,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core';
+import {
+	SortableContext,
+	arrayMove,
+	useSortable,
+	verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+
+import PageIcon from './PageIcon';
+import { collectionTitle } from './CollectionRow';
+import { computeUri } from '../router/useResolveEntity';
+import { whenViewTransitionsSettled } from '../hooks/viewTransition';
+
+const FAVORITE_ADD_ANIMATION_MS = 220;
+const FAVORITE_REMOVE_ANIMATION_MS = 150;
+
+function transformToString( transform ) {
+	if ( ! transform ) {
+		return undefined;
+	}
+	const { x = 0, y = 0, scaleX = 1, scaleY = 1 } = transform;
+	return `translate3d(${ x }px, ${ y }px, 0) scaleX(${ scaleX }) scaleY(${ scaleY })`;
+}
+
+function pageTitle( page ) {
+	return page.title?.rendered?.trim() || __( '(untitled)', 'cortext' );
+}
+
+export function favoriteKey( favorite ) {
+	return `favorite:${ favorite.kind }:${ Number( favorite.id ) }`;
+}
+
+export function moveFavorite( favorites, activeId, overId ) {
+	if ( ! overId || activeId === overId ) {
+		return favorites;
+	}
+
+	const from = favorites.findIndex( ( favorite ) => {
+		return favoriteKey( favorite ) === activeId;
+	} );
+	const to = favorites.findIndex( ( favorite ) => {
+		return favoriteKey( favorite ) === overId;
+	} );
+
+	if ( from < 0 || to < 0 ) {
+		return favorites;
+	}
+
+	return arrayMove( favorites, from, to );
+}
+
+export function resolveFavoriteItems( favorites, pages, collections ) {
+	const pagesById = new Map( pages.map( ( page ) => [ page.id, page ] ) );
+	const collectionsById = new Map(
+		( collections ?? [] ).map( ( collection ) => [
+			collection.id,
+			collection,
+		] )
+	);
+
+	return favorites
+		.map( ( favorite ) => {
+			const id = Number( favorite.id );
+			if ( favorite.kind === 'page' ) {
+				const page = pagesById.get( id );
+				if ( ! page && ! favorite.path ) {
+					return null;
+				}
+				const key = favoriteKey( favorite );
+				return {
+					...favorite,
+					id,
+					key,
+					sortableId: key,
+					record: page,
+					title: page ? pageTitle( page ) : __( 'Page', 'cortext' ),
+					path: page ? computeUri( page, 'page' ) : favorite.path,
+				};
+			}
+
+			if ( favorite.kind === 'collection' ) {
+				const collection = collectionsById.get( id );
+				if ( ! collection && ! favorite.path ) {
+					return null;
+				}
+				const key = favoriteKey( favorite );
+				return {
+					...favorite,
+					id,
+					key,
+					sortableId: key,
+					record: collection,
+					title: collection
+						? collectionTitle( collection )
+						: __( 'Collection', 'cortext' ),
+					path: collection
+						? computeUri( collection, 'collection' )
+						: favorite.path,
+				};
+			}
+
+			return null;
+		} )
+		.filter( Boolean );
+}
+
+function FavoriteIcon( { item } ) {
+	if ( item.kind === 'page' ) {
+		return (
+			<PageIcon
+				icon={ item.record?.meta?.cortext_page_icon ?? '' }
+				size={ 16 }
+			/>
+		);
+	}
+
+	return <Icon icon={ customPostType } size={ 16 } />;
+}
+
+function SortableFavoriteRow( { item, onSelect, onRemove } ) {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable( { id: item.sortableId } );
+	const rowClasses = [ 'cortext-sidebar__row' ];
+	if ( isDragging ) {
+		rowClasses.push( 'is-dragging' );
+	}
+
+	return (
+		<li
+			className={
+				'cortext-sidebar__node cortext-sidebar__favorite-row' +
+				( item.isAdded ? ' is-added' : '' ) +
+				( item.isRemoving ? ' is-removing' : '' )
+			}
+			data-favorite-key={ item.sortableId }
+		>
+			<div
+				ref={ setNodeRef }
+				className={ rowClasses.join( ' ' ) }
+				style={ {
+					transform: transformToString( transform ),
+					transition,
+				} }
+			>
+				<button
+					type="button"
+					className="cortext-sidebar__favorite-drag-handle"
+					aria-label={ __( 'Reorder favorite', 'cortext' ) }
+					{ ...attributes }
+					{ ...listeners }
+				>
+					<span
+						className="cortext-sidebar__favorite-icon"
+						aria-hidden="true"
+					>
+						<FavoriteIcon item={ item } />
+					</span>
+				</button>
+				<button
+					type="button"
+					className="cortext-sidebar__favorite-title"
+					onClick={ ( event ) => {
+						const isMouseClick = event.detail > 0;
+						if ( ! isMouseClick ) {
+							onSelect( item );
+							return;
+						}
+						const button = event.currentTarget;
+						if ( onSelect( item ) ) {
+							// Hold focus through the canvas view transition
+							// so :focus-within keeps the row painted (the
+							// ::view-transition overlay briefly suspends
+							// :hover hit-testing on the sidebar, which would
+							// otherwise flicker). Blur once the transition
+							// finishes so the row doesn't stay highlighted.
+							whenViewTransitionsSettled().then( () =>
+								button.blur()
+							);
+						} else {
+							// No navigation (clicked the active favorite).
+							// Drop focus right away so the row doesn't sit
+							// in :focus-within state.
+							button.blur();
+						}
+					} }
+				>
+					{ item.title }
+				</button>
+				<Button
+					className="cortext-sidebar__favorite-toggle is-favorite"
+					icon={ starFilled }
+					size="small"
+					label={ sprintf(
+						/* translators: %s: favorite title */
+						__( 'Remove %s from favorites', 'cortext' ),
+						item.title
+					) }
+					onClick={ () => onRemove( item ) }
+					aria-pressed
+				/>
+			</div>
+		</li>
+	);
+}
+
+export default function SidebarFavorites( {
+	favorites,
+	pages,
+	collections,
+	isResolving,
+	isResolvingItems,
+	onSelect,
+	onRemove,
+	onReorder,
+} ) {
+	const [ displayFavorites, setDisplayFavorites ] = useState( favorites );
+	const [ addedKeys, setAddedKeys ] = useState( () => new Set() );
+	const [ removingKeys, setRemovingKeys ] = useState( () => new Set() );
+	const previousKeysRef = useRef( null );
+	const timersRef = useRef( [] );
+
+	useEffect( () => {
+		const currentKeys = new Set(
+			favorites.map( ( favorite ) => favoriteKey( favorite ) )
+		);
+		const previousKeys = previousKeysRef.current;
+		previousKeysRef.current = currentKeys;
+
+		if ( ! previousKeys ) {
+			setDisplayFavorites( favorites );
+			return;
+		}
+
+		const nextAdded = new Set(
+			[ ...currentKeys ].filter( ( key ) => ! previousKeys.has( key ) )
+		);
+		const nextRemoved = new Set(
+			[ ...previousKeys ].filter( ( key ) => ! currentKeys.has( key ) )
+		);
+
+		if ( nextAdded.size > 0 ) {
+			setAddedKeys( nextAdded );
+			const timer = setTimeout( () => {
+				setAddedKeys( ( keys ) => {
+					const next = new Set( keys );
+					nextAdded.forEach( ( key ) => next.delete( key ) );
+					return next;
+				} );
+			}, FAVORITE_ADD_ANIMATION_MS );
+			timersRef.current.push( timer );
+		}
+
+		if ( nextRemoved.size > 0 ) {
+			setRemovingKeys( ( keys ) => {
+				const next = new Set( keys );
+				nextRemoved.forEach( ( key ) => next.add( key ) );
+				return next;
+			} );
+			const timer = setTimeout( () => {
+				setRemovingKeys( ( keys ) => {
+					const next = new Set( keys );
+					nextRemoved.forEach( ( key ) => next.delete( key ) );
+					return next;
+				} );
+				setDisplayFavorites( favorites );
+			}, FAVORITE_REMOVE_ANIMATION_MS );
+			timersRef.current.push( timer );
+			return;
+		}
+
+		setDisplayFavorites( favorites );
+	}, [ favorites ] );
+
+	const items = useMemo(
+		() => resolveFavoriteItems( displayFavorites, pages, collections ),
+		[ displayFavorites, pages, collections ]
+	);
+	const sortableIds = useMemo(
+		() => items.map( ( item ) => item.sortableId ),
+		[ items ]
+	);
+	const sensors = useSensors(
+		useSensor( PointerSensor, { activationConstraint: { distance: 5 } } )
+	);
+
+	useEffect( () => {
+		return () => {
+			timersRef.current.forEach( clearTimeout );
+			timersRef.current = [];
+		};
+	}, [] );
+
+	if ( ! isResolving && displayFavorites.length === 0 ) {
+		return null;
+	}
+
+	const handleDragEnd = ( { active, over } ) => {
+		const next = moveFavorite(
+			favorites,
+			String( active.id ),
+			over ? String( over.id ) : null
+		);
+		if ( next !== favorites ) {
+			onReorder( next );
+		}
+	};
+
+	const requestRemove = ( item ) => {
+		setRemovingKeys( ( keys ) => new Set( keys ).add( item.sortableId ) );
+		const timer = setTimeout( () => {
+			onRemove( item );
+			setRemovingKeys( ( keys ) => {
+				const next = new Set( keys );
+				next.delete( item.sortableId );
+				return next;
+			} );
+		}, FAVORITE_REMOVE_ANIMATION_MS );
+		timersRef.current.push( timer );
+	};
+
+	return (
+		<div className="cortext-sidebar__favorites">
+			<div className="cortext-sidebar__section-header">
+				<h2 className="cortext-sidebar__section-title">
+					{ __( 'Favorites', 'cortext' ) }
+				</h2>
+			</div>
+			{ ( isResolving || isResolvingItems ) && items.length === 0 ? (
+				<div className="cortext-sidebar__loading">
+					<Spinner />
+				</div>
+			) : null }
+			{ items.length > 0 ? (
+				<DndContext
+					sensors={ sensors }
+					collisionDetection={ closestCenter }
+					onDragEnd={ handleDragEnd }
+				>
+					<SortableContext
+						items={ sortableIds }
+						strategy={ verticalListSortingStrategy }
+					>
+						<ul className="cortext-sidebar__list">
+							{ items.map( ( item ) => (
+								<SortableFavoriteRow
+									key={ item.key }
+									item={ {
+										...item,
+										isAdded: addedKeys.has(
+											item.sortableId
+										),
+										isRemoving: removingKeys.has(
+											item.sortableId
+										),
+									} }
+									onSelect={ onSelect }
+									onRemove={ requestRemove }
+								/>
+							) ) }
+						</ul>
+					</SortableContext>
+				</DndContext>
+			) : null }
+		</div>
+	);
+}

--- a/src/hooks/useFavorites.js
+++ b/src/hooks/useFavorites.js
@@ -1,0 +1,109 @@
+import apiFetch from '@wordpress/api-fetch';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
+
+const FavoritesContext = createContext( null );
+
+function normalizeFavorite( favorite ) {
+	if ( ! favorite || ! favorite.kind || ! favorite.id ) {
+		return null;
+	}
+	return {
+		...favorite,
+		kind: favorite.kind,
+		id: Number( favorite.id ),
+	};
+}
+
+function normalizeFavorites( favorites ) {
+	if ( ! Array.isArray( favorites ) ) {
+		return [];
+	}
+	return favorites.map( normalizeFavorite ).filter( Boolean );
+}
+
+export function FavoritesProvider( { children } ) {
+	const [ favorites, setFavoritesState ] = useState( [] );
+	const [ isResolving, setIsResolving ] = useState( true );
+	const [ isUpdating, setIsUpdating ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	useEffect( () => {
+		let cancelled = false;
+		setIsResolving( true );
+		setError( null );
+
+		apiFetch( { path: '/cortext/v1/favorites' } )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setFavoritesState( normalizeFavorites( response?.favorites ) );
+				setIsResolving( false );
+			} )
+			.catch( ( nextError ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setFavoritesState( [] );
+				setError( nextError );
+				setIsResolving( false );
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const setFavorites = useCallback( async ( nextFavorites ) => {
+		const normalized = normalizeFavorites( nextFavorites );
+		let previous;
+		setFavoritesState( ( current ) => {
+			previous = current;
+			return normalized;
+		} );
+		setIsUpdating( true );
+		setError( null );
+		try {
+			const response = await apiFetch( {
+				path: '/cortext/v1/favorites',
+				method: 'PUT',
+				data: { favorites: normalized },
+			} );
+			const saved = normalizeFavorites( response?.favorites );
+			setFavoritesState( saved );
+			return saved;
+		} catch ( nextError ) {
+			setFavoritesState( previous ?? [] );
+			setError( nextError );
+			throw nextError;
+		} finally {
+			setIsUpdating( false );
+		}
+	}, [] );
+
+	const value = useMemo(
+		() => ( { favorites, isResolving, isUpdating, error, setFavorites } ),
+		[ favorites, isResolving, isUpdating, error, setFavorites ]
+	);
+
+	return (
+		<FavoritesContext.Provider value={ value }>
+			{ children }
+		</FavoritesContext.Provider>
+	);
+}
+
+export function useFavorites() {
+	const value = useContext( FavoritesContext );
+	if ( ! value ) {
+		throw new Error( 'useFavorites must be used inside FavoritesProvider' );
+	}
+	return value;
+}

--- a/src/hooks/viewTransition.js
+++ b/src/hooks/viewTransition.js
@@ -8,20 +8,66 @@ function prefersReducedMotion() {
 	);
 }
 
+let activeTransition = null;
+
+function supportsViewTransitions() {
+	return (
+		typeof document !== 'undefined' &&
+		typeof document.startViewTransition === 'function'
+	);
+}
+
+function canUseViewTransitions() {
+	return supportsViewTransitions() && ! prefersReducedMotion();
+}
+
 // Wrap a state update so the browser snapshots the canvas before and
 // after, then cross-fades between them. Without View Transitions support
 // or with reduced motion on, just runs the updater directly.
 export function withViewTransition( updater ) {
-	const supported =
-		typeof document !== 'undefined' &&
-		typeof document.startViewTransition === 'function';
-
-	if ( ! supported || prefersReducedMotion() ) {
+	if ( ! canUseViewTransitions() ) {
 		updater();
 		return;
 	}
 
-	document.startViewTransition( () => {
+	const tx = document.startViewTransition( () => {
 		flushSync( updater );
+	} );
+	activeTransition = tx;
+	tx.finished
+		.catch( () => {} )
+		.finally( () => {
+			if ( activeTransition === tx ) {
+				activeTransition = null;
+			}
+		} );
+}
+
+// Resolves once the next view transition (started within `maxStartWait` ms
+// of the call) has finished. Resolves immediately if none starts.
+export function whenViewTransitionsSettled( maxStartWait = 1500 ) {
+	if ( ! canUseViewTransitions() ) {
+		return Promise.resolve();
+	}
+
+	return new Promise( ( resolve ) => {
+		const startedAt =
+			typeof performance !== 'undefined' ? performance.now() : Date.now();
+		const check = () => {
+			if ( activeTransition ) {
+				activeTransition.finished.catch( () => {} ).finally( resolve );
+				return;
+			}
+			const now =
+				typeof performance !== 'undefined'
+					? performance.now()
+					: Date.now();
+			if ( now - startedAt >= maxStartWait ) {
+				resolve();
+				return;
+			}
+			window.requestAnimationFrame( check );
+		};
+		check();
 	} );
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -322,6 +322,45 @@ body.cortext-fullscreen {
 		}
 	}
 
+	/* stylelint-disable no-descending-specificity */
+	&__favorite-row .cortext-sidebar__row {
+		cursor: default;
+	}
+
+	&__favorite-title {
+		flex: 1 1 auto;
+		min-width: 0;
+		height: $grid-unit-40;
+		padding: 0 $grid-unit-05;
+		border: 0;
+		background: transparent;
+		color: var(--cortext-text-muted);
+		font: inherit;
+		text-align: start;
+		cursor: pointer;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		&:hover,
+		&:focus,
+		&:active {
+			background: transparent;
+			color: var(--cortext-text-muted);
+			outline: none;
+		}
+	}
+
+	&__favorite-row.is-added .cortext-sidebar__row {
+		animation: cortext-favorite-add 180ms ease-out;
+	}
+
+	&__favorite-row.is-removing .cortext-sidebar__row {
+		animation: cortext-favorite-remove 150ms ease-in forwards;
+		pointer-events: none;
+	}
+	/* stylelint-enable no-descending-specificity */
+
 	// Chevron button, its placeholder, and the icon button must occupy the
 	// same column width so children's icons align under their parent's icon.
 	// WP's Button defaults to a wider intrinsic size; pin all three to
@@ -400,6 +439,34 @@ body.cortext-fullscreen {
 		}
 	}
 
+	&__favorite-icon {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: $grid-unit-30;
+		height: $grid-unit-30;
+		color: var(--cortext-text-muted);
+	}
+
+	&__favorite-drag-handle {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: $grid-unit-30;
+		height: $grid-unit-30;
+		border: 0;
+		padding: 0;
+		background: transparent;
+		color: var(--cortext-text-muted);
+		cursor: grab;
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+
 	&__rename {
 		flex: 1 1 auto;
 		min-width: 0;
@@ -431,20 +498,28 @@ body.cortext-fullscreen {
 		}
 	}
 
+	&__favorite-toggle,
 	&__menu,
 	&__add-child {
 		flex: 0 0 auto;
 		opacity: 1;
 		transition: opacity 0.12s ease;
+
+		&.is-favorite {
+			color: var(--cortext-text-muted);
+		}
 	}
 
 	@media (hover: hover) and (pointer: fine) {
 
+		&__favorite-toggle,
 		&__menu,
 		&__add-child {
 			opacity: 0;
 		}
 
+		&__row:hover &__favorite-toggle,
+		&__row:focus-within &__favorite-toggle,
 		&__row:hover &__menu,
 		&__row:focus-within &__menu,
 		&__menu.is-pressed,
@@ -659,6 +734,32 @@ body.cortext-fullscreen {
 			width: $grid-unit-30 + $grid-unit-05;
 			min-width: $grid-unit-30 + $grid-unit-05;
 		}
+	}
+}
+
+@keyframes cortext-favorite-add {
+
+	from {
+		opacity: 0;
+		transform: translateY(-4px) scale(0.98);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+
+@keyframes cortext-favorite-remove {
+
+	from {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+
+	to {
+		opacity: 0;
+		transform: translateY(-4px) scale(0.98);
 	}
 }
 

--- a/src/router.js
+++ b/src/router.js
@@ -13,6 +13,7 @@ import Sidebar from './components/Sidebar';
 import EntityRoute from './router/EntityRoute';
 import CommandPalette from './components/CommandPalette';
 import useSidebarLayout from './hooks/useSidebarLayout';
+import { FavoritesProvider } from './hooks/useFavorites';
 import { WorkspaceHomeProvider } from './hooks/useWorkspaceHome';
 import { unlock } from './lock-unlock';
 
@@ -63,22 +64,24 @@ function RootLayout() {
 	return (
 		<SlotFillProvider>
 			<WorkspaceHomeProvider>
-				<div className="cortext-shell">
-					<Sidebar
-						collapsed={ collapsed }
-						width={ width }
-						onToggleCollapsed={ toggleCollapsed }
-						onWidthChange={ setWidth }
-					/>
-					<main
-						ref={ canvasRef }
-						className="cortext-shell__canvas"
-						tabIndex={ -1 }
-					>
-						<EntityRoute history={ router.history } />
-					</main>
-				</div>
-				<CommandPalette canvasRef={ canvasRef } />
+				<FavoritesProvider>
+					<div className="cortext-shell">
+						<Sidebar
+							collapsed={ collapsed }
+							width={ width }
+							onToggleCollapsed={ toggleCollapsed }
+							onWidthChange={ setWidth }
+						/>
+						<main
+							ref={ canvasRef }
+							className="cortext-shell__canvas"
+							tabIndex={ -1 }
+						>
+							<EntityRoute history={ router.history } />
+						</main>
+					</div>
+					<CommandPalette canvasRef={ canvasRef } />
+				</FavoritesProvider>
 			</WorkspaceHomeProvider>
 		</SlotFillProvider>
 	);

--- a/tests/e2e/specs/sidebar-favorites.spec.js
+++ b/tests/e2e/specs/sidebar-favorites.spec.js
@@ -1,0 +1,361 @@
+/**
+ * E2E coverage for per-user sidebar favorites.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SUFFIX = Date.now().toString( 36 ).slice( -4 );
+const PAGE_TITLE = `E2E Favorite Page ${ SUFFIX }`;
+const COLLECTION_TITLE = `E2E Favorite Collection ${ SUFFIX }`;
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+async function storedFavoriteKeys( requestUtils ) {
+	const response = await requestUtils.rest( {
+		path: '/cortext/v1/favorites',
+	} );
+	return ( response?.favorites ?? [] ).map(
+		( favorite ) => `favorite:${ favorite.kind }:${ favorite.id }`
+	);
+}
+
+async function expectStoredFavorites( requestUtils, keys ) {
+	await expect
+		.poll( () => storedFavoriteKeys( requestUtils ) )
+		.toEqual( keys );
+}
+
+async function favoriteFromSidebar( page, title, requestUtils, storedKeys ) {
+	const sidebar = page.locator( '.cortext-sidebar' );
+	await sidebar.getByRole( 'button', { name: title, exact: true } ).hover();
+	await sidebar
+		.getByRole( 'button', {
+			name: `Actions for ${ title }`,
+			exact: true,
+		} )
+		.click( { force: true } );
+	await page.getByRole( 'menuitem', { name: 'Add to favorites' } ).click();
+	await expect(
+		page.locator( '.cortext-sidebar__favorites' ).getByText( title )
+	).toBeVisible();
+	await expectStoredFavorites( requestUtils, storedKeys );
+}
+
+async function removeFavorite( page, title, requestUtils, storedKeys ) {
+	const favorites = page.locator( '.cortext-sidebar__favorites' );
+	await favorites
+		.getByRole( 'button', {
+			name: `Remove ${ title } from favorites`,
+			exact: true,
+		} )
+		.click( { force: true } );
+	await expectStoredFavorites( requestUtils, storedKeys );
+}
+
+async function favoriteTitles( page ) {
+	return page
+		.locator(
+			'.cortext-sidebar__favorites .cortext-sidebar__favorite-title'
+		)
+		.evaluateAll( ( buttons ) =>
+			buttons.map( ( button ) => button.textContent.trim() )
+		);
+}
+
+async function dragFavoriteBefore(
+	page,
+	activeKey,
+	overKey,
+	requestUtils,
+	storedKeys
+) {
+	const active = page.locator(
+		`.cortext-sidebar__favorite-row[data-favorite-key="${ activeKey }"] .cortext-sidebar__favorite-drag-handle`
+	);
+	const over = page.locator(
+		`.cortext-sidebar__favorite-row[data-favorite-key="${ overKey }"] .cortext-sidebar__row`
+	);
+	const activeBox = await active.boundingBox();
+	const overBox = await over.boundingBox();
+	expect( activeBox ).toBeTruthy();
+	expect( overBox ).toBeTruthy();
+
+	await page.mouse.move(
+		activeBox.x + 12,
+		activeBox.y + activeBox.height / 2
+	);
+	await page.mouse.down();
+	await page.mouse.move( overBox.x + 12, overBox.y + overBox.height / 2, {
+		steps: 8,
+	} );
+	await page.mouse.up();
+	await expectStoredFavorites( requestUtils, storedKeys );
+}
+
+async function rowBackground( locator ) {
+	return locator.evaluate(
+		( element ) => window.getComputedStyle( element ).backgroundColor
+	);
+}
+
+async function rowBackgroundFrames( locator, frameCount = 24 ) {
+	return locator.evaluate(
+		( element, count ) =>
+			new Promise( ( resolve ) => {
+				const frames = [];
+				const sample = () => {
+					frames.push(
+						window.getComputedStyle( element ).backgroundColor
+					);
+					if ( frames.length >= count ) {
+						resolve( frames );
+						return;
+					}
+					window.requestAnimationFrame( sample );
+				};
+				window.requestAnimationFrame( sample );
+			} ),
+		frameCount
+	);
+}
+
+async function activeElementClass( page ) {
+	return page
+		.locator( 'body' )
+		.evaluate(
+			( body ) =>
+				body.ownerDocument.activeElement?.className?.toString() ?? ''
+		);
+}
+
+test.describe( 'Sidebar favorites', () => {
+	test( 'star, unstar, reorder, and persist favorites', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let createdPage;
+		let collection;
+
+		try {
+			createdPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: PAGE_TITLE,
+					status: 'private',
+				},
+			} );
+			collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/cortext/v1/collections',
+				data: { title: COLLECTION_TITLE },
+			} );
+			await requestUtils.rest( {
+				method: 'PUT',
+				path: '/cortext/v1/favorites',
+				data: { favorites: [] },
+			} );
+
+			await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+			const pageKey = `favorite:page:${ createdPage.id }`;
+			const collectionKey = `favorite:collection:${ collection.id }`;
+
+			await favoriteFromSidebar( page, PAGE_TITLE, requestUtils, [
+				pageKey,
+			] );
+			await favoriteFromSidebar( page, COLLECTION_TITLE, requestUtils, [
+				pageKey,
+				collectionKey,
+			] );
+
+			const favorites = page.locator( '.cortext-sidebar__favorites' );
+			await expect(
+				favorites.getByRole( 'heading', { name: 'Favorites' } )
+			).toBeVisible();
+			await expect( favorites.getByText( PAGE_TITLE ) ).toBeVisible();
+			await expect(
+				favorites.getByText( COLLECTION_TITLE )
+			).toBeVisible();
+
+			await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+			await expect(
+				page.locator( '.cortext-sidebar__favorites' )
+			).toBeVisible();
+			await expect
+				.poll( () => favoriteTitles( page ) )
+				.toEqual( [ PAGE_TITLE, COLLECTION_TITLE ] );
+
+			await removeFavorite( page, PAGE_TITLE, requestUtils, [
+				collectionKey,
+			] );
+			await expect
+				.poll( () => favoriteTitles( page ) )
+				.toEqual( [ COLLECTION_TITLE ] );
+
+			await favoriteFromSidebar( page, PAGE_TITLE, requestUtils, [
+				collectionKey,
+				pageKey,
+			] );
+			await dragFavoriteBefore(
+				page,
+				pageKey,
+				collectionKey,
+				requestUtils,
+				[ pageKey, collectionKey ]
+			);
+			await expect
+				.poll( () => favoriteTitles( page ) )
+				.toEqual( [ PAGE_TITLE, COLLECTION_TITLE ] );
+
+			await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+			await expect
+				.poll( () => favoriteTitles( page ) )
+				.toEqual( [ PAGE_TITLE, COLLECTION_TITLE ] );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				collection && `/wp/v2/crtxt_collections/${ collection.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				createdPage && `/wp/v2/crtxt_pages/${ createdPage.id }`
+			);
+		}
+	} );
+
+	test( 'favorite title click keeps the hover background stable', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let createdPage;
+		let otherPage;
+
+		try {
+			createdPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: `${ PAGE_TITLE } Flash`,
+					status: 'private',
+				},
+			} );
+			otherPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: `${ PAGE_TITLE } Flash Target`,
+					status: 'private',
+				},
+			} );
+			await requestUtils.rest( {
+				method: 'PUT',
+				path: '/cortext/v1/favorites',
+				data: {
+					favorites: [
+						{
+							kind: 'page',
+							id: createdPage.id,
+						},
+						{
+							kind: 'page',
+							id: otherPage.id,
+						},
+					],
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/page/${ createdPage.id }`
+			);
+
+			const row = page.locator(
+				`.cortext-sidebar__favorite-row[data-favorite-key="favorite:page:${ createdPage.id }"] .cortext-sidebar__row`
+			);
+			const title = row.locator( '.cortext-sidebar__favorite-title' );
+			await expect( row ).toBeVisible();
+			await title.hover();
+
+			const hoveredBackground = await rowBackground( row );
+			const box = await title.boundingBox();
+			expect( box ).toBeTruthy();
+
+			await page.mouse.move(
+				box.x + box.width / 2,
+				box.y + box.height / 2
+			);
+			await page.mouse.down();
+			const downBackground = await rowBackground( row );
+			await page.mouse.up();
+			const upBackground = await rowBackground( row );
+			const activeClass = await activeElementClass( page );
+			const postClickBackgrounds = await rowBackgroundFrames( row );
+
+			expect( downBackground ).toBe( hoveredBackground );
+			expect( upBackground ).toBe( hoveredBackground );
+			expect( activeClass ).not.toContain(
+				'cortext-sidebar__favorite-title'
+			);
+			expect( postClickBackgrounds ).toEqual(
+				Array( postClickBackgrounds.length ).fill( hoveredBackground )
+			);
+
+			const otherRow = page.locator(
+				`.cortext-sidebar__favorite-row[data-favorite-key="favorite:page:${ otherPage.id }"] .cortext-sidebar__row`
+			);
+			const otherTitle = otherRow.locator(
+				'.cortext-sidebar__favorite-title'
+			);
+			await otherTitle.hover();
+			const otherHoveredBackground = await rowBackground( otherRow );
+			const otherBox = await otherTitle.boundingBox();
+			expect( otherBox ).toBeTruthy();
+
+			await page.mouse.move(
+				otherBox.x + otherBox.width / 2,
+				otherBox.y + otherBox.height / 2
+			);
+			await page.mouse.down();
+			const otherDownBackground = await rowBackground( otherRow );
+			await page.mouse.up();
+			const otherUpBackground = await rowBackground( otherRow );
+			const otherPostClickBackgrounds =
+				await rowBackgroundFrames( otherRow );
+
+			expect( otherDownBackground ).toBe( otherHoveredBackground );
+			expect( otherUpBackground ).toBe( otherHoveredBackground );
+			expect( otherPostClickBackgrounds ).toEqual(
+				Array( otherPostClickBackgrounds.length ).fill(
+					otherHoveredBackground
+				)
+			);
+			await expect
+				.poll( () => activeElementClass( page ) )
+				.not.toContain( 'cortext-sidebar__favorite-title' );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				otherPage && `/wp/v2/crtxt_pages/${ otherPage.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				createdPage && `/wp/v2/crtxt_pages/${ createdPage.id }`
+			);
+		}
+	} );
+} );

--- a/tests/js/components/CollectionRow.test.js
+++ b/tests/js/components/CollectionRow.test.js
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import CollectionRow, {
+	collectionTitle,
+} from '../../../src/components/CollectionRow';
+
+function makeCollection( overrides = {} ) {
+	return {
+		id: 7,
+		title: { rendered: 'Books', raw: 'Books' },
+		...overrides,
+	};
+}
+
+function baseProps( overrides = {} ) {
+	return {
+		collection: makeCollection(),
+		isSelected: false,
+		isFavorite: false,
+		isHome: false,
+		isHomeUpdating: false,
+		onSelect: jest.fn(),
+		onToggleFavorite: jest.fn(),
+		onSetHome: jest.fn(),
+		...overrides,
+	};
+}
+
+function renderRow( overrides = {} ) {
+	const props = baseProps( overrides );
+	const utils = render(
+		<ul>
+			<CollectionRow { ...props } />
+		</ul>
+	);
+	return { ...utils, props };
+}
+
+describe( 'CollectionRow', () => {
+	it( 'resolves a collection title from rendered or raw values', () => {
+		expect( collectionTitle( makeCollection() ) ).toBe( 'Books' );
+		expect(
+			collectionTitle(
+				makeCollection( { title: { rendered: '', raw: 'Raw Books' } } )
+			)
+		).toBe( 'Raw Books' );
+	} );
+
+	it( 'calls onSelect when the title is clicked', () => {
+		const { props } = renderRow();
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Books', exact: true } )
+		);
+
+		expect( props.onSelect ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'calls onToggleFavorite from the action menu', () => {
+		const { props } = renderRow();
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Actions for Books' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'menuitem', { name: 'Add to favorites' } )
+		);
+
+		expect( props.onToggleFavorite ).toHaveBeenCalledWith( 7 );
+		expect( props.onSelect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders a remove favorite action when the collection is favorited', () => {
+		renderRow( { isFavorite: true } );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Actions for Books' } )
+		);
+
+		expect(
+			screen.getByRole( 'menuitem', {
+				name: 'Remove from favorites',
+			} )
+		).toBeTruthy();
+	} );
+} );

--- a/tests/js/components/PageRow.test.js
+++ b/tests/js/components/PageRow.test.js
@@ -38,6 +38,8 @@ function baseProps( overrides = {} ) {
 		onRename: jest.fn(),
 		onDuplicate: jest.fn(),
 		onDelete: jest.fn(),
+		isFavorite: false,
+		onToggleFavorite: jest.fn(),
 		onSetHome: jest.fn(),
 		home: null,
 		isHomeUpdating: false,
@@ -147,5 +149,27 @@ describe( 'PageRow', () => {
 		);
 
 		expect( props.onSetHome ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'calls onToggleFavorite from the action menu', () => {
+		const { container, props } = renderRow();
+		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
+		fireEvent.click(
+			screen.getByRole( 'menuitem', { name: 'Add to favorites' } )
+		);
+
+		expect( props.onToggleFavorite ).toHaveBeenCalledWith( 1 );
+		expect( props.onSelect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders a remove favorite action when the page is favorited', () => {
+		const { container } = renderRow( { isFavorite: true } );
+		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
+
+		expect(
+			screen.getByRole( 'menuitem', {
+				name: 'Remove from favorites',
+			} )
+		).toBeTruthy();
 	} );
 } );

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -1,0 +1,83 @@
+import {
+	favoriteKey,
+	moveFavorite,
+	resolveFavoriteItems,
+} from '../../../src/components/SidebarFavorites';
+
+describe( 'SidebarFavorites helpers', () => {
+	it( 'builds stable favorite keys', () => {
+		expect( favoriteKey( { kind: 'page', id: 12 } ) ).toBe(
+			'favorite:page:12'
+		);
+		expect( favoriteKey( { kind: 'collection', id: '9' } ) ).toBe(
+			'favorite:collection:9'
+		);
+	} );
+
+	it( 'moves favorites by sortable id', () => {
+		const favorites = [
+			{ kind: 'page', id: 1 },
+			{ kind: 'collection', id: 2 },
+			{ kind: 'page', id: 3 },
+		];
+
+		expect(
+			moveFavorite( favorites, 'favorite:page:3', 'favorite:page:1' )
+		).toEqual( [
+			{ kind: 'page', id: 3 },
+			{ kind: 'page', id: 1 },
+			{ kind: 'collection', id: 2 },
+		] );
+	} );
+
+	it( 'returns the same list for no-op or unknown moves', () => {
+		const favorites = [ { kind: 'page', id: 1 } ];
+
+		expect(
+			moveFavorite( favorites, 'favorite:page:1', 'favorite:page:1' )
+		).toBe( favorites );
+		expect(
+			moveFavorite( favorites, 'favorite:page:1', 'favorite:page:999' )
+		).toBe( favorites );
+	} );
+
+	it( 'resolves page and collection favorites from loaded records', () => {
+		const items = resolveFavoriteItems(
+			[
+				{ kind: 'page', id: 1, path: 'page/old-1' },
+				{ kind: 'collection', id: 2, path: 'collection/old-2' },
+			],
+			[
+				{
+					id: 1,
+					slug: 'hello',
+					title: { rendered: 'Hello', raw: 'Hello' },
+				},
+			],
+			[
+				{
+					id: 2,
+					slug: 'books',
+					title: { rendered: 'Books', raw: 'Books' },
+				},
+			]
+		);
+
+		expect( items ).toMatchObject( [
+			{
+				kind: 'page',
+				id: 1,
+				title: 'Hello',
+				path: 'page/hello-1',
+				sortableId: 'favorite:page:1',
+			},
+			{
+				kind: 'collection',
+				id: 2,
+				title: 'Books',
+				path: 'collection/books-2',
+				sortableId: 'favorite:collection:2',
+			},
+		] );
+	} );
+} );

--- a/tests/php/test-rest-favorites-controller.php
+++ b/tests/php/test-rest-favorites-controller.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Tests for Cortext\Rest\FavoritesController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\Page;
+use Cortext\Rest\FavoritesController;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Favorites_Controller extends BaseTestCase {
+
+	private const META_KEY = 'cortext_favorites';
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Page() )->register_post_type();
+		( new Collection() )->register_post_type();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new FavoritesController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_get_returns_empty_list_when_no_favorites_are_set(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$response = $this->get_favorites();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data()['favorites'] );
+	}
+
+	public function test_sets_and_reads_page_and_collection_favorites_in_order(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_id       = $this->create_page( array( 'post_name' => 'daily-notes' ) );
+		$collection_id = $this->create_collection( 'books' );
+
+		$set_response = $this->set_favorites(
+			array(
+				array(
+					'kind' => 'collection',
+					'id'   => $collection_id,
+				),
+				array(
+					'kind' => 'page',
+					'id'   => $page_id,
+				),
+			)
+		);
+		$get_response = $this->get_favorites();
+
+		$expected = array(
+			array(
+				'kind' => 'collection',
+				'id'   => $collection_id,
+				'path' => "collection/books-{$collection_id}",
+			),
+			array(
+				'kind' => 'page',
+				'id'   => $page_id,
+				'path' => "page/daily-notes-{$page_id}",
+			),
+		);
+		$this->assertSame( 200, $set_response->get_status() );
+		$this->assertSame( $expected, $set_response->get_data()['favorites'] );
+		$this->assertSame( $expected, $get_response->get_data()['favorites'] );
+		$this->assertSame(
+			array( "collection:{$collection_id}", "page:{$page_id}" ),
+			get_user_meta( get_current_user_id(), self::META_KEY, true )
+		);
+	}
+
+	public function test_favorites_are_stored_per_user(): void {
+		$user_a = $this->create_user( 'administrator' );
+		$user_b = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_a );
+		$page_id = $this->create_page();
+
+		$this->set_favorites(
+			array(
+				array(
+					'kind' => 'page',
+					'id'   => $page_id,
+				),
+			)
+		);
+
+		wp_set_current_user( $user_b );
+		$response = $this->get_favorites();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data()['favorites'] );
+	}
+
+	public function test_reorder_persists(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_a = $this->create_page( array( 'post_name' => 'a' ) );
+		$page_b = $this->create_page( array( 'post_name' => 'b' ) );
+		$this->set_favorites(
+			array(
+				array(
+					'kind' => 'page',
+					'id'   => $page_a,
+				),
+				array(
+					'kind' => 'page',
+					'id'   => $page_b,
+				),
+			)
+		);
+
+		$this->set_favorites(
+			array(
+				array(
+					'kind' => 'page',
+					'id'   => $page_b,
+				),
+				array(
+					'kind' => 'page',
+					'id'   => $page_a,
+				),
+			)
+		);
+		$response = $this->get_favorites();
+
+		$this->assertSame(
+			array( $page_b, $page_a ),
+			array_column( $response->get_data()['favorites'], 'id' )
+		);
+	}
+
+	public function test_rejects_invalid_targets(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$response = $this->set_favorites(
+			array(
+				array(
+					'kind' => 'page',
+					'id'   => 0,
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_rejects_a_non_cortext_target(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$post_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular post',
+			)
+		);
+
+		$response = $this->set_favorites(
+			array(
+				array(
+					'kind' => 'page',
+					'id'   => $post_id,
+				),
+			)
+		);
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame(
+			'cortext_favorites_not_found',
+			$response->get_data()['code']
+		);
+	}
+
+	public function test_rejects_a_target_the_user_cannot_edit(): void {
+		$owner_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $owner_id );
+		$page_id = $this->create_page(
+			array(
+				'post_author' => $owner_id,
+				'post_status' => 'private',
+			)
+		);
+
+		wp_set_current_user( $this->create_user( 'contributor' ) );
+		$response = $this->set_favorites(
+			array(
+				array(
+					'kind' => 'page',
+					'id'   => $page_id,
+				),
+			)
+		);
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame(
+			'cortext_favorites_forbidden',
+			$response->get_data()['code']
+		);
+	}
+
+	public function test_get_omits_invalid_deleted_trashed_duplicate_and_inaccessible_targets(): void {
+		$owner_id = $this->create_user( 'administrator' );
+		$user_id  = $this->create_user( 'contributor' );
+		wp_set_current_user( $owner_id );
+		$valid_page = $this->create_page(
+			array(
+				'post_author' => $user_id,
+				'post_name'   => 'valid',
+				'post_status' => 'draft',
+			)
+		);
+		$trashed    = $this->create_page();
+		$deleted    = $this->create_page();
+		$private    = $this->create_page(
+			array(
+				'post_author' => $owner_id,
+				'post_status' => 'private',
+			)
+		);
+		wp_trash_post( $trashed );
+		wp_delete_post( $deleted, true );
+
+		update_user_meta(
+			$user_id,
+			self::META_KEY,
+			array(
+				"page:{$valid_page}",
+				"page:{$valid_page}",
+				'not-a-target',
+				"page:{$trashed}",
+				"page:{$deleted}",
+				"page:{$private}",
+			)
+		);
+
+		wp_set_current_user( $user_id );
+		$response = $this->get_favorites();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array( $valid_page ),
+			array_column( $response->get_data()['favorites'], 'id' )
+		);
+	}
+
+	public function test_requires_edit_posts_capability(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$response = $this->get_favorites();
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	private function get_favorites() {
+		$request = new WP_REST_Request( 'GET', '/cortext/v1/favorites' );
+		return rest_do_request( $request );
+	}
+
+	private function set_favorites( array $favorites ) {
+		$request = new WP_REST_Request( 'PUT', '/cortext/v1/favorites' );
+		$request->set_body_params(
+			array(
+				'favorites' => $favorites,
+			)
+		);
+		return rest_do_request( $request );
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+
+	private function create_page( array $args = array() ): int {
+		$defaults = array(
+			'post_type'   => Page::POST_TYPE,
+			'post_status' => 'private',
+			'post_title'  => 'Test page ' . wp_generate_uuid4(),
+		);
+
+		$id = wp_insert_post( array_merge( $defaults, $args ) );
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+		return (int) $id;
+	}
+
+	private function create_collection( string $slug ): int {
+		$id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Test collection ' . wp_generate_uuid4(),
+				'meta_input'  => array(
+					'slug' => $slug,
+				),
+			)
+		);
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+		return (int) $id;
+	}
+}


### PR DESCRIPTION
## What

Closes #147

Adds a Favorites section at the top of the sidebar for pinned pages and collections.

Favorites can be added or removed from row menus, reordered by drag, and persist across reloads.

## How

- Storing favorites per user through `/cortext/v1/favorites`.
- Keeping favorite ordering separate from page tree ordering.
- Reusing loaded page and collection data for favorite labels and icons.

## Testing Instructions

1. Add a page and a collection to Favorites from their sidebar menus.
2. Reload and verify that both favorites remain.
3. Drag favorites to reorder them, then reload and verify the order remains.
4. Remove a favorite and verify it disappears from Favorites only.

## Screen recording

https://github.com/user-attachments/assets/eea47df2-6ade-4b83-a9ca-1bcc9a643034