### PR TITLE
Make sidebar favorites more reliable

### DIFF
--- a/src/components/CollectionRow.js
+++ b/src/components/CollectionRow.js
@@ -20,6 +20,7 @@ export default function CollectionRow( {
 	collection,
 	isSelected,
 	isFavorite = false,
+	isFavoriteDisabled = false,
 	isHome,
 	isHomeUpdating,
 	onSelect,
@@ -67,6 +68,7 @@ export default function CollectionRow( {
 						<MenuGroup>
 							<MenuItem
 								icon={ isFavorite ? starFilled : starEmpty }
+								disabled={ isFavoriteDisabled }
 								onClick={ () => {
 									onToggleFavorite?.( collection.id );
 									onClose();

--- a/src/components/PageRow.js
+++ b/src/components/PageRow.js
@@ -41,6 +41,7 @@ export default function PageRow( {
 	onDuplicate,
 	onDelete,
 	isFavorite = false,
+	isFavoriteDisabled = false,
 	onToggleFavorite,
 	onSetHome,
 	home,
@@ -272,6 +273,7 @@ export default function PageRow( {
 									icon={
 										pageIsFavorite ? starFilled : starEmpty
 									}
+									disabled={ isFavoriteDisabled }
 									onClick={ () => {
 										onToggleFavorite?.( page.id );
 										onClose();
@@ -373,6 +375,7 @@ export default function PageRow( {
 								onDuplicate={ onDuplicate }
 								onDelete={ onDelete }
 								isFavorite={ isFavorite }
+								isFavoriteDisabled={ isFavoriteDisabled }
 								onToggleFavorite={ onToggleFavorite }
 								onSetHome={ onSetHome }
 								home={ home }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,7 +9,7 @@ import {
 	useCallback,
 	useEffect,
 } from '@wordpress/element';
-import { Button, Icon, Spinner } from '@wordpress/components';
+import { Button, Icon, Notice, Spinner } from '@wordpress/components';
 import { home as homeIcon, plus, search, wordpress } from '@wordpress/icons';
 
 // Notion-style sidebar toggle: panel outline with a vertical accent on
@@ -58,7 +58,10 @@ import { useNavigate, useParams } from '@tanstack/react-router';
 import CollectionRow from './CollectionRow';
 import PageRow from './PageRow';
 import { openCommandPalette } from './CommandPalette';
-import SidebarFavorites, { favoriteKey } from './SidebarFavorites';
+import SidebarFavorites, {
+	favoriteKey,
+	filterFavoritesForTrashedPage,
+} from './SidebarFavorites';
 import SidebarResizeHandle from './SidebarResizeHandle';
 import SidebarTrash from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
@@ -122,6 +125,7 @@ export default function Sidebar( {
 		favorites,
 		setFavorites,
 		isResolving: isResolvingFavorites,
+		isUpdating: isUpdatingFavorites,
 	} = useFavorites();
 	const { saveEntityRecord, invalidateResolution, receiveEntityRecords } =
 		useDispatch( 'core' );
@@ -154,6 +158,9 @@ export default function Sidebar( {
 			activePrefix === 'collection' ? parseIdFromUri( activeTail ) : null,
 		[ activePrefix, activeTail ]
 	);
+	const [ favoritesError, setFavoritesError ] = useState( null );
+	const areFavoriteActionsDisabled =
+		isResolvingFavorites || isUpdatingFavorites;
 
 	// Keep the URL canonical: once autosave assigns a slug to the active
 	// page (draft → private promotion on first titled save), rewrite
@@ -239,26 +246,47 @@ export default function Sidebar( {
 	);
 	const toggleFavorite = useCallback(
 		async ( kind, id ) => {
+			if ( areFavoriteActionsDisabled ) {
+				return;
+			}
 			const key = favoriteKey( { kind, id } );
-			const exists = favoriteKeys.has( key );
-			const next = exists
-				? favorites.filter(
-						( favorite ) => favoriteKey( favorite ) !== key
-				  )
-				: [ ...favorites, { kind, id } ];
+			setFavoritesError( null );
 			try {
-				await setFavorites( next );
-			} catch {}
+				await setFavorites( ( current ) => {
+					const exists = current.some(
+						( favorite ) => favoriteKey( favorite ) === key
+					);
+					return exists
+						? current.filter(
+								( favorite ) => favoriteKey( favorite ) !== key
+						  )
+						: [ ...current, { kind, id } ];
+				} );
+			} catch ( err ) {
+				setFavoritesError(
+					err?.message ??
+						__( 'Could not update favorites.', 'cortext' )
+				);
+			}
 		},
-		[ favoriteKeys, favorites, setFavorites ]
+		[ areFavoriteActionsDisabled, setFavorites ]
 	);
 	const reorderFavorites = useCallback(
 		async ( next ) => {
+			if ( areFavoriteActionsDisabled ) {
+				return;
+			}
+			setFavoritesError( null );
 			try {
 				await setFavorites( next );
-			} catch {}
+			} catch ( err ) {
+				setFavoritesError(
+					err?.message ??
+						__( 'Could not reorder favorites.', 'cortext' )
+				);
+			}
 		},
-		[ setFavorites ]
+		[ areFavoriteActionsDisabled, setFavorites ]
 	);
 	const selectFavorite = useCallback(
 		( favorite ) => {
@@ -465,8 +493,21 @@ export default function Sidebar( {
 				POST_TYPE,
 				TRASHED_PAGES_QUERY,
 			] );
+			try {
+				await setFavorites( ( current ) =>
+					filterFavoritesForTrashedPage( current, id, pages )
+				);
+			} catch ( err ) {
+				setFavoritesError(
+					err?.message ??
+						__(
+							'Page was moved to trash, but could not be removed from favorites.',
+							'cortext'
+						)
+				);
+			}
 		},
-		[ invalidateResolution, receiveEntityRecords ]
+		[ invalidateResolution, pages, receiveEntityRecords, setFavorites ]
 	);
 
 	// --- Drag and drop -----------------------------------------------------
@@ -620,6 +661,14 @@ export default function Sidebar( {
 			</div>
 			{ ! collapsed && (
 				<div className="cortext-sidebar__content">
+					{ favoritesError ? (
+						<Notice
+							status="error"
+							onRemove={ () => setFavoritesError( null ) }
+						>
+							{ favoritesError }
+						</Notice>
+					) : null }
 					<SidebarFavorites
 						favorites={ favorites }
 						pages={ pages }
@@ -628,6 +677,7 @@ export default function Sidebar( {
 						isResolvingItems={
 							isResolvingPages || isResolvingCollections
 						}
+						isDisabled={ areFavoriteActionsDisabled }
 						onSelect={ selectFavorite }
 						onRemove={ ( favorite ) =>
 							toggleFavorite( favorite.kind, favorite.id )
@@ -683,6 +733,9 @@ export default function Sidebar( {
 									onDuplicate={ duplicatePage }
 									onDelete={ trashPage }
 									isFavorite={ isPageFavorite }
+									isFavoriteDisabled={
+										areFavoriteActionsDisabled
+									}
 									onToggleFavorite={ ( id ) =>
 										toggleFavorite( 'page', id )
 									}
@@ -745,6 +798,9 @@ export default function Sidebar( {
 									isFavorite={ isCollectionFavorite(
 										collection.id
 									) }
+									isFavoriteDisabled={
+										areFavoriteActionsDisabled
+									}
 									isHomeUpdating={ isHomeUpdating }
 									onToggleFavorite={ ( id ) =>
 										toggleFavorite( 'collection', id )

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -501,7 +501,7 @@ export default function Sidebar( {
 				setFavoritesError(
 					err?.message ??
 						__(
-							'Page was moved to trash, but could not be removed from favorites.',
+							'Page moved to Trash, but Favorites could not be updated.',
 							'cortext'
 						)
 				);

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -202,21 +202,15 @@ function SortableFavoriteRow( { item, isDisabled, onSelect, onRemove } ) {
 					transform: transformToString( transform ),
 					transition,
 				} }
+				{ ...attributes }
+				{ ...listeners }
 			>
-				<button
-					type="button"
-					className="cortext-sidebar__favorite-drag-handle"
-					aria-label={ __( 'Reorder favorite', 'cortext' ) }
-					{ ...attributes }
-					{ ...listeners }
+				<span
+					className="cortext-sidebar__favorite-icon"
+					aria-hidden="true"
 				>
-					<span
-						className="cortext-sidebar__favorite-icon"
-						aria-hidden="true"
-					>
-						<FavoriteIcon item={ item } />
-					</span>
-				</button>
+					<FavoriteIcon item={ item } />
+				</span>
 				<button
 					type="button"
 					className="cortext-sidebar__favorite-title"
@@ -257,6 +251,7 @@ function SortableFavoriteRow( { item, isDisabled, onSelect, onRemove } ) {
 						__( 'Remove %s from favorites', 'cortext' ),
 						item.title
 					) }
+					onPointerDown={ ( event ) => event.stopPropagation() }
 					onClick={ () => onRemove( item ) }
 					aria-pressed
 				/>

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -18,6 +18,7 @@ import {
 
 import PageIcon from './PageIcon';
 import { collectionTitle } from './CollectionRow';
+import { collectDescendants } from './pages-tree';
 import { computeUri } from '../router/useResolveEntity';
 import { whenViewTransitionsSettled } from '../hooks/viewTransition';
 
@@ -57,6 +58,19 @@ export function moveFavorite( favorites, activeId, overId ) {
 	}
 
 	return arrayMove( favorites, from, to );
+}
+
+export function filterFavoritesForTrashedPage( favorites, pageId, pages ) {
+	const trashedPageIds = new Set( [
+		Number( pageId ),
+		...collectDescendants( Number( pageId ), pages ),
+	] );
+
+	return favorites.filter(
+		( favorite ) =>
+			favorite.kind !== 'page' ||
+			! trashedPageIds.has( Number( favorite.id ) )
+	);
 }
 
 export function resolveFavoriteItems( favorites, pages, collections ) {
@@ -114,6 +128,37 @@ export function resolveFavoriteItems( favorites, pages, collections ) {
 		.filter( Boolean );
 }
 
+function mergeDisplayFavorites( currentDisplay, nextFavorites, removingKeys ) {
+	const nextByKey = new Map(
+		nextFavorites.map( ( favorite ) => [
+			favoriteKey( favorite ),
+			favorite,
+		] )
+	);
+	const seen = new Set();
+	const merged = [];
+
+	currentDisplay.forEach( ( favorite ) => {
+		const key = favoriteKey( favorite );
+		if ( nextByKey.has( key ) ) {
+			merged.push( nextByKey.get( key ) );
+			seen.add( key );
+		} else if ( removingKeys.has( key ) ) {
+			merged.push( favorite );
+			seen.add( key );
+		}
+	} );
+
+	nextFavorites.forEach( ( favorite ) => {
+		const key = favoriteKey( favorite );
+		if ( ! seen.has( key ) ) {
+			merged.push( favorite );
+		}
+	} );
+
+	return merged;
+}
+
 function FavoriteIcon( { item } ) {
 	if ( item.kind === 'page' ) {
 		return (
@@ -127,7 +172,7 @@ function FavoriteIcon( { item } ) {
 	return <Icon icon={ customPostType } size={ 16 } />;
 }
 
-function SortableFavoriteRow( { item, onSelect, onRemove } ) {
+function SortableFavoriteRow( { item, isDisabled, onSelect, onRemove } ) {
 	const {
 		attributes,
 		listeners,
@@ -206,6 +251,7 @@ function SortableFavoriteRow( { item, onSelect, onRemove } ) {
 					className="cortext-sidebar__favorite-toggle is-favorite"
 					icon={ starFilled }
 					size="small"
+					disabled={ isDisabled }
 					label={ sprintf(
 						/* translators: %s: favorite title */
 						__( 'Remove %s from favorites', 'cortext' ),
@@ -225,6 +271,7 @@ export default function SidebarFavorites( {
 	collections,
 	isResolving,
 	isResolvingItems,
+	isDisabled,
 	onSelect,
 	onRemove,
 	onReorder,
@@ -233,9 +280,12 @@ export default function SidebarFavorites( {
 	const [ addedKeys, setAddedKeys ] = useState( () => new Set() );
 	const [ removingKeys, setRemovingKeys ] = useState( () => new Set() );
 	const previousKeysRef = useRef( null );
+	const latestFavoritesRef = useRef( favorites );
+	const removingKeysRef = useRef( new Set() );
 	const timersRef = useRef( [] );
 
 	useEffect( () => {
+		latestFavoritesRef.current = favorites;
 		const currentKeys = new Set(
 			favorites.map( ( favorite ) => favoriteKey( favorite ) )
 		);
@@ -253,6 +303,9 @@ export default function SidebarFavorites( {
 		const nextRemoved = new Set(
 			[ ...previousKeys ].filter( ( key ) => ! currentKeys.has( key ) )
 		);
+		const nextRemovingKeys = new Set( removingKeysRef.current );
+		nextAdded.forEach( ( key ) => nextRemovingKeys.delete( key ) );
+		nextRemoved.forEach( ( key ) => nextRemovingKeys.add( key ) );
 
 		if ( nextAdded.size > 0 ) {
 			setAddedKeys( nextAdded );
@@ -266,25 +319,32 @@ export default function SidebarFavorites( {
 			timersRef.current.push( timer );
 		}
 
-		if ( nextRemoved.size > 0 ) {
-			setRemovingKeys( ( keys ) => {
-				const next = new Set( keys );
-				nextRemoved.forEach( ( key ) => next.add( key ) );
-				return next;
-			} );
-			const timer = setTimeout( () => {
-				setRemovingKeys( ( keys ) => {
-					const next = new Set( keys );
-					nextRemoved.forEach( ( key ) => next.delete( key ) );
-					return next;
-				} );
-				setDisplayFavorites( favorites );
-			}, FAVORITE_REMOVE_ANIMATION_MS );
-			timersRef.current.push( timer );
-			return;
+		if ( nextAdded.size > 0 || nextRemoved.size > 0 ) {
+			removingKeysRef.current = nextRemovingKeys;
+			setRemovingKeys( nextRemovingKeys );
+			setDisplayFavorites( ( current ) =>
+				mergeDisplayFavorites( current, favorites, nextRemovingKeys )
+			);
+		} else {
+			setDisplayFavorites( favorites );
 		}
 
-		setDisplayFavorites( favorites );
+		if ( nextRemoved.size > 0 ) {
+			const timer = setTimeout( () => {
+				const next = new Set( removingKeysRef.current );
+				nextRemoved.forEach( ( key ) => next.delete( key ) );
+				removingKeysRef.current = next;
+				setRemovingKeys( next );
+				setDisplayFavorites( ( current ) =>
+					mergeDisplayFavorites(
+						current,
+						latestFavoritesRef.current,
+						next
+					)
+				);
+			}, FAVORITE_REMOVE_ANIMATION_MS );
+			timersRef.current.push( timer );
+		}
 	}, [ favorites ] );
 
 	const items = useMemo(
@@ -311,6 +371,9 @@ export default function SidebarFavorites( {
 	}
 
 	const handleDragEnd = ( { active, over } ) => {
+		if ( isDisabled ) {
+			return;
+		}
 		const next = moveFavorite(
 			favorites,
 			String( active.id ),
@@ -322,16 +385,10 @@ export default function SidebarFavorites( {
 	};
 
 	const requestRemove = ( item ) => {
-		setRemovingKeys( ( keys ) => new Set( keys ).add( item.sortableId ) );
-		const timer = setTimeout( () => {
-			onRemove( item );
-			setRemovingKeys( ( keys ) => {
-				const next = new Set( keys );
-				next.delete( item.sortableId );
-				return next;
-			} );
-		}, FAVORITE_REMOVE_ANIMATION_MS );
-		timersRef.current.push( timer );
+		if ( isDisabled ) {
+			return;
+		}
+		onRemove( item );
 	};
 
 	return (
@@ -369,6 +426,7 @@ export default function SidebarFavorites( {
 											item.sortableId
 										),
 									} }
+									isDisabled={ isDisabled }
 									onSelect={ onSelect }
 									onRemove={ requestRemove }
 								/>

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -1,6 +1,12 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Icon, Spinner } from '@wordpress/components';
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { customPostType, starFilled } from '@wordpress/icons';
 import {
 	DndContext,
@@ -181,10 +187,33 @@ function SortableFavoriteRow( { item, isDisabled, onSelect, onRemove } ) {
 		transition,
 		isDragging,
 	} = useSortable( { id: item.sortableId } );
+	const rowRef = useRef( null );
+	const wasDraggingRef = useRef( false );
+	const setRowRef = useCallback(
+		( node ) => {
+			rowRef.current = node;
+			setNodeRef( node );
+		},
+		[ setNodeRef ]
+	);
 	const rowClasses = [ 'cortext-sidebar__row' ];
 	if ( isDragging ) {
 		rowClasses.push( 'is-dragging' );
 	}
+
+	useEffect( () => {
+		if ( wasDraggingRef.current && ! isDragging ) {
+			const activeElement = rowRef.current?.ownerDocument?.activeElement;
+			if (
+				activeElement &&
+				rowRef.current?.contains( activeElement ) &&
+				typeof activeElement.blur === 'function'
+			) {
+				activeElement.blur();
+			}
+		}
+		wasDraggingRef.current = isDragging;
+	}, [ isDragging ] );
 
 	return (
 		<li
@@ -196,7 +225,7 @@ function SortableFavoriteRow( { item, isDisabled, onSelect, onRemove } ) {
 			data-favorite-key={ item.sortableId }
 		>
 			<div
-				ref={ setNodeRef }
+				ref={ setRowRef }
 				className={ rowClasses.join( ' ' ) }
 				style={ {
 					transform: transformToString( transform ),
@@ -369,9 +398,10 @@ export default function SidebarFavorites( {
 		if ( isDisabled ) {
 			return;
 		}
+		const activeId = String( active.id );
 		const next = moveFavorite(
 			favorites,
-			String( active.id ),
+			activeId,
 			over ? String( over.id ) : null
 		);
 		if ( next !== favorites ) {

--- a/src/hooks/useFavorites.js
+++ b/src/hooks/useFavorites.js
@@ -5,6 +5,7 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from '@wordpress/element';
 
@@ -28,65 +29,132 @@ function normalizeFavorites( favorites ) {
 	return favorites.map( normalizeFavorite ).filter( Boolean );
 }
 
+function areFavoritesEqual( a, b ) {
+	if ( a.length !== b.length ) {
+		return false;
+	}
+	return a.every(
+		( favorite, index ) =>
+			favorite.kind === b[ index ]?.kind && favorite.id === b[ index ]?.id
+	);
+}
+
 export function FavoritesProvider( { children } ) {
 	const [ favorites, setFavoritesState ] = useState( [] );
 	const [ isResolving, setIsResolving ] = useState( true );
 	const [ isUpdating, setIsUpdating ] = useState( false );
 	const [ error, setError ] = useState( null );
+	const favoritesRef = useRef( [] );
+	const serverFavoritesRef = useRef( [] );
+	const initialLoadPromiseRef = useRef( null );
+	const initialLoadErrorRef = useRef( null );
+	const hasResolvedInitialLoadRef = useRef( false );
+	const pendingWritesRef = useRef( 0 );
+	const writeChainRef = useRef( Promise.resolve() );
+
+	const applyFavorites = useCallback( ( nextFavorites ) => {
+		favoritesRef.current = nextFavorites;
+		setFavoritesState( nextFavorites );
+	}, [] );
 
 	useEffect( () => {
 		let cancelled = false;
 		setIsResolving( true );
 		setError( null );
+		initialLoadErrorRef.current = null;
 
-		apiFetch( { path: '/cortext/v1/favorites' } )
+		const initialLoadPromise = apiFetch( { path: '/cortext/v1/favorites' } )
 			.then( ( response ) => {
+				const loaded = normalizeFavorites( response?.favorites );
 				if ( cancelled ) {
-					return;
+					return loaded;
 				}
-				setFavoritesState( normalizeFavorites( response?.favorites ) );
+				serverFavoritesRef.current = loaded;
+				applyFavorites( loaded );
+				initialLoadErrorRef.current = null;
+				hasResolvedInitialLoadRef.current = true;
 				setIsResolving( false );
+				return loaded;
 			} )
 			.catch( ( nextError ) => {
 				if ( cancelled ) {
-					return;
+					throw nextError;
 				}
-				setFavoritesState( [] );
+				applyFavorites( [] );
+				initialLoadErrorRef.current = nextError;
 				setError( nextError );
+				hasResolvedInitialLoadRef.current = true;
 				setIsResolving( false );
+				throw nextError;
 			} );
+		initialLoadPromiseRef.current = initialLoadPromise;
+		initialLoadPromise.catch( () => {} );
 
 		return () => {
 			cancelled = true;
 		};
-	}, [] );
+	}, [ applyFavorites ] );
 
-	const setFavorites = useCallback( async ( nextFavorites ) => {
-		const normalized = normalizeFavorites( nextFavorites );
-		let previous;
-		setFavoritesState( ( current ) => {
-			previous = current;
-			return normalized;
-		} );
-		setIsUpdating( true );
-		setError( null );
-		try {
-			const response = await apiFetch( {
-				path: '/cortext/v1/favorites',
-				method: 'PUT',
-				data: { favorites: normalized },
-			} );
-			const saved = normalizeFavorites( response?.favorites );
-			setFavoritesState( saved );
-			return saved;
-		} catch ( nextError ) {
-			setFavoritesState( previous ?? [] );
-			setError( nextError );
-			throw nextError;
-		} finally {
-			setIsUpdating( false );
-		}
-	}, [] );
+	const setFavorites = useCallback(
+		async ( nextFavorites ) => {
+			const write = async () => {
+				if (
+					! hasResolvedInitialLoadRef.current &&
+					initialLoadPromiseRef.current
+				) {
+					await initialLoadPromiseRef.current;
+				}
+				if ( initialLoadErrorRef.current ) {
+					throw initialLoadErrorRef.current;
+				}
+
+				const normalized = normalizeFavorites(
+					typeof nextFavorites === 'function'
+						? nextFavorites( favoritesRef.current )
+						: nextFavorites
+				);
+				if ( areFavoritesEqual( favoritesRef.current, normalized ) ) {
+					return favoritesRef.current;
+				}
+				applyFavorites( normalized );
+				pendingWritesRef.current += 1;
+				setIsUpdating( true );
+				setError( null );
+
+				try {
+					const response = await apiFetch( {
+						path: '/cortext/v1/favorites',
+						method: 'PUT',
+						data: { favorites: normalized },
+					} );
+					const saved = normalizeFavorites( response?.favorites );
+					serverFavoritesRef.current = saved;
+					if (
+						areFavoritesEqual( favoritesRef.current, normalized )
+					) {
+						applyFavorites( saved );
+					}
+					return saved;
+				} catch ( nextError ) {
+					setError( nextError );
+					if (
+						areFavoritesEqual( favoritesRef.current, normalized )
+					) {
+						applyFavorites( serverFavoritesRef.current );
+					}
+					throw nextError;
+				} finally {
+					pendingWritesRef.current -= 1;
+					setIsUpdating( pendingWritesRef.current > 0 );
+				}
+			};
+
+			const promise = writeChainRef.current.then( write, write );
+			writeChainRef.current = promise.catch( () => {} );
+			return promise;
+		},
+		[ applyFavorites ]
+	);
 
 	const value = useMemo(
 		() => ( { favorites, isResolving, isUpdating, error, setFavorites } ),

--- a/src/index.scss
+++ b/src/index.scss
@@ -323,10 +323,6 @@ body.cortext-fullscreen {
 	}
 
 	/* stylelint-disable no-descending-specificity */
-	&__favorite-row .cortext-sidebar__row {
-		cursor: default;
-	}
-
 	&__favorite-title {
 		flex: 1 1 auto;
 		min-width: 0;
@@ -447,24 +443,6 @@ body.cortext-fullscreen {
 		width: $grid-unit-30;
 		height: $grid-unit-30;
 		color: var(--cortext-text-muted);
-	}
-
-	&__favorite-drag-handle {
-		flex: 0 0 auto;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: $grid-unit-30;
-		height: $grid-unit-30;
-		border: 0;
-		padding: 0;
-		background: transparent;
-		color: var(--cortext-text-muted);
-		cursor: grab;
-
-		&:active {
-			cursor: grabbing;
-		}
 	}
 
 	&__rename {

--- a/src/index.scss
+++ b/src/index.scss
@@ -3903,6 +3903,8 @@ thead > tr > th {
 	// color rule above (which would otherwise pin the title to default text).
 	.cortext-sidebar__row:hover .cortext-sidebar__title.components-button,
 	.cortext-sidebar__row:focus-within .cortext-sidebar__title.components-button,
+	.cortext-sidebar__row:hover .cortext-sidebar__favorite-title,
+	.cortext-sidebar__row:focus-within .cortext-sidebar__favorite-title,
 	.cortext-sidebar__row.is-selected .cortext-sidebar__title.components-button {
 		color: var(--cortext-text-strong);
 	}

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1885,7 +1885,7 @@ test.describe( 'Collection view block', () => {
 						return;
 					} catch {}
 				}
-				await page.getByText( name, { exact: true } ).click();
+				await canvas.getByText( name, { exact: true } ).click();
 			};
 
 			await openColumnDropdown(

--- a/tests/e2e/specs/sidebar-favorites.spec.js
+++ b/tests/e2e/specs/sidebar-favorites.spec.js
@@ -83,7 +83,7 @@ async function dragFavoriteBefore(
 	storedKeys
 ) {
 	const active = page.locator(
-		`.cortext-sidebar__favorite-row[data-favorite-key="${ activeKey }"] .cortext-sidebar__favorite-drag-handle`
+		`.cortext-sidebar__favorite-row[data-favorite-key="${ activeKey }"] .cortext-sidebar__row`
 	);
 	const over = page.locator(
 		`.cortext-sidebar__favorite-row[data-favorite-key="${ overKey }"] .cortext-sidebar__row`

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -162,9 +162,7 @@ describe( 'SidebarFavorites helpers', () => {
 			pages,
 		} );
 
-		expect(
-			screen.getByRole( 'button', { name: 'Notes' } )
-		).toBeInTheDocument();
+		expect( screen.getByText( 'Notes' ) ).toBeInTheDocument();
 
 		rerender(
 			<SidebarFavorites
@@ -197,8 +195,6 @@ describe( 'SidebarFavorites helpers', () => {
 			jest.advanceTimersByTime( 151 );
 		} );
 
-		expect(
-			screen.getByRole( 'button', { name: 'Notes' } )
-		).toBeInTheDocument();
+		expect( screen.getByText( 'Notes' ) ).toBeInTheDocument();
 	} );
 } );

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -1,8 +1,32 @@
-import {
+import { act, render, screen } from '@testing-library/react';
+
+import SidebarFavorites, {
 	favoriteKey,
+	filterFavoritesForTrashedPage,
 	moveFavorite,
 	resolveFavoriteItems,
 } from '../../../src/components/SidebarFavorites';
+
+function renderFavorites( props = {} ) {
+	return render(
+		<SidebarFavorites
+			favorites={ [] }
+			pages={ [] }
+			collections={ [] }
+			isResolving={ false }
+			isResolvingItems={ false }
+			isDisabled={ false }
+			onSelect={ jest.fn( () => false ) }
+			onRemove={ jest.fn() }
+			onReorder={ jest.fn() }
+			{ ...props }
+		/>
+	);
+}
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
 
 describe( 'SidebarFavorites helpers', () => {
 	it( 'builds stable favorite keys', () => {
@@ -39,6 +63,29 @@ describe( 'SidebarFavorites helpers', () => {
 		expect(
 			moveFavorite( favorites, 'favorite:page:1', 'favorite:page:999' )
 		).toBe( favorites );
+	} );
+
+	it( 'filters favorites for a trashed page and loaded descendants', () => {
+		const favorites = [
+			{ kind: 'page', id: 1 },
+			{ kind: 'page', id: 2 },
+			{ kind: 'page', id: 3 },
+			{ kind: 'page', id: 4 },
+			{ kind: 'collection', id: 5 },
+		];
+		const pages = [
+			{ id: 1, parent: 0 },
+			{ id: 2, parent: 1 },
+			{ id: 3, parent: 2 },
+			{ id: 4, parent: 0 },
+		];
+
+		expect( filterFavoritesForTrashedPage( favorites, 1, pages ) ).toEqual(
+			[
+				{ kind: 'page', id: 4 },
+				{ kind: 'collection', id: 5 },
+			]
+		);
 	} );
 
 	it( 'resolves page and collection favorites from loaded records', () => {
@@ -79,5 +126,79 @@ describe( 'SidebarFavorites helpers', () => {
 				sortableId: 'favorite:collection:2',
 			},
 		] );
+	} );
+
+	it( 'uses stored paths for favorites missing from loaded sidebar records', () => {
+		const favorites = [ { kind: 'page', id: 1, path: 'page/old-1' } ];
+
+		expect( resolveFavoriteItems( favorites, [], [] ) ).toMatchObject( [
+			{
+				kind: 'page',
+				id: 1,
+				title: 'Page',
+				path: 'page/old-1',
+			},
+		] );
+	} );
+
+	it( 'filters missing favorites that do not have a stored path', () => {
+		expect(
+			resolveFavoriteItems( [ { kind: 'page', id: 1 } ], [], [] )
+		).toEqual( [] );
+	} );
+
+	it( 'does not let stale removal timers hide a re-added favorite', () => {
+		jest.useFakeTimers();
+		const favorite = { kind: 'page', id: 1, path: 'page/notes-1' };
+		const pages = [
+			{
+				id: 1,
+				slug: 'notes',
+				title: { rendered: 'Notes', raw: 'Notes' },
+			},
+		];
+		const { rerender } = renderFavorites( {
+			favorites: [ favorite ],
+			pages,
+		} );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Notes' } )
+		).toBeInTheDocument();
+
+		rerender(
+			<SidebarFavorites
+				favorites={ [] }
+				pages={ pages }
+				collections={ [] }
+				isResolving={ false }
+				isResolvingItems={ false }
+				isDisabled={ false }
+				onSelect={ jest.fn( () => false ) }
+				onRemove={ jest.fn() }
+				onReorder={ jest.fn() }
+			/>
+		);
+		rerender(
+			<SidebarFavorites
+				favorites={ [ favorite ] }
+				pages={ pages }
+				collections={ [] }
+				isResolving={ false }
+				isResolvingItems={ false }
+				isDisabled={ false }
+				onSelect={ jest.fn( () => false ) }
+				onRemove={ jest.fn() }
+				onReorder={ jest.fn() }
+			/>
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 151 );
+		} );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Notes' } )
+		).toBeInTheDocument();
 	} );
 } );

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -65,7 +65,7 @@ describe( 'SidebarFavorites helpers', () => {
 		).toBe( favorites );
 	} );
 
-	it( 'filters favorites for a trashed page and loaded descendants', () => {
+	it( 'removes a trashed page and loaded descendants from favorites', () => {
 		const favorites = [
 			{ kind: 'page', id: 1 },
 			{ kind: 'page', id: 2 },
@@ -128,7 +128,7 @@ describe( 'SidebarFavorites helpers', () => {
 		] );
 	} );
 
-	it( 'uses stored paths for favorites missing from loaded sidebar records', () => {
+	it( 'uses stored paths when sidebar records are missing', () => {
 		const favorites = [ { kind: 'page', id: 1, path: 'page/old-1' } ];
 
 		expect( resolveFavoriteItems( favorites, [], [] ) ).toMatchObject( [
@@ -141,13 +141,13 @@ describe( 'SidebarFavorites helpers', () => {
 		] );
 	} );
 
-	it( 'filters missing favorites that do not have a stored path', () => {
+	it( 'drops missing favorites without a stored path', () => {
 		expect(
 			resolveFavoriteItems( [ { kind: 'page', id: 1 } ], [], [] )
 		).toEqual( [] );
 	} );
 
-	it( 'does not let stale removal timers hide a re-added favorite', () => {
+	it( 'keeps a re-added favorite visible after the removal timer fires', () => {
 		jest.useFakeTimers();
 		const favorite = { kind: 'page', id: 1, path: 'page/notes-1' };
 		const pages = [

--- a/tests/js/hooks/useFavorites.test.js
+++ b/tests/js/hooks/useFavorites.test.js
@@ -1,0 +1,156 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import {
+	FavoritesProvider,
+	useFavorites,
+} from '../../../src/hooks/useFavorites';
+
+function deferred() {
+	let resolve;
+	let reject;
+	const promise = new Promise( ( promiseResolve, promiseReject ) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	} );
+	return { promise, resolve, reject };
+}
+
+function wrapper( { children } ) {
+	return <FavoritesProvider>{ children }</FavoritesProvider>;
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'useFavorites', () => {
+	it( 'loads the current user favorites', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			favorites: [ { kind: 'page', id: '7', path: 'page/notes-7' } ],
+		} );
+
+		const { result } = renderHook( () => useFavorites(), { wrapper } );
+
+		await waitFor( () => {
+			expect( result.current.isResolving ).toBe( false );
+		} );
+
+		expect( result.current.favorites ).toEqual( [
+			{ kind: 'page', id: 7, path: 'page/notes-7' },
+		] );
+	} );
+
+	it( 'waits for initial load before applying updater writes', async () => {
+		const initialLoad = deferred();
+		apiFetch.mockImplementation( ( options ) => {
+			if ( options.method === 'PUT' ) {
+				return Promise.resolve( {
+					favorites: options.data.favorites,
+				} );
+			}
+			return initialLoad.promise;
+		} );
+
+		const { result } = renderHook( () => useFavorites(), { wrapper } );
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/cortext/v1/favorites',
+			} );
+		} );
+
+		let writePromise;
+		act( () => {
+			writePromise = result.current.setFavorites( ( current ) => [
+				...current,
+				{ kind: 'page', id: 2 },
+			] );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => {
+			initialLoad.resolve( {
+				favorites: [ { kind: 'page', id: 1, path: 'page/one-1' } ],
+			} );
+			await writePromise;
+		} );
+
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/cortext/v1/favorites',
+			method: 'PUT',
+			data: {
+				favorites: [
+					{ kind: 'page', id: 1, path: 'page/one-1' },
+					{ kind: 'page', id: 2 },
+				],
+			},
+		} );
+	} );
+
+	it( 'serializes writes so a failed write cannot clobber a later one', async () => {
+		const firstWrite = deferred();
+		const secondWrite = deferred();
+		const putCalls = [];
+		apiFetch.mockImplementation( ( options ) => {
+			if ( options.method !== 'PUT' ) {
+				return Promise.resolve( { favorites: [] } );
+			}
+			putCalls.push( options.data.favorites );
+			if ( putCalls.length === 1 ) {
+				return firstWrite.promise;
+			}
+			return secondWrite.promise;
+		} );
+
+		const { result } = renderHook( () => useFavorites(), { wrapper } );
+		await waitFor( () => {
+			expect( result.current.isResolving ).toBe( false );
+		} );
+
+		let firstPromise;
+		let secondPromise;
+		await act( async () => {
+			firstPromise = result.current.setFavorites( [
+				{ kind: 'page', id: 1 },
+			] );
+			secondPromise = result.current.setFavorites( ( current ) => [
+				...current,
+				{ kind: 'page', id: 2 },
+			] );
+			await Promise.resolve();
+		} );
+
+		await waitFor( () => {
+			expect( putCalls ).toEqual( [ [ { kind: 'page', id: 1 } ] ] );
+		} );
+
+		await act( async () => {
+			firstWrite.reject( new Error( 'first failed' ) );
+			await firstPromise.catch( () => {} );
+		} );
+		await expect( firstPromise ).rejects.toThrow( 'first failed' );
+		await waitFor( () => {
+			expect( putCalls ).toEqual( [
+				[ { kind: 'page', id: 1 } ],
+				[ { kind: 'page', id: 2 } ],
+			] );
+		} );
+
+		await act( async () => {
+			secondWrite.resolve( {
+				favorites: [ { kind: 'page', id: 2 } ],
+			} );
+			await secondPromise;
+		} );
+
+		expect( result.current.favorites ).toEqual( [
+			{ kind: 'page', id: 2 },
+		] );
+	} );
+} );

--- a/tests/js/hooks/useFavorites.test.js
+++ b/tests/js/hooks/useFavorites.test.js
@@ -46,7 +46,7 @@ describe( 'useFavorites', () => {
 		] );
 	} );
 
-	it( 'waits for initial load before applying updater writes', async () => {
+	it( 'waits for the first load before writing updater results', async () => {
 		const initialLoad = deferred();
 		apiFetch.mockImplementation( ( options ) => {
 			if ( options.method === 'PUT' ) {
@@ -93,7 +93,7 @@ describe( 'useFavorites', () => {
 		} );
 	} );
 
-	it( 'serializes writes so a failed write cannot clobber a later one', async () => {
+	it( 'keeps a failed write from overwriting a later one', async () => {
 		const firstWrite = deferred();
 		const secondWrite = deferred();
 		const putCalls = [];


### PR DESCRIPTION
## What

Part of #147

Makes sidebar Favorites more dependable when saves are slow, fail, or happen while pages are being trashed. Reordering now works from the whole row instead of only the icon, save failures show in the sidebar, and child-page favorites are cleared when their parent is trashed.

## Why

Favorites should not disappear, come back in the wrong order, or leave trashed pages behind because a save resolved late.

## Testing Instructions

1. Open Cortext and add a page or collection to Favorites from the sidebar row menu.
2. Remove a favorite from the Favorites section and confirm the row disappears cleanly.
3. Drag a favorite row, reload Cortext, and confirm the order sticks.
4. Favorite a parent page and child page, trash the parent, and confirm both leave Favorites.