### PR TITLE
Add DataView settings to the block inspector

### DIFF
--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -1,24 +1,78 @@
 import { __ } from '@wordpress/i18n';
-import { BlockControls, useBlockProps } from '@wordpress/block-editor';
 import {
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	Button,
+	CheckboxControl,
 	Dropdown,
 	Notice,
+	PanelBody,
 	Placeholder,
+	SelectControl,
 	Spinner,
 	TextControl,
 	ToolbarButton,
 } from '@wordpress/components';
-import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
+import { store as interfaceStore } from '@wordpress/interface';
 import apiFetch from '@wordpress/api-fetch';
-import { plus, replace } from '@wordpress/icons';
+import { cog, plus, replace } from '@wordpress/icons';
 
 import CollectionDataViews from '../../components/CollectionDataViews';
 import AddFieldPopover from '../../components/fields/AddFieldPopover';
 import { COLLECTION_QUERY } from '../../collections';
-import { CollectionFieldsProvider } from '../../components/CollectionFieldsContext';
+import {
+	CollectionFieldsProvider,
+	useCollectionFieldsContext,
+} from '../../components/CollectionFieldsContext';
+import { GHOST_FIELD_ID } from '../../components/dataViewColumns';
+import {
+	DEFAULT_ROW_DETAIL_MODE,
+	ROW_DETAIL_MODES,
+} from '../../components/rowDetailUtils';
+import {
+	ROW_DETAIL_MODE_ICONS,
+	ROW_DETAIL_MODE_LABELS,
+} from '../../components/RowDetailView';
+
+const DENSITY_OPTIONS = [
+	{ value: 'compact', label: __( 'Compact', 'cortext' ) },
+	{ value: 'balanced', label: __( 'Balanced', 'cortext' ) },
+	{ value: 'comfortable', label: __( 'Comfortable', 'cortext' ) },
+];
+
+const PER_PAGE_OPTIONS = [
+	{ value: '10', label: '10' },
+	{ value: '25', label: '25' },
+	{ value: '50', label: '50' },
+	{ value: '100', label: '100' },
+];
+
+// Mirrors the block's `supports.align` (`block.json`). The "Default" option
+// writes the empty string rather than `undefined` so the value survives
+// serialization — otherwise the `block.json` `align` default would reapply
+// on parse and "Default" would round-trip back to "Wide".
+const WIDTH_OPTIONS = [
+	{ value: '', label: __( 'Default', 'cortext' ) },
+	{ value: 'wide', label: __( 'Wide', 'cortext' ) },
+	{ value: 'full', label: __( 'Full', 'cortext' ) },
+];
+
+const ROW_DETAIL_OPTIONS = ROW_DETAIL_MODES.map( ( mode ) => ( {
+	value: mode,
+	label: ROW_DETAIL_MODE_LABELS[ mode ],
+} ) );
 
 function createDefaultView() {
 	return {
@@ -149,11 +203,8 @@ function CollectionCreator( { onCreate } ) {
 }
 
 function CollectionToolbarControl( { collectionId, onSelect } ) {
-	const { record: collection, isResolving } = useEntityRecord(
-		'postType',
-		'crtxt_collection',
-		collectionId ?? 0
-	);
+	const { collection, isResolving } = useCollectionFieldsContext();
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	const isCollectionValid = ! isResolving && collectionId && collection;
 
@@ -204,16 +255,269 @@ function CollectionToolbarControl( { collectionId, onSelect } ) {
 					) }
 				/>
 			) }
+			<ToolbarButton
+				icon={ cog }
+				label={ __( 'View settings', 'cortext' ) }
+				onClick={ () =>
+					enableComplementaryArea(
+						'cortext',
+						'cortext/block-inspector'
+					)
+				}
+			/>
 		</BlockControls>
 	);
 }
 
+function CollectionInspectorControls( {
+	collectionId,
+	view,
+	align,
+	onSelect,
+	onChangeView,
+	onChangeAlign,
+} ) {
+	const {
+		fields: availableFields,
+		collection,
+		isResolving,
+	} = useCollectionFieldsContext();
+	const isCollectionValid = ! isResolving && collectionId && collection;
+	const visibleFieldIds = view?.fields ?? [];
+
+	// Visible fields in `view.fields` order so the inspector list reflects
+	// any column drag-reorder, then hidden fields appended in schema order.
+	const visibleFieldsInOrder = visibleFieldIds
+		.map( ( id ) => availableFields.find( ( f ) => f.id === id ) )
+		.filter( Boolean );
+	const visibleIdSet = new Set( visibleFieldsInOrder.map( ( f ) => f.id ) );
+	const hiddenFields = availableFields.filter(
+		( f ) => ! visibleIdSet.has( f.id )
+	);
+	const orderedFields = [ ...visibleFieldsInOrder, ...hiddenFields ];
+
+	const toggleFieldVisibility = ( fieldId, isVisible ) => {
+		const hasGhost = visibleFieldIds.includes( GHOST_FIELD_ID );
+		const stripped = visibleFieldIds.filter(
+			( id ) => id !== GHOST_FIELD_ID && id !== fieldId
+		);
+		let nextFields;
+		if ( isVisible ) {
+			// Insert at schema position so a re-shown field lands next to
+			// its neighbors instead of at the end. Look backward first
+			// (place after the last preceding visible field); fall back
+			// to forward (place before the first following visible field)
+			// so a re-shown first-in-schema field doesn't get appended.
+			const schemaIdx = availableFields.findIndex(
+				( f ) => f.id === fieldId
+			);
+			let insertAt = -1;
+			for ( let i = schemaIdx - 1; i >= 0; i-- ) {
+				const idx = stripped.indexOf( availableFields[ i ].id );
+				if ( idx >= 0 ) {
+					insertAt = idx + 1;
+					break;
+				}
+			}
+			if ( insertAt === -1 ) {
+				for ( let i = schemaIdx + 1; i < availableFields.length; i++ ) {
+					const idx = stripped.indexOf( availableFields[ i ].id );
+					if ( idx >= 0 ) {
+						insertAt = idx;
+						break;
+					}
+				}
+			}
+			if ( insertAt === -1 ) {
+				insertAt = stripped.length;
+			}
+			nextFields = [
+				...stripped.slice( 0, insertAt ),
+				fieldId,
+				...stripped.slice( insertAt ),
+			];
+		} else {
+			nextFields = stripped;
+		}
+		if ( hasGhost ) {
+			nextFields = [ ...nextFields, GHOST_FIELD_ID ];
+		}
+		onChangeView( { ...view, fields: nextFields } );
+	};
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Collection', 'cortext' ) }>
+				<Dropdown
+					contentClassName="cortext-data-view-toolbar-popover"
+					popoverProps={ { placement: 'left-start' } }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<Button
+							variant="secondary"
+							icon={ replace }
+							onClick={ onToggle }
+							aria-expanded={ isOpen }
+							__next40pxDefaultSize
+						>
+							{ __( 'Change collection', 'cortext' ) }
+						</Button>
+					) }
+					renderContent={ ( { onClose } ) => (
+						<div className="cortext-data-view-toolbar-popover__content">
+							<CollectionPicker
+								selectedId={ collectionId }
+								onSelect={ ( id ) => {
+									onSelect( id );
+									onClose();
+								} }
+							/>
+						</div>
+					) }
+				/>
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Fields', 'cortext' ) }
+				initialOpen={ false }
+			>
+				{ isCollectionValid && (
+					<>
+						<Dropdown
+							contentClassName="cortext-data-view-toolbar-popover"
+							popoverProps={ { placement: 'left-start' } }
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<Button
+									variant="secondary"
+									icon={ plus }
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									__next40pxDefaultSize
+								>
+									{ __( 'Add field', 'cortext' ) }
+								</Button>
+							) }
+							renderContent={ ( { onClose } ) => (
+								<div className="cortext-data-view-toolbar-popover__content">
+									<AddFieldPopover
+										collectionId={ collectionId }
+										onCreate={ onClose }
+									/>
+								</div>
+							) }
+						/>
+						{ orderedFields.length > 0 && (
+							<ul className="cortext-data-view-field-visibility">
+								{ orderedFields.map( ( field ) => (
+									<li key={ field.id }>
+										<CheckboxControl
+											label={ field.label }
+											checked={ visibleFieldIds.includes(
+												field.id
+											) }
+											onChange={ ( isVisible ) =>
+												toggleFieldVisibility(
+													field.id,
+													isVisible
+												)
+											}
+											__nextHasNoMarginBottom
+										/>
+									</li>
+								) ) }
+							</ul>
+						) }
+					</>
+				) }
+			</PanelBody>
+			<PanelBody title={ __( 'View', 'cortext' ) } initialOpen={ false }>
+				{ isCollectionValid && (
+					<>
+						<ToggleGroupControl
+							label={ __( 'Width', 'cortext' ) }
+							value={ align ?? '' }
+							onChange={ onChangeAlign }
+							isBlock
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						>
+							{ WIDTH_OPTIONS.map( ( option ) => (
+								<ToggleGroupControlOption
+									key={ option.value || 'default' }
+									value={ option.value }
+									label={ option.label }
+								/>
+							) ) }
+						</ToggleGroupControl>
+						<SelectControl
+							label={ __( 'Density', 'cortext' ) }
+							value={ view?.layout?.density ?? 'compact' }
+							options={ DENSITY_OPTIONS }
+							onChange={ ( density ) =>
+								onChangeView( {
+									...view,
+									layout: {
+										...( view?.layout ?? {} ),
+										density,
+									},
+								} )
+							}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+						<SelectControl
+							label={ __( 'Rows per page', 'cortext' ) }
+							value={ String( view?.perPage ?? 25 ) }
+							options={ PER_PAGE_OPTIONS }
+							onChange={ ( perPage ) =>
+								onChangeView( {
+									...view,
+									perPage: Number( perPage ),
+									page: 1,
+								} )
+							}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+						<ToggleGroupControl
+							label={ __( 'Row detail', 'cortext' ) }
+							value={
+								view?.rowDetailMode ?? DEFAULT_ROW_DETAIL_MODE
+							}
+							onChange={ ( rowDetailMode ) =>
+								onChangeView( { ...view, rowDetailMode } )
+							}
+							isBlock
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						>
+							{ ROW_DETAIL_OPTIONS.map( ( option ) => (
+								<ToggleGroupControlOptionIcon
+									key={ option.value }
+									value={ option.value }
+									label={ option.label }
+									icon={
+										ROW_DETAIL_MODE_ICONS[ option.value ]
+									}
+								/>
+							) ) }
+						</ToggleGroupControl>
+					</>
+				) }
+			</PanelBody>
+		</InspectorControls>
+	);
+}
+
 export default function Edit( { attributes, setAttributes } ) {
-	const { collectionId, view } = attributes;
+	const { collectionId, view, align } = attributes;
 	const blockProps = useBlockProps();
 
 	const setView = useCallback(
 		( next ) => setAttributes( { view: next } ),
+		[ setAttributes ]
+	);
+
+	const setAlign = useCallback(
+		( next ) => setAttributes( { align: next } ),
 		[ setAttributes ]
 	);
 
@@ -223,9 +527,20 @@ export default function Edit( { attributes, setAttributes } ) {
 		[ setAttributes ]
 	);
 
+	const onSelectCollection = ( id ) => {
+		if ( id !== collectionId ) {
+			selectCollection( id );
+		}
+	};
+
 	if ( ! collectionId ) {
 		return (
 			<div { ...blockProps }>
+				<InspectorControls>
+					<PanelBody title={ __( 'Collection', 'cortext' ) }>
+						<CollectionPicker onSelect={ selectCollection } />
+					</PanelBody>
+				</InspectorControls>
 				<Placeholder
 					label={ __( 'Collection view', 'cortext' ) }
 					instructions={ __(
@@ -251,11 +566,15 @@ export default function Edit( { attributes, setAttributes } ) {
 			<div { ...blockProps }>
 				<CollectionToolbarControl
 					collectionId={ collectionId }
-					onSelect={ ( id ) => {
-						if ( id !== collectionId ) {
-							selectCollection( id );
-						}
-					} }
+					onSelect={ onSelectCollection }
+				/>
+				<CollectionInspectorControls
+					collectionId={ collectionId }
+					view={ view }
+					align={ align }
+					onSelect={ onSelectCollection }
+					onChangeView={ setView }
+					onChangeAlign={ setAlign }
 				/>
 				<CollectionDataViews
 					collectionId={ collectionId }

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -18,6 +18,7 @@ import { plus, replace } from '@wordpress/icons';
 import CollectionDataViews from '../../components/CollectionDataViews';
 import AddFieldPopover from '../../components/fields/AddFieldPopover';
 import { COLLECTION_QUERY } from '../../collections';
+import { CollectionFieldsProvider } from '../../components/CollectionFieldsContext';
 
 function createDefaultView() {
 	return {
@@ -246,37 +247,39 @@ export default function Edit( { attributes, setAttributes } ) {
 	}
 
 	return (
-		<div { ...blockProps }>
-			<CollectionToolbarControl
-				collectionId={ collectionId }
-				onSelect={ ( id ) => {
-					if ( id !== collectionId ) {
-						selectCollection( id );
+		<CollectionFieldsProvider collectionId={ collectionId }>
+			<div { ...blockProps }>
+				<CollectionToolbarControl
+					collectionId={ collectionId }
+					onSelect={ ( id ) => {
+						if ( id !== collectionId ) {
+							selectCollection( id );
+						}
+					} }
+				/>
+				<CollectionDataViews
+					collectionId={ collectionId }
+					view={ view }
+					onChangeView={ setView }
+					loading={ <Spinner /> }
+					invalid={
+						<Notice status="warning" isDismissible={ false }>
+							{ __(
+								'This collection is no longer available. Choose another collection.',
+								'cortext'
+							) }
+						</Notice>
 					}
-				} }
-			/>
-			<CollectionDataViews
-				collectionId={ collectionId }
-				view={ view }
-				onChangeView={ setView }
-				loading={ <Spinner /> }
-				invalid={
-					<Notice status="warning" isDismissible={ false }>
-						{ __(
-							'This collection is no longer available. Choose another collection.',
-							'cortext'
-						) }
-					</Notice>
-				}
-				error={
-					<Notice status="error" isDismissible={ false }>
-						{ __(
-							'Collection rows could not be loaded.',
-							'cortext'
-						) }
-					</Notice>
-				}
-			/>
-		</div>
+					error={
+						<Notice status="error" isDismissible={ false }>
+							{ __(
+								'Collection rows could not be loaded.',
+								'cortext'
+							) }
+						</Notice>
+					}
+				/>
+			</div>
+		</CollectionFieldsProvider>
 	);
 }

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -59,10 +59,8 @@ const PER_PAGE_OPTIONS = [
 	{ value: '100', label: '100' },
 ];
 
-// Mirrors the block's `supports.align` (`block.json`). The "Default" option
-// writes the empty string rather than `undefined` so the value survives
-// serialization — otherwise the `block.json` `align` default would reapply
-// on parse and "Default" would round-trip back to "Wide".
+// The empty string is intentional. `undefined` would be dropped from the
+// block comment, and the `wide` default would come back on the next parse.
 const WIDTH_OPTIONS = [
 	{ value: '', label: __( 'Default', 'cortext' ) },
 	{ value: 'wide', label: __( 'Wide', 'cortext' ) },
@@ -285,8 +283,7 @@ function CollectionInspectorControls( {
 	const isCollectionValid = ! isResolving && collectionId && collection;
 	const visibleFieldIds = view?.fields ?? [];
 
-	// Visible fields in `view.fields` order so the inspector list reflects
-	// any column drag-reorder, then hidden fields appended in schema order.
+	// Checked fields follow the table order. Unchecked fields keep schema order.
 	const visibleFieldsInOrder = visibleFieldIds
 		.map( ( id ) => availableFields.find( ( f ) => f.id === id ) )
 		.filter( Boolean );
@@ -303,11 +300,8 @@ function CollectionInspectorControls( {
 		);
 		let nextFields;
 		if ( isVisible ) {
-			// Insert at schema position so a re-shown field lands next to
-			// its neighbors instead of at the end. Look backward first
-			// (place after the last preceding visible field); fall back
-			// to forward (place before the first following visible field)
-			// so a re-shown first-in-schema field doesn't get appended.
+			// Put the field back near its schema neighbors. Prefer the previous
+			// visible field; for the first field, use the next visible one.
 			const schemaIdx = availableFields.findIndex(
 				( f ) => f.id === fieldId
 			);

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -32,7 +32,7 @@ import {
 	getRowDetailMode,
 	withRowDetailMode,
 } from './rowDetailUtils';
-import useCollectionFields from '../hooks/useCollectionFields';
+import { useCollectionFieldsContext } from './CollectionFieldsContext';
 import useCollectionRows from '../hooks/useCollectionRows';
 import { elementsFromOptions } from '../hooks/optionElements';
 
@@ -281,7 +281,7 @@ export default function CollectionDataViews( {
 	const navigate = useNavigate();
 	const routeSearch = useSearch( { strict: false } );
 	const { fields, collection, slug, isResolving, fieldsResolved } =
-		useCollectionFields( collectionId );
+		useCollectionFieldsContext();
 	const routeRowId = parseSearchId( routeSearch?.[ ROW_SEARCH_KEY ] );
 	const routeRowCollectionId = parseSearchId(
 		routeSearch?.[ ROW_COLLECTION_SEARCH_KEY ]

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -702,22 +702,22 @@ export default function CollectionDataViews( {
 				return;
 			}
 			runDetailTransition( {
-				type: rowDetailMode === 'full' ? 'full' : 'row',
+				type: savedRowDetailMode === 'full' ? 'full' : 'row',
 				rowId: row.id,
 				pushUrl: true,
 			} );
 		},
-		[ openRowId, rowDetailMode, runDetailTransition ]
+		[ openRowId, runDetailTransition, savedRowDetailMode ]
 	);
 
 	const openRowActionContext = useMemo(
 		() => ( {
 			enabled: isTableLayout,
-			icon: ROW_DETAIL_MODE_ICONS[ rowDetailMode ],
+			icon: ROW_DETAIL_MODE_ICONS[ savedRowDetailMode ],
 			openRowId,
 			requestOpenRow,
 		} ),
-		[ isTableLayout, openRowId, requestOpenRow, rowDetailMode ]
+		[ isTableLayout, openRowId, requestOpenRow, savedRowDetailMode ]
 	);
 
 	const rowActions = useMemo(
@@ -725,13 +725,13 @@ export default function CollectionDataViews( {
 			{
 				id: 'open-row',
 				label: __( 'Open row', 'cortext' ),
-				icon: ROW_DETAIL_MODE_ICONS[ rowDetailMode ],
+				icon: ROW_DETAIL_MODE_ICONS[ savedRowDetailMode ],
 				isPrimary: true,
 				context: 'single',
 				callback: ( items ) => requestOpenRow( items?.[ 0 ] ),
 			},
 		],
-		[ requestOpenRow, rowDetailMode ]
+		[ requestOpenRow, savedRowDetailMode ]
 	);
 
 	const dataViewActions = useMemo(
@@ -850,7 +850,7 @@ export default function CollectionDataViews( {
 		}
 
 		runDetailTransition( {
-			type: rowDetailMode === 'full' ? 'full' : 'row',
+			type: savedRowDetailMode === 'full' ? 'full' : 'row',
 			rowId: routeRowId,
 			syncUrl: false,
 		} );
@@ -859,8 +859,8 @@ export default function CollectionDataViews( {
 		clearSuppressedRouteRow,
 		routeRowCollectionId,
 		routeRowId,
-		rowDetailMode,
 		runDetailTransition,
+		savedRowDetailMode,
 		suppressedRouteRow,
 	] );
 

--- a/src/components/CollectionFieldsContext.js
+++ b/src/components/CollectionFieldsContext.js
@@ -2,20 +2,16 @@ import { createContext, useContext, useMemo } from '@wordpress/element';
 
 import useCollectionFields from '../hooks/useCollectionFields';
 
-// Single subscription to a collection's field schema, shared across the
-// data-view block (toolbar, inspector, table) and any column-level UI
-// rendered beneath it. `useCollectionFields` keeps a per-instance latch so
-// refetches don't flash spinners; routing every consumer through one
-// provider means there is exactly one latch and consumers re-render
-// together when a field is added, renamed, or deleted.
+// Keep one field-schema read per collection. `useCollectionFields` latches the
+// last good field list, so sharing it here keeps the toolbar, inspector, table,
+// and field menus in sync after field changes.
 const CollectionFieldsContext = createContext( null );
 
 export function CollectionFieldsProvider( { collectionId, children } ) {
 	const { fields, collection, slug, isResolving, fieldsResolved } =
 		useCollectionFields( collectionId );
-	// `useCollectionFields` returns a fresh object literal each render;
-	// memoizing on the destructured values keeps context identity stable
-	// when nothing actually changed.
+	// `useCollectionFields` returns a fresh object each render. Memoize the
+	// context value so consumers do not re-render when the pieces are unchanged.
 	const value = useMemo(
 		() => ( { fields, collection, slug, isResolving, fieldsResolved } ),
 		[ fields, collection, slug, isResolving, fieldsResolved ]

--- a/src/components/CollectionFieldsContext.js
+++ b/src/components/CollectionFieldsContext.js
@@ -1,0 +1,38 @@
+import { createContext, useContext, useMemo } from '@wordpress/element';
+
+import useCollectionFields from '../hooks/useCollectionFields';
+
+// Single subscription to a collection's field schema, shared across the
+// data-view block (toolbar, inspector, table) and any column-level UI
+// rendered beneath it. `useCollectionFields` keeps a per-instance latch so
+// refetches don't flash spinners; routing every consumer through one
+// provider means there is exactly one latch and consumers re-render
+// together when a field is added, renamed, or deleted.
+const CollectionFieldsContext = createContext( null );
+
+export function CollectionFieldsProvider( { collectionId, children } ) {
+	const { fields, collection, slug, isResolving, fieldsResolved } =
+		useCollectionFields( collectionId );
+	// `useCollectionFields` returns a fresh object literal each render;
+	// memoizing on the destructured values keeps context identity stable
+	// when nothing actually changed.
+	const value = useMemo(
+		() => ( { fields, collection, slug, isResolving, fieldsResolved } ),
+		[ fields, collection, slug, isResolving, fieldsResolved ]
+	);
+	return (
+		<CollectionFieldsContext.Provider value={ value }>
+			{ children }
+		</CollectionFieldsContext.Provider>
+	);
+}
+
+export function useCollectionFieldsContext() {
+	const ctx = useContext( CollectionFieldsContext );
+	if ( ! ctx ) {
+		throw new Error(
+			'useCollectionFieldsContext: missing CollectionFieldsProvider'
+		);
+	}
+	return ctx;
+}

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -55,7 +55,7 @@ export const ROW_DETAIL_MODE_ICONS = {
 	full: fullscreen,
 };
 
-const ROW_DETAIL_MODE_LABELS = {
+export const ROW_DETAIL_MODE_LABELS = {
 	side: __( 'Side peek', 'cortext' ),
 	modal: __( 'Center modal', 'cortext' ),
 	full: __( 'Full page', 'cortext' ),

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -22,9 +22,8 @@ import {
 } from '@wordpress/icons';
 
 import { COLLECTION_QUERY } from '../../collections';
-import useCollectionFields, {
-	buildFieldListQuery,
-} from '../../hooks/useCollectionFields';
+import { buildFieldListQuery } from '../../hooks/useCollectionFields';
+import { useCollectionFieldsContext } from '../CollectionFieldsContext';
 import { useCreateField } from '../../hooks/useFieldMutations';
 
 // Inline SVG for the "number" type. `@wordpress/icons` doesn't ship a
@@ -289,7 +288,6 @@ function RelationConfig( {
 }
 
 function RollupConfig( {
-	collectionId,
 	title,
 	fallbackTitle,
 	isBusy,
@@ -298,7 +296,7 @@ function RollupConfig( {
 	onError,
 	run,
 } ) {
-	const { fields } = useCollectionFields( collectionId );
+	const { fields } = useCollectionFieldsContext();
 	const relationFields = fields.filter(
 		( field ) => field.cortextType === 'relation'
 	);
@@ -597,7 +595,6 @@ export default function AddFieldPopover( { collectionId, onCreate } ) {
 	} else if ( configType === 'rollup' ) {
 		configuration = (
 			<RollupConfig
-				collectionId={ collectionId }
 				title={ title }
 				fallbackTitle={ fallbackTitle }
 				isBusy={ isBusy }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -34,7 +34,7 @@ import AddFieldPopover from './AddFieldPopover';
 import EditOptionsPopover from './EditOptionsPopover';
 import FieldFormatPopover from './FieldFormatPopover';
 import RenameFieldInline from './RenameFieldInline';
-import useCollectionFields from '../../hooks/useCollectionFields';
+import { useCollectionFieldsContext } from '../CollectionFieldsContext';
 import { elementsFromOptions } from '../../hooks/fieldMapping';
 import { TableCalculationPopover } from '../TableCalculationMenu';
 import {
@@ -195,7 +195,7 @@ function FieldActions( {
 	const optionsAnchorRef = useRef( null );
 	const duplicate = useDuplicateField( collectionId );
 	const remove = useDeleteField( collectionId );
-	const { fields } = useCollectionFields( collectionId );
+	const { fields } = useCollectionFieldsContext();
 	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
 	const fieldType = record?.meta?.type;
 	const canFormat = FORMATTABLE_TYPES.has( fieldType );

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -14,6 +14,7 @@ import {
 
 import Canvas from '../components/Canvas';
 import CollectionDataViews from '../components/CollectionDataViews';
+import { CollectionFieldsProvider } from '../components/CollectionFieldsContext';
 import { RowFullEditorContext } from '../components/RowFullEditorContext';
 import { RowDetailSidebarSlot } from '../components/RowDetailSidebarSlot';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
@@ -76,15 +77,17 @@ function CollectionView( { collectionId, onReady } ) {
 
 function CollectionPane( { collectionId, onReady } ) {
 	return (
-		<div className="cortext-collection-pane">
-			<div className="cortext-canvas__table">
-				<CollectionView
-					collectionId={ collectionId }
-					onReady={ onReady }
-				/>
+		<CollectionFieldsProvider collectionId={ collectionId }>
+			<div className="cortext-collection-pane">
+				<div className="cortext-canvas__table">
+					<CollectionView
+						collectionId={ collectionId }
+						onReady={ onReady }
+					/>
+				</div>
+				<RowDetailSidebarSlot />
 			</div>
-			<RowDetailSidebarSlot />
-		</div>
+		</CollectionFieldsProvider>
 	);
 }
 

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -356,7 +356,9 @@ test.describe( 'Collection view block', () => {
 			expect( fixture.createdFieldIds ).toEqual( [] );
 
 			await page
-				.getByRole( 'button', { name: 'Change collection' } )
+				.locator(
+					'[data-toolbar-item="true"][aria-label="Change collection"]'
+				)
 				.click();
 			await page
 				.locator( '.cortext-data-view-toolbar-popover' )

--- a/tests/js/components/fields/AddFieldPopover.test.js
+++ b/tests/js/components/fields/AddFieldPopover.test.js
@@ -7,8 +7,11 @@ jest.mock( '@wordpress/core-data', () => ( {
 
 jest.mock( '../../../../src/hooks/useCollectionFields', () => ( {
 	__esModule: true,
-	default: jest.fn(),
 	buildFieldListQuery: jest.fn( ( ids ) => ( { include: ids } ) ),
+} ) );
+
+jest.mock( '../../../../src/components/CollectionFieldsContext', () => ( {
+	useCollectionFieldsContext: jest.fn(),
 } ) );
 
 jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
@@ -17,7 +20,7 @@ jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
 
 import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 import AddFieldPopover from '../../../../src/components/fields/AddFieldPopover';
-import useCollectionFields from '../../../../src/hooks/useCollectionFields';
+import { useCollectionFieldsContext } from '../../../../src/components/CollectionFieldsContext';
 import { useCreateField } from '../../../../src/hooks/useFieldMutations';
 
 const run = jest.fn();
@@ -38,7 +41,7 @@ beforeEach( () => {
 		isBusy: false,
 		error: null,
 	} );
-	useCollectionFields.mockReturnValue( {
+	useCollectionFieldsContext.mockReturnValue( {
 		fields: [
 			{
 				id: 'field-77',

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -100,9 +100,8 @@ jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
 	useDuplicateField: () => ( { run: jest.fn() } ),
 } ) );
 
-jest.mock( '../../../../src/hooks/useCollectionFields', () => ( {
-	__esModule: true,
-	default: jest.fn(),
+jest.mock( '../../../../src/components/CollectionFieldsContext', () => ( {
+	useCollectionFieldsContext: jest.fn(),
 } ) );
 
 jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
@@ -114,7 +113,7 @@ jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
 
 import ColumnHeaderActions from '../../../../src/components/fields/ColumnHeaderActions';
 import { useEntityRecord } from '@wordpress/core-data';
-import useCollectionFields from '../../../../src/hooks/useCollectionFields';
+import { useCollectionFieldsContext } from '../../../../src/components/CollectionFieldsContext';
 
 function Harness( { collectionId, recordId } ) {
 	return (
@@ -144,7 +143,7 @@ function Harness( { collectionId, recordId } ) {
 
 describe( 'ColumnHeaderActions', () => {
 	beforeEach( () => {
-		useCollectionFields.mockReturnValue( { fields: [] } );
+		useCollectionFieldsContext.mockReturnValue( { fields: [] } );
 		useEntityRecord.mockReturnValue( {
 			record: {
 				id: 77,
@@ -173,7 +172,7 @@ describe( 'ColumnHeaderActions', () => {
 	} );
 
 	it( 'warns when deleting a field will also delete dependent rollups', async () => {
-		useCollectionFields.mockReturnValue( {
+		useCollectionFieldsContext.mockReturnValue( {
 			fields: [
 				{
 					id: 'field-77',


### PR DESCRIPTION
## What

Adds the main collection-view settings into the block inspector: collection switching, field creation and visibility, width, density, rows per page, and row detail mode.

## Why

These settings are easier to find in the sidebar, especially when configuring a DataView block instead of working directly in the table.

## Testing Instructions

1. Open a page with a Cortext collection view block and select the block.
2. Open the block inspector from the View settings toolbar button.
3. Add a field from the sidebar, then hide and re-show fields, and confirm the table updates.
4. Change width, density, rows per page, and row detail mode, then save and reload the page.
5. Set row detail to Full page, open a row from the table and from a row URL, and confirm it opens full-page.

## Screen recording

https://github.com/user-attachments/assets/d4cbd9a6-342c-4d28-8a5f-40c46c982e65

