### PR TITLE
Add Cortext alpha notice modal

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,12 +13,11 @@ function resolveBaseURL() {
 		return process.env.WP_BASE_URL;
 	}
 	try {
-		// eslint-disable-next-line global-require
 		const override = require( './.wp-env.override.json' );
 		if ( override.port ) {
 			return `http://localhost:${ override.port }`;
 		}
-	} catch ( _error ) {
+	} catch {
 		// File is gitignored; absent on CI.
 	}
 	return 'http://localhost:8889';
@@ -32,6 +31,7 @@ const baseConfig = require( '@wordpress/scripts/config/playwright.config.js' );
 module.exports = defineConfig( {
 	...baseConfig,
 	testDir: './tests/e2e/specs',
+	globalSetup: require.resolve( './tests/e2e/global-setup.js' ),
 	// wp-env is started explicitly by the developer / CI.
 	webServer: undefined,
 	use: {

--- a/src/components/AlphaNoticeModal.js
+++ b/src/components/AlphaNoticeModal.js
@@ -1,0 +1,98 @@
+import {
+	Button,
+	CheckboxControl,
+	ExternalLink,
+	Modal,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Icon, backup, bug, comment } from '@wordpress/icons';
+
+const REPO_URL = 'https://github.com/Automattic/cortext';
+
+export default function AlphaNoticeModal( { onAcknowledge, onDismiss } ) {
+	const [ dontShowAgain, setDontShowAgain ] = useState( true );
+
+	return (
+		<Modal
+			className="cortext-alpha-notice"
+			overlayClassName="cortext-alpha-notice-overlay"
+			title={ __( 'Welcome to Cortext (alpha)', 'cortext' ) }
+			onRequestClose={ onDismiss }
+			size="medium"
+		>
+			<p className="cortext-alpha-notice__intro">
+				{ __(
+					'Thanks for trying Cortext! A few things to keep in mind before you dive in:',
+					'cortext'
+				) }
+			</p>
+			<ul className="cortext-alpha-notice__list">
+				<li>
+					<span className="cortext-alpha-notice__icon">
+						<Icon icon={ bug } />
+					</span>
+					<div>
+						<strong>
+							{ __( 'Expect rough edges.', 'cortext' ) }
+						</strong>{ ' ' }
+						{ __(
+							'Cortext is in early alpha. Bugs, missing features, and breaking changes between releases are all on the table.',
+							'cortext'
+						) }
+					</div>
+				</li>
+				<li>
+					<span className="cortext-alpha-notice__icon">
+						<Icon icon={ backup } />
+					</span>
+					<div>
+						<strong>
+							{ __(
+								'The data model is still evolving.',
+								'cortext'
+							) }
+						</strong>{ ' ' }
+						{ __(
+							'Content you create now may not survive future schema changes. Avoid using Cortext for anything you can’t afford to lose.',
+							'cortext'
+						) }
+					</div>
+				</li>
+				<li>
+					<span className="cortext-alpha-notice__icon">
+						<Icon icon={ comment } />
+					</span>
+					<div>
+						<strong>
+							{ __( 'Feedback is welcome.', 'cortext' ) }
+						</strong>{ ' ' }
+						{ __(
+							'Please test on a staging site, not production, and let us know what you find.',
+							'cortext'
+						) }
+					</div>
+				</li>
+			</ul>
+			<p className="cortext-alpha-notice__repo">
+				<ExternalLink href={ REPO_URL }>
+					{ __( 'View Cortext on GitHub', 'cortext' ) }
+				</ExternalLink>
+			</p>
+			<div className="cortext-alpha-notice__footer">
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ __( "Don't show this again", 'cortext' ) }
+					checked={ dontShowAgain }
+					onChange={ setDontShowAgain }
+				/>
+				<Button
+					variant="primary"
+					onClick={ () => onAcknowledge( dontShowAgain ) }
+				>
+					{ __( 'Got it', 'cortext' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/components/AlphaNoticeModal.js
+++ b/src/components/AlphaNoticeModal.js
@@ -10,7 +10,7 @@ import { Icon, backup, bug, comment } from '@wordpress/icons';
 
 const REPO_URL = 'https://github.com/Automattic/cortext';
 
-export default function AlphaNoticeModal( { onAcknowledge, onDismiss } ) {
+export default function AlphaNoticeModal( { onAcknowledge } ) {
 	const [ dontShowAgain, setDontShowAgain ] = useState( true );
 
 	return (
@@ -18,7 +18,7 @@ export default function AlphaNoticeModal( { onAcknowledge, onDismiss } ) {
 			className="cortext-alpha-notice"
 			overlayClassName="cortext-alpha-notice-overlay"
 			title={ __( 'Welcome to Cortext (alpha)', 'cortext' ) }
-			onRequestClose={ onDismiss }
+			onRequestClose={ () => onAcknowledge( dontShowAgain ) }
 			size="medium"
 		>
 			<p className="cortext-alpha-notice__intro">

--- a/src/hooks/useAlphaNotice.js
+++ b/src/hooks/useAlphaNotice.js
@@ -15,10 +15,6 @@ function readSeen() {
 export default function useAlphaNotice() {
 	const [ isOpen, setOpen ] = useState( () => ! readSeen() );
 
-	const dismiss = useCallback( () => {
-		setOpen( false );
-	}, [] );
-
 	const acknowledge = useCallback( ( persist ) => {
 		if ( persist ) {
 			try {
@@ -28,5 +24,5 @@ export default function useAlphaNotice() {
 		setOpen( false );
 	}, [] );
 
-	return { isOpen, dismiss, acknowledge };
+	return { isOpen, acknowledge };
 }

--- a/src/hooks/useAlphaNotice.js
+++ b/src/hooks/useAlphaNotice.js
@@ -1,0 +1,32 @@
+import { useCallback, useState } from '@wordpress/element';
+
+const STORAGE_KEY = 'cortext.alphaNoticeSeen';
+
+function readSeen() {
+	try {
+		return window.localStorage.getItem( STORAGE_KEY ) === 'true';
+	} catch {
+		// Storage denied (private mode, quota). Treat as seen so we don't
+		// nag on every load in environments where the choice can't persist.
+		return true;
+	}
+}
+
+export default function useAlphaNotice() {
+	const [ isOpen, setOpen ] = useState( () => ! readSeen() );
+
+	const dismiss = useCallback( () => {
+		setOpen( false );
+	}, [] );
+
+	const acknowledge = useCallback( ( persist ) => {
+		if ( persist ) {
+			try {
+				window.localStorage.setItem( STORAGE_KEY, 'true' );
+			} catch {}
+		}
+		setOpen( false );
+	}, [] );
+
+	return { isOpen, dismiss, acknowledge };
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -4432,3 +4432,72 @@ body.cortext-hide-block-settings-menu .block-editor-block-switcher {
 		}
 	}
 }
+
+// Opt the alpha notice out of root view transitions. Without this, the
+// initial `withViewTransition` dispatch in EntityRoute snapshots the whole
+// document (modal portal included) and the cross-fade makes the modal
+// visibly blink on first load. Giving the overlay + frame their own names
+// lifts them into separate view-transition layers; setting both old/new
+// to a stable opacity keeps the modal visually stationary for the duration
+// of the transition.
+.cortext-alpha-notice-overlay {
+	view-transition-name: cortext-alpha-notice-overlay;
+}
+
+.cortext-alpha-notice {
+	view-transition-name: cortext-alpha-notice-frame;
+
+	&__intro {
+		margin-top: 0;
+	}
+
+	&__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	&__list li {
+		display: flex;
+		align-items: flex-start;
+		gap: 12px;
+		margin: 0;
+	}
+
+	&__icon {
+		display: inline-flex;
+		flex-shrink: 0;
+		margin-top: 2px;
+		color: var(--wp-admin-theme-color, #007cba);
+	}
+
+	&__repo {
+		margin-top: 20px;
+		margin-bottom: 0;
+	}
+
+	&__footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		margin-top: 24px;
+		padding-top: 16px;
+		border-top: 1px solid #e0e0e0;
+	}
+}
+
+::view-transition-old(cortext-alpha-notice-overlay),
+::view-transition-old(cortext-alpha-notice-frame) {
+	animation: none;
+	opacity: 0;
+}
+
+::view-transition-new(cortext-alpha-notice-overlay),
+::view-transition-new(cortext-alpha-notice-frame) {
+	animation: none;
+	opacity: 1;
+}

--- a/src/router.js
+++ b/src/router.js
@@ -12,7 +12,9 @@ import { SlotFillProvider } from '@wordpress/components';
 import Sidebar from './components/Sidebar';
 import EntityRoute from './router/EntityRoute';
 import CommandPalette from './components/CommandPalette';
+import AlphaNoticeModal from './components/AlphaNoticeModal';
 import useSidebarLayout from './hooks/useSidebarLayout';
+import useAlphaNotice from './hooks/useAlphaNotice';
 import { FavoritesProvider } from './hooks/useFavorites';
 import { WorkspaceHomeProvider } from './hooks/useWorkspaceHome';
 import { unlock } from './lock-unlock';
@@ -44,6 +46,7 @@ function isEditableTarget( target ) {
 
 function RootLayout() {
 	const { collapsed, width, toggleCollapsed, setWidth } = useSidebarLayout();
+	const alphaNotice = useAlphaNotice();
 	const canvasRef = useRef( null );
 
 	useEffect( () => {
@@ -81,6 +84,12 @@ function RootLayout() {
 						</main>
 					</div>
 					<CommandPalette canvasRef={ canvasRef } />
+					{ alphaNotice.isOpen && (
+						<AlphaNoticeModal
+							onAcknowledge={ alphaNotice.acknowledge }
+							onDismiss={ alphaNotice.dismiss }
+						/>
+					) }
 				</FavoritesProvider>
 			</WorkspaceHomeProvider>
 		</SlotFillProvider>

--- a/src/router.js
+++ b/src/router.js
@@ -87,7 +87,6 @@ function RootLayout() {
 					{ alphaNotice.isOpen && (
 						<AlphaNoticeModal
 							onAcknowledge={ alphaNotice.acknowledge }
-							onDismiss={ alphaNotice.dismiss }
 						/>
 					) }
 				</FavoritesProvider>

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,0 +1,61 @@
+const fs = require( 'fs' );
+
+const baseGlobalSetup = require( '@wordpress/scripts/config/playwright/global-setup.js' );
+
+const ALPHA_NOTICE_STORAGE_KEY = 'cortext.alphaNoticeSeen';
+
+/**
+ * @param {string} storageStatePath
+ * @param {string} origin
+ */
+function markAlphaNoticeSeen( storageStatePath, origin ) {
+	const storageState = JSON.parse(
+		fs.readFileSync( storageStatePath, 'utf8' )
+	);
+	const origins = storageState.origins || [];
+	let originState = origins.find( ( item ) => item.origin === origin );
+
+	if ( ! originState ) {
+		originState = { origin, localStorage: [] };
+		origins.push( originState );
+	}
+
+	const localStorage = originState.localStorage || [];
+	const existingEntry = localStorage.find(
+		( item ) => item.name === ALPHA_NOTICE_STORAGE_KEY
+	);
+
+	if ( existingEntry ) {
+		existingEntry.value = 'true';
+	} else {
+		localStorage.push( {
+			name: ALPHA_NOTICE_STORAGE_KEY,
+			value: 'true',
+		} );
+	}
+
+	originState.localStorage = localStorage;
+	storageState.origins = origins;
+
+	fs.writeFileSync(
+		storageStatePath,
+		`${ JSON.stringify( storageState, null, 2 ) }\n`
+	);
+}
+
+/**
+ * @param {import('@playwright/test').FullConfig} config
+ * @return {Promise<void>}
+ */
+async function globalSetup( config ) {
+	await baseGlobalSetup( config );
+
+	const { storageState, baseURL } = config.projects[ 0 ].use;
+	if ( typeof storageState !== 'string' || ! baseURL ) {
+		return;
+	}
+
+	markAlphaNoticeSeen( storageState, new URL( baseURL ).origin );
+}
+
+module.exports = globalSetup;


### PR DESCRIPTION
## What

Adds a first-load alpha notice that warns users about early-alpha rough edges, possible data loss from future schema changes, and staging-site usage. The modal includes a GitHub link and a "Don't show this again" option that is honored whether the user clicks "Got it" or closes the modal.

## Why

Cortext is still in alpha, so users should see the risk before creating content they might expect to keep.

## How

- Persisting the dismissal in `localStorage` when the user keeps "Don't show this again" checked.
- Seeding the Playwright admin storage state with the notice marked as seen so existing E2E flows can keep testing the app shell directly.
- Keeping the modal visually stable during the initial view transition.

## Testing Instructions

1. Clear the site's local storage and load Cortext.
2. Verify the alpha notice appears with the warning copy, GitHub link, checkbox, close button, and "Got it" button.
3. Leave "Don't show this again" checked, close the modal, reload, and verify the notice does not appear again.
4. Clear local storage, reload, uncheck "Don't show this again", click "Got it", reload, and verify the notice appears again.
