### PR TITLE
Implement server-backed row pagination

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -16,33 +16,48 @@ Pair with [decisions.md](decisions.md) for choices we've made peace with and [ro
 
 ## 2. Rows aren't in `core-data`'s entity store `[internal]`
 
-**What.** `useCollectionRows` fetches rows with raw `apiFetch` and keeps its own state, including a `requestId` race guard and a `refresh()` counter callers bump after creating or updating a row. Mutations POST directly via `apiFetch`. The dynamic `crtxt_{slug}` post types are registered with `show_in_rest`, so `core-data`'s resolver should discover their schema lazily; we just haven't wired it.
+Updated by [#80](https://github.com/priethor/cortext/pull/80).
 
-**Where.** `src/hooks/useCollectionRows.js`, with side effects in `src/components/CollectionDataViews.js` (`saveRowField`, `onCreated`).
+**What.** Rows still bypass `core-data`. `useCollectionRows` owns the fetch state, the `requestId` race guard, the manual `refresh()` counter, and the choice between server and client mode. #80 moved the normal table path to paged REST requests, then changed the fallback from one `per_page=-1` request to pages of 100 fetched with a small concurrency cap. That is a better failure mode, but it is still a second row-loading layer beside the WordPress data store.
 
-**Solution.** Switch to `useEntityRecords('postType', \`crtxt_${slug}\`, query)` plus `saveEntityRecord` for writes. `core-data` then handles caching, race protection, and post-mutation invalidation. Knock-on workarounds it deletes:
+The dynamic `crtxt_{slug}` post types already use `show_in_rest`, so `core-data` should be able to discover them lazily. We just have not wired rows through it yet. Mutations still POST directly with `apiFetch`, then ask the hook to refetch.
+
+**Where.** `src/hooks/useCollectionRows.js`, with side effects in `src/components/CollectionDataViews.js` (`saveRowField`, `onCreated`) and forced client mode in `src/components/relations/RelationEditor.js`.
+
+**Solution.** Switch to `useEntityRecords('postType', \`crtxt_${slug}\`, query)` plus `saveEntityRecord` for writes once the remaining query shapes can be expressed there. `core-data` would then own caching, race protection, and post-mutation invalidation. Knock-on workarounds it deletes:
 
 - The `refresh()` handle exists only because rows aren't reactive.
 - Half of `RowMutationContext` (also driven by #1) exists because cells can't reach a `core-data` store that isn't there.
 - `onCreated` runs optimistic `lastPage = ceil((totalItems+1)/perPage)` arithmetic against possibly stale `paginationInfo`. With reactive pagination we'd watch `totalPages` in an effect.
+- The server/client planner becomes normal resolver queries instead of a local fetch policy.
 
 Worth a small spike before committing; `core-data`'s schema cache for rarely-changing post types is the only real risk.
 
-## 3. `view.sort` isn't forwarded to REST `[internal]`
+## 3. Sorting support is split between REST and client mode `[internal]`
 
-**What.** `buildQueryArgs` ignores `view.sort` entirely. As a placeholder, we pin `orderby=date order=asc` whenever `view.sort.field` is unset so newly created rows land at the bottom of the table. If the user picks a sort via the DataViews UI, we silently drop it. Result: the sort UI looks interactive but doesn't stick, and the asc-by-date assumption leaks into the page-jump on row creation.
+Updated by [#80](https://github.com/priethor/cortext/pull/80).
 
-**Where.** `src/hooks/useCollectionRows.js` (`buildQueryArgs`), and the conditional in `onCreated` in `src/components/CollectionDataViews.js`.
+**What.** #80 fixed the old bad state where the sort UI changed but REST ignored it. REST now handles `title`, `created_at`, `modified_at`, and scalar `field-{id}` columns that can sort by `meta_value` or `meta_value_num`. With no explicit sort, REST still uses oldest-first ordering so new rows land at the bottom of the table.
 
-**Solution.** Translate `view.sort` to REST `orderby/order`. Native fields (`title`, `date`, `id`, `menu_order`) map directly. For `field-{id}` keys, add a `rest_{post_type}_query` filter on the row CPT (`includes/PostType/CollectionEntries.php`) that recognizes `orderby=field-X` and rewrites it to `meta_value`/`meta_value_num` with the matching `meta_key`. Standard WordPress pattern; same filter sets us up for #4.
+The debt is the split brain. The client has an allow-list for server-safe sorts, and `RowsController::build_query_args` has the PHP version of the same story. Unsupported sorts fall back to client mode: fetch all pages, then let DataViews sort locally. That keeps the result honest, but it is not where we want sorting to live long-term.
 
-## 4. `view.filters` isn't forwarded to REST `[internal]`
+The hard cases are still display-value sorts: users, relations, list-style rollups, files, and any field where the value users see is not the value stored in meta. That broader choice is tracked in #14.
 
-**What.** Filters round-trip through block attributes and feed `prefillFromFilters` for the New-row prefill, but they don't filter the loaded dataset. The "filter prefill" feature works because we read the stored filter, not because the server applied it. Filters appear functional but the result set never shrinks, which gets loud once a real collection has more than a page of rows.
+**Where.** The query planner and sort allow-lists in `src/hooks/useCollectionRows.js`, the `onCreated` no-sort branch in `src/components/CollectionDataViews.js`, and `validate_sort_field` / `build_query_args` in `includes/Rest/RowsController.php`.
 
-**Where.** `src/hooks/useCollectionRows.js` (`buildQueryArgs`), and `prefillFromFilters` in `src/components/CollectionDataViews.js`.
+**Solution.** Make REST the source of truth for sortable fields and expose that capability to the client instead of mirroring it by hand. Resolve #14 for display-value sorts, then remove the client fallback for sorting except where DataViews really needs a local-only view state.
 
-**Solution.** Extend the same REST filter as #3 with a `meta_query` translation. `is`/`isAny`/`contains` map cleanly to `=`/`IN`/`LIKE` against the right `meta_key`. Once this lands, prefill becomes a side effect of real filtering rather than its only consumer.
+## 4. Filtering support is split between REST and client mode `[internal]`
+
+Updated by [#80](https://github.com/priethor/cortext/pull/80).
+
+**What.** #80 also made simple field filters real on the server. Equality and membership filters for stored `field-{id}` values now become a REST `meta_query`. When the server cannot handle a filter, the hook falls back to client mode, fetches all pages, and lets DataViews filter locally. That is much better than showing a filter UI that does nothing.
+
+The cost is another split support matrix. The client checks field type, operator, and value shape before choosing server mode. `RowsController` validates field ownership and builds the actual `meta_query`. System fields are still deferred (#13), title filtering still is not a REST feature, and operators like `contains` stay client-only until PHP translates them.
+
+**Where.** `isServerSupportedFilter` and `addFiltersToArgs` in `src/hooks/useCollectionRows.js`, `validate_filter_fields` / `build_query_args` in `includes/Rest/RowsController.php`, and `prefillFromFilters` in `src/components/CollectionDataViews.js`.
+
+**Solution.** Move the remaining filter operators and field families into REST, then make the client consume a server-owned capability map instead of maintaining its own allow-list. `contains` can map to `LIKE` for simple meta values; system fields need the date/user handling from #13.
 
 ## 5. Inline-edit layout couplings `[internal]`
 

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -44,6 +44,10 @@ const ROW_DETAIL_MODAL_ENTER_MS = 200;
 const ROW_DETAIL_SIDE_TO_MODAL_HANDOFF_MS =
 	ROW_DETAIL_SIDE_SURFACE_EXIT_MS - ROW_DETAIL_MODAL_ENTER_MS;
 
+function hasActiveCalculations( view ) {
+	return Object.values( view?.calculations ?? {} ).some( Boolean );
+}
+
 function prefersReducedMotion() {
 	return (
 		typeof window !== 'undefined' &&
@@ -304,18 +308,21 @@ export default function CollectionDataViews( {
 
 	const {
 		data,
-		paginationInfo,
+		paginationInfo: serverPaginationInfo,
 		isLoading,
 		hasResolved: rowsResolved,
 		error: rowError,
 		refresh,
+		queryMode,
 	} = useCollectionRows(
 		isResolving ? null : collectionId,
 		reconciledView,
-		availableFields
+		availableFields,
+		{ forceClient: hasActiveCalculations( reconciledView ) }
 	);
 
 	const isTableLayout = view?.type === 'table';
+	const isServerPaginated = queryMode === 'server';
 	const dataViewFields = useMemo(
 		() =>
 			isTableLayout
@@ -355,16 +362,34 @@ export default function CollectionDataViews( {
 
 	const { data: dataFiltered, paginationInfo: clientPaginationInfo } =
 		useMemo( () => {
+			if ( isServerPaginated ) {
+				return {
+					data,
+					paginationInfo: serverPaginationInfo,
+				};
+			}
 			return filterSortAndPaginate( data, view, availableFields );
-		}, [ data, view, availableFields ] );
+		}, [
+			data,
+			view,
+			availableFields,
+			isServerPaginated,
+			serverPaginationInfo,
+		] );
 	const { data: dataFilteredForCalculations } = useMemo( () => {
+		if ( isServerPaginated ) {
+			return { data };
+		}
 		const calculationView = { ...( view ?? {} ) };
 		// tech-debt.md#36: summaries need the filtered row set before
 		// pagination, which DataViews does not expose as a separate result.
 		delete calculationView.page;
 		delete calculationView.perPage;
 		return filterSortAndPaginate( data, calculationView, availableFields );
-	}, [ data, view, availableFields ] );
+	}, [ data, view, availableFields, isServerPaginated ] );
+	const activePaginationInfo = isServerPaginated
+		? serverPaginationInfo
+		: clientPaginationInfo;
 
 	const requestNext = useCallback(
 		( rowId, fieldId, direction ) => {
@@ -456,7 +481,8 @@ export default function CollectionDataViews( {
 			const hasExplicitSort = Boolean( view?.sort?.field );
 			if ( ! hasExplicitSort ) {
 				const perPage = view?.perPage ?? 25;
-				const expectedTotal = ( paginationInfo?.totalItems ?? 0 ) + 1;
+				const expectedTotal =
+					( activePaginationInfo?.totalItems ?? 0 ) + 1;
 				const lastPage = Math.max(
 					1,
 					Math.ceil( expectedTotal / perPage )
@@ -473,7 +499,7 @@ export default function CollectionDataViews( {
 				setEditRequest( { rowId: created.id, fieldId: 'title' } );
 			}
 		},
-		[ refresh, view, paginationInfo, onChangeView ]
+		[ refresh, view, activePaginationInfo, onChangeView ]
 	);
 
 	const viewRef = useRef( view );
@@ -1013,7 +1039,7 @@ export default function CollectionDataViews( {
 							fields={ dataViewFields }
 							view={ view }
 							onChangeView={ onChangeView }
-							paginationInfo={ clientPaginationInfo }
+							paginationInfo={ activePaginationInfo }
 							defaultLayouts={ DEFAULT_LAYOUTS }
 							getItemId={ ( item ) => String( item.id ) }
 							isLoading={ isLoading }

--- a/src/components/relations/RelationEditor.js
+++ b/src/components/relations/RelationEditor.js
@@ -36,7 +36,12 @@ export default function RelationEditor( {
 		data,
 		isLoading,
 		refresh: refreshTargetRows,
-	} = useCollectionRows( targetCollectionId || null, RELATION_PICKER_VIEW );
+	} = useCollectionRows(
+		targetCollectionId || null,
+		RELATION_PICKER_VIEW,
+		[],
+		{ forceClient: true }
+	);
 	const createTitle = search.trim();
 
 	const rows = useMemo( () => {

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -9,16 +9,6 @@ const CLIENT_PER_PAGE = 100;
 const CLIENT_PAGE_FETCH_CONCURRENCY = 4;
 const SERVER_OPERATORS = new Set( [ 'is', 'isNot', 'isAny', 'isNone' ] );
 const SERVER_SORT_FIELDS = new Set( [ 'title', 'created_at', 'modified_at' ] );
-const SERVER_SORT_FIELD_TYPES = new Set( [
-	'text',
-	'number',
-	'email',
-	'url',
-	'select',
-	'date',
-	'datetime',
-	'checkbox',
-] );
 const SERVER_FILTER_FIELD_TYPES = new Set( [
 	'text',
 	'number',
@@ -62,17 +52,11 @@ function perPageNumber( value, fallback = 25 ) {
 	return Math.min( 100, Math.floor( number ) );
 }
 
-function isServerSupportedSort( sort, fieldTypes ) {
+function isServerSupportedSort( sort ) {
 	if ( ! sort?.field ) {
 		return true;
 	}
-	if ( SERVER_SORT_FIELDS.has( sort.field ) ) {
-		return true;
-	}
-	return (
-		isCollectionFieldKey( sort.field ) &&
-		SERVER_SORT_FIELD_TYPES.has( fieldTypes.get( sort.field ) )
-	);
+	return SERVER_SORT_FIELDS.has( sort.field );
 }
 
 function isServerSupportedFilter( filter, fieldTypes ) {
@@ -150,7 +134,7 @@ function buildQueryPlan( collectionId, view, fields = [], options = {} ) {
 		! options.forceClient &&
 		! hasSearch( view ) &&
 		! hasCalculations( view ) &&
-		isServerSupportedSort( view?.sort, fieldTypes ) &&
+		isServerSupportedSort( view?.sort ) &&
 		filters.every( ( filter ) =>
 			isServerSupportedFilter( filter, fieldTypes )
 		);

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -6,6 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 // its own fetch state and exposes a manual refresh() handle.
 
 const CLIENT_PER_PAGE = 100;
+const CLIENT_PAGE_FETCH_CONCURRENCY = 4;
 const SERVER_OPERATORS = new Set( [ 'is', 'isNot', 'isAny', 'isNone' ] );
 const SERVER_SORT_FIELDS = new Set( [ 'title', 'created_at', 'modified_at' ] );
 const SERVER_SORT_FIELD_TYPES = new Set( [
@@ -259,19 +260,47 @@ export default function useCollectionRows(
 					const rows = Array.isArray( firstPage.rows )
 						? [ ...firstPage.rows ]
 						: [];
+					const remainingPages = Array.from(
+						{ length: totalPages - 1 },
+						( _, index ) => index + 2
+					);
+					const remainingPageBodies = [];
+					let nextPageIndex = 0;
 
-					for ( let page = 2; page <= totalPages; page++ ) {
-						const nextPage = await fetchRowsPage( {
-							...activeQueryPlan.args,
-							page,
-						} );
-						if ( requestId !== requestIdRef.current ) {
-							return;
-						}
-						if ( Array.isArray( nextPage.rows ) ) {
-							rows.push( ...nextPage.rows );
+					async function fetchNextPages() {
+						while (
+							nextPageIndex < remainingPages.length &&
+							requestId === requestIdRef.current
+						) {
+							const index = nextPageIndex++;
+							const page = remainingPages[ index ];
+							const nextPage = await fetchRowsPage( {
+								...activeQueryPlan.args,
+								page,
+							} );
+							if ( requestId !== requestIdRef.current ) {
+								return;
+							}
+							remainingPageBodies[ index ] = nextPage;
 						}
 					}
+
+					const workerCount = Math.min(
+						CLIENT_PAGE_FETCH_CONCURRENCY,
+						remainingPages.length
+					);
+					await Promise.all(
+						Array.from( { length: workerCount }, fetchNextPages )
+					);
+					if ( requestId !== requestIdRef.current ) {
+						return;
+					}
+
+					remainingPageBodies.forEach( ( nextPage ) => {
+						if ( Array.isArray( nextPage?.rows ) ) {
+							rows.push( ...nextPage.rows );
+						}
+					} );
 
 					body = { ...firstPage, rows };
 				}

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -5,28 +5,105 @@ import apiFetch from '@wordpress/api-fetch';
 // tech-debt.md#2: rows live outside core-data, so this hook manages
 // its own fetch state and exposes a manual refresh() handle.
 
+const CLIENT_PER_PAGE = 100;
 const SERVER_OPERATORS = new Set( [ 'is', 'isNot', 'isAny', 'isNone' ] );
+const SERVER_SORT_FIELDS = new Set( [ 'title', 'created_at', 'modified_at' ] );
+const SERVER_SORT_FIELD_TYPES = new Set( [
+	'text',
+	'number',
+	'email',
+	'url',
+	'select',
+	'date',
+	'datetime',
+	'checkbox',
+] );
+const SERVER_FILTER_FIELD_TYPES = new Set( [
+	'text',
+	'number',
+	'email',
+	'url',
+	'select',
+	'multiselect',
+	'date',
+	'datetime',
+	'checkbox',
+] );
 
-function buildQueryArgs( collectionId, view, fields = [] ) {
-	const args = {
-		collection: collectionId,
-		per_page: -1,
-	};
-	const fieldTypes = new Map(
-		fields.map( ( f ) => [ f.id, f.cortextType ] )
-	);
+function fieldTypeMap( fields = [] ) {
+	return new Map( fields.map( ( f ) => [ f.id, f.cortextType ] ) );
+}
 
-	// Ignore filters that the server isn't equipped to honor, otherwise
-	// changes in `view` will result in a new query to be requested from the
-	// server, even though the results will be the same.
-	const serverFilters = ( view?.filters ?? [] ).filter(
-		( f ) =>
-			f.field &&
-			f.operator &&
-			SERVER_OPERATORS.has( f.operator ) &&
-			fieldTypes.get( f.field ) !== 'rollup'
+function hasSearch( view ) {
+	return Boolean( String( view?.search ?? '' ).trim() );
+}
+
+function hasCalculations( view ) {
+	return Object.values( view?.calculations ?? {} ).some( Boolean );
+}
+
+function isCollectionFieldKey( field ) {
+	return /^field-\d+$/.test( field );
+}
+
+function pageNumber( value, fallback = 1 ) {
+	const number = Number( value );
+	return Number.isFinite( number ) && number >= 1
+		? Math.floor( number )
+		: fallback;
+}
+
+function perPageNumber( value, fallback = 25 ) {
+	const number = Number( value );
+	if ( ! Number.isFinite( number ) || number < 1 ) {
+		return fallback;
+	}
+	return Math.min( 100, Math.floor( number ) );
+}
+
+function isServerSupportedSort( sort, fieldTypes ) {
+	if ( ! sort?.field ) {
+		return true;
+	}
+	if ( SERVER_SORT_FIELDS.has( sort.field ) ) {
+		return true;
+	}
+	return (
+		isCollectionFieldKey( sort.field ) &&
+		SERVER_SORT_FIELD_TYPES.has( fieldTypes.get( sort.field ) )
 	);
-	serverFilters.forEach( ( filter, i ) => {
+}
+
+function isServerSupportedFilter( filter, fieldTypes ) {
+	if (
+		! filter ||
+		typeof filter !== 'object' ||
+		! filter.field ||
+		! filter.operator ||
+		! SERVER_OPERATORS.has( filter.operator )
+	) {
+		return false;
+	}
+	if (
+		( filter.operator === 'isAny' || filter.operator === 'isNone' ) &&
+		( ! Array.isArray( filter.value ) || filter.value.length === 0 )
+	) {
+		return false;
+	}
+	if (
+		( filter.operator === 'is' || filter.operator === 'isNot' ) &&
+		( filter.value === undefined || Array.isArray( filter.value ) )
+	) {
+		return false;
+	}
+	return (
+		isCollectionFieldKey( filter.field ) &&
+		SERVER_FILTER_FIELD_TYPES.has( fieldTypes.get( filter.field ) )
+	);
+}
+
+function addFiltersToArgs( args, filters ) {
+	filters.forEach( ( filter, i ) => {
 		args[ `filters[${ i }][field]` ] = filter.field;
 		args[ `filters[${ i }][operator]` ] = filter.operator;
 		if ( Array.isArray( filter.value ) ) {
@@ -37,8 +114,57 @@ function buildQueryArgs( collectionId, view, fields = [] ) {
 			args[ `filters[${ i }][value]` ] = filter.value;
 		}
 	} );
+}
+
+function buildClientQueryArgs( collectionId ) {
+	return {
+		collection: collectionId,
+		page: 1,
+		per_page: CLIENT_PER_PAGE,
+	};
+}
+
+function buildServerQueryArgs( collectionId, view ) {
+	const args = {
+		collection: collectionId,
+		page: pageNumber( view?.page ),
+		per_page: perPageNumber( view?.perPage ),
+	};
+
+	if ( view?.sort?.field ) {
+		args[ 'sort[field]' ] = view.sort.field;
+		args[ 'sort[direction]' ] =
+			view.sort.direction === 'asc' ? 'asc' : 'desc';
+	}
+
+	addFiltersToArgs( args, view?.filters ?? [] );
 
 	return args;
+}
+
+function buildQueryPlan( collectionId, view, fields = [], options = {} ) {
+	const fieldTypes = fieldTypeMap( fields );
+	const filters = Array.isArray( view?.filters ) ? view.filters : [];
+	const canUseServer =
+		! options.forceClient &&
+		! hasSearch( view ) &&
+		! hasCalculations( view ) &&
+		isServerSupportedSort( view?.sort, fieldTypes ) &&
+		filters.every( ( filter ) =>
+			isServerSupportedFilter( filter, fieldTypes )
+		);
+
+	if ( ! canUseServer ) {
+		return {
+			mode: 'client',
+			args: buildClientQueryArgs( collectionId ),
+		};
+	}
+
+	return {
+		mode: 'server',
+		args: buildServerQueryArgs( collectionId, view ),
+	};
 }
 
 function schemaSignature( fields = [] ) {
@@ -52,7 +178,23 @@ function schemaSignature( fields = [] ) {
 		.join( '|' );
 }
 
-export default function useCollectionRows( collectionId, view, fields = [] ) {
+function totalPagesNumber( value ) {
+	const number = Number( value );
+	return Number.isFinite( number ) && number >= 1 ? Math.floor( number ) : 1;
+}
+
+async function fetchRowsPage( args ) {
+	return apiFetch( {
+		path: addQueryArgs( '/cortext/v1/rows', args ),
+	} );
+}
+
+export default function useCollectionRows(
+	collectionId,
+	view,
+	fields = [],
+	options = {}
+) {
 	const [ state, setState ] = useState( {
 		data: [],
 		collection: null,
@@ -64,10 +206,14 @@ export default function useCollectionRows( collectionId, view, fields = [] ) {
 	const [ refreshKey, setRefreshKey ] = useState( 0 );
 
 	const requestIdRef = useRef( 0 );
+	const queryPlan = collectionId
+		? buildQueryPlan( collectionId, view, fields, options )
+		: null;
 	const queryKey = collectionId
 		? JSON.stringify( {
-				args: buildQueryArgs( collectionId, view, fields ),
+				args: queryPlan.args,
 				schema: schemaSignature( fields ),
+				mode: queryPlan.mode,
 		  } )
 		: null;
 
@@ -91,10 +237,7 @@ export default function useCollectionRows( collectionId, view, fields = [] ) {
 		}
 
 		const requestId = ++requestIdRef.current;
-		const path = addQueryArgs(
-			'/cortext/v1/rows',
-			buildQueryArgs( collectionId, view, fields )
-		);
+		const activeQueryPlan = queryPlan;
 
 		setState( ( prev ) => ( {
 			...prev,
@@ -103,11 +246,36 @@ export default function useCollectionRows( collectionId, view, fields = [] ) {
 			error: null,
 		} ) );
 
-		apiFetch( { path } )
-			.then( ( body ) => {
+		async function loadRows() {
+			try {
+				const firstPage = await fetchRowsPage( activeQueryPlan.args );
 				if ( requestId !== requestIdRef.current ) {
 					return;
 				}
+
+				let body = firstPage;
+				if ( activeQueryPlan.mode === 'client' ) {
+					const totalPages = totalPagesNumber( firstPage.totalPages );
+					const rows = Array.isArray( firstPage.rows )
+						? [ ...firstPage.rows ]
+						: [];
+
+					for ( let page = 2; page <= totalPages; page++ ) {
+						const nextPage = await fetchRowsPage( {
+							...activeQueryPlan.args,
+							page,
+						} );
+						if ( requestId !== requestIdRef.current ) {
+							return;
+						}
+						if ( Array.isArray( nextPage.rows ) ) {
+							rows.push( ...nextPage.rows );
+						}
+					}
+
+					body = { ...firstPage, rows };
+				}
+
 				setState( {
 					data: Array.isArray( body.rows ) ? body.rows : [],
 					collection: body.collection ?? null,
@@ -119,8 +287,7 @@ export default function useCollectionRows( collectionId, view, fields = [] ) {
 					hasResolved: true,
 					error: null,
 				} );
-			} )
-			.catch( ( error ) => {
+			} catch ( error ) {
 				if ( requestId !== requestIdRef.current ) {
 					return;
 				}
@@ -132,11 +299,14 @@ export default function useCollectionRows( collectionId, view, fields = [] ) {
 					hasResolved: true,
 					error,
 				} );
-			} );
+			}
+		}
+
+		loadRows();
 
 		return undefined;
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ collectionId, queryKey, refreshKey ] );
 
-	return { ...state, refresh };
+	return { ...state, refresh, queryMode: queryPlan?.mode ?? 'client' };
 }

--- a/tests/js/components/relations/RelationEditor.test.js
+++ b/tests/js/components/relations/RelationEditor.test.js
@@ -55,7 +55,9 @@ describe( 'RelationEditor', () => {
 		await waitFor( () => expect( onSave ).toHaveBeenCalledWith( [ 22 ] ) );
 		expect( useCollectionRows ).toHaveBeenCalledWith(
 			9,
-			expect.objectContaining( { type: 'table' } )
+			expect.objectContaining( { type: 'table' } ),
+			[],
+			{ forceClient: true }
 		);
 	} );
 

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -136,6 +136,59 @@ describe( 'useCollectionRows', () => {
 		expect( result.current.queryMode ).toBe( 'client' );
 	} );
 
+	it( 'fetches remaining client-mode pages in parallel', async () => {
+		const resolvers = new Map();
+		apiFetch.mockImplementation( ( { path } ) => {
+			const page = Number(
+				new URL( path, 'https://example.test' ).searchParams.get(
+					'page'
+				)
+			);
+			if ( page === 1 ) {
+				return Promise.resolve( {
+					rows: [ { id: 1 } ],
+					collection: null,
+					total: 4,
+					totalPages: 4,
+				} );
+			}
+			return new Promise( ( resolve ) => {
+				resolvers.set( page, () =>
+					resolve( {
+						rows: [ { id: page } ],
+						collection: null,
+						total: 4,
+						totalPages: 4,
+					} )
+				);
+			} );
+		} );
+
+		const view = {
+			type: 'table',
+			filters: [],
+			page: 1,
+			perPage: 25,
+			search: 'ada',
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 4 ) );
+
+		resolvers.get( 4 )();
+		resolvers.get( 2 )();
+		resolvers.get( 3 )();
+
+		await waitFor( () =>
+			expect( result.current.data.map( ( row ) => row.id ) ).toEqual( [
+				1, 2, 3, 4,
+			] )
+		);
+	} );
+
 	it( 'falls back to paged client mode for unsupported filters and sorts', async () => {
 		const view = {
 			type: 'table',

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -248,6 +248,29 @@ describe( 'useCollectionRows', () => {
 		expect( lastRequestPath() ).not.toContain( 'created_by' );
 	} );
 
+	it( 'falls back for custom field sorts', async () => {
+		const view = {
+			type: 'table',
+			filters: [],
+			sort: {
+				field: 'field-10',
+				direction: 'asc',
+			},
+			page: 1,
+			perPage: 25,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+		expect( lastRequestPath() ).toContain( 'page=1' );
+		expect( lastRequestPath() ).toContain( 'per_page=100' );
+		expect( lastRequestPath() ).not.toContain( 'sort[field]' );
+	} );
+
 	it( 'falls back for incomplete multi-value filters', async () => {
 		const view = {
 			type: 'table',

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -18,7 +18,281 @@ beforeEach( () => {
 	} );
 } );
 
+function lastRequestPath() {
+	return decodeURIComponent( apiFetch.mock.calls.at( -1 )[ 0 ].path );
+}
+
+const baseFields = [
+	{ id: 'title', cortextType: 'title' },
+	{ id: 'created_by', cortextType: 'text' },
+	{ id: 'field-10', recordId: 10, cortextType: 'text' },
+	{ id: 'field-20', recordId: 20, cortextType: 'rollup' },
+];
+
 describe( 'useCollectionRows', () => {
+	it( 'requests the current server page by default', async () => {
+		const view = {
+			type: 'table',
+			filters: [],
+			page: 2,
+			perPage: 50,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'server' );
+		expect( lastRequestPath() ).toContain( 'collection=7' );
+		expect( lastRequestPath() ).toContain( 'page=2' );
+		expect( lastRequestPath() ).toContain( 'per_page=50' );
+	} );
+
+	it( 'refetches when the current server page changes', async () => {
+		const { rerender } = renderHook(
+			( { view } ) => useCollectionRows( 7, view, baseFields ),
+			{
+				initialProps: {
+					view: {
+						type: 'table',
+						filters: [],
+						page: 1,
+						perPage: 25,
+					},
+				},
+			}
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+
+		rerender( {
+			view: {
+				type: 'table',
+				filters: [],
+				page: 3,
+				perPage: 100,
+			},
+		} );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		expect( lastRequestPath() ).toContain( 'page=3' );
+		expect( lastRequestPath() ).toContain( 'per_page=100' );
+	} );
+
+	it( 'falls back to paged client mode for global search', async () => {
+		const view = {
+			type: 'table',
+			filters: [],
+			page: 2,
+			perPage: 50,
+			search: 'ada',
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+		expect( lastRequestPath() ).toContain( 'collection=7' );
+		expect( lastRequestPath() ).toContain( 'page=1' );
+		expect( lastRequestPath() ).toContain( 'per_page=100' );
+		expect( lastRequestPath() ).not.toContain( 'search=ada' );
+	} );
+
+	it( 'accumulates every server page in client mode', async () => {
+		apiFetch.mockImplementation( ( { path } ) => {
+			const page = Number(
+				new URL( path, 'https://example.test' ).searchParams.get(
+					'page'
+				)
+			);
+			return Promise.resolve( {
+				rows: [ { id: page } ],
+				collection: null,
+				total: 3,
+				totalPages: 3,
+			} );
+		} );
+
+		const view = {
+			type: 'table',
+			filters: [],
+			page: 1,
+			perPage: 25,
+			search: 'ada',
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( result.current.data ).toHaveLength( 3 ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 3 );
+		expect( result.current.data.map( ( row ) => row.id ) ).toEqual( [
+			1, 2, 3,
+		] );
+		expect( result.current.queryMode ).toBe( 'client' );
+	} );
+
+	it( 'falls back to paged client mode for unsupported filters and sorts', async () => {
+		const view = {
+			type: 'table',
+			filters: [
+				{
+					field: 'field-10',
+					operator: 'contains',
+					value: 'red',
+				},
+			],
+			sort: {
+				field: 'field-20',
+				direction: 'asc',
+			},
+			page: 2,
+			perPage: 50,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+		expect( lastRequestPath() ).toContain( 'page=1' );
+		expect( lastRequestPath() ).toContain( 'per_page=100' );
+		expect( lastRequestPath() ).not.toContain( 'filters[0][field]' );
+		expect( lastRequestPath() ).not.toContain( 'sort[field]' );
+	} );
+
+	it( 'falls back for text-like system fields the server rejects', async () => {
+		const view = {
+			type: 'table',
+			filters: [
+				{
+					field: 'created_by',
+					operator: 'is',
+					value: 'Ada',
+				},
+			],
+			sort: {
+				field: 'created_by',
+				direction: 'asc',
+			},
+			page: 1,
+			perPage: 25,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+		expect( lastRequestPath() ).toContain( 'page=1' );
+		expect( lastRequestPath() ).toContain( 'per_page=100' );
+		expect( lastRequestPath() ).not.toContain( 'created_by' );
+	} );
+
+	it( 'falls back for incomplete multi-value filters', async () => {
+		const view = {
+			type: 'table',
+			filters: [
+				{
+					field: 'field-10',
+					operator: 'isAny',
+					value: [],
+				},
+			],
+			page: 1,
+			perPage: 25,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+		expect( lastRequestPath() ).toContain( 'page=1' );
+		expect( lastRequestPath() ).toContain( 'per_page=100' );
+		expect( lastRequestPath() ).not.toContain( 'filters[0][field]' );
+	} );
+
+	it( 'falls back to paged client mode when calculations are active', async () => {
+		const view = {
+			type: 'table',
+			filters: [],
+			calculations: {
+				'field-10': 'count',
+			},
+			page: 1,
+			perPage: 25,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+		expect( lastRequestPath() ).toContain( 'page=1' );
+		expect( lastRequestPath() ).toContain( 'per_page=100' );
+	} );
+
+	it( 'forwards supported filters and sort in server mode', async () => {
+		const view = {
+			type: 'table',
+			filters: [
+				{
+					field: 'field-10',
+					operator: 'is',
+					value: 'red',
+				},
+			],
+			sort: {
+				field: 'title',
+				direction: 'asc',
+			},
+			page: 1,
+			perPage: 25,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'server' );
+		expect( lastRequestPath() ).toContain( 'sort[field]=title' );
+		expect( lastRequestPath() ).toContain( 'sort[direction]=asc' );
+		expect( lastRequestPath() ).toContain(
+			'filters[0][field]=field-10'
+		);
+		expect( lastRequestPath() ).toContain( 'filters[0][operator]=is' );
+		expect( lastRequestPath() ).toContain( 'filters[0][value]=red' );
+	} );
+
+	it( 'supports forced paged client mode for relation pickers', async () => {
+		const view = {
+			type: 'table',
+			filters: [],
+			page: 1,
+			perPage: 25,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields, { forceClient: true } )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+		expect( lastRequestPath() ).toContain( 'collection=7' );
+		expect( lastRequestPath() ).toContain( 'page=1' );
+		expect( lastRequestPath() ).toContain( 'per_page=100' );
+	} );
+
 	it( 'refetches rows when the visible schema gains a rollup field', async () => {
 		const view = { type: 'table', filters: [] };
 		const initialFields = [

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -229,6 +229,21 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertIsArray( $data['fields'] );
 	}
 
+	public function test_rejects_legacy_all_rows_per_page_sentinel(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$fixture = $this->create_collection_fixture( 'allrows' );
+
+		$response = $this->query_rows(
+			array(
+				'collection' => $fixture['collection_id'],
+				'per_page'   => -1,
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
 	public function test_field_definitions_in_response(): void {
 		wp_set_current_user( $this->create_user( 'author' ) );
 


### PR DESCRIPTION
## What

Closes #127

This moves the normal collection table path to server-backed pagination. When the rows endpoint can handle the current view, the client now requests only the page it is showing instead of loading the whole collection first.

Some views still need the old client-side path: search, active calculations, unsupported filters or sorts, and relation pickers still need the full row set locally for now. In those cases, we still load all rows, but we do it by walking valid pages of up to 100 rows instead of sending `per_page=-1`.

## Why

`per_page=-1` was being used as an “all rows” shortcut, but the rows endpoint does not actually define that as valid REST input. Its schema only allows `per_page` values from `1` to `100`.

This PR gives the common browsing path real pagination now, and keeps the fallback path correct without depending on an invalid request.

## How

The row hook now chooses a mode for each view:

- Server mode sends `page`, `per_page`, supported sort, and supported filters to `/cortext/v1/rows`.
- Client mode fetches row pages in batches of 100, combines them, then runs the existing DataViews filtering, sorting, pagination, and calculations.
- Relation pickers stay in client mode until they have their own server-backed search/pagination.
- A PHP test locks in the current REST behavior for `per_page=-1`.

## Testing Instructions

1. Open a collection with enough rows to show more than one page.
2. With no search, calculations, or unsupported filters active, open DevTools Network and inspect `/cortext/v1/rows`.
3. Confirm the request uses the visible page and page size, for example `page=1&per_page=25`.
4. Move to page 2 and confirm the next `/rows` request uses `page=2`.
5. Add a global search or active calculation and reload the view.
6. Confirm fallback mode requests rows in batches like `page=1&per_page=100`, followed by more pages if needed.
7. Open a relation picker and confirm it also uses the paged client fallback.