### PR TITLE
Add collapsible sidebar sections

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -64,6 +64,7 @@ import SidebarFavorites, {
 } from './SidebarFavorites';
 import SidebarResizeHandle from './SidebarResizeHandle';
 import SidebarRecents from './SidebarRecents';
+import SidebarSection from './SidebarSection';
 import SidebarTrash from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
 import {
@@ -87,6 +88,7 @@ import {
 import { COLLECTION_QUERY } from '../collections';
 import { useFavorites } from '../hooks/useFavorites';
 import { useRecents } from '../hooks/useRecents';
+import useSidebarSections from '../hooks/useSidebarSections';
 import { useWorkspaceHomePath } from '../hooks/useWorkspaceHomePath';
 
 const AUTO_EXPAND_DELAY = 700;
@@ -165,6 +167,7 @@ export default function Sidebar( {
 	const [ favoritesError, setFavoritesError ] = useState( null );
 	const areFavoriteActionsDisabled =
 		isResolvingFavorites || isUpdatingFavorites;
+	const { isSectionCollapsed, toggleSection } = useSidebarSections();
 
 	// Keep the URL canonical: once autosave assigns a slug to the active
 	// page (draft → private promotion on first titled save), rewrite
@@ -674,164 +677,195 @@ export default function Sidebar( {
 							{ favoritesError }
 						</Notice>
 					) : null }
-					<SidebarFavorites
-						favorites={ favorites }
-						pages={ pages }
-						collections={ collections ?? [] }
-						isResolving={ isResolvingFavorites }
-						isResolvingItems={
-							isResolvingPages || isResolvingCollections
-						}
-						isDisabled={ areFavoriteActionsDisabled }
-						onSelect={ selectFavorite }
-						onRemove={ ( favorite ) =>
-							toggleFavorite( favorite.kind, favorite.id )
-						}
-						onReorder={ reorderFavorites }
-					/>
-					<SidebarRecents />
-
-					<div className="cortext-sidebar__section-header">
-						<h2 className="cortext-sidebar__section-title">
-							{ __( 'Pages', 'cortext' ) }
-						</h2>
-						<Button
-							className="cortext-sidebar__section-action"
-							icon={ plus }
-							size="small"
-							label={ __( 'New page', 'cortext' ) }
-							onClick={ createRootPage }
-						/>
-					</div>
-					{ isResolvingPages && pages.length === 0 && (
-						<div className="cortext-sidebar__loading">
-							<Spinner />
-						</div>
-					) }
-					{ ! isResolvingPages && pages.length === 0 && (
-						<p className="cortext-sidebar__empty">
-							{ __( 'No pages yet.', 'cortext' ) }
-						</p>
-					) }
-
-					<DndContext
-						sensors={ sensors }
-						collisionDetection={ pointerWithin }
-						onDragStart={ handleDragStart }
-						onDragOver={ handleDragOver }
-						onDragEnd={ handleDragEnd }
-						onDragCancel={ handleDragCancel }
+					<SidebarSection
+						id="recents"
+						title={ __( 'Recents', 'cortext' ) }
+						isCollapsed={ isSectionCollapsed( 'recents' ) }
+						onToggle={ () => toggleSection( 'recents' ) }
 					>
-						<ul className="cortext-sidebar__list">
-							{ tree.map( ( node ) => (
-								<PageRow
-									key={ node.page.id }
-									node={ node }
-									depth={ 0 }
-									selectedId={ selectedId }
-									expandedIds={ expandedIds }
-									draggedId={ draggedId }
-									activeDrop={ activeDrop }
-									onSelect={ onSelect }
-									onToggleExpand={ toggleExpand }
-									onCreateChild={ createChildPage }
-									onRename={ renamePage }
-									onDuplicate={ duplicatePage }
-									onDelete={ trashPage }
-									isFavorite={ isPageFavorite }
-									isFavoriteDisabled={
-										areFavoriteActionsDisabled
-									}
-									onToggleFavorite={ ( id ) =>
-										toggleFavorite( 'page', id )
-									}
-									onSetHome={ setPageHome }
-									home={ home }
-									isHomeUpdating={ isHomeUpdating }
-									autoRenameId={ autoRenameId }
-									onAutoRenameConsumed={ () =>
-										setAutoRenameId( null )
-									}
-								/>
-							) ) }
-						</ul>
+						<SidebarRecents />
+					</SidebarSection>
 
-						<DragOverlay>
-							{ draggedPage ? (
-								<div className="cortext-sidebar__drag-preview">
-									{ draggedPage.title?.rendered?.trim() ||
-										__( '(untitled)', 'cortext' ) }
-								</div>
-							) : null }
-						</DragOverlay>
-					</DndContext>
-
-					<div className="cortext-sidebar__section-header">
-						<h2 className="cortext-sidebar__section-title">
-							{ __( 'Collections', 'cortext' ) }
-						</h2>
-						<Button
-							className="cortext-sidebar__section-action"
-							icon={ plus }
-							size="small"
-							label={ __( 'New collection', 'cortext' ) }
-							onClick={ createRootCollection }
+					<SidebarSection
+						id="favorites"
+						title={ __( 'Favorites', 'cortext' ) }
+						isCollapsed={ isSectionCollapsed( 'favorites' ) }
+						onToggle={ () => toggleSection( 'favorites' ) }
+					>
+						<SidebarFavorites
+							favorites={ favorites }
+							pages={ pages }
+							collections={ collections ?? [] }
+							isResolving={ isResolvingFavorites }
+							isResolvingItems={
+								isResolvingPages || isResolvingCollections
+							}
+							isDisabled={ areFavoriteActionsDisabled }
+							onSelect={ selectFavorite }
+							onRemove={ ( favorite ) =>
+								toggleFavorite( favorite.kind, favorite.id )
+							}
+							onReorder={ reorderFavorites }
 						/>
-					</div>
-					{ isResolvingCollections && ! collections?.length && (
-						<div className="cortext-sidebar__loading">
-							<Spinner />
-						</div>
-					) }
-					{ ! isResolvingCollections && ! collections?.length && (
-						<p className="cortext-sidebar__empty">
-							{ __( 'No collections yet.', 'cortext' ) }
-						</p>
-					) }
-					{ collections?.length > 0 && (
-						<ul className="cortext-sidebar__list">
-							{ collections.map( ( collection ) => (
-								<CollectionRow
-									key={ collection.id }
-									collection={ collection }
-									isSelected={
-										selectedCollectionId === collection.id
-									}
-									isHome={
-										home?.kind === 'collection' &&
-										home.id === collection.id
-									}
-									isFavorite={ isCollectionFavorite(
-										collection.id
-									) }
-									isFavoriteDisabled={
-										areFavoriteActionsDisabled
-									}
-									isHomeUpdating={ isHomeUpdating }
-									onToggleFavorite={ ( id ) =>
-										toggleFavorite( 'collection', id )
-									}
-									onSetHome={ setCollectionHome }
-									onSelect={ () =>
-										navigate( {
-											to: '/$',
-											params: {
-												_splat: computeCollectionUri(
-													collection
-												),
-											},
-										} )
-									}
-								/>
-							) ) }
-						</ul>
-					) }
+					</SidebarSection>
 
-					<SidebarTrash
-						activePages={ pages }
-						selectedId={ selectedId }
-						onSelect={ onSelect }
-					/>
+					<SidebarSection
+						id="pages"
+						title={ __( 'Pages', 'cortext' ) }
+						isCollapsed={ isSectionCollapsed( 'pages' ) }
+						onToggle={ () => toggleSection( 'pages' ) }
+						actions={
+							<Button
+								className="cortext-sidebar__section-action"
+								icon={ plus }
+								size="small"
+								label={ __( 'New page', 'cortext' ) }
+								onClick={ createRootPage }
+							/>
+						}
+					>
+						{ isResolvingPages && pages.length === 0 && (
+							<div className="cortext-sidebar__loading">
+								<Spinner />
+							</div>
+						) }
+						{ ! isResolvingPages && pages.length === 0 && (
+							<p className="cortext-sidebar__empty">
+								{ __( 'No pages yet.', 'cortext' ) }
+							</p>
+						) }
+
+						<DndContext
+							sensors={ sensors }
+							collisionDetection={ pointerWithin }
+							onDragStart={ handleDragStart }
+							onDragOver={ handleDragOver }
+							onDragEnd={ handleDragEnd }
+							onDragCancel={ handleDragCancel }
+						>
+							<ul className="cortext-sidebar__list">
+								{ tree.map( ( node ) => (
+									<PageRow
+										key={ node.page.id }
+										node={ node }
+										depth={ 0 }
+										selectedId={ selectedId }
+										expandedIds={ expandedIds }
+										draggedId={ draggedId }
+										activeDrop={ activeDrop }
+										onSelect={ onSelect }
+										onToggleExpand={ toggleExpand }
+										onCreateChild={ createChildPage }
+										onRename={ renamePage }
+										onDuplicate={ duplicatePage }
+										onDelete={ trashPage }
+										isFavorite={ isPageFavorite }
+										isFavoriteDisabled={
+											areFavoriteActionsDisabled
+										}
+										onToggleFavorite={ ( id ) =>
+											toggleFavorite( 'page', id )
+										}
+										onSetHome={ setPageHome }
+										home={ home }
+										isHomeUpdating={ isHomeUpdating }
+										autoRenameId={ autoRenameId }
+										onAutoRenameConsumed={ () =>
+											setAutoRenameId( null )
+										}
+									/>
+								) ) }
+							</ul>
+
+							<DragOverlay>
+								{ draggedPage ? (
+									<div className="cortext-sidebar__drag-preview">
+										{ draggedPage.title?.rendered?.trim() ||
+											__( '(untitled)', 'cortext' ) }
+									</div>
+								) : null }
+							</DragOverlay>
+						</DndContext>
+					</SidebarSection>
+
+					<SidebarSection
+						id="collections"
+						title={ __( 'Collections', 'cortext' ) }
+						isCollapsed={ isSectionCollapsed( 'collections' ) }
+						onToggle={ () => toggleSection( 'collections' ) }
+						actions={
+							<Button
+								className="cortext-sidebar__section-action"
+								icon={ plus }
+								size="small"
+								label={ __( 'New collection', 'cortext' ) }
+								onClick={ createRootCollection }
+							/>
+						}
+					>
+						{ isResolvingCollections && ! collections?.length && (
+							<div className="cortext-sidebar__loading">
+								<Spinner />
+							</div>
+						) }
+						{ ! isResolvingCollections && ! collections?.length && (
+							<p className="cortext-sidebar__empty">
+								{ __( 'No collections yet.', 'cortext' ) }
+							</p>
+						) }
+						{ collections?.length > 0 && (
+							<ul className="cortext-sidebar__list">
+								{ collections.map( ( collection ) => (
+									<CollectionRow
+										key={ collection.id }
+										collection={ collection }
+										isSelected={
+											selectedCollectionId ===
+											collection.id
+										}
+										isHome={
+											home?.kind === 'collection' &&
+											home.id === collection.id
+										}
+										isFavorite={ isCollectionFavorite(
+											collection.id
+										) }
+										isFavoriteDisabled={
+											areFavoriteActionsDisabled
+										}
+										isHomeUpdating={ isHomeUpdating }
+										onToggleFavorite={ ( id ) =>
+											toggleFavorite( 'collection', id )
+										}
+										onSetHome={ setCollectionHome }
+										onSelect={ () =>
+											navigate( {
+												to: '/$',
+												params: {
+													_splat: computeCollectionUri(
+														collection
+													),
+												},
+											} )
+										}
+									/>
+								) ) }
+							</ul>
+						) }
+					</SidebarSection>
+
+					<SidebarSection
+						id="trash"
+						title={ __( 'Trash', 'cortext' ) }
+						isCollapsed={ isSectionCollapsed( 'trash' ) }
+						onToggle={ () => toggleSection( 'trash' ) }
+					>
+						<SidebarTrash
+							activePages={ pages }
+							selectedId={ selectedId }
+							onSelect={ onSelect }
+						/>
+					</SidebarSection>
 				</div>
 			) }
 			<div className="cortext-sidebar__footer">

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -393,10 +393,6 @@ export default function SidebarFavorites( {
 		};
 	}, [] );
 
-	if ( ! isResolving && displayFavorites.length === 0 ) {
-		return null;
-	}
-
 	const handleDragEnd = ( { active, over } ) => {
 		if ( isDisabled ) {
 			return;
@@ -418,18 +414,26 @@ export default function SidebarFavorites( {
 		}
 		onRemove( item );
 	};
+	const hasFavorites = favorites.length > 0;
+	const isLoading =
+		isResolving ||
+		( hasFavorites && isResolvingItems && items.length === 0 );
+	const isEmpty = ! isLoading && ! hasFavorites;
 
 	return (
 		<div className="cortext-sidebar__favorites">
-			<div className="cortext-sidebar__section-header">
-				<h2 className="cortext-sidebar__section-title">
-					{ __( 'Favorites', 'cortext' ) }
-				</h2>
-			</div>
-			{ ( isResolving || isResolvingItems ) && items.length === 0 ? (
+			{ isLoading ? (
 				<div className="cortext-sidebar__loading">
 					<Spinner />
 				</div>
+			) : null }
+			{ isEmpty ? (
+				<p className="cortext-sidebar__empty cortext-sidebar__empty--inline">
+					{ __(
+						'Star a page from its title menu to pin it here.',
+						'cortext'
+					) }
+				</p>
 			) : null }
 			{ items.length > 0 ? (
 				<DndContext

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -154,11 +154,6 @@ export default function SidebarRecents() {
 
 	return (
 		<>
-			<div className="cortext-sidebar__section-header cortext-sidebar__section-header--recents">
-				<h2 className="cortext-sidebar__section-title">
-					{ __( 'Recents', 'cortext' ) }
-				</h2>
-			</div>
 			{ isResolving && recents.length === 0 && (
 				<div className="cortext-sidebar__loading">
 					<Spinner />

--- a/src/components/SidebarSection.js
+++ b/src/components/SidebarSection.js
@@ -1,0 +1,66 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+export default function SidebarSection( {
+	id,
+	title,
+	isCollapsed,
+	onToggle,
+	actions = null,
+	children,
+} ) {
+	const bodyId = `cortext-sidebar-section-${ id }`;
+	const isExpanded = ! isCollapsed;
+	const label = isCollapsed
+		? sprintf(
+				/* translators: %s: sidebar section title */
+				__( 'Expand %s', 'cortext' ),
+				title
+		  )
+		: sprintf(
+				/* translators: %s: sidebar section title */
+				__( 'Collapse %s', 'cortext' ),
+				title
+		  );
+
+	return (
+		<section
+			className={ `cortext-sidebar__section cortext-sidebar__section--${ id }` }
+			data-sidebar-section={ id }
+			data-section-collapsed={ isCollapsed ? 'true' : 'false' }
+		>
+			<div className="cortext-sidebar__section-header">
+				<h2 className="cortext-sidebar__section-title">
+					<Button
+						className="cortext-sidebar__section-title-button"
+						size="small"
+						variant="tertiary"
+						label={ label }
+						aria-expanded={ isExpanded }
+						aria-controls={ bodyId }
+						onClick={ onToggle }
+					>
+						{ title }
+					</Button>
+				</h2>
+				{ actions ? (
+					<div className="cortext-sidebar__section-actions">
+						{ actions }
+					</div>
+				) : null }
+			</div>
+			<div
+				className={
+					'cortext-sidebar__section-body-wrapper' +
+					( isExpanded ? ' is-expanded' : '' )
+				}
+				aria-hidden={ isCollapsed ? 'true' : undefined }
+				{ ...( isCollapsed ? { inert: '' } : {} ) }
+			>
+				<div id={ bodyId } className="cortext-sidebar__section-body">
+					{ children }
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -231,10 +231,6 @@ export default function SidebarTrash( { activePages, selectedId, onSelect } ) {
 
 	return (
 		<>
-			<h2 className="cortext-sidebar__section-title">
-				{ __( 'Trash', 'cortext' ) }
-			</h2>
-
 			{ isLoading && (
 				<div className="cortext-sidebar__loading">
 					<Spinner />

--- a/src/hooks/useSidebarSections.js
+++ b/src/hooks/useSidebarSections.js
@@ -1,0 +1,105 @@
+import { useCallback, useState } from '@wordpress/element';
+
+export const SIDEBAR_SECTIONS_COLLAPSED_KEY =
+	'cortext.sidebarSectionsCollapsed';
+
+export const SIDEBAR_SECTION_DEFAULTS = {
+	recents: true,
+	favorites: false,
+	pages: false,
+	collections: false,
+	trash: false,
+};
+
+export function normalizeSidebarSectionsCollapsed( value ) {
+	let parsed = value;
+
+	if ( typeof value === 'string' ) {
+		try {
+			parsed = JSON.parse( value );
+		} catch {
+			return { ...SIDEBAR_SECTION_DEFAULTS };
+		}
+	}
+
+	if ( ! parsed || typeof parsed !== 'object' || Array.isArray( parsed ) ) {
+		return { ...SIDEBAR_SECTION_DEFAULTS };
+	}
+
+	return Object.entries( parsed ).reduce(
+		( next, [ key, isCollapsed ] ) => {
+			if ( typeof isCollapsed === 'boolean' ) {
+				next[ key ] = isCollapsed;
+			}
+			return next;
+		},
+		{ ...SIDEBAR_SECTION_DEFAULTS }
+	);
+}
+
+function readStoredSections() {
+	try {
+		return normalizeSidebarSectionsCollapsed(
+			window.localStorage.getItem( SIDEBAR_SECTIONS_COLLAPSED_KEY )
+		);
+	} catch {
+		return { ...SIDEBAR_SECTION_DEFAULTS };
+	}
+}
+
+function persistSections( sections ) {
+	try {
+		window.localStorage.setItem(
+			SIDEBAR_SECTIONS_COLLAPSED_KEY,
+			JSON.stringify( sections )
+		);
+	} catch {
+		// Storage can be denied; keep the in-memory choice for this session.
+	}
+}
+
+export default function useSidebarSections() {
+	const [ collapsedSections, setCollapsedSections ] =
+		useState( readStoredSections );
+
+	const setSectionCollapsed = useCallback( ( id, isCollapsed ) => {
+		setCollapsedSections( ( current ) => {
+			const next = {
+				...SIDEBAR_SECTION_DEFAULTS,
+				...current,
+				[ id ]: Boolean( isCollapsed ),
+			};
+			persistSections( next );
+			return next;
+		} );
+	}, [] );
+
+	const toggleSection = useCallback( ( id ) => {
+		setCollapsedSections( ( current ) => {
+			const merged = { ...SIDEBAR_SECTION_DEFAULTS, ...current };
+			const next = {
+				...merged,
+				[ id ]: ! Boolean( merged[ id ] ),
+			};
+			persistSections( next );
+			return next;
+		} );
+	}, [] );
+
+	const isSectionCollapsed = useCallback(
+		( id ) =>
+			Boolean(
+				collapsedSections[ id ] ??
+					SIDEBAR_SECTION_DEFAULTS[ id ] ??
+					false
+			),
+		[ collapsedSections ]
+	);
+
+	return {
+		collapsedSections,
+		isSectionCollapsed,
+		setSectionCollapsed,
+		toggleSection,
+	};
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -152,7 +152,6 @@ body.cortext-fullscreen {
 	&__section-header {
 		display: flex;
 		align-items: center;
-		justify-content: space-between;
 		gap: $grid-unit-05;
 		margin: $grid-unit-15 0 $grid-unit-05 0;
 		padding: 0 $grid-unit-05;
@@ -160,8 +159,52 @@ body.cortext-fullscreen {
 		// Title margin/padding moves to the row.
 		/* stylelint-disable-next-line no-descending-specificity */
 		.cortext-sidebar__section-title {
+			flex: 1 1 auto;
+			min-width: 0;
 			margin: 0;
 			padding: 0;
+		}
+	}
+
+	&__section-title-button.components-button {
+		width: 100%;
+		min-width: 0;
+		height: $grid-unit-30;
+		padding: 0 $grid-unit-05;
+		justify-content: flex-start;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		color: var(--cortext-text-muted);
+		text-align: start;
+
+		&:hover:not(:disabled),
+		&:focus:not(:disabled) {
+			background: var(--cortext-state-hover);
+			color: var(--cortext-text-strong);
+		}
+	}
+
+	&__section-actions {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		margin-left: auto;
+	}
+
+	&__section-body-wrapper {
+		display: grid;
+		grid-template-rows: 0fr;
+		transition: grid-template-rows 160ms ease;
+
+		> .cortext-sidebar__section-body {
+			min-height: 0;
+			overflow: hidden;
+		}
+
+		&.is-expanded {
+			grid-template-rows: 1fr;
 		}
 	}
 
@@ -255,6 +298,12 @@ body.cortext-fullscreen {
 	&__empty {
 		color: var(--cortext-text-muted);
 		padding: $grid-unit-10;
+	}
+
+	&__empty--inline {
+		margin: 0;
+		font-size: 12px;
+		line-height: 16px;
 	}
 
 	&__list,

--- a/tests/e2e/specs/recents.spec.js
+++ b/tests/e2e/specs/recents.spec.js
@@ -47,6 +47,27 @@ async function readRecentsPlacement( page ) {
 	} );
 }
 
+async function clearSidebarSectionPrefs( page ) {
+	await page.evaluate( () => {
+		try {
+			window.localStorage.removeItem(
+				'cortext.sidebarSectionsCollapsed'
+			);
+		} catch {}
+	} );
+}
+
+async function expandRecentsIfCollapsed( page ) {
+	const sidebar = page.locator( '.cortext-sidebar' );
+	const expandRecents = sidebar.getByRole( 'button', {
+		name: 'Expand Recents',
+	} );
+
+	if ( await expandRecents.count() ) {
+		await expandRecents.click();
+	}
+}
+
 async function createCollectionFixture( requestUtils ) {
 	const suffix = Date.now().toString( 36 ).slice( -4 );
 	const slug = `e2erec${ suffix }`;
@@ -145,9 +166,15 @@ test.describe( 'Sidebar recents', () => {
 				'admin.php',
 				`page=cortext&p=/page/${ recentPage.id }`
 			);
+			await clearSidebarSectionPrefs( page );
+			await page.reload();
 			await waitForEditorPost( page, recentPage.id );
 
 			const sidebar = page.locator( '.cortext-sidebar' );
+			await expect(
+				sidebar.getByRole( 'button', { name: 'Expand Recents' } )
+			).toBeVisible();
+			await expandRecentsIfCollapsed( page );
 			await expect(
 				sidebar.getByRole( 'button', {
 					name: `Recent page: ${ pageTitle }`,
@@ -250,6 +277,7 @@ test.describe( 'Sidebar recents', () => {
 				.toBe( 'U. K. Le Guin' );
 
 			const sidebar = page.locator( '.cortext-sidebar' );
+			await expandRecentsIfCollapsed( page );
 			const recentRow = sidebar.getByRole( 'button', {
 				name: `Recent row: The Left Hand of Darkness in ${ fixture.collectionTitle }`,
 			} );

--- a/tests/e2e/specs/sidebar-favorites.spec.js
+++ b/tests/e2e/specs/sidebar-favorites.spec.js
@@ -182,7 +182,9 @@ test.describe( 'Sidebar favorites', () => {
 				collectionKey,
 			] );
 
-			const favorites = page.locator( '.cortext-sidebar__favorites' );
+			const favorites = page.locator(
+				'.cortext-sidebar__section--favorites'
+			);
 			await expect(
 				favorites.getByRole( 'heading', { name: 'Favorites' } )
 			).toBeVisible();

--- a/tests/e2e/specs/sidebar-layout.spec.js
+++ b/tests/e2e/specs/sidebar-layout.spec.js
@@ -220,6 +220,9 @@ async function clearSidebarPrefs( page ) {
 		try {
 			window.localStorage.removeItem( 'cortext.sidebarCollapsed' );
 			window.localStorage.removeItem( 'cortext.sidebarWidth' );
+			window.localStorage.removeItem(
+				'cortext.sidebarSectionsCollapsed'
+			);
 		} catch {}
 	} );
 }
@@ -530,6 +533,99 @@ test.describe( 'Sidebar layout controls', () => {
 		expect( Math.abs( afterReload - beforeReload ) ).toBeLessThanOrEqual(
 			2
 		);
+	} );
+
+	test( 'section collapse persists without changing page subtree state', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const parentTitle = `E2E Section Parent ${ suffix }`;
+		const childTitle = `E2E Section Child ${ suffix }`;
+		const fixture = {};
+
+		try {
+			fixture.parent = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: parentTitle,
+					status: 'private',
+				},
+			} );
+			fixture.child = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: childTitle,
+					status: 'private',
+					parent: fixture.parent.id,
+				},
+			} );
+
+			await admin.visitAdminPage(
+				SHELL_PATH,
+				`page=cortext&p=/${ fixture.child.id }`
+			);
+			await clearSidebarPrefs( page );
+			await page.reload();
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			await expect(
+				sidebar.getByRole( 'button', {
+					name: childTitle,
+					exact: true,
+				} )
+			).toBeVisible();
+
+			await sidebar
+				.getByRole( 'button', { name: 'Collapse Pages' } )
+				.click();
+
+			await expect(
+				sidebar.getByRole( 'button', {
+					name: childTitle,
+					exact: true,
+				} )
+			).toHaveCount( 0 );
+
+			await page.reload();
+
+			await expect(
+				sidebar.getByRole( 'button', { name: 'Expand Pages' } )
+			).toBeVisible();
+			await expect(
+				sidebar.getByRole( 'button', {
+					name: childTitle,
+					exact: true,
+				} )
+			).toHaveCount( 0 );
+
+			await sidebar
+				.getByRole( 'button', { name: 'Expand Pages' } )
+				.click();
+
+			await expect(
+				sidebar.getByRole( 'button', {
+					name: childTitle,
+					exact: true,
+				} )
+			).toBeVisible();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.child
+					? `/wp/v2/crtxt_pages/${ fixture.child.id }`
+					: null
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.parent
+					? `/wp/v2/crtxt_pages/${ fixture.parent.id }`
+					: null
+			);
+		}
 	} );
 
 	test( 'Cmd/Ctrl+\\ toggles collapse', async ( { page } ) => {

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -29,6 +29,16 @@ afterEach( () => {
 } );
 
 describe( 'SidebarFavorites helpers', () => {
+	it( 'renders an inline empty state when there are no favorites', () => {
+		renderFavorites();
+
+		expect(
+			screen.getByText(
+				'Star a page from its title menu to pin it here.'
+			)
+		).toBeInTheDocument();
+	} );
+
 	it( 'builds stable favorite keys', () => {
 		expect( favoriteKey( { kind: 'page', id: 12 } ) ).toBe(
 			'favorite:page:12'
@@ -196,5 +206,38 @@ describe( 'SidebarFavorites helpers', () => {
 		} );
 
 		expect( screen.getByText( 'Notes' ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the empty state when favorites is empty and sidebar records re-resolve', () => {
+		const { container, rerender } = renderFavorites();
+
+		expect(
+			screen.getByText(
+				'Star a page from its title menu to pin it here.'
+			)
+		).toBeInTheDocument();
+
+		rerender(
+			<SidebarFavorites
+				favorites={ [] }
+				pages={ [] }
+				collections={ [] }
+				isResolving={ false }
+				isResolvingItems
+				isDisabled={ false }
+				onSelect={ jest.fn( () => false ) }
+				onRemove={ jest.fn() }
+				onReorder={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText(
+				'Star a page from its title menu to pin it here.'
+			)
+		).toBeInTheDocument();
+		expect(
+			container.querySelector( '.cortext-sidebar__loading' )
+		).toBeNull();
 	} );
 } );

--- a/tests/js/components/SidebarSection.test.js
+++ b/tests/js/components/SidebarSection.test.js
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import SidebarSection from '../../../src/components/SidebarSection';
+
+describe( 'SidebarSection', () => {
+	it( 'renders an expanded section with accessible toggle state', () => {
+		render(
+			<SidebarSection
+				id="pages"
+				title="Pages"
+				isCollapsed={ false }
+				onToggle={ jest.fn() }
+			>
+				<div>Page row</div>
+			</SidebarSection>
+		);
+
+		const toggle = screen.getByRole( 'button', {
+			name: 'Collapse Pages',
+		} );
+
+		expect( toggle ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( screen.getByText( 'Page row' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the body when collapsed and calls onToggle from the title', () => {
+		const onToggle = jest.fn();
+		render(
+			<SidebarSection
+				id="pages"
+				title="Pages"
+				isCollapsed
+				onToggle={ onToggle }
+			>
+				<div>Page row</div>
+			</SidebarSection>
+		);
+
+		const toggle = screen.getByRole( 'button', {
+			name: 'Expand Pages',
+		} );
+
+		expect( toggle ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect(
+			screen
+				.getByText( 'Page row' )
+				.closest( '.cortext-sidebar__section-body-wrapper' )
+		).toHaveAttribute( 'aria-hidden', 'true' );
+		expect(
+			screen
+				.getByText( 'Page row' )
+				.closest( '.cortext-sidebar__section-body-wrapper' )
+		).toHaveAttribute( 'inert' );
+
+		fireEvent.click( toggle );
+
+		expect( onToggle ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'renders header actions without making them section toggles', () => {
+		const onToggle = jest.fn();
+		const onAction = jest.fn();
+		render(
+			<SidebarSection
+				id="pages"
+				title="Pages"
+				isCollapsed={ false }
+				onToggle={ onToggle }
+				actions={ <button onClick={ onAction }>New page</button> }
+			>
+				<div>Page row</div>
+			</SidebarSection>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'New page' } ) );
+
+		expect( onAction ).toHaveBeenCalledTimes( 1 );
+		expect( onToggle ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/js/hooks/useSidebarSections.test.js
+++ b/tests/js/hooks/useSidebarSections.test.js
@@ -1,0 +1,126 @@
+import { act, renderHook } from '@testing-library/react';
+
+import useSidebarSections, {
+	normalizeSidebarSectionsCollapsed,
+	SIDEBAR_SECTION_DEFAULTS,
+	SIDEBAR_SECTIONS_COLLAPSED_KEY,
+} from '../../../src/hooks/useSidebarSections';
+
+beforeEach( () => {
+	window.localStorage.clear();
+} );
+
+describe( 'normalizeSidebarSectionsCollapsed', () => {
+	it( 'defaults recents collapsed and durable sections expanded', () => {
+		expect( normalizeSidebarSectionsCollapsed( null ) ).toEqual(
+			SIDEBAR_SECTION_DEFAULTS
+		);
+		expect( normalizeSidebarSectionsCollapsed( '{ nope' ) ).toEqual(
+			SIDEBAR_SECTION_DEFAULTS
+		);
+		expect( normalizeSidebarSectionsCollapsed( [] ) ).toEqual(
+			SIDEBAR_SECTION_DEFAULTS
+		);
+	} );
+
+	it( 'merges stored booleans over the defaults', () => {
+		expect(
+			normalizeSidebarSectionsCollapsed(
+				JSON.stringify( {
+					recents: false,
+					favorites: true,
+					pages: true,
+					collections: 'yes',
+					custom: true,
+				} )
+			)
+		).toEqual( {
+			...SIDEBAR_SECTION_DEFAULTS,
+			recents: false,
+			favorites: true,
+			pages: true,
+			custom: true,
+		} );
+	} );
+} );
+
+describe( 'useSidebarSections', () => {
+	it( 'seeds from default section state', () => {
+		const { result } = renderHook( () => useSidebarSections() );
+
+		expect( result.current.isSectionCollapsed( 'recents' ) ).toBe( true );
+		expect( result.current.isSectionCollapsed( 'favorites' ) ).toBe(
+			false
+		);
+		expect( result.current.isSectionCollapsed( 'pages' ) ).toBe( false );
+		expect( result.current.isSectionCollapsed( 'collections' ) ).toBe(
+			false
+		);
+		expect( result.current.isSectionCollapsed( 'trash' ) ).toBe( false );
+	} );
+
+	it( 'seeds from localStorage with missing keys filled from defaults', () => {
+		window.localStorage.setItem(
+			SIDEBAR_SECTIONS_COLLAPSED_KEY,
+			JSON.stringify( { pages: true } )
+		);
+
+		const { result } = renderHook( () => useSidebarSections() );
+
+		expect( result.current.isSectionCollapsed( 'pages' ) ).toBe( true );
+		expect( result.current.isSectionCollapsed( 'recents' ) ).toBe( true );
+		expect( result.current.isSectionCollapsed( 'collections' ) ).toBe(
+			false
+		);
+		expect( result.current.isSectionCollapsed( 'trash' ) ).toBe( false );
+	} );
+
+	it( 'toggles a section and persists the merged state', () => {
+		const { result } = renderHook( () => useSidebarSections() );
+
+		act( () => {
+			result.current.toggleSection( 'pages' );
+		} );
+
+		expect( result.current.isSectionCollapsed( 'pages' ) ).toBe( true );
+		expect(
+			JSON.parse(
+				window.localStorage.getItem( SIDEBAR_SECTIONS_COLLAPSED_KEY )
+			)
+		).toMatchObject( {
+			recents: true,
+			favorites: false,
+			pages: true,
+			collections: false,
+			trash: false,
+		} );
+	} );
+
+	it( 'sets a section explicitly', () => {
+		const { result } = renderHook( () => useSidebarSections() );
+
+		act( () => {
+			result.current.setSectionCollapsed( 'favorites', true );
+		} );
+
+		expect( result.current.isSectionCollapsed( 'favorites' ) ).toBe( true );
+	} );
+
+	it( 'survives a localStorage write failure', () => {
+		const original = window.localStorage.setItem;
+		window.localStorage.setItem = () => {
+			throw new Error( 'quota' );
+		};
+
+		const { result } = renderHook( () => useSidebarSections() );
+
+		expect( () =>
+			act( () => {
+				result.current.toggleSection( 'pages' );
+			} )
+		).not.toThrow();
+		expect( result.current.isSectionCollapsed( 'pages' ) ).toBe( true );
+
+		window.localStorage.setItem = original;
+	} );
+} );


### PR DESCRIPTION
## What

Makes the left sidebar sections collapsible without mixing that state into the page tree. Recents starts closed by default; Favorites, Pages, Collections, and Trash start open. Empty Favorites now shows a short inline message instead of disappearing, which keeps that section steady while sidebar records refresh.

## How

The shared section wrapper owns the toggle semantics and accessibility attributes. Collapse state is kept in local storage and merged with defaults on read, while page subtree expansion stays in the existing page-tree state. The New page and New collection buttons stay separate from the section toggle.

## Testing Instructions

1. Open Cortext with a page that has an expanded child in the sidebar, collapse Pages, then expand it again and confirm the child is still expanded.
2. Reload Cortext and confirm the Pages collapsed state persists.
3. Clear local storage for `cortext.sidebarSectionsCollapsed`, reload, and confirm Recents starts collapsed while Favorites, Pages, Collections, and Trash start expanded.
4. With no favorites, switch between pages and confirm the Favorites empty message remains stable.

## Screen recording

https://github.com/user-attachments/assets/005861e9-6ead-4daa-9513-c43c0e2e6a68
