### PR TITLE
Refine sidebar structure and favorites loading

### DIFF
--- a/includes/Rest/FavoritesController.php
+++ b/includes/Rest/FavoritesController.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Cortext\Rest;
 
 use Cortext\PostType\Collection;
+use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Page;
 use WP_Error;
 use WP_Post;
@@ -182,7 +183,7 @@ final class FavoritesController {
 	 * @param string $kind Target kind.
 	 * @param int    $id Target post ID.
 	 * @param bool   $require_edit Whether to enforce edit_post capability.
-	 * @return array{kind:string,id:int,path:string}|WP_Error
+	 * @return array<string,mixed>|WP_Error
 	 */
 	private function format_target( string $kind, int $id, bool $require_edit ) {
 		if ( ! in_array( $kind, array( 'page', 'collection' ), true ) || $id < 1 ) {
@@ -206,11 +207,20 @@ final class FavoritesController {
 			);
 		}
 
-		return array(
-			'kind' => $kind,
-			'id'   => $id,
-			'path' => $this->target_path( $post, $kind ),
+		$target = array(
+			'kind'  => $kind,
+			'id'    => $id,
+			'title' => $this->post_title( $post ),
+			'path'  => $this->target_path( $post, $kind ),
 		);
+		if ( 'page' === $kind ) {
+			$icon = get_post_meta( $id, DocumentIdentity::META_KEY, true );
+			if ( is_string( $icon ) && '' !== $icon ) {
+				$target['icon'] = $icon;
+			}
+		}
+
+		return $target;
 	}
 
 	private function invalid_target_error(): WP_Error {
@@ -228,6 +238,11 @@ final class FavoritesController {
 
 		$type = 'page' === $kind ? Page::POST_TYPE : Collection::POST_TYPE;
 		return $type === $post->post_type;
+	}
+
+	private function post_title( WP_Post $post ): string {
+		$title = trim( $post->post_title );
+		return '' === $title ? __( '(untitled)', 'cortext' ) : $title;
 	}
 
 	private function target_path( WP_Post $post, string $kind ): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"@wordpress/icons": "^12.2.0",
 				"@wordpress/interface": "^9.0.0",
 				"@wordpress/keyboard-shortcuts": "^5.44.0",
+				"@wordpress/keycodes": "^4.45.0",
 				"@wordpress/media-utils": "^5.45.0",
 				"@wordpress/notices": "^5.44.0",
 				"@wordpress/preferences": "^4.44.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"@wordpress/icons": "^12.2.0",
 		"@wordpress/interface": "^9.0.0",
 		"@wordpress/keyboard-shortcuts": "^5.44.0",
+		"@wordpress/keycodes": "^4.45.0",
 		"@wordpress/media-utils": "^5.45.0",
 		"@wordpress/notices": "^5.44.0",
 		"@wordpress/preferences": "^4.44.0",

--- a/src/components/CollectionRow.js
+++ b/src/components/CollectionRow.js
@@ -1,6 +1,8 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import {
+	Icon,
+	customPostType,
 	home as homeIcon,
 	moreVertical,
 	starEmpty,
@@ -36,6 +38,13 @@ export default function CollectionRow( {
 	return (
 		<li className="cortext-sidebar__node">
 			<div className={ rowClasses.join( ' ' ) }>
+				<span
+					className="cortext-sidebar__chevron cortext-sidebar__chevron--placeholder"
+					aria-hidden="true"
+				/>
+				<span className="cortext-sidebar__icon" aria-hidden="true">
+					<Icon icon={ customPostType } size={ 16 } />
+				</span>
 				<Button
 					className="cortext-sidebar__title"
 					size="compact"

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -22,7 +22,11 @@ import { store as commandsStore } from '@wordpress/commands';
 // can live in their own section.
 const ITEM_ID_PREFIX = 'command-palette-item-';
 const RECENT_COMMAND_PREFIX = 'cortext/recent/';
-const inputLabel = __( 'Search commands and settings' );
+const commandMenuLabel = __( 'Search or run a command', 'cortext' );
+const inputPlaceholder = __(
+	'Search pages, collections, and actions',
+	'cortext'
+);
 
 const CATEGORY_LABELS = {
 	command: __( 'Command' ),
@@ -147,7 +151,7 @@ function CommandInput( { search, setSearch } ) {
 			ref={ commandMenuInput }
 			value={ search }
 			onValueChange={ setSearch }
-			placeholder={ inputLabel }
+			placeholder={ inputPlaceholder }
 			aria-activedescendant={ selectedItemId }
 		/>
 	);
@@ -257,7 +261,7 @@ export default function CortextCommandMenu() {
 			contentLabel={ __( 'Command palette' ) }
 		>
 			<div className="commands-command-menu__container">
-				<Command label={ inputLabel } loop>
+				<Command label={ commandMenuLabel } loop>
 					<div className="commands-command-menu__header">
 						<Icon
 							className="commands-command-menu__header-search-icon"

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,4 +1,4 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -10,7 +10,14 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { Button, Icon, Notice, Spinner } from '@wordpress/components';
-import { home as homeIcon, plus, search, wordpress } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
+import {
+	home as homeIcon,
+	plus,
+	search,
+	trash as trashIcon,
+	wordpress,
+} from '@wordpress/icons';
 
 // Sidebar toggle: panel outline with a vertical accent on
 // the left side. Same icon for both states; the aria-label tells the
@@ -44,6 +51,35 @@ const sidebarToggleIcon = (
 		/>
 	</svg>
 );
+
+const cortextMarkIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<ellipse
+			cx="12"
+			cy="12"
+			rx="7"
+			ry="6"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			fill="none"
+		/>
+		<path
+			d="M12 6v12M8.5 8.5 12 10l3.5-1.5"
+			stroke="currentColor"
+			strokeWidth="1.4"
+			strokeLinecap="round"
+			fill="none"
+		/>
+		<circle cx="12" cy="10" r="0.9" fill="currentColor" />
+	</svg>
+);
 import {
 	DndContext,
 	DragOverlay,
@@ -65,7 +101,7 @@ import SidebarFavorites, {
 import SidebarResizeHandle from './SidebarResizeHandle';
 import SidebarRecents from './SidebarRecents';
 import SidebarSection from './SidebarSection';
-import SidebarTrash from './SidebarTrash';
+import SidebarTrash, { computeSidebarTrashRoots } from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
 import {
 	buildTree,
@@ -117,6 +153,11 @@ export default function Sidebar( {
 	// expand) or a paginated fetch of the full page set.
 	const { records: collections, isResolving: isResolvingCollections } =
 		useEntityRecords( 'postType', 'crtxt_collection', COLLECTION_QUERY );
+	const { records: trashedPages } = useEntityRecords(
+		'postType',
+		POST_TYPE,
+		TRASHED_PAGES_QUERY
+	);
 	const {
 		pages,
 		homePath,
@@ -140,6 +181,7 @@ export default function Sidebar( {
 	const activeUri = params._splat ?? '';
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
 	const userName = window.cortextSettings?.userDisplayName ?? '';
+	const commandPaletteShortcut = displayShortcut.primary( 'k' );
 	const brandLabel = userName
 		? sprintf(
 				/* translators: %s: user display name */
@@ -219,6 +261,14 @@ export default function Sidebar( {
 			params: { _splat: homePath },
 		} );
 	}, [ homePath, navigate ] );
+	const toggleTrashPanel = useCallback( () => {
+		if ( collapsed ) {
+			setIsTrashPanelOpen( true );
+			onToggleCollapsed?.();
+			return;
+		}
+		setIsTrashPanelOpen( ( current ) => ! current );
+	}, [ collapsed, onToggleCollapsed ] );
 
 	const setPageHome = useCallback(
 		async ( id ) => {
@@ -319,8 +369,28 @@ export default function Sidebar( {
 	const [ draggedId, setDraggedId ] = useState( null );
 	const [ activeDrop, setActiveDrop ] = useState( null );
 	const [ autoRenameId, setAutoRenameId ] = useState( null );
+	const [ isTrashPanelOpen, setIsTrashPanelOpen ] = useState( false );
 
 	const autoExpandTimerRef = useRef( null );
+	const trashCount = useMemo(
+		() => computeSidebarTrashRoots( trashedPages ?? [] ).roots.length,
+		[ trashedPages ]
+	);
+	let trashButtonLabel = __( 'Open Trash', 'cortext' );
+	if ( isTrashPanelOpen ) {
+		trashButtonLabel = __( 'Close Trash', 'cortext' );
+	} else if ( trashCount > 0 ) {
+		trashButtonLabel = sprintf(
+			/* translators: %d: number of trashed pages */
+			_n(
+				'Open Trash, %d item',
+				'Open Trash, %d items',
+				trashCount,
+				'cortext'
+			),
+			trashCount
+		);
+	}
 
 	useEffect( () => {
 		if ( selectedId === null ) {
@@ -342,6 +412,12 @@ export default function Sidebar( {
 			return changed ? next : prev;
 		} );
 	}, [ selectedId, pages ] );
+
+	useEffect( () => {
+		if ( collapsed ) {
+			setIsTrashPanelOpen( false );
+		}
+	}, [ collapsed ] );
 
 	const getEntityRecord = useSelect(
 		( select ) => select( 'core' ).getEntityRecord,
@@ -470,7 +546,7 @@ export default function Sidebar( {
 	);
 
 	// Soft-delete: the server-side cascade trashes descendants. Trash is
-	// reversible (the user can restore from the Trash section), so no
+	// reversible (the user can restore from the Trash panel), so no
 	// confirmation. The editor stays on the trashed page so the user can
 	// review what they trashed before deciding whether to restore.
 	//
@@ -514,6 +590,7 @@ export default function Sidebar( {
 						)
 				);
 			}
+			setIsTrashPanelOpen( true );
 		},
 		[ invalidateResolution, pages, receiveEntityRecords, setFavorites ]
 	);
@@ -634,7 +711,15 @@ export default function Sidebar( {
 			<div className="cortext-sidebar__header">
 				{ ! collapsed && (
 					<span className="cortext-sidebar__brand">
-						{ brandLabel }
+						<span
+							className="cortext-sidebar__brand-mark"
+							aria-hidden="true"
+						>
+							{ cortextMarkIcon }
+						</span>
+						<span className="cortext-sidebar__brand-text">
+							{ brandLabel }
+						</span>
 					</span>
 				) }
 				<Button
@@ -654,18 +739,31 @@ export default function Sidebar( {
 				aria-label={ __( 'Quick actions', 'cortext' ) }
 			>
 				<Button
+					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--search"
+					label={ __( 'Search or run a command', 'cortext' ) }
+					onClick={ () => openCommandPalette() }
+				>
+					<Icon icon={ search } size={ 16 } />
+					{ ! collapsed && (
+						<>
+							<span className="cortext-sidebar__quick-action-label">
+								{ __( 'Search or run a command', 'cortext' ) }
+							</span>
+							<kbd className="cortext-sidebar__quick-action-kbd">
+								{ commandPaletteShortcut }
+							</kbd>
+						</>
+					) }
+				</Button>
+				<Button
 					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--home"
-					icon={ homeIcon }
 					label={ __( 'Home', 'cortext' ) }
 					disabled={ ! homePath || isResolvingHomePath }
 					onClick={ goHome }
-				/>
-				<Button
-					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--search"
-					icon={ search }
-					label={ __( 'Search', 'cortext' ) }
-					onClick={ () => openCommandPalette() }
-				/>
+				>
+					<Icon icon={ homeIcon } size={ 16 } />
+					{ ! collapsed && <span>{ __( 'Home', 'cortext' ) }</span> }
+				</Button>
 			</div>
 			{ ! collapsed && (
 				<div className="cortext-sidebar__content">
@@ -853,29 +951,61 @@ export default function Sidebar( {
 							</ul>
 						) }
 					</SidebarSection>
-
-					<SidebarSection
-						id="trash"
-						title={ __( 'Trash', 'cortext' ) }
-						isCollapsed={ isSectionCollapsed( 'trash' ) }
-						onToggle={ () => toggleSection( 'trash' ) }
-					>
-						<SidebarTrash
-							activePages={ pages }
-							selectedId={ selectedId }
-							onSelect={ onSelect }
-						/>
-					</SidebarSection>
 				</div>
 			) }
+			{ ! collapsed && isTrashPanelOpen && (
+				<section
+					id="cortext-sidebar-trash-panel"
+					className="cortext-sidebar__trash-panel"
+					aria-label={ __( 'Trash', 'cortext' ) }
+				>
+					<div className="cortext-sidebar__trash-panel-header">
+						<h2 className="cortext-sidebar__section-title">
+							{ __( 'Trash', 'cortext' ) }
+						</h2>
+					</div>
+					<SidebarTrash
+						activePages={ pages }
+						selectedId={ selectedId }
+						onSelect={ onSelect }
+					/>
+				</section>
+			) }
 			<div className="cortext-sidebar__footer">
-				<Button
-					className="cortext-sidebar__back"
-					label={ __( 'Go to WordPress', 'cortext' ) }
-					href={ adminUrl }
-					icon={ <Icon icon={ wordpress } size={ 24 } /> }
+				<div className="cortext-sidebar__footer-group cortext-sidebar__footer-group--navigation">
+					<Button
+						className="cortext-sidebar__footer-button cortext-sidebar__trash-footer"
+						label={ trashButtonLabel }
+						aria-expanded={ ! collapsed && isTrashPanelOpen }
+						aria-controls="cortext-sidebar-trash-panel"
+						isPressed={ ! collapsed && isTrashPanelOpen }
+						onClick={ toggleTrashPanel }
+					>
+						<Icon icon={ trashIcon } size={ 20 } />
+						{ trashCount > 0 && (
+							<span
+								className="cortext-sidebar__footer-count"
+								aria-hidden="true"
+							>
+								{ trashCount > 99 ? '99+' : trashCount }
+							</span>
+						) }
+					</Button>
+				</div>
+				<div className="cortext-sidebar__footer-spacer" />
+				<div
+					className="cortext-sidebar__footer-separator"
+					aria-hidden="true"
 				/>
-				<ThemeToggle />
+				<div className="cortext-sidebar__footer-group cortext-sidebar__footer-group--preferences">
+					<ThemeToggle />
+					<Button
+						className="cortext-sidebar__back"
+						label={ __( 'Go to WordPress', 'cortext' ) }
+						href={ adminUrl }
+						icon={ <Icon icon={ wordpress } size={ 24 } /> }
+					/>
+				</div>
 			</div>
 			{ ! collapsed && (
 				<SidebarResizeHandle

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -46,6 +46,10 @@ function pageTitle( page ) {
 	return page.title?.rendered?.trim() || __( '(untitled)', 'cortext' );
 }
 
+function favoriteTitle( favorite, fallback ) {
+	return favorite.title?.trim?.() || fallback;
+}
+
 export function favoriteKey( favorite ) {
 	return `favorite:${ favorite.kind }:${ Number( favorite.id ) }`;
 }
@@ -106,8 +110,13 @@ export function resolveFavoriteItems( favorites, pages, collections ) {
 					key,
 					sortableId: key,
 					record: page,
-					title: page ? pageTitle( page ) : __( 'Page', 'cortext' ),
+					title: page
+						? pageTitle( page )
+						: favoriteTitle( favorite, __( 'Page', 'cortext' ) ),
 					path: page ? computeDocumentUri( page ) : favorite.path,
+					icon: page
+						? page.meta?.cortext_document_icon ?? ''
+						: favorite.icon ?? '',
 				};
 			}
 
@@ -125,7 +134,10 @@ export function resolveFavoriteItems( favorites, pages, collections ) {
 					record: collection,
 					title: collection
 						? collectionTitle( collection )
-						: __( 'Collection', 'cortext' ),
+						: favoriteTitle(
+								favorite,
+								__( 'Collection', 'cortext' )
+						  ),
 					path: collection
 						? computeCollectionUri( collection )
 						: favorite.path,
@@ -170,12 +182,7 @@ function mergeDisplayFavorites( currentDisplay, nextFavorites, removingKeys ) {
 
 function FavoriteIcon( { item } ) {
 	if ( item.kind === 'page' ) {
-		return (
-			<PageIcon
-				icon={ item.record?.meta?.cortext_document_icon ?? '' }
-				size={ 16 }
-			/>
-		);
+		return <PageIcon icon={ item.icon ?? '' } size={ 16 } />;
 	}
 
 	return <Icon icon={ customPostType } size={ 16 } />;
@@ -309,6 +316,7 @@ export default function SidebarFavorites( {
 	const previousKeysRef = useRef( null );
 	const latestFavoritesRef = useRef( favorites );
 	const removingKeysRef = useRef( new Set() );
+	const hasCompletedInitialLoadRef = useRef( ! isResolving );
 	const timersRef = useRef( [] );
 
 	useEffect( () => {
@@ -318,9 +326,13 @@ export default function SidebarFavorites( {
 		);
 		const previousKeys = previousKeysRef.current;
 		previousKeysRef.current = currentKeys;
+		const canAnimateChanges = hasCompletedInitialLoadRef.current;
 
 		if ( ! previousKeys ) {
 			setDisplayFavorites( favorites );
+			if ( ! isResolving ) {
+				hasCompletedInitialLoadRef.current = true;
+			}
 			return;
 		}
 
@@ -334,7 +346,7 @@ export default function SidebarFavorites( {
 		nextAdded.forEach( ( key ) => nextRemovingKeys.delete( key ) );
 		nextRemoved.forEach( ( key ) => nextRemovingKeys.add( key ) );
 
-		if ( nextAdded.size > 0 ) {
+		if ( canAnimateChanges && nextAdded.size > 0 ) {
 			setAddedKeys( nextAdded );
 			const timer = setTimeout( () => {
 				setAddedKeys( ( keys ) => {
@@ -372,7 +384,11 @@ export default function SidebarFavorites( {
 			}, FAVORITE_REMOVE_ANIMATION_MS );
 			timersRef.current.push( timer );
 		}
-	}, [ favorites ] );
+
+		if ( ! isResolving ) {
+			hasCompletedInitialLoadRef.current = true;
+		}
+	}, [ favorites, isResolving ] );
 
 	const items = useMemo(
 		() => resolveFavoriteItems( displayFavorites, pages, collections ),

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -22,8 +22,48 @@ import {
 // exposed via REST as part of the `meta` field on each page record.
 const MARKER_META = '_cortext_trashed_by_parent';
 
+export function computeSidebarTrashRoots( trashedPages = [] ) {
+	const all = Array.isArray( trashedPages ) ? trashedPages : [];
+	const trashedById = new Map( all.map( ( page ) => [ page.id, page ] ) );
+	const childrenByMarker = new Map();
+
+	const markerOf = ( page ) => Number( page.meta?.[ MARKER_META ] ?? 0 );
+
+	all.forEach( ( page ) => {
+		const marker = markerOf( page );
+		if ( marker > 0 && trashedById.has( marker ) ) {
+			if ( ! childrenByMarker.has( marker ) ) {
+				childrenByMarker.set( marker, [] );
+			}
+			childrenByMarker.get( marker ).push( page );
+		}
+	} );
+
+	const roots = all.filter( ( page ) => {
+		const marker = markerOf( page );
+		return marker === 0 || ! trashedById.has( marker );
+	} );
+
+	const descendantCountById = new Map();
+	roots.forEach( ( root ) => {
+		let count = 0;
+		const stack = [ ...( childrenByMarker.get( root.id ) ?? [] ) ];
+		while ( stack.length ) {
+			const node = stack.pop();
+			count++;
+			const kids = childrenByMarker.get( node.id );
+			if ( kids ) {
+				stack.push( ...kids );
+			}
+		}
+		descendantCountById.set( root.id, count );
+	} );
+
+	return { roots, descendantCountById };
+}
+
 /**
- * Renders the sidebar Trash section: a flat list of trashed pages with a
+ * Renders the sidebar Trash panel: a flat list of trashed pages with a
  * breadcrumb on each row plus inline Restore and Delete-permanently actions.
  *
  * Only cascade roots are listed. Subpages dragged into trash by a parent's
@@ -89,45 +129,10 @@ export default function SidebarTrash( { activePages, selectedId, onSelect } ) {
 	// Cascade roots: pages with no marker, plus pages whose marker points at
 	// a page that's no longer in trash (its tagged parent was permanently
 	// deleted). Without the second clause those orphans would be hidden.
-	const { roots, descendantCountById } = useMemo( () => {
-		const all = visibleTrashed;
-		const trashedById = new Map( all.map( ( p ) => [ p.id, p ] ) );
-		const childrenByMarker = new Map();
-
-		const markerOf = ( page ) => Number( page.meta?.[ MARKER_META ] ?? 0 );
-
-		all.forEach( ( page ) => {
-			const marker = markerOf( page );
-			if ( marker > 0 && trashedById.has( marker ) ) {
-				if ( ! childrenByMarker.has( marker ) ) {
-					childrenByMarker.set( marker, [] );
-				}
-				childrenByMarker.get( marker ).push( page );
-			}
-		} );
-
-		const computedRoots = all.filter( ( page ) => {
-			const marker = markerOf( page );
-			return marker === 0 || ! trashedById.has( marker );
-		} );
-
-		const counts = new Map();
-		computedRoots.forEach( ( root ) => {
-			let count = 0;
-			const stack = [ ...( childrenByMarker.get( root.id ) ?? [] ) ];
-			while ( stack.length ) {
-				const node = stack.pop();
-				count++;
-				const kids = childrenByMarker.get( node.id );
-				if ( kids ) {
-					stack.push( ...kids );
-				}
-			}
-			counts.set( root.id, count );
-		} );
-
-		return { roots: computedRoots, descendantCountById: counts };
-	}, [ visibleTrashed ] );
+	const { roots, descendantCountById } = useMemo(
+		() => computeSidebarTrashRoots( visibleTrashed ),
+		[ visibleTrashed ]
+	);
 
 	const buildBreadcrumb = useCallback(
 		( page ) => {

--- a/src/hooks/useSidebarSections.js
+++ b/src/hooks/useSidebarSections.js
@@ -8,7 +8,6 @@ export const SIDEBAR_SECTION_DEFAULTS = {
 	favorites: false,
 	pages: false,
 	collections: false,
-	trash: false,
 };
 
 export function normalizeSidebarSectionsCollapsed( value ) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -127,10 +127,34 @@ body.cortext-fullscreen {
 	&__brand {
 		flex: 1 1 auto;
 		min-width: 0;
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
 		font-weight: 600;
 		font-size: 13px;
 		line-height: 20px;
 		color: var(--cortext-text);
+	}
+
+	&__brand-mark {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: $grid-unit-30;
+		height: $grid-unit-30;
+		color: var(--cortext-accent-contrast);
+		background: var(--cortext-accent);
+		border-radius: 50%;
+	}
+
+	&__brand-mark svg {
+		width: 18px;
+		height: 18px;
+	}
+
+	&__brand-text {
+		min-width: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -139,9 +163,64 @@ body.cortext-fullscreen {
 	&__quick-actions {
 		flex: 0 0 auto;
 		display: flex;
+		flex-direction: column;
 		align-items: center;
 		gap: $grid-unit-05;
 		padding: 0 $grid-unit-20 $grid-unit-10;
+	}
+
+	&__quick-action.components-button {
+		width: 100%;
+		min-width: 0;
+		height: $grid-unit-40;
+		padding: 0 $grid-unit-10;
+		justify-content: flex-start;
+		gap: $grid-unit-05;
+		color: var(--cortext-text-muted);
+		text-align: start;
+	}
+
+	&__quick-action--search.components-button {
+		border: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
+		background: var(--cortext-control-surface);
+		box-shadow: inset 0 1px 0 var(--cortext-control-highlight);
+	}
+
+	&__quick-action--search.components-button:hover:not(:disabled),
+	&__quick-action--search.components-button:focus:not(:disabled) {
+		border-color: var(--cortext-accent);
+		background: var(--cortext-control-hover-surface);
+	}
+
+	&__quick-action--home.components-button:hover:not(:disabled),
+	&__quick-action--home.components-button:focus:not(:disabled) {
+		background: var(--cortext-state-hover);
+		color: var(--cortext-text-strong);
+	}
+
+	&__quick-action-label {
+		flex: 1 1 auto;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__quick-action-kbd {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: $grid-unit-30;
+		height: $grid-unit-20;
+		padding: 0 6px;
+		border: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
+		border-radius: var(--cortext-shell-radius);
+		background: var(--cortext-keycap-surface);
+		color: var(--cortext-text-muted);
+		font-size: 11px;
+		font-family: inherit;
+		line-height: 1;
 	}
 
 	&__collapse-toggle {
@@ -269,11 +348,30 @@ body.cortext-fullscreen {
 		margin-top: auto;
 		display: flex;
 		align-items: center;
-		gap: $grid-unit-10;
+		gap: $grid-unit-05;
 		padding: $grid-unit-10 $grid-unit-15;
 		border-top: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	}
 
+	&__footer-group {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		min-width: 0;
+	}
+
+	&__footer-spacer {
+		flex: 1 1 auto;
+		min-width: $grid-unit-10;
+	}
+
+	&__footer-separator {
+		width: var(--cortext-shell-border-width);
+		height: $grid-unit-20;
+		background: var(--cortext-chrome-border);
+	}
+
+	&__footer-button.components-button,
 	&__back.components-button,
 	&__theme-toggle.components-button {
 		width: $grid-unit-40;
@@ -281,6 +379,47 @@ body.cortext-fullscreen {
 		height: $grid-unit-40;
 		padding: 0;
 		justify-content: center;
+	}
+
+	&__trash-footer.components-button {
+		width: auto;
+		gap: $grid-unit-05;
+		padding: 0 $grid-unit-10;
+	}
+
+	&__footer-count {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 16px;
+		height: 16px;
+		padding: 0 5px;
+		border-radius: 999px;
+		background: var(--cortext-count-badge-surface);
+		color: var(--cortext-count-badge-text);
+		font-size: 10px;
+		font-weight: 600;
+		line-height: 16px;
+		text-align: center;
+	}
+
+	&__trash-panel {
+		flex: 0 1 auto;
+		max-height: min(280px, 38vh);
+		overflow-y: auto;
+		padding: 0 $grid-unit-15 $grid-unit-10;
+		border-top: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
+	}
+
+	&__trash-panel-header {
+		display: flex;
+		align-items: center;
+		padding: $grid-unit-10 $grid-unit-05 0;
+	}
+
+	&__trash-panel-header &__section-title {
+		margin: 0;
+		padding: 0;
 	}
 
 	/* stylelint-disable-next-line no-descending-specificity */
@@ -496,13 +635,17 @@ body.cortext-fullscreen {
 		will-change: transform, opacity;
 	}
 
-	&__icon.components-button {
+	&__icon {
 		flex: 0 0 auto;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
 		width: $grid-unit-30;
 		height: $grid-unit-30;
+		color: var(--cortext-text-muted);
+	}
+
+	&__icon.components-button {
 		padding: 0;
 		min-width: 0;
 		background: transparent;
@@ -772,6 +915,16 @@ body.cortext-fullscreen {
 			padding: $grid-unit-05 0;
 		}
 
+		.cortext-sidebar__footer-group {
+			flex-direction: column;
+			gap: $grid-unit-05;
+		}
+
+		.cortext-sidebar__footer-spacer,
+		.cortext-sidebar__footer-separator {
+			display: none;
+		}
+
 		.cortext-sidebar__collapse-toggle {
 			order: 1;
 			margin-left: 0;
@@ -789,6 +942,22 @@ body.cortext-fullscreen {
 		.cortext-sidebar__quick-action.components-button {
 			width: $grid-unit-30 + $grid-unit-05;
 			min-width: $grid-unit-30 + $grid-unit-05;
+		}
+
+		.cortext-sidebar__quick-action--search.components-button {
+			border-color: transparent;
+			background: transparent;
+			box-shadow: none;
+		}
+
+		.cortext-sidebar__trash-footer.components-button {
+			width: $grid-unit-40;
+			min-width: $grid-unit-40;
+			padding: 0;
+		}
+
+		.cortext-sidebar__footer-count {
+			display: none;
 		}
 	}
 }

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -83,10 +83,11 @@
 	--cortext-text-strong: #{colors.$gray-900};
 	--cortext-shadow-color: rgba(0, 0, 0, 0.12);
 
-	// Accent follows the active admin/components theme by default, but is
-	// exposed as a Cortext role so shell themes don't depend on WP internals.
-	--cortext-accent: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
-	--cortext-accent-contrast: var(--wp-components-color-accent-inverted, #{colors.$white});
+	// Cortext-owned product accent. WordPress blue stays available through
+	// WP component variables, but shell chrome should not inherit it as the
+	// default brand color.
+	--cortext-accent: #0a1530;
+	--cortext-accent-contrast: #5ad9ff;
 
 	// Shell buttons. These map onto @wordpress/components buttons only inside
 	// Cortext-owned chrome, not globally in wp-admin or inside the iframe.
@@ -98,8 +99,16 @@
 	--cortext-button-hover-surface: var(--cortext-state-hover);
 	--cortext-button-pressed-surface: var(--cortext-state-selected);
 	--cortext-button-primary-surface: var(--cortext-accent);
-	--cortext-button-primary-hover-surface: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, var(--cortext-accent)));
+	--cortext-button-primary-hover-surface: color-mix(in srgb, var(--cortext-accent) 88%, var(--cortext-accent-contrast));
 	--cortext-button-primary-text: var(--cortext-accent-contrast);
+
+	// Compact chrome controls.
+	--cortext-control-surface: var(--cortext-shell-surface);
+	--cortext-control-hover-surface: var(--cortext-shell-surface);
+	--cortext-control-highlight: var(--cortext-state-selected-highlight);
+	--cortext-keycap-surface: var(--cortext-sidebar-surface);
+	--cortext-count-badge-surface: var(--cortext-state-hover-strong);
+	--cortext-count-badge-text: var(--cortext-text-muted);
 
 	// Foundation values. Defaults come from WordPress base-styles; keeping
 	// them behind Cortext names lets the shell diverge later without making

--- a/tests/e2e/specs/page-trash.spec.js
+++ b/tests/e2e/specs/page-trash.spec.js
@@ -2,7 +2,7 @@
  * E2E coverage for the page trash flow in the Cortext shell.
  *
  * Walks the user-visible path the unit tests can't: open a page, trash it
- * from the sidebar dropdown, see the Trash section pick it up with the
+ * from the sidebar dropdown, see the Trash panel pick it up with the
  * cascade subpage count, the canvas locked behind a notice, and Restore
  * via the banner unwinding the whole thing.
  */
@@ -90,7 +90,7 @@ test.describe( 'Page trash flow', () => {
 				.click( { force: true } );
 			await page.getByRole( 'menuitem', { name: 'Trash' } ).click();
 
-			// Active sidebar drops the whole subtree; the Trash section
+			// Active sidebar drops the whole subtree; the Trash panel
 			// shows the cascade root with the subpage count.
 			await expect(
 				sidebar.getByRole( 'button', {
@@ -123,7 +123,14 @@ test.describe( 'Page trash flow', () => {
 					exact: true,
 				} )
 			).toBeVisible();
-			await expect( trashList ).toHaveCount( 0 );
+			await expect(
+				page
+					.locator( '#cortext-sidebar-trash-panel' )
+					.getByRole( 'button', {
+						name: PARENT_TITLE,
+						exact: true,
+					} )
+			).toHaveCount( 0 );
 		} finally {
 			await deleteIfCreated( requestUtils, child?.id );
 			await deleteIfCreated( requestUtils, parent?.id );

--- a/tests/e2e/specs/sidebar-layout.spec.js
+++ b/tests/e2e/specs/sidebar-layout.spec.js
@@ -126,7 +126,7 @@ async function readCollapsedRailAlignment( page ) {
 				quickActionsBox.xCenter - headerBox.xCenter
 			),
 			actionColumnDelta: Math.abs( homeBox.xCenter - searchBox.xCenter ),
-			actionGap: searchBox.top - homeBox.bottom,
+			actionGap: homeBox.top - searchBox.bottom,
 			toolbarBelowHeader: quickActionsBox.top - headerBox.bottom,
 			footerIconDelta: Math.abs( backBox.xCenter - themeBox.xCenter ),
 		};

--- a/tests/js/components/CortextCommandMenu.test.js
+++ b/tests/js/components/CortextCommandMenu.test.js
@@ -84,7 +84,9 @@ describe( 'CortextCommandMenu', () => {
 		} );
 
 		expect(
-			await screen.findByPlaceholderText( 'Search commands and settings' )
+			await screen.findByPlaceholderText(
+				'Search pages, collections, and actions'
+			)
 		).toBeInTheDocument();
 		expect( screen.getByText( 'Test command' ) ).toBeInTheDocument();
 	} );

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -139,14 +139,47 @@ describe( 'SidebarFavorites helpers', () => {
 	} );
 
 	it( 'uses stored paths when sidebar records are missing', () => {
-		const favorites = [ { kind: 'page', id: 1, path: 'page/old-1' } ];
+		const favorites = [
+			{
+				kind: 'page',
+				id: 1,
+				title: 'Stored Notes',
+				path: 'page/old-1',
+				icon: 'notebook',
+			},
+		];
 
 		expect( resolveFavoriteItems( favorites, [], [] ) ).toMatchObject( [
 			{
 				kind: 'page',
 				id: 1,
-				title: 'Page',
+				title: 'Stored Notes',
 				path: 'page/old-1',
+				icon: 'notebook',
+			},
+		] );
+	} );
+
+	it( 'uses stored collection titles when sidebar records are missing', () => {
+		expect(
+			resolveFavoriteItems(
+				[
+					{
+						kind: 'collection',
+						id: 2,
+						title: 'Stored Books',
+						path: 'collection/books-2',
+					},
+				],
+				[],
+				[]
+			)
+		).toMatchObject( [
+			{
+				kind: 'collection',
+				id: 2,
+				title: 'Stored Books',
+				path: 'collection/books-2',
 			},
 		] );
 	} );
@@ -206,6 +239,83 @@ describe( 'SidebarFavorites helpers', () => {
 		} );
 
 		expect( screen.getByText( 'Notes' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not mark initially loaded favorites as newly added', () => {
+		const favorite = { kind: 'page', id: 1 };
+		const pages = [
+			{
+				id: 1,
+				slug: 'notes',
+				title: { rendered: 'Notes', raw: 'Notes' },
+			},
+		];
+		const { rerender } = renderFavorites( {
+			favorites: [],
+			pages,
+			isResolving: true,
+		} );
+
+		rerender(
+			<SidebarFavorites
+				favorites={ [ favorite ] }
+				pages={ pages }
+				collections={ [] }
+				isResolving={ false }
+				isResolvingItems={ false }
+				isDisabled={ false }
+				onSelect={ jest.fn( () => false ) }
+				onRemove={ jest.fn() }
+				onReorder={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen
+				.getByText( 'Notes' )
+				.closest( '.cortext-sidebar__favorite-row' )
+		).not.toHaveClass( 'is-added' );
+	} );
+
+	it( 'marks favorites added after initial load as newly added', () => {
+		const notes = { kind: 'page', id: 1 };
+		const tasks = { kind: 'page', id: 2 };
+		const pages = [
+			{
+				id: 1,
+				slug: 'notes',
+				title: { rendered: 'Notes', raw: 'Notes' },
+			},
+			{
+				id: 2,
+				slug: 'tasks',
+				title: { rendered: 'Tasks', raw: 'Tasks' },
+			},
+		];
+		const { rerender } = renderFavorites( {
+			favorites: [ notes ],
+			pages,
+		} );
+
+		rerender(
+			<SidebarFavorites
+				favorites={ [ notes, tasks ] }
+				pages={ pages }
+				collections={ [] }
+				isResolving={ false }
+				isResolvingItems={ false }
+				isDisabled={ false }
+				onSelect={ jest.fn( () => false ) }
+				onRemove={ jest.fn() }
+				onReorder={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen
+				.getByText( 'Tasks' )
+				.closest( '.cortext-sidebar__favorite-row' )
+		).toHaveClass( 'is-added' );
 	} );
 
 	it( 'keeps the empty state when favorites is empty and sidebar records re-resolve', () => {

--- a/tests/js/hooks/useSidebarSections.test.js
+++ b/tests/js/hooks/useSidebarSections.test.js
@@ -56,7 +56,6 @@ describe( 'useSidebarSections', () => {
 		expect( result.current.isSectionCollapsed( 'collections' ) ).toBe(
 			false
 		);
-		expect( result.current.isSectionCollapsed( 'trash' ) ).toBe( false );
 	} );
 
 	it( 'seeds from localStorage with missing keys filled from defaults', () => {
@@ -72,7 +71,6 @@ describe( 'useSidebarSections', () => {
 		expect( result.current.isSectionCollapsed( 'collections' ) ).toBe(
 			false
 		);
-		expect( result.current.isSectionCollapsed( 'trash' ) ).toBe( false );
 	} );
 
 	it( 'toggles a section and persists the merged state', () => {
@@ -92,7 +90,6 @@ describe( 'useSidebarSections', () => {
 			favorites: false,
 			pages: true,
 			collections: false,
-			trash: false,
 		} );
 	} );
 

--- a/tests/php/test-rest-favorites-controller.php
+++ b/tests/php/test-rest-favorites-controller.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Cortext\Tests;
 
 use Cortext\PostType\Collection;
+use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Page;
 use Cortext\Rest\FavoritesController;
 use WorDBless\BaseTestCase;
@@ -47,8 +48,20 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 
 	public function test_sets_and_reads_page_and_collection_favorites_in_order(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$page_id       = $this->create_page( array( 'post_name' => 'daily-notes' ) );
-		$collection_id = $this->create_collection( 'books' );
+		$page_id       = $this->create_page(
+			array(
+				'post_name'  => 'daily-notes',
+				'post_title' => 'Daily Notes',
+			)
+		);
+		$page_icon = wp_json_encode(
+			array(
+				'type' => 'wp',
+				'name' => 'notebook',
+			)
+		);
+		update_post_meta( $page_id, DocumentIdentity::META_KEY, $page_icon );
+		$collection_id = $this->create_collection( 'books', 'Books' );
 
 		$set_response = $this->set_favorites(
 			array(
@@ -66,14 +79,17 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 
 		$expected = array(
 			array(
-				'kind' => 'collection',
-				'id'   => $collection_id,
-				'path' => "collection/books-{$collection_id}",
+				'kind'  => 'collection',
+				'id'    => $collection_id,
+				'title' => 'Books',
+				'path'  => "collection/books-{$collection_id}",
 			),
 			array(
-				'kind' => 'page',
-				'id'   => $page_id,
-				'path' => "page/daily-notes-{$page_id}",
+				'kind'  => 'page',
+				'id'    => $page_id,
+				'title' => 'Daily Notes',
+				'path'  => "page/daily-notes-{$page_id}",
+				'icon'  => $page_icon,
 			),
 		);
 		$this->assertSame( 200, $set_response->get_status() );
@@ -303,12 +319,12 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 		return (int) $id;
 	}
 
-	private function create_collection( string $slug ): int {
+	private function create_collection( string $slug, string $title = '' ): int {
 		$id = wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
 				'post_status' => 'private',
-				'post_title'  => 'Test collection ' . wp_generate_uuid4(),
+				'post_title'  => '' === $title ? 'Test collection ' . wp_generate_uuid4() : $title,
 				'meta_input'  => array(
 					'slug' => $slug,
 				),


### PR DESCRIPTION
## What

Moves Trash out of the main section stack and into a footer button that opens a compact panel with a count badge. It also tightens the sidebar chrome and keeps Favorites readable during cold loads, so saved favorites do not briefly fall back to generic labels while their backing records resolve.

## How

Trash no longer participates in section-collapse defaults because it is no longer a section. Favorites REST entries include saved title data and page icon data, and the client uses those values until the page or collection record is available. The sidebar search shortcut now uses the platform-aware WordPress key display.

## Testing Instructions

1. Trash a page from the sidebar and confirm the Trash footer button opens a panel with the trashed page and count badge.
2. Add page and collection favorites, reload Cortext, and confirm Favorites keeps readable rows while page and collection records resolve.
3. Open the command palette from the sidebar search control and confirm the search label and shortcut display look correct for the platform.

## Screenshot
| Before | After |
| - | - |
| <img width="277" height="770" alt="image" src="https://github.com/user-attachments/assets/381ac9f7-3ae8-414d-8bda-a4e0120b899d" /> | <img width="278" height="752" alt="image" src="https://github.com/user-attachments/assets/22dd23e6-01e8-44e2-adb0-811bf955eac3" /> |