### PR TITLE
Add server row sorting, filtering, and search

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -35,29 +35,29 @@ Worth a small spike before committing; `core-data`'s schema cache for rarely-cha
 
 ## 3. Sorting support is split between REST and client mode `[internal]`
 
-Updated by [#80](https://github.com/priethor/cortext/pull/80).
+Updated by [#80](https://github.com/priethor/cortext/pull/80) and RSM-1459.
 
-**What.** #80 fixed the old bad state where the sort UI changed but REST ignored it. REST now handles `title`, `created_at`, `modified_at`, and scalar `field-{id}` columns that can sort by `meta_value` or `meta_value_num`. With no explicit sort, REST still uses oldest-first ordering so new rows land at the bottom of the table.
+**What.** #80 fixed the old bad state where the sort UI changed but REST ignored it. RSM-1459 moved the supported scalar collection sorts into `/cortext/v1/rows`: title, timestamps, text-like fields, number, date/datetime, select, checkbox, email, and URL. With no explicit sort, REST still uses oldest-first ordering so new rows land at the bottom of the table.
 
-The debt is the split brain. The client has an allow-list for server-safe sorts, and `RowsController::build_query_args` has the PHP version of the same story. Unsupported sorts fall back to client mode: fetch all pages, then let DataViews sort locally. That keeps the result honest, but it is not where we want sorting to live long-term.
+The debt is the split brain. The client has an allow-list for server-safe sorts, and `FieldTypeRegistry` / `RowsFilterQuery` own the PHP version of the same story. Unsupported display-value sorts fall back to client mode: fetch all pages, then let DataViews sort locally. That keeps the result honest, but it is not where we want sorting to live long-term.
 
 The hard cases are still display-value sorts: users, relations, list-style rollups, files, and any field where the value users see is not the value stored in meta. That broader choice is tracked in #14.
 
-**Where.** The query planner and sort allow-lists in `src/hooks/useCollectionRows.js`, the `onCreated` no-sort branch in `src/components/CollectionDataViews.js`, and `validate_sort_field` / `build_query_args` in `includes/Rest/RowsController.php`.
+**Where.** The query planner and sort allow-lists in `src/hooks/useCollectionRows.js`, the `onCreated` no-sort branch in `src/components/CollectionDataViews.js`, `FieldTypeRegistry`, and `RowsFilterQuery::validate_sort()`.
 
 **Solution.** Make REST the source of truth for sortable fields and expose that capability to the client instead of mirroring it by hand. Resolve #14 for display-value sorts, then remove the client fallback for sorting except where DataViews really needs a local-only view state.
 
-## 4. Filtering support is split between REST and client mode `[internal]`
+## 4. Filtering support is split between REST and client mode `[upstream, internal]`
 
-Updated by [#80](https://github.com/priethor/cortext/pull/80).
+Updated by [#80](https://github.com/priethor/cortext/pull/80) and RSM-1459.
 
-**What.** #80 also made simple field filters real on the server. Equality and membership filters for stored `field-{id}` values now become a REST `meta_query`. When the server cannot handle a filter, the hook falls back to client mode, fetches all pages, and lets DataViews filter locally. That is much better than showing a filter UI that does nothing.
+**What.** #80 made simple field filters real on the server. RSM-1459 expanded that to the supported Notion-style operators, title filters, split-term search, and nested `AND` / `OR` groups through `RowsFilterQuery` and `RowsMetaQuery`. When the server cannot handle a filter, the hook falls back to client mode, fetches all pages, applies grouped filters in a small Cortext wrapper, and lets DataViews handle the remaining flat search/sort/pagination work.
 
-The cost is another split support matrix. The client checks field type, operator, and value shape before choosing server mode. `RowsController` validates field ownership and builds the actual `meta_query`. System fields are still deferred (#13), title filtering still is not a REST feature, and operators like `contains` stay client-only until PHP translates them.
+The cost is another split support matrix. The client checks field type, operator, grouping, and value shape before choosing server mode. PHP validates the same contract from the collection schema. `FieldTypeRegistry` is Cortext's local stand-in for an upstream field-query capability contract: sortable, filterable, text-like, storage type, and supported operators. WordPress post meta and DataViews each know part of that story, but neither exposes the whole contract for custom field types today. System fields are still deferred (#13), display-value fields are still client-only, and grouped filters only go server-side when every descendant is supported.
 
-**Where.** `isServerSupportedFilter` and `addFiltersToArgs` in `src/hooks/useCollectionRows.js`, `validate_filter_fields` / `build_query_args` in `includes/Rest/RowsController.php`, and `prefillFromFilters` in `src/components/CollectionDataViews.js`.
+**Where.** `FieldTypeRegistry`, `serverFilterNode` / `buildQueryPlan` in `src/hooks/useCollectionRows.js`, `filterSortAndPaginateWithGroups` in `src/components/groupedFilters.js`, `RowsFilterQuery`, `RowsMetaQuery`, and `prefillFromFilters` in `src/components/CollectionDataViews.js`.
 
-**Solution.** Move the remaining filter operators and field families into REST, then make the client consume a server-owned capability map instead of maintaining its own allow-list. `contains` can map to `LIKE` for simple meta values; system fields need the date/user handling from #13.
+**Solution.** Make the server-owned capability map the only local source of truth, then shrink it if DataViews or WordPress grows a first-class query-capability contract for custom fields. System fields need the date/user handling from #13, and display-value fields need dedicated query semantics instead of pretending stored meta is the UI value.
 
 ## 5. Inline-edit layout couplings `[internal]`
 
@@ -103,13 +103,13 @@ The cost is another split support matrix. The client checks field type, operator
 
 **Solution.** Either switch the PHP test harness to `wp-env` + `WP_UnitTestCase` (which runs against a real database) or rely on e2e coverage in `tests/e2e/specs/data-view-block.spec.js` to close the gap. The e2e suite already exercises row loading, but dedicated integration tests for sort, filter, and pagination against real data would be more targeted.
 
-## 10. DataViews `FieldType` union has no `number` or `url` `[upstream]`
+## 10. DataViews `FieldType` union has no decimal `number` or `url` `[upstream]`
 
-**What.** DataViews v6's `FieldType` union is `'text' | 'integer' | 'datetime' | 'date' | 'media' | 'boolean' | 'email' | 'array'`. Cortext has `number` (decimals allowed) and `url`, neither of which has an exact match. We map both to `'text'`: `'integer'` rejects non-integers at validation time, and there's nothing closer for url. The cost lands on the column-level sort comparator: text sort is lexicographic, so `"10"` would sort before `"9"` for a number column. Today this is invisible because `view.sort` isn't forwarded to REST (#3), but the day sort lands, decimal columns will sort wrong unless we add a custom `sort` per field or DataViews ships the missing types.
+**What.** DataViews v6's `FieldType` union is `'text' | 'integer' | 'datetime' | 'date' | 'media' | 'boolean' | 'email' | 'array'`. Cortext has `number` (decimals allowed) and `url`, neither of which has an exact match. We map numbers to `'integer'` so the filter UI can offer numeric operators, then disable DataViews' integer-only validator, attach a decimal-aware sort comparator, and provide a decimal-safe number filter control because the built-in integer `between` control applies whole-number min/max bounds. URLs still map to `'text'`, which is close enough for contains/starts-with filters but not an exact semantic type.
 
 **Where.** `mapField` in `src/hooks/fieldMapping.js`.
 
-**Solution.** Either DataViews adds `'number'` and `'url'` to the `FieldType` union, or we attach a custom numeric `sort` to number fields when sort lands. Filing a Gutenberg issue is the cheaper play.
+**Solution.** DataViews adds a decimal-friendly `'number'` type and a `'url'` type, or exposes a cleaner way for consumers to supply custom field controls/operator sets without borrowing the nearest built-in type. Filing a Gutenberg issue is the cheaper play.
 
 ## 11. DataViews `Option` type has no `color` `[upstream]`
 
@@ -394,3 +394,19 @@ The user-facing placeholder is still Core's generic "Search commands and setting
 **Where.** `src/router/EntityRoute.js`, `src/hooks/useAutosave.js`, `src/components/Sidebar.js`, `src/components/CollectionDataViews.js`, and `src/components/relations/RelationEditor.js`.
 
 **Solution.** If more activity surfaces appear, move this behind a small workspace activity helper or event. Route visits can stay in the router, but writes should eventually report through the same mutation path instead of each component remembering to call `touchRecent`. If rows move into `core-data` (#2), that would be a natural time to centralize row touches too.
+
+## 45. Select server sort uses stored values, not option order `[internal]`
+
+**What.** Server-side row sorting treats select fields as scalar stored values. That keeps `GET /cortext/v1/rows` sortable without joining or decoding option metadata, but it differs from Notion-style curated option ordering.
+
+**Where.** `RowsFilterQuery::apply_sort_clauses()` in `includes/Rest/RowsFilterQuery.php`.
+
+**Solution.** If users expect select order to follow the field's configured options, compile select sorts into an option-order `CASE` expression generated from the field schema. Until then, document stored-value sorting as the v1 behavior.
+
+## 46. Row filters extend `WP_Meta_Query` with custom compares `[upstream, soft]`
+
+**What.** `RowsMetaQuery` keeps row filters on WordPress's native meta-query tree instead of building a parallel SQL compiler, but core's compares do not cover every database-style operator Cortext needs. `LIKE` always wraps both sides, so starts-with and ends-with need one-sided patterns. Multi-value fields need "no meta row has this value" for `isNone` / `notContains`, which is not the same as a plain `!=` join. Title filters also live on `wp_posts.post_title`, outside post meta, so they ride through a sentinel clause.
+
+**Where.** `RowsMetaQuery` in `includes/Rest/RowsMetaQuery.php`, called from `RowsFilterQuery::meta_query_sql()`.
+
+**Solution.** Upstream `WP_Meta_Query` could grow one-sided `LIKE` compares and value-bearing negative `NOT EXISTS` compares. A structured title-query helper in `WP_Query` would cover the title sentinel separately. If those land, `RowsMetaQuery` shrinks back toward a thin adapter or disappears.

--- a/includes/Fields/FieldTypeRegistry.php
+++ b/includes/Fields/FieldTypeRegistry.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Per-type policy table for Cortext field types.
+ *
+ * Single source of truth for which capabilities each field type has —
+ * whether it can be sorted or filtered, which filter operators it accepts,
+ * whether it is included in full-text search, and how its values are typed in WP postmeta. Consumers
+ * (`FieldsController`, `CollectionEntries`, `RowsFilterQuery`) read
+ * from here instead of re-listing types in scattered constants.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Fields;
+
+final class FieldTypeRegistry {
+
+	private const TEXT_OPERATORS = array(
+		'is',
+		'isNot',
+		'contains',
+		'notContains',
+		'startsWith',
+		'endsWith',
+		'isEmpty',
+		'isNotEmpty',
+	);
+
+	private const NUMBER_OPERATORS = array(
+		'is',
+		'greaterThan',
+		'lessThan',
+		'between',
+		'isEmpty',
+	);
+
+	private const DATE_OPERATORS = array(
+		'is',
+		'on',
+		'before',
+		'after',
+		'between',
+		'isEmpty',
+	);
+
+	private const SELECT_OPERATORS = array(
+		'is',
+		'isNot',
+		'isAny',
+		'isNone',
+	);
+
+	private const MULTISELECT_OPERATORS = array(
+		'contains',
+		'notContains',
+		'isAny',
+		'isNone',
+	);
+
+	private const CHECKBOX_OPERATORS = array(
+		'isChecked',
+		'isUnchecked',
+	);
+
+	/**
+	 * Per-type policy. `wp_meta_type` matches the values accepted by
+	 * `register_post_meta`'s `type` option ('string'|'number'|'boolean').
+	 */
+	private const TYPES = array(
+		'text'        => array(
+			'sortable'     => true,
+			'filterable'   => true,
+			'text_like'    => true,
+			'wp_meta_type' => 'string',
+			'operators'    => self::TEXT_OPERATORS,
+		),
+		'email'       => array(
+			'sortable'     => true,
+			'filterable'   => true,
+			'text_like'    => true,
+			'wp_meta_type' => 'string',
+			'operators'    => self::TEXT_OPERATORS,
+		),
+		'url'         => array(
+			'sortable'     => true,
+			'filterable'   => true,
+			'text_like'    => true,
+			'wp_meta_type' => 'string',
+			'operators'    => self::TEXT_OPERATORS,
+		),
+		'number'      => array(
+			'sortable'     => true,
+			'filterable'   => true,
+			'text_like'    => false,
+			'wp_meta_type' => 'number',
+			'operators'    => self::NUMBER_OPERATORS,
+		),
+		'date'        => array(
+			'sortable'     => true,
+			'filterable'   => true,
+			'text_like'    => false,
+			'wp_meta_type' => 'string',
+			'operators'    => self::DATE_OPERATORS,
+		),
+		'datetime'    => array(
+			'sortable'     => true,
+			'filterable'   => true,
+			'text_like'    => false,
+			'wp_meta_type' => 'string',
+			'operators'    => self::DATE_OPERATORS,
+		),
+		'checkbox'    => array(
+			'sortable'     => true,
+			'filterable'   => true,
+			'text_like'    => false,
+			'wp_meta_type' => 'boolean',
+			'operators'    => self::CHECKBOX_OPERATORS,
+		),
+		'select'      => array(
+			'sortable'     => true,
+			'filterable'   => true,
+			'text_like'    => false,
+			'wp_meta_type' => 'string',
+			'operators'    => self::SELECT_OPERATORS,
+		),
+		'multiselect' => array(
+			'sortable'     => false,
+			'filterable'   => true,
+			'text_like'    => false,
+			'wp_meta_type' => 'string',
+			'operators'    => self::MULTISELECT_OPERATORS,
+		),
+		'relation'    => array(
+			'sortable'     => false,
+			'filterable'   => false,
+			'text_like'    => false,
+			'wp_meta_type' => 'string',
+			'operators'    => array(),
+		),
+		'rollup'      => array(
+			'sortable'     => false,
+			'filterable'   => false,
+			'text_like'    => false,
+			'wp_meta_type' => 'string',
+			'operators'    => array(),
+		),
+	);
+
+	/**
+	 * Per-type policy. `wp_meta_type` matches the values accepted by
+	 * `register_post_meta`'s `type` option ('string'|'number'|'boolean').
+	 *
+	 * @return array<string,array{sortable:bool,filterable:bool,text_like:bool,wp_meta_type:string,operators:string[]}>
+	 */
+	public static function all(): array {
+		return self::TYPES;
+	}
+
+	/**
+	 * Returns all known field type keys.
+	 *
+	 * @return string[]
+	 */
+	public static function types(): array {
+		return array_keys( self::all() );
+	}
+
+	public static function exists( string $type ): bool {
+		return isset( self::all()[ $type ] );
+	}
+
+	public static function is_sortable( string $type ): bool {
+		return self::all()[ $type ]['sortable'] ?? false;
+	}
+
+	public static function is_filterable( string $type ): bool {
+		return self::all()[ $type ]['filterable'] ?? false;
+	}
+
+	public static function is_text_like( string $type ): bool {
+		return self::all()[ $type ]['text_like'] ?? false;
+	}
+
+	public static function wp_meta_type( string $type ): string {
+		return self::all()[ $type ]['wp_meta_type'] ?? 'string';
+	}
+
+	/**
+	 * Returns the client-facing filter operators supported by a field type.
+	 *
+	 * @param string $type Cortext field type.
+	 * @return string[]
+	 */
+	public static function operators_for( string $type ): array {
+		return self::all()[ $type ]['operators'] ?? array();
+	}
+
+	/**
+	 * Returns the REST-safe query capabilities for a field type.
+	 *
+	 * @param string $type Cortext field type.
+	 * @return array{sortable:bool,filterable:bool,operators:string[]}
+	 */
+	public static function capabilities_for( string $type ): array {
+		return array(
+			'sortable'   => self::is_sortable( $type ),
+			'filterable' => self::is_filterable( $type ),
+			'operators'  => self::operators_for( $type ),
+		);
+	}
+}

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -13,6 +13,7 @@ declare( strict_types=1 );
 
 namespace Cortext\PostType;
 
+use Cortext\Fields\FieldTypeRegistry;
 use Cortext\Relations;
 use WP_Post;
 
@@ -490,10 +491,6 @@ final class CollectionEntries {
 	}
 
 	public static function wp_meta_type_for( string $cortext_type ): string {
-		return match ( $cortext_type ) {
-			'number'   => 'number',
-			'checkbox' => 'boolean',
-			default    => 'string',
-		};
+		return FieldTypeRegistry::wp_meta_type( $cortext_type );
 	}
 }

--- a/includes/PostType/Field.php
+++ b/includes/PostType/Field.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\PostType;
 
+use Cortext\Fields\FieldTypeRegistry;
+
 final class Field {
 
 	public const POST_TYPE = 'crtxt_field';
@@ -49,6 +51,52 @@ final class Field {
 		);
 
 		$this->register_meta();
+		$this->register_rest_fields();
+	}
+
+	public function register_rest_fields(): void {
+		register_rest_field(
+			self::POST_TYPE,
+			'cortext_capabilities',
+			array(
+				'get_callback' => array( $this, 'get_rest_capabilities' ),
+				'schema'       => array(
+					'type'       => 'object',
+					'context'    => array( 'view', 'edit' ),
+					'readonly'   => true,
+					'properties' => array(
+						'sortable'   => array(
+							'type'     => 'boolean',
+							'readonly' => true,
+						),
+						'filterable' => array(
+							'type'     => 'boolean',
+							'readonly' => true,
+						),
+						'operators'  => array(
+							'type'     => 'array',
+							'readonly' => true,
+							'items'    => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Returns query capabilities for one field REST record.
+	 *
+	 * @param array<string,mixed> $field_record REST post response data.
+	 * @return array{sortable:bool,filterable:bool,operators:string[]}
+	 */
+	public function get_rest_capabilities( array $field_record ): array {
+		$field_id = isset( $field_record['id'] ) ? (int) $field_record['id'] : 0;
+		$type     = $field_id > 0 ? (string) get_post_meta( $field_id, 'type', true ) : '';
+
+		return FieldTypeRegistry::capabilities_for( $type );
 	}
 
 	private function register_meta(): void {

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+use Cortext\Fields\FieldTypeRegistry;
 use Cortext\OptionPalette;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
@@ -22,20 +23,6 @@ use WP_REST_Response;
 final class FieldsController {
 
 	private const NAMESPACE = 'cortext/v1';
-
-	private const ALLOWED_TYPES = array(
-		'text',
-		'email',
-		'url',
-		'number',
-		'date',
-		'datetime',
-		'checkbox',
-		'select',
-		'multiselect',
-		'relation',
-		'rollup',
-	);
 
 	private const ROLLUP_AGGREGATORS = array(
 		'count',
@@ -98,7 +85,7 @@ final class FieldsController {
 						'type'                     => array(
 							'type'     => 'string',
 							'required' => true,
-							'enum'     => self::ALLOWED_TYPES,
+							'enum'     => FieldTypeRegistry::types(),
 						),
 						'options'                  => array(
 							'type'     => 'array',

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -14,7 +14,6 @@ use Cortext\PostType\CollectionEntries;
 use Cortext\Relations;
 use WP_Error;
 use WP_Post;
-use WP_Query;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -224,45 +223,15 @@ final class RowsController {
 		// re-fetch the field type for every row.
 		$multi_field_ids = $this->multi_value_field_ids( $field_ids );
 
-		$query_args                             = $this->build_query_args( $request, $slug, $where_sql, $filter_sql['join'] );
-		$token                                  = uniqid( 'cortext_rows_', true );
-		$query_args['cortext_rows_query_token'] = $token;
-		$query_args['cortext_rows_sort']        = $request->get_param( 'sort' );
-
-		$where_callback = function ( string $where, WP_Query $query ) use ( $token ): string {
-			if ( $query->get( 'cortext_rows_query_token' ) !== $token ) {
-				return $where;
-			}
-			$extra = (string) $query->get( 'cortext_rows_where' );
-			if ( '' === $extra ) {
-				return $where;
-			}
-			return "{$where} AND {$extra}";
-		};
-
-		$clauses_callback = function ( array $clauses, WP_Query $query ) use ( $token, $row_query, $field_schema ): array {
-			if ( $query->get( 'cortext_rows_query_token' ) !== $token ) {
-				return $clauses;
-			}
-			$clauses = $row_query->apply_filter_join_clauses(
-				$clauses,
-				(string) $query->get( 'cortext_rows_join' )
-			);
-			return $row_query->apply_sort_clauses(
-				$clauses,
-				$query->get( 'cortext_rows_sort' ),
-				$field_schema
-			);
-		};
-
-		add_filter( 'posts_where', $where_callback, 10, 2 );
-		add_filter( 'posts_clauses', $clauses_callback, 10, 2 );
-		try {
-			$query = new WP_Query( $query_args );
-		} finally {
-			remove_filter( 'posts_where', $where_callback, 10 );
-			remove_filter( 'posts_clauses', $clauses_callback, 10 );
-		}
+		$query_args = $this->build_query_args( $request, $slug );
+		$scope      = new RowsQueryScope(
+			$row_query,
+			$field_schema,
+			$where_sql,
+			$filter_sql['join'],
+			$request->get_param( 'sort' )
+		);
+		$query      = $scope->run( $query_args );
 
 		// Prime the user object cache once before mapping rows so per-row
 		// display name lookups in format_row hit the cache instead of
@@ -464,24 +433,15 @@ final class RowsController {
 	 *
 	 * @param WP_REST_Request $request Full request object.
 	 * @param string          $slug    Collection slug.
-	 * @param string          $where_sql Prepared row filter/search SQL.
-	 * @param string          $join_sql Prepared row filter JOIN SQL.
 	 * @return array
 	 */
-	private function build_query_args( WP_REST_Request $request, string $slug, string $where_sql = '', string $join_sql = '' ): array {
+	private function build_query_args( WP_REST_Request $request, string $slug ): array {
 		$args = array(
 			'post_type'      => CollectionEntries::CPT_PREFIX . $slug,
 			'post_status'    => array( 'draft', 'private', 'publish' ),
 			'posts_per_page' => (int) $request->get_param( 'per_page' ),
 			'paged'          => (int) $request->get_param( 'page' ),
 		);
-
-		if ( '' !== $where_sql ) {
-			$args['cortext_rows_where'] = $where_sql;
-		}
-		if ( '' !== $join_sql ) {
-			$args['cortext_rows_join'] = $join_sql;
-		}
 
 		$sort = $request->get_param( 'sort' );
 		if ( ! is_array( $sort ) || empty( $sort['field'] ) ) {

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -22,16 +22,6 @@ final class RowsController {
 
 	private const NAMESPACE = 'cortext/v1';
 
-	/**
-	 * Supported filter operators and their WP_Query compare equivalents.
-	 */
-	private const FILTER_OPERATORS = array(
-		'is'     => '=',
-		'isNot'  => '!=',
-		'isAny'  => 'IN',
-		'isNone' => 'NOT IN',
-	);
-
 	public function register(): void {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
@@ -71,10 +61,9 @@ final class RowsController {
 							'minimum' => 1,
 						),
 						'per_page'   => array(
-							'type'    => 'integer',
-							'default' => 25,
-							'minimum' => 1,
-							'maximum' => 100,
+							'type'              => 'integer',
+							'default'           => 25,
+							'validate_callback' => static fn( $value ) => (int) $value >= 1 && (int) $value <= 100,
 						),
 						'search'     => array(
 							'type'    => 'string',
@@ -94,16 +83,6 @@ final class RowsController {
 						'filters'    => array(
 							'type'    => 'array',
 							'default' => array(),
-							'items'   => array(
-								'type'       => 'object',
-								'properties' => array(
-									'field'    => array( 'type' => 'string' ),
-									'operator' => array( 'type' => 'string' ),
-									'value'    => array(
-										'type' => array( 'string', 'number', 'boolean', 'array' ),
-									),
-								),
-							),
 						),
 					),
 				),
@@ -216,34 +195,74 @@ final class RowsController {
 		$slug      = (string) get_post_meta( $collection->ID, 'slug', true );
 		$field_ids = $this->collection_field_ids( $collection->ID );
 
-		// Validate sort and filter references separately. Sort accepts
-		// 'title', 'field-N', and the sortable system fields; filters
-		// accept 'field-N' only — system field filtering is deferred
-		// (tech-debt.md#13).
-		$sort_validation = $this->validate_sort_field(
+		$row_query    = new RowsFilterQuery();
+		$field_schema = $row_query->field_schema_for( $collection_id );
+
+		$sort_validation = $row_query->validate_sort(
 			$request->get_param( 'sort' ),
-			$field_ids,
+			$field_schema,
 			$collection_id
 		);
 		if ( is_wp_error( $sort_validation ) ) {
 			return $sort_validation;
 		}
 
-		$filter_validation = $this->validate_filter_fields(
+		$filter_sql = $row_query->compile_filters(
 			$request->get_param( 'filters' ),
-			$field_ids,
+			$field_schema,
 			$collection_id
 		);
-		if ( is_wp_error( $filter_validation ) ) {
-			return $filter_validation;
+		if ( is_wp_error( $filter_sql ) ) {
+			return $filter_sql;
 		}
+
+		$search_where = $row_query->compile_search( (string) $request->get_param( 'search' ), $field_schema );
+		$where_parts  = array_values( array_filter( array( $filter_sql['where'], $search_where ) ) );
+		$where_sql    = count( $where_parts ) > 0 ? '( ' . implode( ' AND ', $where_parts ) . ' )' : '';
 
 		// Precompute which fields are multi-value so format_row does not
 		// re-fetch the field type for every row.
 		$multi_field_ids = $this->multi_value_field_ids( $field_ids );
 
-		$query_args = $this->build_query_args( $request, $slug );
-		$query      = new WP_Query( $query_args );
+		$query_args                             = $this->build_query_args( $request, $slug, $where_sql, $filter_sql['join'] );
+		$token                                  = uniqid( 'cortext_rows_', true );
+		$query_args['cortext_rows_query_token'] = $token;
+		$query_args['cortext_rows_sort']        = $request->get_param( 'sort' );
+
+		$where_callback = function ( string $where, WP_Query $query ) use ( $token ): string {
+			if ( $query->get( 'cortext_rows_query_token' ) !== $token ) {
+				return $where;
+			}
+			$extra = (string) $query->get( 'cortext_rows_where' );
+			if ( '' === $extra ) {
+				return $where;
+			}
+			return "{$where} AND {$extra}";
+		};
+
+		$clauses_callback = function ( array $clauses, WP_Query $query ) use ( $token, $row_query, $field_schema ): array {
+			if ( $query->get( 'cortext_rows_query_token' ) !== $token ) {
+				return $clauses;
+			}
+			$clauses = $row_query->apply_filter_join_clauses(
+				$clauses,
+				(string) $query->get( 'cortext_rows_join' )
+			);
+			return $row_query->apply_sort_clauses(
+				$clauses,
+				$query->get( 'cortext_rows_sort' ),
+				$field_schema
+			);
+		};
+
+		add_filter( 'posts_where', $where_callback, 10, 2 );
+		add_filter( 'posts_clauses', $clauses_callback, 10, 2 );
+		try {
+			$query = new WP_Query( $query_args );
+		} finally {
+			remove_filter( 'posts_where', $where_callback, 10 );
+			remove_filter( 'posts_clauses', $clauses_callback, 10 );
+		}
 
 		// Prime the user object cache once before mapping rows so per-row
 		// display name lookups in format_row hit the cache instead of
@@ -441,97 +460,15 @@ final class RowsController {
 	}
 
 	/**
-	 * Validates the `sort` param's field key.
-	 *
-	 * Accepts `'title'`, any `field-N` belonging to the collection, and the
-	 * sortable system field keys (`'created_at'`, `'modified_at'`). Rejects
-	 * the `*_by` system field keys and any other identifier — sort on
-	 * display-value properties is an open architectural decision shared
-	 * with relations and rollups (tech-debt.md#14).
-	 *
-	 * @param mixed $sort           Sort param from the request.
-	 * @param int[] $field_ids      Valid field IDs for the collection.
-	 * @param int   $collection_id  Collection ID for error messages.
-	 * @return true|WP_Error
-	 */
-	private function validate_sort_field( $sort, array $field_ids, int $collection_id ) {
-		if ( ! is_array( $sort ) || empty( $sort['field'] ) ) {
-			return true;
-		}
-
-		$allowed = array( 'title', 'created_at', 'modified_at' );
-		foreach ( $field_ids as $id ) {
-			$allowed[] = "field-{$id}";
-		}
-
-		if ( ! in_array( $sort['field'], $allowed, true ) ) {
-			return new WP_Error(
-				'cortext_invalid_sort_field',
-				sprintf(
-					/* translators: 1: field key, 2: collection ID */
-					__( 'Field "%1$s" cannot be used to sort collection %2$d.', 'cortext' ),
-					$sort['field'],
-					$collection_id
-				),
-				array( 'status' => 400 )
-			);
-		}
-
-		return true;
-	}
-
-	/**
-	 * Validates every `filters[].field` reference.
-	 *
-	 * Accepts only `field-N` keys belonging to the collection. Title and
-	 * system fields are intentionally excluded: title isn't filterable
-	 * today (preserved from prior behavior), and system field filtering
-	 * is deferred (tech-debt.md#13). Rejection produces a clean 400.
-	 *
-	 * @param mixed $filters        Filters param from the request.
-	 * @param int[] $field_ids      Valid field IDs for the collection.
-	 * @param int   $collection_id  Collection ID for error messages.
-	 * @return true|WP_Error
-	 */
-	private function validate_filter_fields( $filters, array $field_ids, int $collection_id ) {
-		if ( ! is_array( $filters ) || count( $filters ) === 0 ) {
-			return true;
-		}
-
-		$allowed = array();
-		foreach ( $field_ids as $id ) {
-			$allowed[] = "field-{$id}";
-		}
-
-		foreach ( $filters as $filter ) {
-			if ( ! is_array( $filter ) || empty( $filter['field'] ) ) {
-				continue;
-			}
-			if ( ! in_array( $filter['field'], $allowed, true ) ) {
-				return new WP_Error(
-					'cortext_invalid_filter_field',
-					sprintf(
-						/* translators: 1: field key, 2: collection ID */
-						__( 'Field "%1$s" cannot be used to filter collection %2$d.', 'cortext' ),
-						$filter['field'],
-						$collection_id
-					),
-					array( 'status' => 400 )
-				);
-			}
-		}
-
-		return true;
-	}
-
-	/**
 	 * Translates REST params into WP_Query arguments.
 	 *
 	 * @param WP_REST_Request $request Full request object.
 	 * @param string          $slug    Collection slug.
+	 * @param string          $where_sql Prepared row filter/search SQL.
+	 * @param string          $join_sql Prepared row filter JOIN SQL.
 	 * @return array
 	 */
-	private function build_query_args( WP_REST_Request $request, string $slug ): array {
+	private function build_query_args( WP_REST_Request $request, string $slug, string $where_sql = '', string $join_sql = '' ): array {
 		$args = array(
 			'post_type'      => CollectionEntries::CPT_PREFIX . $slug,
 			'post_status'    => array( 'draft', 'private', 'publish' ),
@@ -539,9 +476,11 @@ final class RowsController {
 			'paged'          => (int) $request->get_param( 'page' ),
 		);
 
-		$search = $request->get_param( 'search' );
-		if ( '' !== $search ) {
-			$args['s'] = $search;
+		if ( '' !== $where_sql ) {
+			$args['cortext_rows_where'] = $where_sql;
+		}
+		if ( '' !== $join_sql ) {
+			$args['cortext_rows_join'] = $join_sql;
 		}
 
 		$sort = $request->get_param( 'sort' );
@@ -563,58 +502,8 @@ final class RowsController {
 				$args['orderby'] = 'modified';
 				$args['order']   = $direction;
 			} else {
-				$field_id   = $this->field_id_from_key( $sort['field'] );
-				$field_type = $field_id ? (string) get_post_meta( $field_id, 'type', true ) : '';
-				if ( 'rollup' === $field_type ) {
-					$args['orderby'] = 'date';
-					$args['order']   = 'ASC';
-				} else {
-					$wp_type = CollectionEntries::wp_meta_type_for( $field_type );
-
-					$args['meta_key'] = $sort['field']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					$args['orderby']  = 'number' === $wp_type ? 'meta_value_num' : 'meta_value';
-					$args['order']    = $direction;
-				}
-			}
-		}
-
-		$filters = $request->get_param( 'filters' );
-		if ( is_array( $filters ) && count( $filters ) > 0 ) {
-			$meta_query = array();
-
-			foreach ( $filters as $filter ) {
-				if ( ! is_array( $filter ) ) {
-					continue;
-				}
-
-				$field    = $filter['field'] ?? '';
-				$operator = $filter['operator'] ?? '';
-				$value    = $filter['value'] ?? '';
-
-				if ( '' === $field || ! isset( self::FILTER_OPERATORS[ $operator ] ) ) {
-					continue;
-				}
-				$field_id = $this->field_id_from_key( $field );
-				if ( $field_id && 'rollup' === (string) get_post_meta( $field_id, 'type', true ) ) {
-					continue;
-				}
-
-				$compare = self::FILTER_OPERATORS[ $operator ];
-
-				// IN / NOT IN require array values.
-				if ( in_array( $compare, array( 'IN', 'NOT IN' ), true ) && ! is_array( $value ) ) {
-					$value = array( $value );
-				}
-
-				$meta_query[] = array(
-					'key'     => $field,
-					'value'   => $value,
-					'compare' => $compare,
-				);
-			}
-
-			if ( count( $meta_query ) > 0 ) {
-				$args['meta_query'] = $meta_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				$args['orderby'] = 'none';
+				$args['order']   = $direction;
 			}
 		}
 
@@ -651,7 +540,34 @@ final class RowsController {
 			return;
 		}
 
+		if ( 'date' === $field_type || 'datetime' === $field_type ) {
+			update_post_meta( $row_id, $key, $this->normalize_date_field_value( $value, $field_type ) );
+			return;
+		}
+
 		update_post_meta( $row_id, $key, sanitize_text_field( (string) $value ) );
+	}
+
+	private function normalize_date_field_value( mixed $value, string $field_type ): string {
+		$text = trim( (string) $value );
+		if ( '' === $text ) {
+			return '';
+		}
+
+		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})/', $text, $matches ) ) {
+			if ( 'date' === $field_type ) {
+				return $matches[1];
+			}
+			$timestamp = strtotime( $text );
+			return false === $timestamp ? sanitize_text_field( $text ) : gmdate( DATE_RFC3339, $timestamp );
+		}
+
+		$timestamp = strtotime( $text );
+		if ( false === $timestamp ) {
+			return sanitize_text_field( $text );
+		}
+
+		return 'date' === $field_type ? gmdate( 'Y-m-d', $timestamp ) : gmdate( DATE_RFC3339, $timestamp );
 	}
 
 	/**

--- a/includes/Rest/RowsFilterQuery.php
+++ b/includes/Rest/RowsFilterQuery.php
@@ -1,0 +1,778 @@
+<?php
+/**
+ * Query helpers for collection row sorting, filtering, and search.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use Cortext\Fields\FieldTypeRegistry;
+use WP_Error;
+
+final class RowsFilterQuery {
+
+	private const MAX_GROUP_DEPTH = 2;
+
+	/**
+	 * Field schema cache keyed by collection post ID.
+	 *
+	 * @var array<int,array<string,array{id:int,key:string,type:string,sortable:bool,filterable:bool,operators:string[],system?:bool}>>
+	 */
+	private array $schema_cache = array();
+
+	/**
+	 * Builds a row-query field schema for one collection.
+	 *
+	 * @param int $collection_id Collection post ID.
+	 * @return array<string,array{id:int,key:string,type:string,sortable:bool,filterable:bool,operators:string[],system?:bool}>
+	 */
+	public function field_schema_for( int $collection_id ): array {
+		if ( isset( $this->schema_cache[ $collection_id ] ) ) {
+			return $this->schema_cache[ $collection_id ];
+		}
+
+		$schema = array(
+			'title'       => array(
+				'id'         => 0,
+				'key'        => 'title',
+				'type'       => 'title',
+				'sortable'   => true,
+				'filterable' => true,
+				'operators'  => FieldTypeRegistry::operators_for( 'text' ),
+				'system'     => true,
+			),
+			'created_at'  => array(
+				'id'         => 0,
+				'key'        => 'created_at',
+				'type'       => 'datetime',
+				'sortable'   => true,
+				'filterable' => false,
+				'operators'  => array(),
+				'system'     => true,
+			),
+			'modified_at' => array(
+				'id'         => 0,
+				'key'        => 'modified_at',
+				'type'       => 'datetime',
+				'sortable'   => true,
+				'filterable' => false,
+				'operators'  => array(),
+				'system'     => true,
+			),
+		);
+
+		foreach ( get_post_meta( $collection_id, 'fields', false ) as $raw_field_id ) {
+			$field_id = (int) $raw_field_id;
+			if ( $field_id < 1 ) {
+				continue;
+			}
+			$type = (string) get_post_meta( $field_id, 'type', true );
+			$key  = "field-{$field_id}";
+
+			$schema[ $key ] = array(
+				'id'         => $field_id,
+				'key'        => $key,
+				'type'       => $type,
+				'sortable'   => FieldTypeRegistry::is_sortable( $type ),
+				'filterable' => FieldTypeRegistry::is_filterable( $type ),
+				'operators'  => FieldTypeRegistry::operators_for( $type ),
+			);
+		}
+
+		$this->schema_cache[ $collection_id ] = $schema;
+		return $schema;
+	}
+
+	/**
+	 * Validates a sort request against the collection schema.
+	 *
+	 * @param mixed $sort          Sort request value.
+	 * @param array $field_schema  Field schema from field_schema_for().
+	 * @param int   $collection_id Collection post ID for errors.
+	 * @return bool|WP_Error
+	 */
+	public function validate_sort( mixed $sort, array $field_schema, int $collection_id ): bool|WP_Error {
+		if ( ! is_array( $sort ) || empty( $sort['field'] ) ) {
+			return true;
+		}
+
+		$field = (string) $sort['field'];
+		if ( ! isset( $field_schema[ $field ] ) || ! $field_schema[ $field ]['sortable'] ) {
+			return new WP_Error(
+				'cortext_invalid_sort_field',
+				sprintf(
+					/* translators: 1: field key, 2: collection ID */
+					__( 'Field "%1$s" cannot be used to sort collection %2$d.', 'cortext' ),
+					$field,
+					$collection_id
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates and compiles a filter tree into prepared JOIN/WHERE SQL.
+	 *
+	 * @param mixed $filters       REST filters param.
+	 * @param array $field_schema  Field schema from field_schema_for().
+	 * @param int   $collection_id Collection post ID for errors.
+	 * @return array{join:string,where:string}|WP_Error SQL fragments, or empty strings.
+	 */
+	public function compile_filters( mixed $filters, array $field_schema, int $collection_id ): array|WP_Error {
+		if ( ! is_array( $filters ) || count( $filters ) === 0 ) {
+			return $this->empty_sql_clauses();
+		}
+
+		$query = array( 'relation' => 'AND' );
+		foreach ( $filters as $filter ) {
+			$compiled = $this->compile_filter_node( $filter, $field_schema, $collection_id, 0 );
+			if ( is_wp_error( $compiled ) ) {
+				return $compiled;
+			}
+			if ( count( $compiled ) > 0 ) {
+				$query[] = $compiled;
+			}
+		}
+
+		if ( count( $query ) === 1 ) {
+			return $this->empty_sql_clauses();
+		}
+
+		return $this->meta_query_sql( $query );
+	}
+
+	/**
+	 * Compiles split-term search across title plus text-like meta fields.
+	 *
+	 * @param string $search       Search string.
+	 * @param array  $field_schema Field schema from field_schema_for().
+	 * @return string SQL fragment without leading AND, or empty string.
+	 */
+	public function compile_search( string $search, array $field_schema ): string {
+		$terms = preg_split( '/\s+/', trim( $search ) );
+		$terms = is_array( $terms ) ? $terms : array();
+		$terms = array_values(
+			array_filter(
+				$terms,
+				static fn( $term ) => '' !== $term
+			)
+		);
+		if ( count( $terms ) === 0 ) {
+			return '';
+		}
+
+		$text_keys = array();
+		foreach ( $field_schema as $field ) {
+			if ( empty( $field['system'] ) && FieldTypeRegistry::is_text_like( $field['type'] ) ) {
+				$text_keys[] = $field['key'];
+			}
+		}
+
+		$parts = array();
+		foreach ( $terms as $term ) {
+			$parts[] = $this->search_term_sql( (string) $term, $text_keys );
+		}
+		return '( ' . implode( ' AND ', $parts ) . ' )';
+	}
+
+	/**
+	 * Applies custom sort clauses for row-field sorts that need LEFT JOIN.
+	 *
+	 * @param array $clauses      WP_Query SQL clauses.
+	 * @param mixed $sort         Sort request value.
+	 * @param array $field_schema Field schema from field_schema_for().
+	 * @return array
+	 */
+	public function apply_sort_clauses( array $clauses, mixed $sort, array $field_schema ): array {
+		if ( ! is_array( $sort ) || empty( $sort['field'] ) ) {
+			return $clauses;
+		}
+
+		$field_key = (string) $sort['field'];
+		if ( ! str_starts_with( $field_key, 'field-' ) || empty( $field_schema[ $field_key ] ) ) {
+			return $clauses;
+		}
+
+		global $wpdb;
+
+		$direction = ( $sort['direction'] ?? 'asc' ) === 'desc' ? 'DESC' : 'ASC';
+		$field     = $field_schema[ $field_key ];
+		$alias     = 'cortext_sort_meta';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$clauses['join'] .= $wpdb->prepare(
+			" LEFT JOIN {$wpdb->postmeta} AS {$alias} ON ({$alias}.post_id = {$wpdb->posts}.ID AND {$alias}.meta_key = %s)",
+			$field_key
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		if ( 'checkbox' === $field['type'] ) {
+			$clauses['orderby'] = "CASE WHEN {$alias}.meta_value = '1' THEN 1 ELSE 0 END {$direction}, {$wpdb->posts}.ID ASC";
+			return $clauses;
+		}
+
+		$empty_order = "CASE WHEN {$alias}.meta_id IS NULL OR {$alias}.meta_value = '' THEN 1 ELSE 0 END ASC";
+		$value_expr  = 'number' === $field['type']
+			? "CAST({$alias}.meta_value AS DECIMAL(20,6))"
+			: "{$alias}.meta_value";
+
+		$clauses['orderby'] = "{$empty_order}, {$value_expr} {$direction}, {$wpdb->posts}.ID ASC";
+		return $clauses;
+	}
+
+	/**
+	 * Adds compiled filter JOINs and de-duplicates joined rows.
+	 *
+	 * WP_Query normally adds `GROUP BY posts.ID` when its own `meta_query`
+	 * object introduces meta joins. RSM-1459 builds SQL through RowsMetaQuery
+	 * and injects it as scoped clause filters, so we need to add the same
+	 * de-duplication ourselves for multi-value meta filters.
+	 *
+	 * @param array  $clauses WP_Query SQL clauses.
+	 * @param string $join    Compiled filter JOIN SQL.
+	 * @return array
+	 */
+	public function apply_filter_join_clauses( array $clauses, string $join ): array {
+		if ( '' === $join ) {
+			return $clauses;
+		}
+
+		global $wpdb;
+
+		$clauses['join'] = (string) ( $clauses['join'] ?? '' ) . $join;
+
+		$post_id = "{$wpdb->posts}.ID";
+		$groupby = trim( (string) ( $clauses['groupby'] ?? '' ) );
+		if ( '' === $groupby ) {
+			$clauses['groupby'] = $post_id;
+		} elseif ( ! str_contains( $groupby, $post_id ) ) {
+			$clauses['groupby'] = "{$groupby}, {$post_id}";
+		}
+
+		return $clauses;
+	}
+
+	/**
+	 * Compiles one leaf or group node.
+	 *
+	 * @param mixed $node          Filter node.
+	 * @param array $field_schema  Field schema from field_schema_for().
+	 * @param int   $collection_id Collection post ID for errors.
+	 * @param int   $depth         Group depth; top-level leaves are 0.
+	 * @return array|WP_Error
+	 */
+	private function compile_filter_node( mixed $node, array $field_schema, int $collection_id, int $depth ): array|WP_Error {
+		if ( ! is_array( $node ) ) {
+			return $this->invalid_filter( __( 'Filter must be an object.', 'cortext' ) );
+		}
+
+		$is_group = isset( $node['relation'] ) || isset( $node['filters'] );
+		$is_leaf  = isset( $node['field'] ) || isset( $node['operator'] );
+
+		if ( $is_group && $is_leaf ) {
+			return $this->invalid_filter( __( 'Filter cannot be both a group and a leaf.', 'cortext' ) );
+		}
+
+		if ( $is_group ) {
+			return $this->compile_filter_group( $node, $field_schema, $collection_id, $depth );
+		}
+
+		if ( ! $is_leaf ) {
+			return $this->invalid_filter( __( 'Filter must include a field and operator.', 'cortext' ) );
+		}
+
+		return $this->compile_filter_leaf( $node, $field_schema, $collection_id );
+	}
+
+	/**
+	 * Compiles an AND/OR filter group.
+	 *
+	 * @param array $group         Filter group.
+	 * @param array $field_schema  Field schema from field_schema_for().
+	 * @param int   $collection_id Collection post ID for errors.
+	 * @param int   $depth         Group depth.
+	 * @return array|WP_Error
+	 */
+	private function compile_filter_group( array $group, array $field_schema, int $collection_id, int $depth ): array|WP_Error {
+		if ( $depth > self::MAX_GROUP_DEPTH ) {
+			return new WP_Error(
+				'cortext_filter_depth_exceeded',
+				__( 'Filter groups cannot be nested more than two levels deep.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$relation = strtoupper( (string) ( $group['relation'] ?? 'AND' ) );
+		if ( ! in_array( $relation, array( 'AND', 'OR' ), true ) ) {
+			return new WP_Error(
+				'cortext_invalid_filter_relation',
+				__( 'Filter group relation must be AND or OR.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! isset( $group['filters'] ) || ! is_array( $group['filters'] ) || count( $group['filters'] ) === 0 ) {
+			return $this->invalid_filter( __( 'Filter group must include child filters.', 'cortext' ) );
+		}
+
+		$query = array( 'relation' => $relation );
+		foreach ( $group['filters'] as $child ) {
+			$compiled = $this->compile_filter_node( $child, $field_schema, $collection_id, $depth + 1 );
+			if ( is_wp_error( $compiled ) ) {
+				return $compiled;
+			}
+			if ( count( $compiled ) > 0 ) {
+				$query[] = $compiled;
+			}
+		}
+
+		if ( count( $query ) === 1 ) {
+			return array();
+		}
+		return $query;
+	}
+
+	/**
+	 * Compiles one field/operator/value filter.
+	 *
+	 * @param array $filter        Filter leaf.
+	 * @param array $field_schema  Field schema from field_schema_for().
+	 * @param int   $collection_id Collection post ID for errors.
+	 * @return array|WP_Error
+	 */
+	private function compile_filter_leaf( array $filter, array $field_schema, int $collection_id ): array|WP_Error {
+		$field_key = isset( $filter['field'] ) ? (string) $filter['field'] : '';
+		$operator  = isset( $filter['operator'] ) ? (string) $filter['operator'] : '';
+
+		if ( '' === $field_key || '' === $operator ) {
+			return $this->invalid_filter( __( 'Filter must include a field and operator.', 'cortext' ) );
+		}
+
+		if ( ! isset( $field_schema[ $field_key ] ) || ! $field_schema[ $field_key ]['filterable'] ) {
+			return new WP_Error(
+				'cortext_invalid_filter_field',
+				sprintf(
+					/* translators: 1: field key, 2: collection ID */
+					__( 'Field "%1$s" cannot be used to filter collection %2$d.', 'cortext' ),
+					$field_key,
+					$collection_id
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		$field = $field_schema[ $field_key ];
+		$type  = $field['type'];
+		$value = $filter['value'] ?? null;
+		if ( ! in_array( $operator, $field['operators'], true ) ) {
+			return $this->invalid_filter_operator( $operator, $field_key );
+		}
+		if ( 'title' === $field_key ) {
+			return $this->title_filter_sql( $operator, $value );
+		}
+
+		return match ( $type ) {
+			'text', 'email', 'url' => $this->text_filter_sql( $field_key, $operator, $value ),
+			'number' => $this->number_filter_sql( $field_key, $operator, $value ),
+			'date', 'datetime' => $this->date_filter_sql( $field_key, $type, $operator, $value ),
+			'select' => $this->select_filter_sql( $field_key, $operator, $value ),
+			'multiselect' => $this->multiselect_filter_sql( $field_key, $operator, $value ),
+			'checkbox' => $this->checkbox_filter_sql( $field_key, $operator ),
+			default => $this->invalid_filter_field_type(),
+		};
+	}
+
+	private function title_filter_sql( string $operator, mixed $value ): array|WP_Error {
+		return match ( $operator ) {
+			'is' => $this->title_clause( '=', $this->string_value( $value, $operator ) ),
+			'isNot' => $this->title_clause( '!=', $this->string_value( $value, $operator ) ),
+			'contains' => $this->title_clause( 'LIKE', $this->string_value( $value, $operator ) ),
+			'notContains' => $this->title_clause( 'NOT_CONTAINS', $this->string_value( $value, $operator ) ),
+			'startsWith' => $this->title_clause( 'STARTS_WITH', $this->string_value( $value, $operator ) ),
+			'endsWith' => $this->title_clause( 'ENDS_WITH', $this->string_value( $value, $operator ) ),
+			'isEmpty' => $this->title_clause( '=', '' ),
+			'isNotEmpty' => $this->title_clause( '!=', '' ),
+			default => $this->invalid_filter_operator( $operator, 'title' ),
+		};
+	}
+
+	private function text_filter_sql( string $key, string $operator, mixed $value ): array|WP_Error {
+		return match ( $operator ) {
+			'is' => $this->meta_clause( $key, '=', $this->string_value( $value, $operator ) ),
+			'isNot' => $this->meta_clause( $key, 'NOT_EQUALS', $this->string_value( $value, $operator ) ),
+			'contains' => $this->meta_clause( $key, 'LIKE', $this->string_value( $value, $operator ) ),
+			'notContains' => $this->meta_clause( $key, 'NOT_CONTAINS', $this->string_value( $value, $operator ) ),
+			'startsWith' => $this->meta_clause( $key, 'STARTS_WITH', $this->string_value( $value, $operator ) ),
+			'endsWith' => $this->meta_clause( $key, 'ENDS_WITH', $this->string_value( $value, $operator ) ),
+			'isEmpty' => $this->empty_meta_clause( $key ),
+			'isNotEmpty' => $this->meta_clause( $key, '!=', '' ),
+			default => $this->invalid_filter_operator( $operator, $key ),
+		};
+	}
+
+	private function number_filter_sql( string $key, string $operator, mixed $value ): array|WP_Error {
+		if ( 'isEmpty' === $operator ) {
+			return $this->empty_meta_clause( $key );
+		}
+		if ( 'between' === $operator ) {
+			$range = $this->numeric_range_value( $value, $operator );
+			if ( is_wp_error( $range ) ) {
+				return $range;
+			}
+			return $this->meta_clause( $key, 'BETWEEN', $range, 'DECIMAL(20,6)' );
+		}
+
+		$number = $this->numeric_value( $value, $operator );
+		if ( is_wp_error( $number ) ) {
+			return $number;
+		}
+
+		return match ( $operator ) {
+			'is' => $this->meta_clause( $key, '=', $number, 'DECIMAL(20,6)' ),
+			'greaterThan' => $this->meta_clause( $key, '>', $number, 'DECIMAL(20,6)' ),
+			'lessThan' => $this->meta_clause( $key, '<', $number, 'DECIMAL(20,6)' ),
+			default => $this->invalid_filter_operator( $operator, $key ),
+		};
+	}
+
+	private function date_filter_sql( string $key, string $type, string $operator, mixed $value ): array|WP_Error {
+		if ( 'isEmpty' === $operator ) {
+			return $this->empty_meta_clause( $key );
+		}
+		if ( 'between' === $operator ) {
+			$range = $this->date_range_value( $value, $type, $operator );
+			if ( is_wp_error( $range ) ) {
+				return $range;
+			}
+			return $this->meta_clause( $key, 'BETWEEN', $range );
+		}
+		if ( 'on' === $operator || 'is' === $operator ) {
+			$day = $this->date_day_value( $value, $operator );
+			if ( is_wp_error( $day ) ) {
+				return $day;
+			}
+			return array(
+				'relation' => 'OR',
+				$this->meta_clause( $key, '=', $day ),
+				$this->meta_clause( $key, 'STARTS_WITH', $day ),
+			);
+		}
+
+		$date = $this->date_compare_value( $value, $type, $operator );
+		if ( is_wp_error( $date ) ) {
+			return $date;
+		}
+
+		return match ( $operator ) {
+			'before' => $this->meta_clause( $key, '<', $date ),
+			'after' => $this->meta_clause( $key, '>', $date ),
+			default => $this->invalid_filter_operator( $operator, $key ),
+		};
+	}
+
+	private function select_filter_sql( string $key, string $operator, mixed $value ): array|WP_Error {
+		return match ( $operator ) {
+			'is' => $this->meta_clause( $key, '=', $this->string_value( $value, $operator ) ),
+			'isNot' => $this->meta_clause( $key, 'NOT_EQUALS', $this->string_value( $value, $operator ) ),
+			'isAny' => $this->meta_clause( $key, 'IN', $this->array_value( $value, $operator ) ),
+			'isNone' => $this->meta_clause( $key, 'NONE_IN', $this->array_value( $value, $operator ) ),
+			default => $this->invalid_filter_operator( $operator, $key ),
+		};
+	}
+
+	private function multiselect_filter_sql( string $key, string $operator, mixed $value ): array|WP_Error {
+		return match ( $operator ) {
+			'contains' => $this->meta_clause( $key, '=', $this->string_value( $value, $operator ) ),
+			'notContains' => $this->meta_clause( $key, 'NOT_EQUALS', $this->string_value( $value, $operator ) ),
+			'isAny' => $this->meta_clause( $key, 'IN', $this->array_value( $value, $operator ) ),
+			'isNone' => $this->meta_clause( $key, 'NONE_IN', $this->array_value( $value, $operator ) ),
+			default => $this->invalid_filter_operator( $operator, $key ),
+		};
+	}
+
+	private function checkbox_filter_sql( string $key, string $operator ): array|WP_Error {
+		return match ( $operator ) {
+			'isChecked' => $this->meta_clause( $key, '=', '1' ),
+			'isUnchecked' => $this->empty_meta_clause( $key ),
+			default => $this->invalid_filter_operator( $operator, $key ),
+		};
+	}
+
+	private function title_clause( string $compare, string|WP_Error $value ): array|WP_Error {
+		if ( is_wp_error( $value ) ) {
+			return $value;
+		}
+
+		return array(
+			'key'     => RowsMetaQuery::TITLE_KEY,
+			'compare' => $compare,
+			'value'   => $value,
+		);
+	}
+
+	private function meta_clause( string $key, string $compare, mixed $value, string $type = 'CHAR' ): array|WP_Error {
+		if ( is_wp_error( $value ) ) {
+			return $value;
+		}
+
+		return array(
+			'key'     => $key,
+			'compare' => $compare,
+			'value'   => $value,
+			'type'    => $type,
+		);
+	}
+
+	private function empty_meta_clause( string $key ): array {
+		return array(
+			'relation' => 'OR',
+			array(
+				'key'     => $key,
+				'compare' => 'NOT EXISTS',
+			),
+			array(
+				'key'     => $key,
+				'compare' => '=',
+				'value'   => '',
+			),
+		);
+	}
+
+	/**
+	 * Runs the compiled filter tree through RowsMetaQuery.
+	 *
+	 * @param array $query WP_Meta_Query-style query tree.
+	 * @return array{join:string,where:string}
+	 */
+	private function meta_query_sql( array $query ): array {
+		global $wpdb;
+
+		$meta_query = new RowsMetaQuery( $query );
+		$sql        = $meta_query->get_sql( 'post', $wpdb->posts, 'ID' );
+		if ( ! is_array( $sql ) ) {
+			return $this->empty_sql_clauses();
+		}
+
+		return array(
+			'join'  => (string) ( $sql['join'] ?? '' ),
+			'where' => preg_replace( '/^\s*AND\s+/i', '', (string) ( $sql['where'] ?? '' ) ) ?? '',
+		);
+	}
+
+	/**
+	 * Returns empty SQL clauses.
+	 *
+	 * @return array{join:string,where:string}
+	 */
+	private function empty_sql_clauses(): array {
+		return array(
+			'join'  => '',
+			'where' => '',
+		);
+	}
+
+	private function search_term_sql( string $term, array $text_keys ): string {
+		global $wpdb;
+
+		$like  = '%' . $wpdb->esc_like( $term ) . '%';
+		$parts = array(
+			$wpdb->prepare( "{$wpdb->posts}.post_title LIKE %s", $like ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		if ( count( $text_keys ) > 0 ) {
+			$parts[] = $this->meta_key_in_like_sql( $text_keys, $like );
+		}
+
+		return '( ' . implode( ' OR ', $parts ) . ' )';
+	}
+
+	private function meta_key_in_like_sql( array $keys, string $like ): string {
+		global $wpdb;
+
+		$placeholders = implode( ', ', array_fill( 0, count( $keys ), '%s' ) );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$sql = $wpdb->prepare(
+			"EXISTS (SELECT 1 FROM {$wpdb->postmeta} AS cortext_search_meta WHERE cortext_search_meta.post_id = {$wpdb->posts}.ID AND cortext_search_meta.meta_key IN ({$placeholders}) AND cortext_search_meta.meta_value LIKE %s)",
+			array_merge( $keys, array( $like ) )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		return $sql;
+	}
+
+	private function string_value( mixed $value, string $operator ): string|WP_Error {
+		if ( is_array( $value ) || is_object( $value ) || null === $value ) {
+			return $this->invalid_filter(
+				sprintf(
+					/* translators: %s: filter operator */
+					__( 'Operator "%s" requires a scalar value.', 'cortext' ),
+					$operator
+				)
+			);
+		}
+		return (string) $value;
+	}
+
+	private function array_value( mixed $value, string $operator ): array|WP_Error {
+		$values = is_array( $value ) ? $value : array( $value );
+		$values = array_values(
+			array_filter(
+				array_map(
+					static fn( $item ) => is_scalar( $item ) ? (string) $item : '',
+					$values
+				),
+				static fn( $item ) => '' !== $item
+			)
+		);
+
+		if ( count( $values ) === 0 ) {
+			return $this->invalid_filter(
+				sprintf(
+					/* translators: %s: filter operator */
+					__( 'Operator "%s" requires at least one value.', 'cortext' ),
+					$operator
+				)
+			);
+		}
+		return $values;
+	}
+
+	private function numeric_value( mixed $value, string $operator ): float|WP_Error {
+		if ( ! is_numeric( $value ) ) {
+			return $this->invalid_filter(
+				sprintf(
+					/* translators: %s: filter operator */
+					__( 'Operator "%s" requires a numeric value.', 'cortext' ),
+					$operator
+				)
+			);
+		}
+		return (float) $value;
+	}
+
+	/**
+	 * Normalizes a two-number filter range.
+	 *
+	 * @param mixed  $value    Raw filter value.
+	 * @param string $operator Filter operator.
+	 * @return array{0:float,1:float}|WP_Error
+	 */
+	private function numeric_range_value( mixed $value, string $operator ): array|WP_Error {
+		if ( ! is_array( $value ) || count( $value ) !== 2 ) {
+			return $this->invalid_filter(
+				sprintf(
+					/* translators: %s: filter operator */
+					__( 'Operator "%s" requires exactly two values.', 'cortext' ),
+					$operator
+				)
+			);
+		}
+		$min = $this->numeric_value( $value[0], $operator );
+		$max = $this->numeric_value( $value[1], $operator );
+		if ( is_wp_error( $min ) ) {
+			return $min;
+		}
+		if ( is_wp_error( $max ) ) {
+			return $max;
+		}
+		return array( min( $min, $max ), max( $min, $max ) );
+	}
+
+	/**
+	 * Normalizes a two-date filter range.
+	 *
+	 * @param mixed  $value    Raw filter value.
+	 * @param string $type     Field type.
+	 * @param string $operator Filter operator.
+	 * @return array{0:string,1:string}|WP_Error
+	 */
+	private function date_range_value( mixed $value, string $type, string $operator ): array|WP_Error {
+		if ( ! is_array( $value ) || count( $value ) !== 2 ) {
+			return $this->invalid_filter(
+				sprintf(
+					/* translators: %s: filter operator */
+					__( 'Operator "%s" requires exactly two values.', 'cortext' ),
+					$operator
+				)
+			);
+		}
+		$start = $this->date_compare_value( $value[0], $type, $operator );
+		$end   = $this->date_compare_value( $value[1], $type, $operator );
+		if ( is_wp_error( $start ) ) {
+			return $start;
+		}
+		if ( is_wp_error( $end ) ) {
+			return $end;
+		}
+		return $start <= $end ? array( $start, $end ) : array( $end, $start );
+	}
+
+	private function date_day_value( mixed $value, string $operator ): string|WP_Error {
+		$text = $this->string_value( $value, $operator );
+		if ( is_wp_error( $text ) ) {
+			return $text;
+		}
+		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})/', $text, $matches ) ) {
+			return $matches[1];
+		}
+		$timestamp = strtotime( $text );
+		if ( false === $timestamp ) {
+			return $this->invalid_filter( __( 'Date filter value must be parseable.', 'cortext' ) );
+		}
+		return gmdate( 'Y-m-d', $timestamp );
+	}
+
+	private function date_compare_value( mixed $value, string $type, string $operator ): string|WP_Error {
+		$day = $this->date_day_value( $value, $operator );
+		if ( is_wp_error( $day ) ) {
+			return $day;
+		}
+		if ( 'date' === $type ) {
+			return $day;
+		}
+
+		$text = $this->string_value( $value, $operator );
+		if ( is_wp_error( $text ) ) {
+			return $text;
+		}
+		$timestamp = strtotime( $text );
+		if ( false === $timestamp ) {
+			return $this->invalid_filter( __( 'Datetime filter value must be parseable.', 'cortext' ) );
+		}
+		return gmdate( DATE_RFC3339, $timestamp );
+	}
+
+	private function invalid_filter( string $message ): WP_Error {
+		return new WP_Error(
+			'cortext_invalid_filter',
+			$message,
+			array( 'status' => 400 )
+		);
+	}
+
+	private function invalid_filter_operator( string $operator, string $field_key ): WP_Error {
+		return new WP_Error(
+			'cortext_invalid_filter_operator',
+			sprintf(
+				/* translators: 1: operator, 2: field key */
+				__( 'Operator "%1$s" cannot be used to filter field "%2$s".', 'cortext' ),
+				$operator,
+				$field_key
+			),
+			array( 'status' => 400 )
+		);
+	}
+
+	private function invalid_filter_field_type(): WP_Error {
+		return new WP_Error(
+			'cortext_invalid_filter_field',
+			__( 'Unsupported filter field type.', 'cortext' ),
+			array( 'status' => 400 )
+		);
+	}
+}

--- a/includes/Rest/RowsMetaQuery.php
+++ b/includes/Rest/RowsMetaQuery.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * WP_Meta_Query extension for collection row filters.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use WP_Meta_Query;
+
+final class RowsMetaQuery extends WP_Meta_Query {
+
+	public const TITLE_KEY = '__cortext_title';
+
+	private const STARTS_WITH  = 'STARTS_WITH';
+	private const ENDS_WITH    = 'ENDS_WITH';
+	private const NOT_EQUALS   = 'NOT_EQUALS';
+	private const NOT_CONTAINS = 'NOT_CONTAINS';
+	private const NONE_IN      = 'NONE_IN';
+
+	/**
+	 * Generates SQL for one first-order clause.
+	 *
+	 * @param array  $clause       Query clause passed by reference.
+	 * @param array  $parent_query Parent query array.
+	 * @param string $clause_key   Optional clause key.
+	 * @return array{join:string[],where:string[]}
+	 */
+	public function get_sql_for_clause( &$clause, $parent_query, $clause_key = '' ) {
+		$compare = strtoupper( trim( (string) ( $clause['compare'] ?? ( isset( $clause['value'] ) && is_array( $clause['value'] ) ? 'IN' : '=' ) ) ) );
+		$key     = (string) ( $clause['key'] ?? '' );
+
+		if ( self::TITLE_KEY === $key ) {
+			return $this->title_clause_sql( $clause, $compare );
+		}
+
+		if ( in_array( $compare, array( self::STARTS_WITH, self::ENDS_WITH ), true ) ) {
+			return $this->positive_like_meta_clause_sql( $clause, $compare );
+		}
+
+		if ( in_array( $compare, array( self::NOT_EQUALS, self::NOT_CONTAINS, self::NONE_IN ), true ) ) {
+			return $this->negative_meta_clause_sql( $clause, $compare );
+		}
+
+		return parent::get_sql_for_clause( $clause, $parent_query, $clause_key );
+	}
+
+	/**
+	 * Builds a post-title SQL clause.
+	 *
+	 * @param array  $clause Filter clause.
+	 * @param string $compare Uppercase compare operator.
+	 * @return array{join:string[],where:string[]}
+	 */
+	private function title_clause_sql( array $clause, string $compare ): array {
+		global $wpdb;
+
+		$value  = (string) ( $clause['value'] ?? '' );
+		$column = "{$this->primary_table}.post_title";
+
+		if ( '=' === $compare || '!=' === $compare ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$where = $wpdb->prepare( "{$column} {$compare} %s", $value );
+			return array(
+				'join'  => array(),
+				'where' => array( $where ),
+			);
+		}
+
+		$like = match ( $compare ) {
+			self::STARTS_WITH => $wpdb->esc_like( $value ) . '%',
+			self::ENDS_WITH => '%' . $wpdb->esc_like( $value ),
+			default => '%' . $wpdb->esc_like( $value ) . '%',
+		};
+		$operator = self::NOT_CONTAINS === $compare ? 'NOT LIKE' : 'LIKE';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$where = $wpdb->prepare( "{$column} {$operator} %s", $like );
+		return array(
+			'join'  => array(),
+			'where' => array( $where ),
+		);
+	}
+
+	/**
+	 * Builds a one-sided meta LIKE SQL clause.
+	 *
+	 * @param array  $clause Filter clause.
+	 * @param string $compare Uppercase compare operator.
+	 * @return array{join:string[],where:string[]}
+	 */
+	private function positive_like_meta_clause_sql( array $clause, string $compare ): array {
+		global $wpdb;
+
+		$key   = (string) ( $clause['key'] ?? '' );
+		$value = (string) ( $clause['value'] ?? '' );
+		$alias = $this->next_table_alias();
+		$like  = self::STARTS_WITH === $compare
+			? $wpdb->esc_like( $value ) . '%'
+			: '%' . $wpdb->esc_like( $value );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$where = $wpdb->prepare(
+			"( {$alias}.meta_key = %s AND {$alias}.meta_value LIKE %s )",
+			$key,
+			$like
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array(
+			'join'  => array( $this->inner_join_for_alias( $alias ) ),
+			'where' => array( $where ),
+		);
+	}
+
+	/**
+	 * Builds a negative value SQL clause using NOT EXISTS.
+	 *
+	 * @param array  $clause Filter clause.
+	 * @param string $compare Uppercase compare operator.
+	 * @return array{join:string[],where:string[]}
+	 */
+	private function negative_meta_clause_sql( array $clause, string $compare ): array {
+		global $wpdb;
+
+		$key = (string) ( $clause['key'] ?? '' );
+		if ( self::NONE_IN === $compare ) {
+			$values = is_array( $clause['value'] ?? null ) ? array_values( $clause['value'] ) : array();
+			$values = array_map( 'strval', $values );
+			if ( count( $values ) === 0 ) {
+				return array(
+					'join'  => array(),
+					'where' => array(),
+				);
+			}
+
+			$placeholders = implode( ', ', array_fill( 0, count( $values ), '%s' ) );
+			$alias        = $this->negative_subquery_alias();
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			$where = $wpdb->prepare(
+				"NOT EXISTS (SELECT 1 FROM {$this->meta_table} AS {$alias} WHERE {$alias}.{$this->meta_id_column} = {$this->primary_table}.{$this->primary_id_column} AND {$alias}.meta_key = %s AND {$alias}.meta_value IN ({$placeholders}))",
+				array_merge( array( $key ), $values )
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+			return array(
+				'join'  => array(),
+				'where' => array( $where ),
+			);
+		}
+
+		$value      = (string) ( $clause['value'] ?? '' );
+		$operator   = self::NOT_CONTAINS === $compare ? 'LIKE' : '=';
+		$sql_value  = self::NOT_CONTAINS === $compare ? '%' . $wpdb->esc_like( $value ) . '%' : $value;
+		$alias      = $this->negative_subquery_alias();
+		$comparison = "{$alias}.meta_value {$operator} %s";
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$where = $wpdb->prepare(
+			"NOT EXISTS (SELECT 1 FROM {$this->meta_table} AS {$alias} WHERE {$alias}.{$this->meta_id_column} = {$this->primary_table}.{$this->primary_id_column} AND {$alias}.meta_key = %s AND {$comparison})",
+			$key,
+			$sql_value
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		return array(
+			'join'  => array(),
+			'where' => array( $where ),
+		);
+	}
+
+	private function next_table_alias(): string {
+		$index = count( $this->table_aliases );
+		$alias = $index ? 'mt' . $index : $this->meta_table;
+
+		$this->table_aliases[] = $alias;
+		return $alias;
+	}
+
+	private function inner_join_for_alias( string $alias ): string {
+		$join  = " INNER JOIN {$this->meta_table}";
+		$join .= $alias === $this->meta_table ? '' : " AS {$alias}";
+		$join .= " ON ( {$this->primary_table}.{$this->primary_id_column} = {$alias}.{$this->meta_id_column} )";
+
+		return $join;
+	}
+
+	private function negative_subquery_alias(): string {
+		return 'cortext_meta_not_' . count( $this->table_aliases );
+	}
+}

--- a/includes/Rest/RowsQueryScope.php
+++ b/includes/Rest/RowsQueryScope.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Scoped WP_Query runner for the rows endpoint.
+ *
+ * Wires the filter/search/sort SQL fragments produced by
+ * `RowsFilterQuery` into a single `WP_Query` execution and tears the
+ * hooks back down when the query finishes. Callers see a `run()`
+ * method instead of token-guarded callbacks and magic query vars.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use WP_Query;
+
+final class RowsQueryScope {
+
+	private const TOKEN_QUERY_VAR = 'cortext_rows_query_token';
+
+	private string $token;
+	private string $where_sql;
+	private string $join_sql;
+	private mixed $sort;
+	private array $field_schema;
+	private RowsFilterQuery $row_query;
+
+	public function __construct(
+		RowsFilterQuery $row_query,
+		array $field_schema,
+		string $where_sql,
+		string $join_sql,
+		mixed $sort
+	) {
+		$this->row_query    = $row_query;
+		$this->field_schema = $field_schema;
+		$this->where_sql    = $where_sql;
+		$this->join_sql     = $join_sql;
+		$this->sort         = $sort;
+		$this->token        = uniqid( 'cortext_rows_', true );
+	}
+
+	/**
+	 * Runs WP_Query with the scope's SQL fragments installed for the
+	 * duration of the query. The fragments come off the filter chain
+	 * before the method returns, even on exception.
+	 *
+	 * @param array $query_args Base WP_Query arguments.
+	 * @return WP_Query
+	 */
+	public function run( array $query_args ): WP_Query {
+		$query_args[ self::TOKEN_QUERY_VAR ] = $this->token;
+
+		$where_callback   = function ( string $where, WP_Query $query ): string {
+			if ( ! $this->owns( $query ) ) {
+				return $where;
+			}
+			return '' === $this->where_sql ? $where : "{$where} AND {$this->where_sql}";
+		};
+		$clauses_callback = function ( array $clauses, WP_Query $query ): array {
+			if ( ! $this->owns( $query ) ) {
+				return $clauses;
+			}
+			$clauses = $this->row_query->apply_filter_join_clauses( $clauses, $this->join_sql );
+			return $this->row_query->apply_sort_clauses( $clauses, $this->sort, $this->field_schema );
+		};
+
+		add_filter( 'posts_where', $where_callback, 10, 2 );
+		add_filter( 'posts_clauses', $clauses_callback, 10, 2 );
+		try {
+			return new WP_Query( $query_args );
+		} finally {
+			remove_filter( 'posts_where', $where_callback, 10 );
+			remove_filter( 'posts_clauses', $clauses_callback, 10 );
+		}
+	}
+
+	private function owns( WP_Query $query ): bool {
+		return $query->get( self::TOKEN_QUERY_VAR ) === $this->token;
+	}
+}

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Button, Notice } from '@wordpress/components';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { DataViews } from '@wordpress/dataviews';
 import {
 	createContext,
 	useCallback,
@@ -17,6 +17,7 @@ import { useNavigate } from '@wordpress/route';
 import DataViewColumnInteractions from './DataViewColumnInteractions';
 import EditableCell, { RowMutationContext } from './EditableCell';
 import PageIcon from './PageIcon';
+import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
 import ColumnHeaderActions from './fields/ColumnHeaderActions';
 import RowDetailView, { ROW_DETAIL_MODE_ICONS } from './RowDetailView';
@@ -26,6 +27,7 @@ import {
 	TITLE_FIELD_ID,
 	isDefaultVisibleField,
 	normalizeView,
+	pruneFiltersForFields,
 } from './dataViewColumns';
 import {
 	adjacentRowId,
@@ -33,6 +35,7 @@ import {
 	withRowDetailMode,
 } from './rowDetailUtils';
 import { useCollectionFieldsContext } from './CollectionFieldsContext';
+import { dataViewsFilterByForType } from '../hooks/fieldMapping';
 import useCollectionRows from '../hooks/useCollectionRows';
 import { useRecents } from '../hooks/useRecents';
 import { elementsFromOptions } from '../hooks/optionElements';
@@ -40,6 +43,16 @@ import { computeDocumentUri } from '../router/useResolveEntity';
 
 const DEFAULT_LAYOUTS = { table: { density: 'compact' }, grid: {}, list: {} };
 const TITLE_LABEL = __( 'Title', 'cortext' );
+const TITLE_FILTER_OPERATORS = [
+	'is',
+	'isNot',
+	'contains',
+	'notContains',
+	'startsWith',
+	'endsWith',
+	'isEmpty',
+	'isNotEmpty',
+];
 const ROW_DETAIL_SIDE_SURFACE_EXIT_MS = 300;
 const ROW_DETAIL_MODAL_ENTER_MS = 200;
 const ROW_DETAIL_SIDE_TO_MODAL_HANDOFF_MS =
@@ -122,6 +135,7 @@ function TitleCell( { item } ) {
 
 const TITLE_FIELD = {
 	id: TITLE_FIELD_ID,
+	type: 'text',
 	label: TITLE_LABEL,
 	header: (
 		<span className="cortext-column-header-label">{ TITLE_LABEL }</span>
@@ -130,10 +144,19 @@ const TITLE_FIELD = {
 	// the unfiltered string (the_title encodes `&` as `&#038;`, which
 	// would otherwise sort under that literal entity). Same reason as
 	// `mapField`'s label fallback in `src/hooks/fieldMapping.js`.
-	getValue: ( { item } ) => item?.title?.raw ?? item?.title?.rendered ?? '',
+	getValue: ( { item } ) => {
+		const title = item?.title;
+		return typeof title === 'string'
+			? title
+			: title?.raw ?? title?.rendered ?? '';
+	},
 	render: ( { item } ) => <TitleCell item={ item } />,
 	editable: true,
 	cortextType: 'title',
+	sortable: true,
+	filterable: true,
+	operators: TITLE_FILTER_OPERATORS,
+	filterBy: dataViewsFilterByForType( 'text', TITLE_FILTER_OPERATORS ),
 	enableGlobalSearch: true,
 	// The title column can't be hidden (it's the row identity), but it
 	// reorders and resizes like any other column. `normalizeView` re-adds
@@ -152,6 +175,10 @@ const GHOST_FIELD = {
 	type: 'text',
 	cortextType: 'ghost',
 	label: '',
+	sortable: false,
+	filterable: false,
+	operators: [],
+	filterBy: false,
 	enableSorting: false,
 	enableHiding: false,
 	editable: false,
@@ -169,8 +196,8 @@ const GHOST_FIELD = {
 };
 
 // Pulls a "single equality" prefill out of the active filters: only filters
-// whose operator is `is` (or its alias `equals`) and whose value is a single
-// scalar contribute. Multi-value operators (`isAny`, `isNone`, …) are skipped
+// whose operator is `is` and whose value is a single scalar contribute.
+// Multi-value operators (`isAny`, `isNone`, …) are skipped
 // because the issue scopes prefill to single equality clauses only.
 //
 // The server now applies filters via GET /cortext/v1/rows, so prefill
@@ -185,7 +212,7 @@ function prefillFromFilters( filters, fieldIds ) {
 			continue;
 		}
 		const op = filter.operator;
-		if ( op !== 'is' && op !== 'equals' ) {
+		if ( op !== 'is' ) {
 			continue;
 		}
 		const { field, value } = filter;
@@ -299,10 +326,8 @@ export default function CollectionDataViews( {
 		}
 		const validIds = new Set( availableFields.map( ( f ) => f.id ) );
 		const currentFilters = view?.filters ?? [];
-		const nextFilters = currentFilters.filter( ( filter ) =>
-			validIds.has( filter.field )
-		);
-		if ( nextFilters.length !== currentFilters.length ) {
+		const nextFilters = pruneFiltersForFields( currentFilters, validIds );
+		if ( nextFilters !== currentFilters ) {
 			return { ...view, filters: nextFilters };
 		}
 		return view;
@@ -370,7 +395,11 @@ export default function CollectionDataViews( {
 					paginationInfo: serverPaginationInfo,
 				};
 			}
-			return filterSortAndPaginate( data, view, availableFields );
+			return filterSortAndPaginateWithGroups(
+				data,
+				view,
+				availableFields
+			);
 		}, [
 			data,
 			view,
@@ -387,7 +416,11 @@ export default function CollectionDataViews( {
 		// pagination, which DataViews does not expose as a separate result.
 		delete calculationView.page;
 		delete calculationView.perPage;
-		return filterSortAndPaginate( data, calculationView, availableFields );
+		return filterSortAndPaginateWithGroups(
+			data,
+			calculationView,
+			availableFields
+		);
 	}, [ data, view, availableFields, isServerPaginated ] );
 	const activePaginationInfo = isServerPaginated
 		? serverPaginationInfo
@@ -914,12 +947,10 @@ export default function CollectionDataViews( {
 				: null;
 
 		const currentFilters = normalized.filters ?? [];
-		const nextFilters = currentFilters.filter( ( filter ) =>
-			validIds.has( filter.field )
-		);
+		const nextFilters = pruneFiltersForFields( currentFilters, validIds );
 
 		const sortChanged = currentSort !== nextSort;
-		const filtersChanged = currentFilters.length !== nextFilters.length;
+		const filtersChanged = currentFilters !== nextFilters;
 		const normalizedChanged = normalized !== currentView;
 
 		if ( normalizedChanged || sortChanged || filtersChanged ) {

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -656,6 +656,9 @@ export default function RowDetailView( {
 							meta:
 								pane.detail.record.meta ??
 								pane.detail.row?.meta,
+							cortext_hydrated_meta:
+								pane.detail.record.cortext_hydrated_meta ??
+								pane.detail.row?.cortext_hydrated_meta,
 						};
 
 						return (

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -37,9 +37,12 @@ import { TITLE_FIELD_ID } from './dataViewColumns';
 import EditOptionsPopover from './fields/EditOptionsPopover';
 import { toRecordId } from '../hooks/fieldIds';
 import {
+	isRowDetailFieldEditable,
 	isValidNumberDraft,
 	parseNumberPropertyValue,
+	rowDetailFieldType as fieldType,
 	splitPropertyPatch,
+	valueForField,
 } from './rowDetailUtils';
 
 function emptyLabel() {
@@ -219,41 +222,6 @@ function DatePropertyControl( { field, value, type, onChange } ) {
 			) }
 		/>
 	);
-}
-
-function fieldType( field ) {
-	if ( field.id === TITLE_FIELD_ID ) {
-		return 'text';
-	}
-	return field.cortextFieldType ?? field.type ?? 'text';
-}
-
-function isRowDetailFieldEditable( field ) {
-	if ( fieldType( field ) === 'relation' ) {
-		return false;
-	}
-
-	return (
-		field.id === TITLE_FIELD_ID ||
-		( field.editable && field.id?.startsWith?.( 'field-' ) )
-	);
-}
-
-function valueForField( field, data ) {
-	if ( field.id === TITLE_FIELD_ID ) {
-		return data.title ?? '';
-	}
-	if ( field.id?.startsWith?.( 'field-' ) ) {
-		// Relation and rollup values arrive on a separate, read-only
-		// response key so the editor's save path doesn't try to round-
-		// trip hydrated objects back into string-typed meta.
-		const type = fieldType( field );
-		if ( type === 'relation' || type === 'rollup' ) {
-			return data.hydratedMeta?.[ field.id ] ?? null;
-		}
-		return data.meta?.[ field.id ] ?? null;
-	}
-	return field.getValue?.( { item: data.row } ) ?? null;
 }
 
 function EditablePropertyText( { label, inputMode, value, onChange } ) {
@@ -473,26 +441,28 @@ export default function RowProperties( { fields, row, visible = true } ) {
 		( select ) => ( {
 			title: select( editorStore ).getEditedPostAttribute( 'title' ),
 			meta: select( editorStore ).getEditedPostAttribute( 'meta' ) ?? {},
-			hydratedMeta:
-				select( editorStore ).getEditedPostAttribute(
-					'cortext_hydrated_meta'
-				) ?? {},
+			hydratedMeta: select( editorStore ).getEditedPostAttribute(
+				'cortext_hydrated_meta'
+			),
 		} ),
 		[]
 	);
 
-	const data = useMemo(
-		() => ( {
+	const data = useMemo( () => {
+		const storeHydratedMeta =
+			hydratedMeta && Object.keys( hydratedMeta ).length > 0
+				? hydratedMeta
+				: null;
+		return {
 			row,
 			title:
 				typeof title === 'string'
 					? title
 					: row?.title?.raw ?? row?.title?.rendered ?? '',
 			meta: meta ?? {},
-			hydratedMeta: hydratedMeta ?? {},
-		} ),
-		[ hydratedMeta, meta, row, title ]
-	);
+			hydratedMeta: storeHydratedMeta ?? row?.cortext_hydrated_meta ?? {},
+		};
+	}, [ hydratedMeta, meta, row, title ] );
 
 	const update = useCallback(
 		( patch ) => {

--- a/src/components/dataViewColumns.js
+++ b/src/components/dataViewColumns.js
@@ -71,6 +71,51 @@ function sameShallowObject( a, b ) {
 	);
 }
 
+function pruneFilterNodeForFields( filter, validSet ) {
+	if ( ! filter || typeof filter !== 'object' ) {
+		return null;
+	}
+
+	const isGroup = Boolean( filter.relation || filter.filters );
+	if ( ! isGroup ) {
+		return filter.field && validSet.has( filter.field ) ? filter : null;
+	}
+
+	const currentChildren = Array.isArray( filter.filters )
+		? filter.filters
+		: [];
+	const nextChildren = pruneFiltersForFields( currentChildren, validSet );
+	if ( nextChildren.length === 0 ) {
+		return null;
+	}
+	return nextChildren === currentChildren
+		? filter
+		: { ...filter, filters: nextChildren };
+}
+
+export function pruneFiltersForFields( filters, validIds ) {
+	if ( ! Array.isArray( filters ) ) {
+		return [];
+	}
+
+	const validSet =
+		validIds instanceof Set ? validIds : new Set( validIds ?? [] );
+	let changed = false;
+	const next = [];
+	for ( const filter of filters ) {
+		const pruned = pruneFilterNodeForFields( filter, validSet );
+		if ( ! pruned ) {
+			changed = true;
+			continue;
+		}
+		if ( pruned !== filter ) {
+			changed = true;
+		}
+		next.push( pruned );
+	}
+	return changed ? next : filters;
+}
+
 // Reconciles a saved view against the live field set: drops style entries for
 // fields that no longer exist, clamps persisted widths into the current
 // [min, max] range, and re-prepends the title id when reorder/cleanup left it

--- a/src/components/groupedFilters.js
+++ b/src/components/groupedFilters.js
@@ -1,0 +1,291 @@
+import { getDate } from '@wordpress/date';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+
+function isGroupFilter( filter ) {
+	return Boolean( filter?.relation || filter?.filters );
+}
+
+function hasGroupFilters( filters ) {
+	return Array.isArray( filters ) && filters.some( isGroupFilter );
+}
+
+function valuesIntersect( fieldValue, filterValues ) {
+	if ( Array.isArray( fieldValue ) ) {
+		return filterValues.some( ( value ) => fieldValue.includes( value ) );
+	}
+	return filterValues.includes( fieldValue );
+}
+
+function normalizeText( value ) {
+	return String( value ).toLowerCase();
+}
+
+function isEmptyValue( value ) {
+	return (
+		value === undefined ||
+		value === null ||
+		value === '' ||
+		( Array.isArray( value ) && value.length === 0 )
+	);
+}
+
+function dateOrNull( value ) {
+	const date = getDate( value );
+	return Number.isNaN( date.getTime() ) ? null : date;
+}
+
+function relativeDate( value, unit ) {
+	const date = new Date();
+	const amount = Number( value );
+	if ( ! Number.isFinite( amount ) ) {
+		return date;
+	}
+
+	switch ( unit ) {
+		case 'days':
+			date.setDate( date.getDate() - amount );
+			return date;
+		case 'weeks':
+			date.setDate( date.getDate() - amount * 7 );
+			return date;
+		case 'months':
+			date.setMonth( date.getMonth() - amount );
+			return date;
+		case 'years':
+			date.setFullYear( date.getFullYear() - amount );
+			return date;
+		default:
+			return date;
+	}
+}
+
+function matchesLeaf( item, filter, fieldMap ) {
+	const field = filter?.field ? fieldMap.get( filter.field ) : null;
+	if ( ! field ) {
+		return true;
+	}
+
+	const fieldValue = field.getValue( { item } );
+	const filterValue = filter.value;
+	const filterValues = Array.isArray( filterValue ) ? filterValue : [];
+
+	switch ( filter.operator ) {
+		case 'isAny':
+			return filterValues.length > 0
+				? valuesIntersect( fieldValue, filterValues )
+				: true;
+		case 'isNone':
+			return filterValues.length > 0
+				? ! valuesIntersect( fieldValue, filterValues )
+				: true;
+		case 'isAll':
+			return filterValues.length > 0 && Array.isArray( fieldValue )
+				? filterValues.every( ( value ) =>
+						fieldValue.includes( value )
+				  )
+				: true;
+		case 'isNotAll':
+			return filterValues.length > 0 && Array.isArray( fieldValue )
+				? filterValues.every(
+						( value ) => ! fieldValue.includes( value )
+				  )
+				: true;
+		case 'is':
+			return filterValue === undefined || filterValue === fieldValue;
+		case 'isNot':
+			return filterValue !== fieldValue;
+		case 'contains': {
+			if ( filterValue === undefined || ! filterValue ) {
+				return true;
+			}
+			if ( Array.isArray( fieldValue ) ) {
+				return fieldValue.includes( filterValue );
+			}
+			return (
+				typeof fieldValue === 'string' &&
+				normalizeText( fieldValue ).includes(
+					normalizeText( filterValue )
+				)
+			);
+		}
+		case 'notContains': {
+			if ( filterValue === undefined || ! filterValue ) {
+				return true;
+			}
+			if ( Array.isArray( fieldValue ) ) {
+				return ! fieldValue.includes( filterValue );
+			}
+			return (
+				typeof fieldValue === 'string' &&
+				! normalizeText( fieldValue ).includes(
+					normalizeText( filterValue )
+				)
+			);
+		}
+		case 'startsWith':
+			return filterValue === undefined || ! filterValue
+				? true
+				: typeof fieldValue === 'string' &&
+						normalizeText( fieldValue ).startsWith(
+							normalizeText( filterValue )
+						);
+		case 'endsWith':
+			return filterValue === undefined || ! filterValue
+				? true
+				: typeof fieldValue === 'string' &&
+						normalizeText( fieldValue ).endsWith(
+							normalizeText( filterValue )
+						);
+		case 'lessThan':
+			return filterValue === undefined ? true : fieldValue < filterValue;
+		case 'greaterThan':
+			return filterValue === undefined ? true : fieldValue > filterValue;
+		case 'lessThanOrEqual':
+			return filterValue === undefined ? true : fieldValue <= filterValue;
+		case 'greaterThanOrEqual':
+			return filterValue === undefined ? true : fieldValue >= filterValue;
+		case 'between':
+			return (
+				Array.isArray( filterValue ) &&
+				filterValue.length === 2 &&
+				filterValue[ 0 ] !== undefined &&
+				filterValue[ 1 ] !== undefined &&
+				fieldValue >= filterValue[ 0 ] &&
+				fieldValue <= filterValue[ 1 ]
+			);
+		case 'on': {
+			if ( filterValue === undefined ) {
+				return true;
+			}
+			const fieldDate = dateOrNull( fieldValue );
+			const filterDate = dateOrNull( filterValue );
+			return Boolean(
+				fieldDate &&
+					filterDate &&
+					fieldDate.getTime() === filterDate.getTime()
+			);
+		}
+		case 'notOn': {
+			if ( filterValue === undefined ) {
+				return true;
+			}
+			const fieldDate = dateOrNull( fieldValue );
+			const filterDate = dateOrNull( filterValue );
+			return Boolean(
+				fieldDate &&
+					filterDate &&
+					fieldDate.getTime() !== filterDate.getTime()
+			);
+		}
+		case 'before':
+		case 'after':
+		case 'beforeInc':
+		case 'afterInc': {
+			if ( filterValue === undefined ) {
+				return true;
+			}
+			const fieldDate = dateOrNull( fieldValue );
+			const filterDate = dateOrNull( filterValue );
+			if ( ! fieldDate || ! filterDate ) {
+				return false;
+			}
+			if ( filter.operator === 'before' ) {
+				return fieldDate < filterDate;
+			}
+			if ( filter.operator === 'after' ) {
+				return fieldDate > filterDate;
+			}
+			if ( filter.operator === 'beforeInc' ) {
+				return fieldDate <= filterDate;
+			}
+			return fieldDate >= filterDate;
+		}
+		case 'inThePast':
+		case 'over': {
+			if (
+				filterValue?.value === undefined ||
+				filterValue?.unit === undefined
+			) {
+				return true;
+			}
+			const fieldDate = dateOrNull( fieldValue );
+			if ( ! fieldDate ) {
+				return false;
+			}
+			const targetDate = relativeDate(
+				filterValue.value,
+				filterValue.unit
+			);
+			return filter.operator === 'inThePast'
+				? fieldDate >= targetDate && fieldDate <= new Date()
+				: fieldDate < targetDate;
+		}
+		case 'isEmpty':
+			return isEmptyValue( fieldValue );
+		case 'isNotEmpty':
+			return ! isEmptyValue( fieldValue );
+		case 'isChecked':
+			return (
+				fieldValue === true || fieldValue === 1 || fieldValue === '1'
+			);
+		case 'isUnchecked':
+			return (
+				fieldValue === false ||
+				fieldValue === 0 ||
+				fieldValue === '0' ||
+				isEmptyValue( fieldValue )
+			);
+		default:
+			return true;
+	}
+}
+
+function matchesFilterNode( item, filter, fieldMap ) {
+	if ( ! filter || typeof filter !== 'object' ) {
+		return true;
+	}
+
+	if ( ! isGroupFilter( filter ) ) {
+		return matchesLeaf( item, filter, fieldMap );
+	}
+
+	const children = Array.isArray( filter.filters ) ? filter.filters : [];
+	if ( children.length === 0 ) {
+		return true;
+	}
+
+	const relation = String( filter.relation ?? 'AND' ).toUpperCase();
+	return relation === 'OR'
+		? children.some( ( child ) =>
+				matchesFilterNode( item, child, fieldMap )
+		  )
+		: children.every( ( child ) =>
+				matchesFilterNode( item, child, fieldMap )
+		  );
+}
+
+function matchesFilters( item, filters, fieldMap ) {
+	if ( ! Array.isArray( filters ) || filters.length === 0 ) {
+		return true;
+	}
+	return filters.every( ( filter ) =>
+		matchesFilterNode( item, filter, fieldMap )
+	);
+}
+
+export function filterSortAndPaginateWithGroups( data, view, fields ) {
+	if ( ! hasGroupFilters( view?.filters ) ) {
+		return filterSortAndPaginate( data, view, fields );
+	}
+
+	const fieldMap = new Map( fields.map( ( field ) => [ field.id, field ] ) );
+	const filteredData = ( Array.isArray( data ) ? data : [] ).filter(
+		( item ) => matchesFilters( item, view?.filters, fieldMap )
+	);
+
+	return filterSortAndPaginate(
+		filteredData,
+		{ ...( view ?? {} ), filters: [] },
+		fields
+	);
+}

--- a/src/components/rowDetailUtils.js
+++ b/src/components/rowDetailUtils.js
@@ -30,6 +30,43 @@ export function adjacentRowId( rows, currentRowId, direction ) {
 	return next?.id ?? null;
 }
 
+export function rowDetailFieldType( field ) {
+	if ( field.id === 'title' ) {
+		return 'text';
+	}
+	return field.cortextFieldType ?? field.type ?? 'text';
+}
+
+export function isRowDetailFieldEditable( field ) {
+	if ( rowDetailFieldType( field ) === 'relation' ) {
+		return false;
+	}
+
+	return (
+		field.id === 'title' ||
+		( field.editable && field.id?.startsWith?.( 'field-' ) )
+	);
+}
+
+export function valueForField( field, data ) {
+	if ( field.id === 'title' ) {
+		return data.title ?? '';
+	}
+	if ( field.id?.startsWith?.( 'field-' ) ) {
+		if (
+			! isRowDetailFieldEditable( field ) &&
+			Object.prototype.hasOwnProperty.call(
+				data.hydratedMeta ?? {},
+				field.id
+			)
+		) {
+			return data.hydratedMeta[ field.id ] ?? null;
+		}
+		return data.meta?.[ field.id ] ?? null;
+	}
+	return field.getValue?.( { item: data.row } ) ?? null;
+}
+
 export function splitPropertyPatch( patch ) {
 	const next = {
 		title: undefined,

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -1,5 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
+import {
+	BaseControl,
+	Flex,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalNumberControl as NumberControl,
+} from '@wordpress/components';
 
 import EditableCell from '../components/EditableCell';
 import { elementsFromOptions } from './optionElements';
@@ -47,6 +53,32 @@ export const EDITABLE_TYPES = new Set( [
 ] );
 
 const SEARCHABLE_TYPES = new Set( [ 'text', 'email', 'url' ] );
+const DATAVIEWS_TEXT_FILTER_OPERATORS = [
+	'is',
+	'isNot',
+	'contains',
+	'notContains',
+	'startsWith',
+];
+const DATAVIEWS_NUMBER_FILTER_OPERATORS = [
+	'is',
+	'greaterThan',
+	'lessThan',
+	'between',
+];
+const DATAVIEWS_DATE_FILTER_OPERATORS = [ 'on', 'before', 'after', 'between' ];
+const DATAVIEWS_DATETIME_FILTER_OPERATORS = [ 'on', 'before', 'after' ];
+const DATAVIEWS_OPTION_FILTER_OPERATORS = [ 'isAny', 'isNone' ];
+const SERVER_SORT_ONLY = {
+	sortable: true,
+	filterable: false,
+	operators: [],
+};
+const NOT_SERVER_QUERYABLE = {
+	sortable: false,
+	filterable: false,
+	operators: [],
+};
 const ROLLUP_VALUE_AGGREGATORS = new Set( [ 'show_original', 'show_unique' ] );
 const ROLLUP_NUMERIC_AGGREGATORS = new Set( [
 	'count',
@@ -151,6 +183,161 @@ function fieldRelationConfig( field, type, rollupTargetType ) {
 	return undefined;
 }
 
+function isEmptySortValue( value ) {
+	return value === null || value === undefined || value === '';
+}
+
+function compareEmptyLast( aValue, bValue ) {
+	const aEmpty = isEmptySortValue( aValue );
+	const bEmpty = isEmptySortValue( bValue );
+	if ( aEmpty && bEmpty ) {
+		return 0;
+	}
+	if ( aEmpty ) {
+		return 1;
+	}
+	if ( bEmpty ) {
+		return -1;
+	}
+	return null;
+}
+
+function sortNumberValues( getValue ) {
+	return ( a, b, direction ) => {
+		const av = getValue( { item: a } );
+		const bv = getValue( { item: b } );
+		const emptyCompare = compareEmptyLast( av, bv );
+		if ( emptyCompare !== null ) {
+			return emptyCompare;
+		}
+
+		const an = Number( av );
+		const bn = Number( bv );
+		const diff =
+			Number.isFinite( an ) && Number.isFinite( bn )
+				? an - bn
+				: String( av ).localeCompare( String( bv ) );
+		return direction === 'asc' ? diff : -diff;
+	};
+}
+
+function numberFilterValue( value ) {
+	return value === '' || value === undefined ? undefined : Number( value );
+}
+
+function NumberFilterControl( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	operator,
+} ) {
+	const { id, label, description } = field;
+	const value = field.getValue( { item: data } ) ?? '';
+
+	if ( operator === 'between' ) {
+		const [ min = '', max = '' ] = Array.isArray( value ) ? value : [];
+		return (
+			<BaseControl __nextHasNoMarginBottom>
+				<Flex direction="row" gap={ 4 }>
+					<NumberControl
+						label={ __( 'Min.', 'cortext' ) }
+						value={ min }
+						onChange={ ( next ) =>
+							onChange( {
+								[ id ]: [ numberFilterValue( next ), max ],
+							} )
+						}
+						__next40pxDefaultSize
+						hideLabelFromVision={ hideLabelFromVision }
+					/>
+					<NumberControl
+						label={ __( 'Max.', 'cortext' ) }
+						value={ max }
+						onChange={ ( next ) =>
+							onChange( {
+								[ id ]: [ min, numberFilterValue( next ) ],
+							} )
+						}
+						__next40pxDefaultSize
+						hideLabelFromVision={ hideLabelFromVision }
+					/>
+				</Flex>
+			</BaseControl>
+		);
+	}
+
+	return (
+		<NumberControl
+			label={ label }
+			help={ description }
+			value={ value }
+			onChange={ ( next ) =>
+				onChange( { [ id ]: numberFilterValue( next ) } )
+			}
+			__next40pxDefaultSize
+			hideLabelFromVision={ hideLabelFromVision }
+		/>
+	);
+}
+
+function supportedDataViewsOperators( operators, candidates ) {
+	return candidates.filter( ( operator ) => operators.includes( operator ) );
+}
+
+export function dataViewsFilterByForType( type, operators ) {
+	let supported = [];
+	switch ( type ) {
+		case 'text':
+		case 'email':
+		case 'url':
+			supported = supportedDataViewsOperators(
+				operators,
+				DATAVIEWS_TEXT_FILTER_OPERATORS
+			);
+			break;
+		case 'number':
+			supported = supportedDataViewsOperators(
+				operators,
+				DATAVIEWS_NUMBER_FILTER_OPERATORS
+			);
+			break;
+		case 'date':
+			supported = supportedDataViewsOperators(
+				operators,
+				DATAVIEWS_DATE_FILTER_OPERATORS
+			);
+			break;
+		case 'datetime':
+			supported = supportedDataViewsOperators(
+				operators,
+				DATAVIEWS_DATETIME_FILTER_OPERATORS
+			);
+			break;
+		case 'select':
+		case 'multiselect':
+			supported = supportedDataViewsOperators(
+				operators,
+				DATAVIEWS_OPTION_FILTER_OPERATORS
+			);
+			break;
+		default:
+			return undefined;
+	}
+	return supported.length > 0 ? { operators: supported } : undefined;
+}
+
+function fieldValue( item, id ) {
+	if ( item && Object.prototype.hasOwnProperty.call( item, id ) ) {
+		return item[ id ];
+	}
+	return item?.meta?.[ id ] ?? null;
+}
+
+function checkboxFieldValue( item, id ) {
+	return parseBooleanMeta( fieldValue( item, id ), false );
+}
+
 // Returns the four read-only system fields surfaced alongside each
 // collection's custom fields: created at, last edited at, created by,
 // last edited by. The values come straight off the row payload (the
@@ -174,6 +361,7 @@ export function systemFields() {
 			label: __( 'Created', 'cortext' ),
 			type: 'datetime',
 			cortextType: 'datetime',
+			...SERVER_SORT_ONLY,
 			editable: false,
 			enableSorting: true,
 			getValue: ( { item } ) => item?.created_at ?? null,
@@ -188,6 +376,7 @@ export function systemFields() {
 			label: __( 'Created by', 'cortext' ),
 			type: 'text',
 			cortextType: 'text',
+			...NOT_SERVER_QUERYABLE,
 			editable: false,
 			enableSorting: false,
 			getValue: ( { item } ) => item?.created_by ?? null,
@@ -202,6 +391,7 @@ export function systemFields() {
 			label: __( 'Last edited', 'cortext' ),
 			type: 'datetime',
 			cortextType: 'datetime',
+			...SERVER_SORT_ONLY,
 			editable: false,
 			enableSorting: true,
 			getValue: ( { item } ) => item?.modified_at ?? null,
@@ -216,6 +406,7 @@ export function systemFields() {
 			label: __( 'Last edited by', 'cortext' ),
 			type: 'text',
 			cortextType: 'text',
+			...NOT_SERVER_QUERYABLE,
 			editable: false,
 			enableSorting: false,
 			getValue: ( { item } ) => item?.modified_by ?? null,
@@ -263,11 +454,19 @@ export function mapField( field ) {
 		}
 	}
 	const relation = fieldRelationConfig( field, type, rollupTargetType );
+	const capabilities = field.cortext_capabilities ?? {};
+	const operators = Array.isArray( capabilities.operators )
+		? capabilities.operators
+		: [];
 	const base = {
 		id,
 		label,
 		recordId: field.id,
 		cortextType: type,
+		sortable: capabilities.sortable === true,
+		filterable: capabilities.filterable === true,
+		operators,
+		filterBy: dataViewsFilterByForType( type, operators ),
 		relatedCollectionId: relation?.targetCollectionId,
 		relationMultiple: relation?.multiple,
 		rollupAggregator: field.meta?.rollup_aggregator,
@@ -288,7 +487,7 @@ export function mapField( field ) {
 				/>
 			</HeaderLabel>
 		),
-		getValue: ( { item } ) => item?.meta?.[ id ] ?? null,
+		getValue: ( { item } ) => fieldValue( item, id ),
 		render: buildRender( id, type, label, elements, format, relation ),
 		editable: EDITABLE_TYPES.has( type ),
 		enableGlobalSearch: SEARCHABLE_TYPES.has( type ),
@@ -303,12 +502,19 @@ export function mapField( field ) {
 	// EditableCell drives the actual edit/display, so these mappings only
 	// affect column-level metadata (default sort comparator, future filter
 	// UI). We pick the closest honest type rather than the prettiest one:
-	// numbers and url go through 'text' because there's nothing closer
-	// (tech-debt.md#10), multiselect goes through 'array' so DataViews
-	// understands the value cardinality.
+	// decimals go through 'integer' with DataViews' integer-only
+	// validator disabled because there's no exact number type
+	// (tech-debt.md#10), url goes through 'text', and multiselect goes
+	// through 'array' so DataViews understands the value cardinality.
 	switch ( type ) {
 		case 'number':
-			return { ...base, type: 'text' };
+			return {
+				...base,
+				type: 'integer',
+				Edit: NumberFilterControl,
+				isValid: { custom: () => null },
+				sort: sortNumberValues( base.getValue ),
+			};
 		case 'email':
 			return { ...base, type: 'email' };
 		case 'url':
@@ -317,6 +523,12 @@ export function mapField( field ) {
 			return { ...base, type: 'text', elements };
 		case 'multiselect':
 			return { ...base, type: 'array', elements };
+		case 'checkbox':
+			return {
+				...base,
+				type: 'boolean',
+				getValue: ( { item } ) => checkboxFieldValue( item, id ),
+			};
 		case 'relation':
 			return {
 				...base,
@@ -361,10 +573,9 @@ export function mapField( field ) {
 			};
 		}
 		case 'date':
+			return { ...base, type: 'date' };
 		case 'datetime':
 			return { ...base, type: 'datetime' };
-		case 'checkbox':
-			return { ...base, type: 'boolean' };
 		case 'text':
 		default:
 			return { ...base, type: 'text' };

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -7,34 +7,24 @@ import apiFetch from '@wordpress/api-fetch';
 
 const CLIENT_PER_PAGE = 100;
 const CLIENT_PAGE_FETCH_CONCURRENCY = 4;
-const SERVER_OPERATORS = new Set( [ 'is', 'isNot', 'isAny', 'isNone' ] );
-const SERVER_SORT_FIELDS = new Set( [ 'title', 'created_at', 'modified_at' ] );
-const SERVER_FILTER_FIELD_TYPES = new Set( [
-	'text',
-	'number',
-	'email',
-	'url',
-	'select',
-	'multiselect',
-	'date',
-	'datetime',
-	'checkbox',
-] );
 
-function fieldTypeMap( fields = [] ) {
-	return new Map( fields.map( ( f ) => [ f.id, f.cortextType ] ) );
+function serverFieldInfo( field ) {
+	return {
+		filterable: field.filterable === true,
+		sortable: field.sortable === true,
+		type: field.cortextFieldType ?? field.cortextType ?? field.type,
+		operators: Array.isArray( field.operators )
+			? field.operators
+			: undefined,
+	};
 }
 
-function hasSearch( view ) {
-	return Boolean( String( view?.search ?? '' ).trim() );
+function fieldInfoMap( fields = [] ) {
+	return new Map( fields.map( ( f ) => [ f.id, serverFieldInfo( f ) ] ) );
 }
 
 function hasCalculations( view ) {
 	return Object.values( view?.calculations ?? {} ).some( Boolean );
-}
-
-function isCollectionFieldKey( field ) {
-	return /^field-\d+$/.test( field );
 }
 
 function pageNumber( value, fallback = 1 ) {
@@ -52,53 +42,213 @@ function perPageNumber( value, fallback = 25 ) {
 	return Math.min( 100, Math.floor( number ) );
 }
 
-function isServerSupportedSort( sort ) {
+function isServerSupportedSort( sort, fieldInfo ) {
 	if ( ! sort?.field ) {
 		return true;
 	}
-	return SERVER_SORT_FIELDS.has( sort.field );
+	const info = fieldInfo.get( sort.field );
+	return info?.sortable === true;
 }
 
-function isServerSupportedFilter( filter, fieldTypes ) {
-	if (
-		! filter ||
-		typeof filter !== 'object' ||
-		! filter.field ||
-		! filter.operator ||
-		! SERVER_OPERATORS.has( filter.operator )
-	) {
-		return false;
-	}
-	if (
-		( filter.operator === 'isAny' || filter.operator === 'isNone' ) &&
-		( ! Array.isArray( filter.value ) || filter.value.length === 0 )
-	) {
-		return false;
-	}
-	if (
-		( filter.operator === 'is' || filter.operator === 'isNot' ) &&
-		( filter.value === undefined || Array.isArray( filter.value ) )
-	) {
-		return false;
-	}
-	return (
-		isCollectionFieldKey( filter.field ) &&
-		SERVER_FILTER_FIELD_TYPES.has( fieldTypes.get( filter.field ) )
-	);
+function filterInfo( filter, fieldInfo ) {
+	return filter?.field ? fieldInfo.get( filter.field ) : undefined;
 }
 
-function addFiltersToArgs( args, filters ) {
-	filters.forEach( ( filter, i ) => {
-		args[ `filters[${ i }][field]` ] = filter.field;
-		args[ `filters[${ i }][operator]` ] = filter.operator;
-		if ( Array.isArray( filter.value ) ) {
-			filter.value.forEach( ( v, j ) => {
-				args[ `filters[${ i }][value][${ j }]` ] = v;
-			} );
-		} else {
-			args[ `filters[${ i }][value]` ] = filter.value;
+function hasUsableFilterValue( filter ) {
+	const operator = filter?.operator;
+	if (
+		operator === 'isEmpty' ||
+		operator === 'isNotEmpty' ||
+		operator === 'isChecked' ||
+		operator === 'isUnchecked'
+	) {
+		return true;
+	}
+	if ( operator === 'between' ) {
+		return Array.isArray( filter.value ) && filter.value.length === 2;
+	}
+	if ( operator === 'isAny' || operator === 'isNone' ) {
+		return Array.isArray( filter.value ) && filter.value.length > 0;
+	}
+	return filter?.value !== undefined && ! Array.isArray( filter.value );
+}
+
+function booleanFilterValue( value ) {
+	if ( value === true || value === 1 ) {
+		return true;
+	}
+	if ( value === false || value === 0 || value === '' ) {
+		return false;
+	}
+	if ( typeof value !== 'string' ) {
+		return undefined;
+	}
+
+	const normalized = value.trim().toLowerCase();
+	if ( [ '1', 'true', 'yes', 'on' ].includes( normalized ) ) {
+		return true;
+	}
+	if ( [ '0', 'false', 'no', 'off' ].includes( normalized ) ) {
+		return false;
+	}
+	return undefined;
+}
+
+function normalizeFilterForServer( filter, fieldInfo ) {
+	const info = filterInfo( filter, fieldInfo );
+	if (
+		( info?.type === 'select' || info?.type === 'multiselect' ) &&
+		( filter?.operator === 'isAny' || filter?.operator === 'isNone' ) &&
+		filter.value !== undefined &&
+		! Array.isArray( filter.value )
+	) {
+		return { ...filter, value: [ filter.value ] };
+	}
+
+	if (
+		info?.type === 'select' &&
+		( filter?.operator === 'is' || filter?.operator === 'isNot' ) &&
+		Array.isArray( filter.value ) &&
+		filter.value.length === 1
+	) {
+		return { ...filter, value: filter.value[ 0 ] };
+	}
+
+	if (
+		info?.type !== 'checkbox' ||
+		( filter?.operator !== 'is' && filter?.operator !== 'isNot' )
+	) {
+		return filter;
+	}
+
+	const value = booleanFilterValue( filter.value );
+	if ( value === undefined ) {
+		return filter;
+	}
+
+	const checked = filter.operator === 'is' ? value : ! value;
+	const { value: _value, ...normalized } = filter;
+	return {
+		...normalized,
+		operator: checked ? 'isChecked' : 'isUnchecked',
+	};
+}
+
+function leafFilterResult( filter, fieldInfo ) {
+	const info = filterInfo( filter, fieldInfo );
+	if (
+		! info?.filterable ||
+		! filter?.operator ||
+		! Array.isArray( info.operators ) ||
+		! info.operators.includes( filter.operator )
+	) {
+		return { node: null, hasUnsupported: true, alwaysTrue: false };
+	}
+
+	if ( ! hasUsableFilterValue( filter ) ) {
+		return { node: null, hasUnsupported: false, alwaysTrue: true };
+	}
+
+	return { node: filter, hasUnsupported: false, alwaysTrue: false };
+}
+
+function serverFilterNode( filter, fieldInfo ) {
+	if ( ! filter || typeof filter !== 'object' ) {
+		return { node: null, hasUnsupported: true, alwaysTrue: false };
+	}
+
+	const isGroup = Boolean( filter.relation || filter.filters );
+	if ( ! isGroup ) {
+		const normalized = normalizeFilterForServer( filter, fieldInfo );
+		return leafFilterResult( normalized, fieldInfo );
+	}
+
+	const relation = String( filter.relation ?? 'AND' ).toUpperCase();
+	if ( relation !== 'AND' && relation !== 'OR' ) {
+		return { node: null, hasUnsupported: true, alwaysTrue: false };
+	}
+	if ( ! Array.isArray( filter.filters ) || filter.filters.length === 0 ) {
+		return { node: null, hasUnsupported: true, alwaysTrue: false };
+	}
+
+	const children = [];
+	let hasUnsupported = false;
+	let hasAlwaysTrue = false;
+	for ( const child of filter.filters ) {
+		const result = serverFilterNode( child, fieldInfo );
+		if ( result.node ) {
+			children.push( result.node );
 		}
-	} );
+		if ( result.hasUnsupported ) {
+			hasUnsupported = true;
+		}
+		if ( result.alwaysTrue ) {
+			hasAlwaysTrue = true;
+		}
+	}
+
+	// DataViews' final client pass only understands flat leaf filters.
+	// Forward grouped filters only when the whole tree can run server-side.
+	if ( hasUnsupported ) {
+		return { node: null, hasUnsupported: true, alwaysTrue: false };
+	}
+	if ( relation === 'OR' && hasAlwaysTrue ) {
+		return { node: null, hasUnsupported: false, alwaysTrue: true };
+	}
+	if ( children.length === 0 ) {
+		return { node: null, hasUnsupported: false, alwaysTrue: true };
+	}
+	return {
+		node: { relation, filters: children },
+		hasUnsupported: false,
+		alwaysTrue: false,
+	};
+}
+
+function serverFilterResult( filters, fieldInfo ) {
+	if ( ! Array.isArray( filters ) ) {
+		return { filters: [], hasUnsupported: false };
+	}
+
+	const supported = [];
+	let hasUnsupported = false;
+	for ( const filter of filters ) {
+		const result = serverFilterNode( filter, fieldInfo );
+		if ( result.node ) {
+			supported.push( result.node );
+		}
+		if ( result.hasUnsupported ) {
+			hasUnsupported = true;
+		}
+	}
+	return { filters: supported, hasUnsupported };
+}
+
+function addValueArgs( args, prefix, value ) {
+	if ( value === undefined ) {
+		return;
+	}
+	if ( Array.isArray( value ) ) {
+		value.forEach( ( item, i ) => {
+			args[ `${ prefix }[value][${ i }]` ] = item;
+		} );
+		return;
+	}
+	args[ `${ prefix }[value]` ] = value;
+}
+
+function addFilterArgs( args, prefix, filter ) {
+	if ( filter.relation && Array.isArray( filter.filters ) ) {
+		args[ `${ prefix }[relation]` ] = filter.relation;
+		filter.filters.forEach( ( child, i ) => {
+			addFilterArgs( args, `${ prefix }[filters][${ i }]`, child );
+		} );
+		return;
+	}
+
+	args[ `${ prefix }[field]` ] = filter.field;
+	args[ `${ prefix }[operator]` ] = filter.operator;
+	addValueArgs( args, prefix, filter.value );
 }
 
 function buildClientQueryArgs( collectionId ) {
@@ -109,35 +259,55 @@ function buildClientQueryArgs( collectionId ) {
 	};
 }
 
-function buildServerQueryArgs( collectionId, view ) {
+export function buildQueryArgs( collectionId, view, fields = [] ) {
+	const fieldInfo = fieldInfoMap( fields );
+	const serverView = isServerSupportedSort( view?.sort, fieldInfo )
+		? view
+		: { ...( view ?? {} ), sort: null };
+	return buildServerQueryArgs(
+		collectionId,
+		serverView,
+		serverFilterResult( view?.filters, fieldInfo ).filters
+	);
+}
+
+function buildServerQueryArgs( collectionId, view, filters = [] ) {
 	const args = {
 		collection: collectionId,
 		page: pageNumber( view?.page ),
 		per_page: perPageNumber( view?.perPage ),
 	};
 
+	if ( view?.search ) {
+		args.search = view.search;
+	}
+
 	if ( view?.sort?.field ) {
 		args[ 'sort[field]' ] = view.sort.field;
 		args[ 'sort[direction]' ] =
-			view.sort.direction === 'asc' ? 'asc' : 'desc';
+			view.sort.direction === 'desc' ? 'desc' : 'asc';
 	}
 
-	addFiltersToArgs( args, view?.filters ?? [] );
+	filters.forEach( ( filter, i ) => {
+		addFilterArgs( args, `filters[${ i }]`, filter );
+	} );
 
 	return args;
 }
 
-function buildQueryPlan( collectionId, view, fields = [], options = {} ) {
-	const fieldTypes = fieldTypeMap( fields );
-	const filters = Array.isArray( view?.filters ) ? view.filters : [];
+export function buildQueryPlan(
+	collectionId,
+	view,
+	fields = [],
+	options = {}
+) {
+	const fieldInfo = fieldInfoMap( fields );
+	const filterResult = serverFilterResult( view?.filters, fieldInfo );
 	const canUseServer =
 		! options.forceClient &&
-		! hasSearch( view ) &&
 		! hasCalculations( view ) &&
-		isServerSupportedSort( view?.sort ) &&
-		filters.every( ( filter ) =>
-			isServerSupportedFilter( filter, fieldTypes )
-		);
+		isServerSupportedSort( view?.sort, fieldInfo ) &&
+		! filterResult.hasUnsupported;
 
 	if ( ! canUseServer ) {
 		return {
@@ -148,7 +318,7 @@ function buildQueryPlan( collectionId, view, fields = [], options = {} ) {
 
 	return {
 		mode: 'server',
-		args: buildServerQueryArgs( collectionId, view ),
+		args: buildServerQueryArgs( collectionId, view, filterResult.filters ),
 	};
 }
 
@@ -158,6 +328,12 @@ function schemaSignature( fields = [] ) {
 			( field ) =>
 				`${ field.id }:${ field.recordId ?? '' }:${
 					field.cortextType ?? ''
+				}:${ field.sortable === true ? '1' : '0' }:${
+					field.filterable === true ? '1' : '0'
+				}:${
+					Array.isArray( field.operators )
+						? field.operators.join( ',' )
+						: '?'
 				}`
 		)
 		.join( '|' );

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -964,9 +964,7 @@ test.describe( 'Collection view block', () => {
 			// The row detail chrome now mirrors the post title as an
 			// `<h2>`; the editable input lives inside the row's
 			// EditorBody iframe (locked `core/post-title` block).
-			const detailTitle = detail.locator(
-				'.cortext-row-detail__title'
-			);
+			const detailTitle = detail.locator( '.cortext-row-detail__title' );
 			await expect( detailTitle ).toHaveText(
 				'The Left Hand of Darkness'
 			);
@@ -1121,9 +1119,7 @@ test.describe( 'Collection view block', () => {
 			// collection's own management surface, which renders the same
 			// DataViews table directly (no editor iframe).
 			await expect(
-				page
-					.getByRole( 'button', { name: 'Open row' } )
-					.first()
+				page.getByRole( 'button', { name: 'Open row' } ).first()
 			).toBeAttached();
 
 			await expect

--- a/tests/e2e/specs/page-trash.spec.js
+++ b/tests/e2e/specs/page-trash.spec.js
@@ -111,7 +111,9 @@ test.describe( 'Page trash flow', () => {
 
 			// Canvas keeps the parent open with a trashed banner.
 			const notice = page.locator( '.cortext-canvas__notice' );
-			await expect( notice ).toContainText( 'This document is in trash.' );
+			await expect( notice ).toContainText(
+				'This document is in trash.'
+			);
 
 			// Restore via the banner. Subtree returns; banner disappears.
 			await notice.getByRole( 'button', { name: 'Restore' } ).click();

--- a/tests/e2e/specs/rows-query.spec.js
+++ b/tests/e2e/specs/rows-query.spec.js
@@ -1,0 +1,236 @@
+/**
+ * E2E coverage for server-backed row query behavior.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; failures here should not mask the test result.
+	}
+}
+
+function rowsPath( params ) {
+	const query = new URLSearchParams();
+	for ( const [ key, value ] of Object.entries( params ) ) {
+		query.append( key, String( value ) );
+	}
+	return `/cortext/v1/rows?${ query.toString() }`;
+}
+
+async function queryRows( requestUtils, collectionId, params = {} ) {
+	return requestUtils.rest( {
+		path: rowsPath( {
+			collection: collectionId,
+			per_page: 100,
+			...params,
+		} ),
+	} );
+}
+
+function rowIds( response ) {
+	return response.rows.map( ( row ) => row.id );
+}
+
+async function createField( requestUtils, title, type ) {
+	return requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_fields',
+		data: {
+			title,
+			status: 'private',
+			meta: { type },
+		},
+	} );
+}
+
+async function createRowsQueryFixture( requestUtils ) {
+	const suffix = `${ Date.now().toString( 36 ).slice( -5 ) }${ Math.random()
+		.toString( 36 )
+		.slice( 2, 4 ) }`;
+	const slug = `rows${ suffix }`;
+
+	const collection = await requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_collections',
+		data: {
+			title: `E2E Rows ${ suffix }`,
+			status: 'private',
+			meta: { slug },
+		},
+	} );
+
+	const fields = {
+		status: await createField( requestUtils, 'Status', 'text' ),
+		notes: await createField( requestUtils, 'Notes', 'text' ),
+		score: await createField( requestUtils, 'Score', 'number' ),
+		due: await createField( requestUtils, 'Due', 'date' ),
+		phase: await createField( requestUtils, 'Phase', 'select' ),
+	};
+
+	await requestUtils.rest( {
+		method: 'POST',
+		path: `/wp/v2/crtxt_collections/${ collection.id }`,
+		data: {
+			meta: {
+				fields: Object.values( fields ).map( ( field ) =>
+					String( field.id )
+				),
+			},
+		},
+	} );
+
+	const rows = {};
+	for ( const spec of [
+		{
+			key: 'alpha',
+			title: 'Alpha',
+			status: 'red',
+			notes: 'ordinary note',
+			score: '9',
+			due: '2026-02-01',
+			phase: 'beta',
+		},
+		{
+			key: 'bravo',
+			title: 'Bravo',
+			status: 'blue',
+			notes: 'needle in the meta field',
+			score: '10',
+			due: '2026-03-01',
+			phase: 'gamma',
+		},
+		{
+			key: 'charlie',
+			title: 'Charlie',
+			status: 'blue',
+			notes: 'ordinary note',
+			score: '2',
+			due: '2026-01-01',
+			phase: 'alpha',
+		},
+	] ) {
+		rows[ spec.key ] = await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/crtxt_${ slug }`,
+			data: {
+				title: spec.title,
+				status: 'private',
+				meta: {
+					[ `field-${ fields.status.id }` ]: spec.status,
+					[ `field-${ fields.notes.id }` ]: spec.notes,
+					[ `field-${ fields.score.id }` ]: spec.score,
+					[ `field-${ fields.due.id }` ]: spec.due,
+					[ `field-${ fields.phase.id }` ]: spec.phase,
+				},
+			},
+		} );
+	}
+
+	return { collection, fields, rows, slug };
+}
+
+test.describe( 'rows endpoint server query', () => {
+	test( 'searches meta, applies grouped filters, and sorts supported fields', async ( {
+		requestUtils,
+	} ) => {
+		let fixture;
+		try {
+			fixture = await createRowsQueryFixture( requestUtils );
+			const { collection, fields, rows } = fixture;
+
+			const search = await queryRows( requestUtils, collection.id, {
+				search: 'needle',
+			} );
+			expect( rowIds( search ) ).toEqual( [ rows.bravo.id ] );
+
+			const grouped = await queryRows( requestUtils, collection.id, {
+				'sort[field]': 'title',
+				'sort[direction]': 'asc',
+				'filters[0][relation]': 'AND',
+				'filters[0][filters][0][field]': 'title',
+				'filters[0][filters][0][operator]': 'notContains',
+				'filters[0][filters][0][value]': 'Charlie',
+				'filters[0][filters][1][relation]': 'OR',
+				'filters[0][filters][1][filters][0][field]': `field-${ fields.status.id }`,
+				'filters[0][filters][1][filters][0][operator]': 'is',
+				'filters[0][filters][1][filters][0][value]': 'red',
+				'filters[0][filters][1][filters][1][field]': `field-${ fields.score.id }`,
+				'filters[0][filters][1][filters][1][operator]': 'greaterThan',
+				'filters[0][filters][1][filters][1][value]': 9,
+			} );
+			expect( rowIds( grouped ) ).toEqual( [
+				rows.alpha.id,
+				rows.bravo.id,
+			] );
+
+			const titleSort = await queryRows( requestUtils, collection.id, {
+				'sort[field]': 'title',
+				'sort[direction]': 'asc',
+			} );
+			expect( rowIds( titleSort ) ).toEqual( [
+				rows.alpha.id,
+				rows.bravo.id,
+				rows.charlie.id,
+			] );
+
+			const numberSort = await queryRows( requestUtils, collection.id, {
+				'sort[field]': `field-${ fields.score.id }`,
+				'sort[direction]': 'asc',
+			} );
+			expect( rowIds( numberSort ) ).toEqual( [
+				rows.charlie.id,
+				rows.alpha.id,
+				rows.bravo.id,
+			] );
+
+			const dateSort = await queryRows( requestUtils, collection.id, {
+				'sort[field]': `field-${ fields.due.id }`,
+				'sort[direction]': 'asc',
+			} );
+			expect( rowIds( dateSort ) ).toEqual( [
+				rows.charlie.id,
+				rows.alpha.id,
+				rows.bravo.id,
+			] );
+
+			const selectSort = await queryRows( requestUtils, collection.id, {
+				'sort[field]': `field-${ fields.phase.id }`,
+				'sort[direction]': 'asc',
+			} );
+			expect( rowIds( selectSort ) ).toEqual( [
+				rows.charlie.id,
+				rows.alpha.id,
+				rows.bravo.id,
+			] );
+		} finally {
+			if ( fixture ) {
+				for ( const row of Object.values( fixture.rows ) ) {
+					await deleteIfCreated(
+						requestUtils,
+						`/wp/v2/crtxt_${ fixture.slug }/${ row.id }`
+					);
+				}
+				for ( const field of Object.values( fixture.fields ) ) {
+					await deleteIfCreated(
+						requestUtils,
+						`/wp/v2/crtxt_fields/${ field.id }`
+					);
+				}
+				await deleteIfCreated(
+					requestUtils,
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+				);
+			}
+		}
+	} );
+} );

--- a/tests/js/components/dataViewColumns.test.js
+++ b/tests/js/components/dataViewColumns.test.js
@@ -7,6 +7,7 @@ import {
 	getMinWidth,
 	isDefaultVisibleField,
 	normalizeView,
+	pruneFiltersForFields,
 	withColumnOrder,
 	withColumnWidth,
 } from '../../../src/components/dataViewColumns';
@@ -77,6 +78,71 @@ describe( 'isDefaultVisibleField', () => {
 				editable: false,
 			} )
 		).toBe( false );
+	} );
+} );
+
+describe( 'pruneFiltersForFields', () => {
+	it( 'preserves grouped filters when every descendant field is valid', () => {
+		const filters = [
+			{
+				relation: 'OR',
+				filters: [
+					{ field: 'title', operator: 'contains', value: 'A' },
+					{ field: 'field-1', operator: 'is', value: 'open' },
+				],
+			},
+		];
+
+		expect(
+			pruneFiltersForFields(
+				filters,
+				new Set( [ TITLE_FIELD_ID, 'field-1' ] )
+			)
+		).toBe( filters );
+	} );
+
+	it( 'prunes stale leaves inside groups without dropping the whole group', () => {
+		const filters = [
+			{
+				relation: 'AND',
+				filters: [
+					{ field: 'field-1', operator: 'is', value: 'open' },
+					{ field: 'field-deleted', operator: 'is', value: 'gone' },
+				],
+			},
+		];
+
+		expect(
+			pruneFiltersForFields(
+				filters,
+				new Set( [ TITLE_FIELD_ID, 'field-1' ] )
+			)
+		).toEqual( [
+			{
+				relation: 'AND',
+				filters: [
+					{ field: 'field-1', operator: 'is', value: 'open' },
+				],
+			},
+		] );
+	} );
+
+	it( 'drops groups that have no valid descendants', () => {
+		const filters = [
+			{
+				relation: 'OR',
+				filters: [
+					{ field: 'field-deleted', operator: 'is', value: 'gone' },
+				],
+			},
+		];
+
+		expect(
+			pruneFiltersForFields(
+				filters,
+				new Set( [ TITLE_FIELD_ID, 'field-1' ] )
+			)
+		).toEqual( [] );
 	} );
 } );
 

--- a/tests/js/components/groupedFilters.test.js
+++ b/tests/js/components/groupedFilters.test.js
@@ -1,0 +1,145 @@
+import { filterSortAndPaginateWithGroups } from '../../../src/components/groupedFilters';
+
+const fields = [
+	{
+		id: 'title',
+		type: 'text',
+		label: 'Title',
+		enableGlobalSearch: true,
+		getValue: ( { item } ) => item.title,
+	},
+	{
+		id: 'notes',
+		type: 'text',
+		label: 'Notes',
+		enableGlobalSearch: true,
+		getValue: ( { item } ) => item.notes,
+	},
+	{
+		id: 'links',
+		type: 'array',
+		label: 'Links',
+		getValue: ( { item } ) => item.links,
+	},
+	{
+		id: 'score',
+		type: 'integer',
+		label: 'Score',
+		getValue: ( { item } ) => item.score,
+	},
+];
+
+describe( 'filterSortAndPaginateWithGroups', () => {
+	it( 'applies OR groups in client mode instead of letting DataViews ignore them', () => {
+		const result = filterSortAndPaginateWithGroups(
+			[
+				{ id: 1, title: 'Alpha', notes: 'draft', links: [] },
+				{
+					id: 2,
+					title: 'Beta',
+					notes: 'done',
+					links: [ 'relation-b' ],
+				},
+				{ id: 3, title: 'Gamma', notes: 'done', links: [] },
+			],
+			{
+				filters: [
+					{
+						relation: 'OR',
+						filters: [
+							{
+								field: 'title',
+								operator: 'contains',
+								value: 'alp',
+							},
+							{
+								field: 'links',
+								operator: 'contains',
+								value: 'relation-b',
+							},
+						],
+					},
+				],
+			},
+			fields
+		);
+
+		expect( result.data.map( ( row ) => row.id ) ).toEqual( [ 1, 2 ] );
+	} );
+
+	it( 'applies nested AND and OR groups before DataViews pagination', () => {
+		const result = filterSortAndPaginateWithGroups(
+			[
+				{ id: 1, title: 'Alpha', notes: 'draft', score: 2 },
+				{ id: 2, title: 'Beta', notes: 'done', score: 8 },
+				{ id: 3, title: 'Gamma', notes: 'done', score: 12 },
+			],
+			{
+				page: 1,
+				perPage: 1,
+				filters: [
+					{
+						relation: 'AND',
+						filters: [
+							{
+								field: 'notes',
+								operator: 'is',
+								value: 'done',
+							},
+							{
+								relation: 'OR',
+								filters: [
+									{
+										field: 'score',
+										operator: 'lessThan',
+										value: 10,
+									},
+									{
+										field: 'title',
+										operator: 'is',
+										value: 'Alpha',
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+			fields
+		);
+
+		expect( result.data.map( ( row ) => row.id ) ).toEqual( [ 2 ] );
+		expect( result.paginationInfo ).toEqual( {
+			totalItems: 1,
+			totalPages: 1,
+		} );
+	} );
+
+	it( 'keeps DataViews search semantics after grouped filtering', () => {
+		const result = filterSortAndPaginateWithGroups(
+			[
+				{ id: 1, title: 'Alpha', notes: 'keep' },
+				{ id: 2, title: 'Beta', notes: 'keep' },
+				{ id: 3, title: 'Gamma', notes: 'drop' },
+			],
+			{
+				search: 'bet',
+				filters: [
+					{
+						relation: 'OR',
+						filters: [
+							{
+								field: 'notes',
+								operator: 'is',
+								value: 'keep',
+							},
+						],
+					},
+				],
+			},
+			fields
+		);
+
+		expect( result.data.map( ( row ) => row.id ) ).toEqual( [ 2 ] );
+	} );
+} );

--- a/tests/js/components/rowDetailUtils.test.js
+++ b/tests/js/components/rowDetailUtils.test.js
@@ -5,6 +5,7 @@ import {
 	normalizeRowDetailMode,
 	parseNumberPropertyValue,
 	splitPropertyPatch,
+	valueForField,
 	withRowDetailMode,
 } from '../../../src/components/rowDetailUtils';
 
@@ -84,6 +85,63 @@ describe( 'splitPropertyPatch', () => {
 			title: 'Only title',
 			meta: null,
 		} );
+	} );
+} );
+
+describe( 'valueForField', () => {
+	it( 'uses hydrated relation values for readonly relation properties', () => {
+		const relation = [
+			{
+				id: 123,
+				title: { raw: 'Target row', rendered: 'Target row' },
+			},
+		];
+
+		expect(
+			valueForField(
+				{
+					id: 'field-7',
+					cortextFieldType: 'relation',
+					editable: true,
+				},
+				{
+					meta: { 'field-7': [ '123' ] },
+					hydratedMeta: { 'field-7': relation },
+				}
+			)
+		).toBe( relation );
+	} );
+
+	it( 'uses hydrated rollup values for readonly rollup properties', () => {
+		expect(
+			valueForField(
+				{
+					id: 'field-8',
+					cortextFieldType: 'rollup',
+					editable: false,
+				},
+				{
+					meta: { 'field-8': '' },
+					hydratedMeta: { 'field-8': 42 },
+				}
+			)
+		).toBe( 42 );
+	} );
+
+	it( 'keeps editable fields on raw meta so saves do not round-trip hydrated data', () => {
+		expect(
+			valueForField(
+				{
+					id: 'field-9',
+					cortextFieldType: 'text',
+					editable: true,
+				},
+				{
+					meta: { 'field-9': 'raw value' },
+					hydratedMeta: { 'field-9': 'display value' },
+				}
+			)
+		).toBe( 'raw value' );
 	} );
 } );
 

--- a/tests/js/hooks/fieldMapping.test.js
+++ b/tests/js/hooks/fieldMapping.test.js
@@ -90,16 +90,207 @@ describe( 'mapField', () => {
 		meta: { type: 'text', ...( overrides ?? {} ) },
 	} );
 
-	it( "maps Cortext's number to DataViews 'text' so decimals sort correctly", () => {
-		expect( mapField( baseField( { type: 'number' } ) ).type ).toBe(
-			'text'
-		);
+	it( "maps Cortext's number to DataViews 'integer' with a decimal-safe filter control", () => {
+		const mapped = mapField( baseField( { type: 'number' } ) );
+
+		expect( mapped.type ).toBe( 'integer' );
+		expect( mapped.Edit ).toEqual( expect.any( Function ) );
+		expect( mapped.isValid.custom() ).toBeNull();
 	} );
 
-	it( "maps checkbox to DataViews 'boolean'", () => {
-		expect( mapField( baseField( { type: 'checkbox' } ) ).type ).toBe(
-			'boolean'
+	it( 'carries server query capabilities from the REST field record', () => {
+		const mapped = mapField( {
+			...baseField( { type: 'select' } ),
+			cortext_capabilities: {
+				sortable: true,
+				filterable: true,
+				operators: [ 'is', 'isAny' ],
+			},
+		} );
+
+		expect( mapped.sortable ).toBe( true );
+		expect( mapped.filterable ).toBe( true );
+		expect( mapped.operators ).toEqual( [ 'is', 'isAny' ] );
+	} );
+
+	it( 'configures DataViews text filters from UI-supported server operators', () => {
+		const mapped = mapField( {
+			...baseField( { type: 'text' } ),
+			cortext_capabilities: {
+				sortable: true,
+				filterable: true,
+				operators: [
+					'is',
+					'isNot',
+					'contains',
+					'notContains',
+					'startsWith',
+					'endsWith',
+					'isEmpty',
+				],
+			},
+		} );
+
+		expect( mapped.filterBy ).toEqual( {
+			operators: [
+				'is',
+				'isNot',
+				'contains',
+				'notContains',
+				'startsWith',
+			],
+		} );
+	} );
+
+	it( 'configures DataViews number filters from UI-supported server operators', () => {
+		const mapped = mapField( {
+			...baseField( { type: 'number' } ),
+			cortext_capabilities: {
+				sortable: true,
+				filterable: true,
+				operators: [
+					'is',
+					'greaterThan',
+					'lessThan',
+					'between',
+					'isEmpty',
+				],
+			},
+		} );
+
+		expect( mapped.filterBy ).toEqual( {
+			operators: [ 'is', 'greaterThan', 'lessThan', 'between' ],
+		} );
+	} );
+
+	it( 'configures DataViews date filters from UI-supported server operators', () => {
+		const mapped = mapField( {
+			...baseField( { type: 'date' } ),
+			cortext_capabilities: {
+				sortable: true,
+				filterable: true,
+				operators: [
+					'on',
+					'is',
+					'before',
+					'after',
+					'between',
+					'isEmpty',
+				],
+			},
+		} );
+
+		expect( mapped.filterBy ).toEqual( {
+			operators: [ 'on', 'before', 'after', 'between' ],
+		} );
+	} );
+
+	it( 'configures DataViews datetime filters without unsupported date-only range operators', () => {
+		const mapped = mapField( {
+			...baseField( { type: 'datetime' } ),
+			cortext_capabilities: {
+				sortable: true,
+				filterable: true,
+				operators: [
+					'on',
+					'is',
+					'before',
+					'after',
+					'between',
+					'isEmpty',
+				],
+			},
+		} );
+
+		expect( mapped.filterBy ).toEqual( {
+			operators: [ 'on', 'before', 'after' ],
+		} );
+	} );
+
+	it( 'configures DataViews option filters from UI-supported server operators', () => {
+		const select = mapField( {
+			...baseField( { type: 'select' } ),
+			cortext_capabilities: {
+				sortable: true,
+				filterable: true,
+				operators: [ 'is', 'isNot', 'isAny', 'isNone' ],
+			},
+		} );
+		const multiselect = mapField( {
+			...baseField( { type: 'multiselect' } ),
+			cortext_capabilities: {
+				sortable: false,
+				filterable: true,
+				operators: [ 'contains', 'notContains', 'isAny', 'isNone' ],
+			},
+		} );
+
+		expect( select.filterBy ).toEqual( {
+			operators: [ 'isAny', 'isNone' ],
+		} );
+		expect( multiselect.filterBy ).toEqual( {
+			operators: [ 'isAny', 'isNone' ],
+		} );
+	} );
+
+	it( 'defaults missing server query capabilities to unsupported', () => {
+		const mapped = mapField( baseField( { type: 'text' } ) );
+
+		expect( mapped.sortable ).toBe( false );
+		expect( mapped.filterable ).toBe( false );
+		expect( mapped.operators ).toEqual( [] );
+	} );
+
+	it( 'reads filter control data from top-level field ids', () => {
+		const mapped = mapField( baseField( { type: 'text' } ) );
+
+		expect( mapped.getValue( { item: { 'field-5': 'alpha' } } ) ).toBe(
+			'alpha'
 		);
+		expect(
+			mapped.getValue( { item: { meta: { 'field-5': 'beta' } } } )
+		).toBe( 'beta' );
+	} );
+
+	it( 'sorts number field values numerically with empty values last', () => {
+		const mapped = mapField( baseField( { type: 'number' } ) );
+
+		expect(
+			mapped.sort(
+				{ meta: { 'field-5': '2' } },
+				{ meta: { 'field-5': '10' } },
+				'asc'
+			)
+		).toBeLessThan( 0 );
+		expect(
+			mapped.sort(
+				{ meta: { 'field-5': '2' } },
+				{ meta: { 'field-5': '10' } },
+				'desc'
+			)
+		).toBeGreaterThan( 0 );
+		expect(
+			mapped.sort(
+				{ meta: { 'field-5': '' } },
+				{ meta: { 'field-5': '10' } },
+				'asc'
+			)
+		).toBeGreaterThan( 0 );
+	} );
+
+	it( "maps checkbox to DataViews 'boolean' values", () => {
+		const mapped = mapField( baseField( { type: 'checkbox' } ) );
+
+		expect( mapped.type ).toBe( 'boolean' );
+		expect(
+			mapped.getValue( { item: { meta: { 'field-5': '1' } } } )
+		).toBe( true );
+		expect( mapped.getValue( { item: { meta: { 'field-5': '' } } } ) ).toBe(
+			false
+		);
+		expect(
+			mapped.getValue( { item: { meta: { 'field-5': false } } } )
+		).toBe( false );
 	} );
 
 	it( "maps multiselect to DataViews 'array' (not text + isMultiple)", () => {
@@ -256,10 +447,8 @@ describe( 'mapField', () => {
 		expect( mapField( baseField( { type: 'url' } ) ).type ).toBe( 'text' );
 	} );
 
-	it( 'maps date and datetime to DataViews datetime', () => {
-		expect( mapField( baseField( { type: 'date' } ) ).type ).toBe(
-			'datetime'
-		);
+	it( 'maps date and datetime to matching DataViews date types', () => {
+		expect( mapField( baseField( { type: 'date' } ) ).type ).toBe( 'date' );
 		expect( mapField( baseField( { type: 'datetime' } ) ).type ).toBe(
 			'datetime'
 		);
@@ -314,6 +503,17 @@ describe( 'systemFields', () => {
 		expect( byId( 'modified_at' ).enableSorting ).toBe( true );
 		expect( byId( 'created_by' ).enableSorting ).toBe( false );
 		expect( byId( 'modified_by' ).enableSorting ).toBe( false );
+	} );
+
+	it( 'marks only timestamp system fields as server-sortable', () => {
+		expect( byId( 'created_at' ).sortable ).toBe( true );
+		expect( byId( 'modified_at' ).sortable ).toBe( true );
+		expect( byId( 'created_by' ).sortable ).toBe( false );
+		expect( byId( 'modified_by' ).sortable ).toBe( false );
+		fields.forEach( ( f ) => {
+			expect( f.filterable ).toBe( false );
+			expect( f.operators ).toEqual( [] );
+		} );
 	} );
 
 	it( 'maps timestamps to DataViews datetime and names to text', () => {

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -6,7 +6,10 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 
 import apiFetch from '@wordpress/api-fetch';
-import useCollectionRows from '../../../src/hooks/useCollectionRows';
+import useCollectionRows, {
+	buildQueryArgs,
+	buildQueryPlan,
+} from '../../../src/hooks/useCollectionRows';
 
 beforeEach( () => {
 	jest.clearAllMocks();
@@ -22,11 +25,96 @@ function lastRequestPath() {
 	return decodeURIComponent( apiFetch.mock.calls.at( -1 )[ 0 ].path );
 }
 
+const textOperators = [
+	'is',
+	'isNot',
+	'contains',
+	'notContains',
+	'startsWith',
+	'endsWith',
+	'isEmpty',
+	'isNotEmpty',
+];
+const numberOperators = [
+	'is',
+	'greaterThan',
+	'lessThan',
+	'between',
+	'isEmpty',
+];
+const selectOperators = [ 'is', 'isNot', 'isAny', 'isNone' ];
+const checkboxOperators = [ 'isChecked', 'isUnchecked' ];
+
 const baseFields = [
-	{ id: 'title', cortextType: 'title' },
-	{ id: 'created_by', cortextType: 'text' },
-	{ id: 'field-10', recordId: 10, cortextType: 'text' },
-	{ id: 'field-20', recordId: 20, cortextType: 'rollup' },
+	{
+		id: 'title',
+		cortextType: 'title',
+		sortable: true,
+		filterable: true,
+		operators: textOperators,
+	},
+	{
+		id: 'created_at',
+		cortextType: 'datetime',
+		sortable: true,
+		filterable: false,
+		operators: [],
+	},
+	{
+		id: 'created_by',
+		cortextType: 'text',
+		sortable: false,
+		filterable: false,
+		operators: [],
+	},
+	{
+		id: 'field-10',
+		recordId: 10,
+		cortextType: 'text',
+		sortable: true,
+		filterable: true,
+		operators: textOperators,
+	},
+	{
+		id: 'field-20',
+		recordId: 20,
+		cortextType: 'number',
+		sortable: true,
+		filterable: true,
+		operators: numberOperators,
+	},
+	{
+		id: 'field-30',
+		recordId: 30,
+		cortextType: 'relation',
+		sortable: false,
+		filterable: false,
+		operators: [],
+	},
+	{
+		id: 'field-40',
+		recordId: 40,
+		cortextType: 'rollup',
+		sortable: false,
+		filterable: false,
+		operators: [],
+	},
+	{
+		id: 'field-50',
+		recordId: 50,
+		cortextType: 'checkbox',
+		sortable: true,
+		filterable: true,
+		operators: checkboxOperators,
+	},
+	{
+		id: 'field-60',
+		recordId: 60,
+		cortextType: 'select',
+		sortable: true,
+		filterable: true,
+		operators: selectOperators,
+	},
 ];
 
 describe( 'useCollectionRows', () => {
@@ -80,13 +168,17 @@ describe( 'useCollectionRows', () => {
 		expect( lastRequestPath() ).toContain( 'per_page=100' );
 	} );
 
-	it( 'falls back to paged client mode for global search', async () => {
+	it( 'forwards search and supported sort in server mode', async () => {
 		const view = {
 			type: 'table',
+			search: 'alpha beta',
 			filters: [],
-			page: 2,
-			perPage: 50,
-			search: 'ada',
+			sort: {
+				field: 'field-20',
+				direction: 'desc',
+			},
+			page: 1,
+			perPage: 25,
 		};
 
 		const { result } = renderHook( () =>
@@ -94,11 +186,10 @@ describe( 'useCollectionRows', () => {
 		);
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
-		expect( result.current.queryMode ).toBe( 'client' );
-		expect( lastRequestPath() ).toContain( 'collection=7' );
-		expect( lastRequestPath() ).toContain( 'page=1' );
-		expect( lastRequestPath() ).toContain( 'per_page=100' );
-		expect( lastRequestPath() ).not.toContain( 'search=ada' );
+		expect( result.current.queryMode ).toBe( 'server' );
+		expect( lastRequestPath() ).toContain( 'search=alpha beta' );
+		expect( lastRequestPath() ).toContain( 'sort[field]=field-20' );
+		expect( lastRequestPath() ).toContain( 'sort[direction]=desc' );
 	} );
 
 	it( 'accumulates every server page in client mode', async () => {
@@ -119,9 +210,11 @@ describe( 'useCollectionRows', () => {
 		const view = {
 			type: 'table',
 			filters: [],
+			calculations: {
+				'field-10': 'count',
+			},
 			page: 1,
 			perPage: 25,
-			search: 'ada',
 		};
 
 		const { result } = renderHook( () =>
@@ -167,9 +260,11 @@ describe( 'useCollectionRows', () => {
 		const view = {
 			type: 'table',
 			filters: [],
+			calculations: {
+				'field-10': 'count',
+			},
 			page: 1,
 			perPage: 25,
-			search: 'ada',
 		};
 
 		const { result } = renderHook( () =>
@@ -194,13 +289,13 @@ describe( 'useCollectionRows', () => {
 			type: 'table',
 			filters: [
 				{
-					field: 'field-10',
+					field: 'field-30',
 					operator: 'contains',
-					value: 'red',
+					value: 'unsupported relation',
 				},
 			],
 			sort: {
-				field: 'field-20',
+				field: 'field-40',
 				direction: 'asc',
 			},
 			page: 2,
@@ -248,35 +343,12 @@ describe( 'useCollectionRows', () => {
 		expect( lastRequestPath() ).not.toContain( 'created_by' );
 	} );
 
-	it( 'falls back for custom field sorts', async () => {
-		const view = {
-			type: 'table',
-			filters: [],
-			sort: {
-				field: 'field-10',
-				direction: 'asc',
-			},
-			page: 1,
-			perPage: 25,
-		};
-
-		const { result } = renderHook( () =>
-			useCollectionRows( 7, view, baseFields )
-		);
-
-		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
-		expect( result.current.queryMode ).toBe( 'client' );
-		expect( lastRequestPath() ).toContain( 'page=1' );
-		expect( lastRequestPath() ).toContain( 'per_page=100' );
-		expect( lastRequestPath() ).not.toContain( 'sort[field]' );
-	} );
-
-	it( 'falls back for incomplete multi-value filters', async () => {
+	it( 'omits incomplete known filters instead of falling back to client mode', async () => {
 		const view = {
 			type: 'table',
 			filters: [
 				{
-					field: 'field-10',
+					field: 'field-60',
 					operator: 'isAny',
 					value: [],
 				},
@@ -290,41 +362,31 @@ describe( 'useCollectionRows', () => {
 		);
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
-		expect( result.current.queryMode ).toBe( 'client' );
+		expect( result.current.queryMode ).toBe( 'server' );
 		expect( lastRequestPath() ).toContain( 'page=1' );
-		expect( lastRequestPath() ).toContain( 'per_page=100' );
+		expect( lastRequestPath() ).toContain( 'per_page=25' );
 		expect( lastRequestPath() ).not.toContain( 'filters[0][field]' );
 	} );
 
-	it( 'falls back to paged client mode when calculations are active', async () => {
-		const view = {
-			type: 'table',
-			filters: [],
-			calculations: {
-				'field-10': 'count',
-			},
-			page: 1,
-			perPage: 25,
-		};
-
-		const { result } = renderHook( () =>
-			useCollectionRows( 7, view, baseFields )
-		);
-
-		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
-		expect( result.current.queryMode ).toBe( 'client' );
-		expect( lastRequestPath() ).toContain( 'page=1' );
-		expect( lastRequestPath() ).toContain( 'per_page=100' );
-	} );
-
-	it( 'forwards supported filters and sort in server mode', async () => {
+	it( 'forwards supported leaf and grouped filters in server mode', async () => {
 		const view = {
 			type: 'table',
 			filters: [
+				{ field: 'title', operator: 'startsWith', value: 'A' },
 				{
-					field: 'field-10',
-					operator: 'is',
-					value: 'red',
+					relation: 'OR',
+					filters: [
+						{
+							field: 'field-10',
+							operator: 'contains',
+							value: 'urgent',
+						},
+						{
+							field: 'field-20',
+							operator: 'greaterThan',
+							value: 10,
+						},
+					],
 				},
 			],
 			sort: {
@@ -342,12 +404,375 @@ describe( 'useCollectionRows', () => {
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
 		expect( result.current.queryMode ).toBe( 'server' );
 		expect( lastRequestPath() ).toContain( 'sort[field]=title' );
-		expect( lastRequestPath() ).toContain( 'sort[direction]=asc' );
+		expect( lastRequestPath() ).toContain( 'filters[0][field]=title' );
+		expect( lastRequestPath() ).toContain( 'filters[1][relation]=OR' );
 		expect( lastRequestPath() ).toContain(
-			'filters[0][field]=field-10'
+			'filters[1][filters][0][field]=field-10'
 		);
-		expect( lastRequestPath() ).toContain( 'filters[0][operator]=is' );
-		expect( lastRequestPath() ).toContain( 'filters[0][value]=red' );
+		expect( lastRequestPath() ).toContain(
+			'filters[1][filters][1][field]=field-20'
+		);
+	} );
+
+	it( 'falls back when an AND group has an unsupported descendant', async () => {
+		const view = {
+			type: 'table',
+			filters: [
+				{
+					relation: 'AND',
+					filters: [
+						{
+							field: 'field-10',
+							operator: 'contains',
+							value: 'urgent',
+						},
+						{
+							field: 'field-30',
+							operator: 'contains',
+							value: 'unsupported relation',
+						},
+					],
+				},
+			],
+			page: 1,
+			perPage: 25,
+		};
+
+		const { result } = renderHook( () =>
+			useCollectionRows( 7, view, baseFields )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+		expect( lastRequestPath() ).not.toContain( 'filters[0][field]' );
+	} );
+
+	it( 'serializes array filter values', () => {
+		const args = buildQueryArgs(
+			7,
+			{
+				filters: [
+					{
+						field: 'field-10',
+						operator: 'isAny',
+						value: [ 'alpha', 'beta' ],
+					},
+				],
+			},
+			[
+				{
+					id: 'title',
+					cortextType: 'title',
+					sortable: true,
+					filterable: true,
+					operators: textOperators,
+				},
+				{
+					id: 'field-10',
+					cortextType: 'select',
+					sortable: true,
+					filterable: true,
+					operators: selectOperators,
+				},
+			]
+		);
+
+		expect( args[ 'filters[0][value][0]' ] ).toBe( 'alpha' );
+		expect( args[ 'filters[0][value][1]' ] ).toBe( 'beta' );
+	} );
+
+	it( 'normalizes DataViews option filter value shapes for server queries', () => {
+		const multiValueArgs = buildQueryArgs(
+			7,
+			{
+				filters: [
+					{
+						field: 'field-60',
+						operator: 'isAny',
+						value: 'Finished',
+					},
+				],
+			},
+			baseFields
+		);
+		const singleValueArgs = buildQueryArgs(
+			7,
+			{
+				filters: [
+					{
+						field: 'field-60',
+						operator: 'is',
+						value: [ 'Finished' ],
+					},
+				],
+			},
+			baseFields
+		);
+
+		expect( multiValueArgs[ 'filters[0][operator]' ] ).toBe( 'isAny' );
+		expect( multiValueArgs[ 'filters[0][value][0]' ] ).toBe( 'Finished' );
+		expect( singleValueArgs[ 'filters[0][operator]' ] ).toBe( 'is' );
+		expect( singleValueArgs[ 'filters[0][value]' ] ).toBe( 'Finished' );
+		expect(
+			buildQueryPlan(
+				7,
+				{
+					filters: [
+						{
+							field: 'field-60',
+							operator: 'isAny',
+							value: 'Finished',
+						},
+					],
+				},
+				baseFields
+			).mode
+		).toBe( 'server' );
+	} );
+
+	it( 'treats incomplete grouped filters as no-op filters with relation semantics', () => {
+		const andArgs = buildQueryArgs(
+			7,
+			{
+				filters: [
+					{
+						relation: 'AND',
+						filters: [
+							{
+								field: 'field-60',
+								operator: 'isAny',
+								value: [],
+							},
+							{
+								field: 'field-10',
+								operator: 'contains',
+								value: 'urgent',
+							},
+						],
+					},
+				],
+			},
+			baseFields
+		);
+		const orArgs = buildQueryArgs(
+			7,
+			{
+				filters: [
+					{
+						relation: 'OR',
+						filters: [
+							{
+								field: 'field-60',
+								operator: 'isAny',
+								value: [],
+							},
+							{
+								field: 'field-10',
+								operator: 'contains',
+								value: 'urgent',
+							},
+						],
+					},
+				],
+			},
+			baseFields
+		);
+
+		expect( andArgs[ 'filters[0][relation]' ] ).toBe( 'AND' );
+		expect( andArgs[ 'filters[0][filters][0][field]' ] ).toBe( 'field-10' );
+		expect( orArgs[ 'filters[0][relation]' ] ).toBeUndefined();
+		expect( orArgs[ 'filters[0][filters][0][field]' ] ).toBeUndefined();
+	} );
+
+	it( 'normalizes DataViews boolean checkbox filters to server checkbox operators', () => {
+		const checkedArgs = buildQueryArgs(
+			7,
+			{
+				filters: [
+					{
+						field: 'field-50',
+						operator: 'is',
+						value: true,
+					},
+				],
+			},
+			baseFields
+		);
+		const uncheckedArgs = buildQueryArgs(
+			7,
+			{
+				filters: [
+					{
+						field: 'field-50',
+						operator: 'isNot',
+						value: true,
+					},
+				],
+			},
+			baseFields
+		);
+
+		expect( checkedArgs[ 'filters[0][operator]' ] ).toBe( 'isChecked' );
+		expect( checkedArgs[ 'filters[0][value]' ] ).toBeUndefined();
+		expect( uncheckedArgs[ 'filters[0][operator]' ] ).toBe( 'isUnchecked' );
+		expect( uncheckedArgs[ 'filters[0][value]' ] ).toBeUndefined();
+		expect(
+			buildQueryPlan(
+				7,
+				{
+					filters: [
+						{
+							field: 'field-50',
+							operator: 'is',
+							value: false,
+						},
+					],
+				},
+				baseFields
+			).mode
+		).toBe( 'server' );
+	} );
+
+	it( 'refetches when select and checkbox filters become complete server filters', async () => {
+		const { rerender } = renderHook(
+			( { view } ) => useCollectionRows( 7, view, baseFields ),
+			{
+				initialProps: {
+					view: {
+						type: 'table',
+						filters: [],
+						page: 1,
+						perPage: 25,
+					},
+				},
+			}
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+
+		rerender( {
+			view: {
+				type: 'table',
+				filters: [
+					{
+						field: 'field-60',
+						operator: 'isAny',
+						value: [ 'Finished' ],
+					},
+				],
+				page: 1,
+				perPage: 25,
+			},
+		} );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		expect( lastRequestPath() ).toContain( 'filters[0][field]=field-60' );
+		expect( lastRequestPath() ).toContain( 'filters[0][operator]=isAny' );
+		expect( lastRequestPath() ).toContain(
+			'filters[0][value][0]=Finished'
+		);
+
+		rerender( {
+			view: {
+				type: 'table',
+				filters: [
+					{
+						field: 'field-50',
+						operator: 'is',
+						value: true,
+					},
+				],
+				page: 1,
+				perPage: 25,
+			},
+		} );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 3 ) );
+		expect( lastRequestPath() ).toContain( 'filters[0][field]=field-50' );
+		expect( lastRequestPath() ).toContain(
+			'filters[0][operator]=isChecked'
+		);
+	} );
+
+	it( 'uses field operators instead of inferring support from type', () => {
+		const view = {
+			filters: [
+				{
+					field: 'field-10',
+					operator: 'contains',
+					value: 'alpha',
+				},
+			],
+		};
+
+		expect(
+			buildQueryPlan( 7, view, [
+				{
+					id: 'field-10',
+					recordId: 10,
+					cortextType: 'text',
+					sortable: true,
+					filterable: true,
+					operators: [ 'contains' ],
+				},
+			] ).mode
+		).toBe( 'server' );
+
+		expect(
+			buildQueryPlan( 7, view, [
+				{
+					id: 'field-10',
+					recordId: 10,
+					cortextType: 'text',
+					sortable: true,
+					filterable: true,
+					operators: [ 'is' ],
+				},
+			] ).mode
+		).toBe( 'client' );
+	} );
+
+	it( 'treats missing operator metadata as unsupported', () => {
+		const plan = buildQueryPlan(
+			7,
+			{
+				filters: [
+					{
+						field: 'field-10',
+						operator: 'contains',
+						value: 'alpha',
+					},
+				],
+			},
+			[
+				{
+					id: 'field-10',
+					recordId: 10,
+					cortextType: 'text',
+					sortable: true,
+					filterable: true,
+				},
+			]
+		);
+
+		expect( plan.mode ).toBe( 'client' );
+	} );
+
+	it( 'does not serialize unsupported sorts in direct query args', () => {
+		const args = buildQueryArgs(
+			7,
+			{
+				sort: {
+					field: 'field-30',
+					direction: 'asc',
+				},
+				filters: [],
+			},
+			baseFields
+		);
+
+		expect( args[ 'sort[field]' ] ).toBeUndefined();
+		expect( args[ 'sort[direction]' ] ).toBeUndefined();
 	} );
 
 	it( 'supports forced paged client mode for relation pickers', async () => {
@@ -364,13 +789,11 @@ describe( 'useCollectionRows', () => {
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
 		expect( result.current.queryMode ).toBe( 'client' );
-		expect( lastRequestPath() ).toContain( 'collection=7' );
-		expect( lastRequestPath() ).toContain( 'page=1' );
 		expect( lastRequestPath() ).toContain( 'per_page=100' );
 	} );
 
 	it( 'refetches rows when the visible schema gains a rollup field', async () => {
-		const view = { type: 'table', filters: [] };
+		const view = { type: 'table', filters: [], page: 1, perPage: 25 };
 		const initialFields = [
 			{ id: 'title', cortextType: 'title' },
 			{ id: 'field-10', recordId: 10, cortextType: 'relation' },

--- a/tests/php/test-post-type-field.php
+++ b/tests/php/test-post-type-field.php
@@ -11,8 +11,16 @@ namespace Cortext\Tests;
 
 use Cortext\PostType\Field;
 use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
 
 final class Test_Post_Type_Field extends BaseTestCase {
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
 
 	public function test_post_type_constant_matches_expected_slug(): void {
 		$this->assertSame( 'crtxt_field', Field::POST_TYPE );
@@ -77,5 +85,48 @@ final class Test_Post_Type_Field extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'related_collection_id', $registered );
 		$this->assertSame( 'integer', $registered['related_collection_id']['type'] );
+	}
+
+	public function test_rest_response_includes_cortext_capabilities(): void {
+		$field_post_type = new Field();
+		$field_post_type->register_post_type();
+
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Status',
+				'meta_input'  => array( 'type' => 'select' ),
+			)
+		);
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/crtxt_fields/{$field_id}" );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'sortable'   => true,
+				'filterable' => true,
+				'operators'  => array( 'is', 'isNot', 'isAny', 'isNone' ),
+			),
+			$data['cortext_capabilities']
+		);
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
 	}
 }

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -365,14 +365,13 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertSame( 'ASC', $args['order'] );
 	}
 
-	public function test_build_query_args_with_search(): void {
+	public function test_build_query_args_carries_compiled_filter_sql(): void {
 		$fixture = $this->create_collection_fixture( 'bqas' );
 
 		$request = new WP_REST_Request( 'GET', '/cortext/v1/rows' );
 		$request->set_query_params(
 			array(
 				'collection' => $fixture['collection_id'],
-				'search'     => 'hello',
 			)
 		);
 		$request->set_default_params(
@@ -389,9 +388,11 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$method     = new \ReflectionMethod( $controller, 'build_query_args' );
 		$method->setAccessible( true );
 
-		$args = $method->invoke( $controller, $request, 'bqas' );
+		$args = $method->invoke( $controller, $request, 'bqas', 'compiled where sql', 'compiled join sql' );
 
-		$this->assertSame( 'hello', $args['s'] );
+		$this->assertArrayNotHasKey( 's', $args );
+		$this->assertSame( 'compiled where sql', $args['cortext_rows_where'] );
+		$this->assertSame( 'compiled join sql', $args['cortext_rows_join'] );
 	}
 
 	public function test_build_query_args_with_title_sort(): void {
@@ -456,12 +457,12 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 
 		$args = $method->invoke( $controller, $request, 'bqan' );
 
-		$this->assertSame( "field-{$fixture['field_id']}", $args['meta_key'] );
-		$this->assertSame( 'meta_value_num', $args['orderby'] );
+		$this->assertArrayNotHasKey( 'meta_key', $args );
+		$this->assertSame( 'none', $args['orderby'] );
 		$this->assertSame( 'ASC', $args['order'] );
 	}
 
-	public function test_build_query_args_with_filters(): void {
+	public function test_build_query_args_ignores_raw_filters(): void {
 		$fixture = $this->create_collection_fixture( 'bqaf', 'text' );
 
 		$request = new WP_REST_Request( 'GET', '/cortext/v1/rows' );
@@ -498,28 +499,26 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 
 		$args = $method->invoke( $controller, $request, 'bqaf' );
 
-		$this->assertArrayHasKey( 'meta_query', $args );
-		$this->assertCount( 2, $args['meta_query'] );
-
-		$this->assertSame( "field-{$fixture['field_id']}", $args['meta_query'][0]['key'] );
-		$this->assertSame( '=', $args['meta_query'][0]['compare'] );
-		$this->assertSame( 'red', $args['meta_query'][0]['value'] );
-
-		$this->assertSame( 'IN', $args['meta_query'][1]['compare'] );
-		$this->assertSame( array( 'blue', 'green' ), $args['meta_query'][1]['value'] );
+		$this->assertArrayNotHasKey( 'meta_query', $args );
 	}
 
-	public function test_build_query_args_skips_rollup_sort_and_filter_meta_query(): void {
+	public function test_query_rows_rejects_rollup_sort_and_filter(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+
 		$fixture = $this->create_collection_fixture( 'bqaroll', 'rollup' );
 
-		$request = new WP_REST_Request( 'GET', '/cortext/v1/rows' );
-		$request->set_query_params(
+		$sort_response = $this->query_rows(
 			array(
 				'collection' => $fixture['collection_id'],
 				'sort'       => array(
 					'field'     => "field-{$fixture['field_id']}",
 					'direction' => 'desc',
 				),
+			)
+		);
+		$filter_response = $this->query_rows(
+			array(
+				'collection' => $fixture['collection_id'],
 				'filters'    => array(
 					array(
 						'field'    => "field-{$fixture['field_id']}",
@@ -529,26 +528,9 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 				),
 			)
 		);
-		$request->set_default_params(
-			array(
-				'per_page' => 25,
-				'page'     => 1,
-				'search'   => '',
-				'sort'     => null,
-				'filters'  => array(),
-			)
-		);
 
-		$controller = new RowsController();
-		$method     = new \ReflectionMethod( $controller, 'build_query_args' );
-		$method->setAccessible( true );
-
-		$args = $method->invoke( $controller, $request, 'bqaroll' );
-
-		$this->assertSame( 'date', $args['orderby'] );
-		$this->assertSame( 'ASC', $args['order'] );
-		$this->assertArrayNotHasKey( 'meta_key', $args );
-		$this->assertArrayNotHasKey( 'meta_query', $args );
+		$this->assertSame( 400, $sort_response->get_status() );
+		$this->assertSame( 400, $filter_response->get_status() );
 	}
 
 	// -- Relation and rollup tests --------------------------------------

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -365,37 +365,7 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertSame( 'ASC', $args['order'] );
 	}
 
-	public function test_build_query_args_carries_compiled_filter_sql(): void {
-		$fixture = $this->create_collection_fixture( 'bqas' );
-
-		$request = new WP_REST_Request( 'GET', '/cortext/v1/rows' );
-		$request->set_query_params(
-			array(
-				'collection' => $fixture['collection_id'],
-			)
-		);
-		$request->set_default_params(
-			array(
-				'per_page' => 25,
-				'page'     => 1,
-				'search'   => '',
-				'sort'     => null,
-				'filters'  => array(),
-			)
-		);
-
-		$controller = new RowsController();
-		$method     = new \ReflectionMethod( $controller, 'build_query_args' );
-		$method->setAccessible( true );
-
-		$args = $method->invoke( $controller, $request, 'bqas', 'compiled where sql', 'compiled join sql' );
-
-		$this->assertArrayNotHasKey( 's', $args );
-		$this->assertSame( 'compiled where sql', $args['cortext_rows_where'] );
-		$this->assertSame( 'compiled join sql', $args['cortext_rows_join'] );
-	}
-
-	public function test_build_query_args_with_title_sort(): void {
+public function test_build_query_args_with_title_sort(): void {
 		$fixture = $this->create_collection_fixture( 'bqat' );
 
 		$request = new WP_REST_Request( 'GET', '/cortext/v1/rows' );

--- a/tests/php/test-rest-rows-filter-query.php
+++ b/tests/php/test-rest-rows-filter-query.php
@@ -1,0 +1,412 @@
+<?php
+/**
+ * Tests for Cortext\Rest\RowsFilterQuery.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Fields\FieldTypeRegistry;
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Field;
+use Cortext\Rest\RowsFilterQuery;
+use WorDBless\BaseTestCase;
+
+final class Test_Rest_Rows_Filter_Query extends BaseTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->unregister_dynamic_collection_post_types();
+		( new Collection() )->register_post_type();
+		( new Field() )->register_post_type();
+	}
+
+	public function test_field_schema_caches_collection_fields(): void {
+		$collection_id = $this->create_collection_with_slug( 'Cache', 'rows-cache' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Label', 'text' );
+		$query         = new RowsFilterQuery();
+
+		$first = $query->field_schema_for( $collection_id );
+		update_post_meta( $field_id, 'type', 'number' );
+		$second = $query->field_schema_for( $collection_id );
+
+		$this->assertSame( 'text', $first[ "field-{$field_id}" ]['type'] );
+		$this->assertSame( 'text', $second[ "field-{$field_id}" ]['type'] );
+	}
+
+	public function test_compiles_supported_operators_by_field_type(): void {
+		$collection_id = $this->create_collection_with_slug( 'Operators', 'rows-operators' );
+		$field_ids     = array(
+			'text'        => $this->create_collection_field( $collection_id, 'Text', 'text' ),
+			'email'       => $this->create_collection_field( $collection_id, 'Email', 'email' ),
+			'url'         => $this->create_collection_field( $collection_id, 'URL', 'url' ),
+			'number'      => $this->create_collection_field( $collection_id, 'Number', 'number' ),
+			'date'        => $this->create_collection_field( $collection_id, 'Date', 'date' ),
+			'datetime'    => $this->create_collection_field( $collection_id, 'Datetime', 'datetime' ),
+			'select'      => $this->create_collection_field( $collection_id, 'Select', 'select' ),
+			'multiselect' => $this->create_collection_field( $collection_id, 'Multi', 'multiselect' ),
+			'checkbox'    => $this->create_collection_field( $collection_id, 'Done', 'checkbox' ),
+		);
+		$query         = new RowsFilterQuery();
+		$field_schema  = $query->field_schema_for( $collection_id );
+
+		$cases = array( array( 'title', 'text', 'title' ) );
+		foreach ( $field_ids as $type => $field_id ) {
+			$cases[] = array( "field-{$field_id}", $type, "field-{$field_id}" );
+		}
+
+		foreach ( $cases as $case ) {
+			list( $field_key, $type, $label ) = $case;
+			foreach ( FieldTypeRegistry::operators_for( $type ) as $operator ) {
+				$result = $query->compile_filters(
+					array(
+						array(
+							'field'    => $field_key,
+							'operator' => $operator,
+							'value'    => $this->value_for_operator( $type, $operator ),
+						),
+					),
+					$field_schema,
+					$collection_id
+				);
+				$this->assertFalse( is_wp_error( $result ), "{$label} {$operator} should compile." );
+				$this->assertIsArray( $result );
+				$this->assertNotSame( '', $result['where'] );
+			}
+		}
+	}
+
+	public function test_rejects_unsupported_filter_operator(): void {
+		$collection_id = $this->create_collection_with_slug( 'Bad op', 'rows-bad-op' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Number', 'number' );
+		$query         = new RowsFilterQuery();
+
+		$result = $query->compile_filters(
+			array(
+				array(
+					'field'    => "field-{$field_id}",
+					'operator' => 'contains',
+					'value'    => '10',
+				),
+			),
+			$query->field_schema_for( $collection_id ),
+			$collection_id
+		);
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'cortext_invalid_filter_operator', $result->get_error_code() );
+	}
+
+	public function test_empty_and_not_empty_compile_expected_meta_sql(): void {
+		$collection_id = $this->create_collection_with_slug( 'Empty', 'rows-empty' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Text', 'text' );
+		$query         = new RowsFilterQuery();
+		$field_schema  = $query->field_schema_for( $collection_id );
+		$field_key     = "field-{$field_id}";
+
+		$empty = $query->compile_filters(
+			array(
+				array(
+					'field'    => $field_key,
+					'operator' => 'isEmpty',
+				),
+			),
+			$field_schema,
+			$collection_id
+		);
+		$this->assertFalse( is_wp_error( $empty ) );
+		$this->assertStringContainsString( 'LEFT JOIN', $empty['join'] );
+		$this->assertStringContainsString( 'IS NULL', $empty['where'] );
+		$this->assertStringContainsString( "meta_value = ''", $empty['where'] );
+
+		$not_empty = $query->compile_filters(
+			array(
+				array(
+					'field'    => $field_key,
+					'operator' => 'isNotEmpty',
+				),
+			),
+			$field_schema,
+			$collection_id
+		);
+		$this->assertFalse( is_wp_error( $not_empty ) );
+		$this->assertStringContainsString( "meta_value != ''", $not_empty['where'] );
+	}
+
+	public function test_title_filter_compiles_against_post_title(): void {
+		$collection_id = $this->create_collection_with_slug( 'Title', 'rows-title-filter' );
+		$query         = new RowsFilterQuery();
+
+		$result = $query->compile_filters(
+			array(
+				array(
+					'field'    => 'title',
+					'operator' => 'startsWith',
+					'value'    => 'Alpha',
+				),
+			),
+			$query->field_schema_for( $collection_id ),
+			$collection_id
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertStringContainsString( 'post_title LIKE', $result['where'] );
+	}
+
+	public function test_title_filter_compiles_inside_or_group(): void {
+		$collection_id = $this->create_collection_with_slug( 'Title OR', 'rows-title-or' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Text', 'text' );
+		$query         = new RowsFilterQuery();
+
+		$result = $query->compile_filters(
+			array(
+				array(
+					'relation' => 'OR',
+					'filters'  => array(
+						array(
+							'field'    => 'title',
+							'operator' => 'startsWith',
+							'value'    => 'Alpha',
+						),
+						array(
+							'field'    => "field-{$field_id}",
+							'operator' => 'is',
+							'value'    => 'blue',
+						),
+					),
+				),
+			),
+			$query->field_schema_for( $collection_id ),
+			$collection_id
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertStringContainsString( 'post_title LIKE', $result['where'] );
+		$this->assertStringContainsString( ' OR ', $result['where'] );
+	}
+
+	public function test_date_filter_values_must_be_parseable(): void {
+		$collection_id = $this->create_collection_with_slug( 'Dates', 'rows-date-validation' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Due', 'date' );
+		$query         = new RowsFilterQuery();
+
+		$result = $query->compile_filters(
+			array(
+				array(
+					'field'    => "field-{$field_id}",
+					'operator' => 'before',
+					'value'    => 'not a date',
+				),
+			),
+			$query->field_schema_for( $collection_id ),
+			$collection_id
+		);
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'cortext_invalid_filter', $result->get_error_code() );
+	}
+
+	public function test_group_nesting_allows_two_nested_levels_and_rejects_third(): void {
+		$collection_id = $this->create_collection_with_slug( 'Groups', 'rows-groups' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Text', 'text' );
+		$query         = new RowsFilterQuery();
+		$field_schema  = $query->field_schema_for( $collection_id );
+		$leaf          = array(
+			'field'    => "field-{$field_id}",
+			'operator' => 'is',
+			'value'    => 'alpha',
+		);
+
+		$allowed = $query->compile_filters(
+			array(
+				array(
+					'relation' => 'AND',
+					'filters'  => array(
+						array(
+							'relation' => 'OR',
+							'filters'  => array(
+								array(
+									'relation' => 'AND',
+									'filters'  => array( $leaf ),
+								),
+							),
+						),
+					),
+				),
+			),
+			$field_schema,
+			$collection_id
+		);
+		$this->assertFalse( is_wp_error( $allowed ) );
+
+		$too_deep = $query->compile_filters(
+			array(
+				array(
+					'relation' => 'AND',
+					'filters'  => array(
+						array(
+							'relation' => 'OR',
+							'filters'  => array(
+								array(
+									'relation' => 'AND',
+									'filters'  => array(
+										array(
+											'relation' => 'OR',
+											'filters'  => array( $leaf ),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+			$field_schema,
+			$collection_id
+		);
+		$this->assertTrue( is_wp_error( $too_deep ) );
+		$this->assertSame( 'cortext_filter_depth_exceeded', $too_deep->get_error_code() );
+	}
+
+	public function test_search_splits_terms_with_and_semantics_and_includes_text_meta(): void {
+		$collection_id = $this->create_collection_with_slug( 'Search', 'rows-search' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Notes', 'text' );
+		$query         = new RowsFilterQuery();
+
+		$sql = $query->compile_search( 'alpha beta', $query->field_schema_for( $collection_id ) );
+
+		$this->assertSame( 2, substr_count( $sql, 'post_title LIKE' ) );
+		$this->assertStringContainsString( ' AND ', $sql );
+		$this->assertStringContainsString( "field-{$field_id}", $sql );
+	}
+
+	public function test_filter_join_clauses_group_by_post_id_to_avoid_duplicate_rows(): void {
+		global $wpdb;
+
+		$query = new RowsFilterQuery();
+
+		$clauses = $query->apply_filter_join_clauses(
+			array(
+				'join'    => ' INNER JOIN existing_table ON 1 = 1',
+				'groupby' => '',
+			),
+			' INNER JOIN wp_postmeta AS mt1 ON mt1.post_id = wp_posts.ID'
+		);
+
+		$this->assertStringContainsString( 'existing_table', $clauses['join'] );
+		$this->assertStringContainsString( 'wp_postmeta AS mt1', $clauses['join'] );
+		$this->assertSame( "{$wpdb->posts}.ID", $clauses['groupby'] );
+	}
+
+	public function test_filter_join_clauses_preserve_existing_group_by(): void {
+		global $wpdb;
+
+		$query = new RowsFilterQuery();
+
+		$clauses = $query->apply_filter_join_clauses(
+			array(
+				'join'    => '',
+				'groupby' => 'custom_column',
+			),
+			' INNER JOIN wp_postmeta AS mt1 ON mt1.post_id = wp_posts.ID'
+		);
+
+		$this->assertSame( "custom_column, {$wpdb->posts}.ID", $clauses['groupby'] );
+
+		$unchanged = $query->apply_filter_join_clauses(
+			$clauses,
+			' INNER JOIN wp_postmeta AS mt2 ON mt2.post_id = wp_posts.ID'
+		);
+		$this->assertSame( "custom_column, {$wpdb->posts}.ID", $unchanged['groupby'] );
+	}
+
+	public function test_rejects_rollup_sort(): void {
+		$collection_id = $this->create_collection_with_slug( 'Rollup sort', 'rows-roll-sort' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Rollup', 'rollup' );
+		$query         = new RowsFilterQuery();
+
+		$result = $query->validate_sort(
+			array(
+				'field'     => "field-{$field_id}",
+				'direction' => 'asc',
+			),
+			$query->field_schema_for( $collection_id ),
+			$collection_id
+		);
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'cortext_invalid_sort_field', $result->get_error_code() );
+	}
+
+	private function create_collection_with_slug( string $title, string $slug ): int {
+		$collection_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => array( 'slug' => $slug ),
+			)
+		);
+
+		( new CollectionEntries() )->register_for_collection( get_post( $collection_id ) );
+
+		return $collection_id;
+	}
+
+	private function create_collection_field( int $collection_id, string $title, string $type ): int {
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => array( 'type' => $type ),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+
+		return $field_id;
+	}
+
+	private function value_for_operator( string $type, string $operator ): mixed {
+		if ( in_array( $operator, array( 'isEmpty', 'isNotEmpty', 'isChecked', 'isUnchecked' ), true ) ) {
+			return null;
+		}
+		if ( 'between' === $operator ) {
+			if ( 'number' === $type ) {
+				return array( 2, 10 );
+			}
+			return 'datetime' === $type
+				? array( '2026-05-01T00:00:00+00:00', '2026-05-31T23:59:59+00:00' )
+				: array( '2026-05-01', '2026-05-31' );
+		}
+		if ( in_array( $operator, array( 'isAny', 'isNone' ), true ) ) {
+			return array( 'alpha', 'beta' );
+		}
+		if ( 'number' === $type ) {
+			return 10;
+		}
+		if ( 'datetime' === $type ) {
+			return '2026-05-11T12:30:00+00:00';
+		}
+		if ( 'date' === $type ) {
+			return '2026-05-11';
+		}
+		return 'alpha';
+	}
+
+	private function unregister_dynamic_collection_post_types(): void {
+		foreach ( get_post_types() as $post_type ) {
+			if (
+				str_starts_with( $post_type, CollectionEntries::CPT_PREFIX ) &&
+				! in_array( $post_type, array( Collection::POST_TYPE, Field::POST_TYPE ), true )
+			) {
+				unregister_post_type( $post_type );
+			}
+		}
+	}
+}

--- a/tests/php/test-rest-rows-meta-query.php
+++ b/tests/php/test-rest-rows-meta-query.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Tests for Cortext\Rest\RowsMetaQuery.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Rest\RowsMetaQuery;
+use WorDBless\BaseTestCase;
+
+final class Test_Rest_Rows_Meta_Query extends BaseTestCase {
+
+	public function test_custom_like_compares_do_not_auto_wrap_both_sides(): void {
+		$starts = $this->sql_for(
+			array(
+				array(
+					'key'     => 'field-1',
+					'compare' => 'STARTS_WITH',
+					'value'   => 'alpha',
+				),
+			)
+		);
+		$ends   = $this->sql_for(
+			array(
+				array(
+					'key'     => 'field-1',
+					'compare' => 'ENDS_WITH',
+					'value'   => 'omega',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( "meta_value LIKE 'alpha%'", $starts['where'] );
+		$this->assertStringContainsString( "meta_value LIKE '%omega'", $ends['where'] );
+	}
+
+	public function test_negative_custom_compares_use_not_exists_subqueries(): void {
+		$not_contains = $this->sql_for(
+			array(
+				array(
+					'key'     => 'field-1',
+					'compare' => 'NOT_CONTAINS',
+					'value'   => 'needle',
+				),
+			)
+		);
+		$none_in      = $this->sql_for(
+			array(
+				array(
+					'key'     => 'field-1',
+					'compare' => 'NONE_IN',
+					'value'   => array( 'alpha', 'beta' ),
+				),
+			)
+		);
+
+		$this->assertSame( '', $not_contains['join'] );
+		$this->assertStringContainsString( 'NOT EXISTS', $not_contains['where'] );
+		$this->assertStringContainsString( "meta_value LIKE '%needle%'", $not_contains['where'] );
+		$this->assertStringContainsString( 'NOT EXISTS', $none_in['where'] );
+		$this->assertStringContainsString( "meta_value IN ('alpha', 'beta')", $none_in['where'] );
+	}
+
+	public function test_title_clause_composes_inside_or_group(): void {
+		$sql = $this->sql_for(
+			array(
+				'relation' => 'OR',
+				array(
+					'key'     => RowsMetaQuery::TITLE_KEY,
+					'compare' => 'STARTS_WITH',
+					'value'   => 'Alpha',
+				),
+				array(
+					'key'     => 'field-1',
+					'compare' => '=',
+					'value'   => 'blue',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'post_title LIKE', $sql['where'] );
+		$this->assertStringContainsString( ' OR ', $sql['where'] );
+		$this->assertStringContainsString( 'INNER JOIN', $sql['join'] );
+	}
+
+	/**
+	 * Compiles one RowsMetaQuery tree.
+	 *
+	 * @param array $query WP_Meta_Query-style query.
+	 * @return array{join:string,where:string}
+	 */
+	private function sql_for( array $query ): array {
+		global $wpdb;
+
+		$meta_query = new RowsMetaQuery( $query );
+		$sql        = $meta_query->get_sql( 'post', $wpdb->posts, 'ID' );
+
+		$this->assertIsArray( $sql );
+		return array(
+			'join'  => (string) $sql['join'],
+			'where' => $wpdb->remove_placeholder_escape( (string) $sql['where'] ),
+		);
+	}
+}

--- a/tests/php/test-rest-rows-query-scope.php
+++ b/tests/php/test-rest-rows-query-scope.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Tests for Cortext\Rest\RowsQueryScope.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Field;
+use Cortext\Rest\RowsFilterQuery;
+use Cortext\Rest\RowsQueryScope;
+use WorDBless\BaseTestCase;
+use WP_Query;
+
+final class Test_Rest_Rows_Query_Scope extends BaseTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->unregister_dynamic_collection_post_types();
+		( new Collection() )->register_post_type();
+		( new Field() )->register_post_type();
+	}
+
+	public function test_run_appends_where_sql_for_scoped_query(): void {
+		$scope          = $this->build_scope( 'WHERE_FRAGMENT', '', null );
+		$query          = $this->mock_query_with_token( $scope );
+		$where_callback = $this->grab_callback( $scope, 'posts_where' );
+
+		$this->assertSame(
+			"original_where AND WHERE_FRAGMENT",
+			$where_callback( 'original_where', $query )
+		);
+	}
+
+	public function test_run_leaves_unrelated_queries_untouched(): void {
+		$scope          = $this->build_scope( 'WHERE_FRAGMENT', '', null );
+		$other_query    = $this->mock_query_with_token( $scope, 'a-different-token' );
+		$where_callback = $this->grab_callback( $scope, 'posts_where' );
+
+		$this->assertSame(
+			'original_where',
+			$where_callback( 'original_where', $other_query ),
+			'Scope should ignore queries that did not register its token.'
+		);
+	}
+
+	public function test_run_returns_unchanged_where_when_fragment_is_empty(): void {
+		$scope          = $this->build_scope( '', '', null );
+		$query          = $this->mock_query_with_token( $scope );
+		$where_callback = $this->grab_callback( $scope, 'posts_where' );
+
+		$this->assertSame( 'original_where', $where_callback( 'original_where', $query ) );
+	}
+
+	public function test_run_unregisters_filters_when_done(): void {
+		$scope = $this->build_scope( 'IRRELEVANT', '', null );
+
+		try {
+			$reflection = new \ReflectionClass( $scope );
+			$method     = $reflection->getMethod( 'run' );
+			$method->setAccessible( true );
+			$method->invoke( $scope, array( 'post_type' => 'crtxt_does_not_exist' ) );
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Even if WP_Query throws on the unknown post type, the
+			// scope's cleanup contract still applies.
+		}
+
+		$this->assertFalse(
+			$this->scope_callback_is_registered( 'posts_where' ),
+			'posts_where callback should have been removed.'
+		);
+		$this->assertFalse(
+			$this->scope_callback_is_registered( 'posts_clauses' ),
+			'posts_clauses callback should have been removed.'
+		);
+	}
+
+	/**
+	 * Builds a real RowsQueryScope and starts its run() machinery so the
+	 * callbacks attach. Returns the scope object; the caller is expected
+	 * to read the closures via grab_callback() and then trigger cleanup
+	 * either by running a query or by directly removing.
+	 */
+	private function build_scope( string $where_sql, string $join_sql, mixed $sort ): RowsQueryScope {
+		$row_query = new RowsFilterQuery();
+		return new RowsQueryScope( $row_query, array(), $where_sql, $join_sql, $sort );
+	}
+
+	/**
+	 * Returns a WP_Query whose cortext_rows_query_token matches the
+	 * scope (so the scope's callbacks treat it as "ours"). When a custom
+	 * token is supplied, the query looks like someone else's run.
+	 */
+	private function mock_query_with_token( RowsQueryScope $scope, ?string $token = null ): WP_Query {
+		$reflection  = new \ReflectionClass( $scope );
+		$token_prop  = $reflection->getProperty( 'token' );
+		$token_prop->setAccessible( true );
+		$scope_token = $token_prop->getValue( $scope );
+
+		$query = new WP_Query();
+		$query->set( 'cortext_rows_query_token', $token ?? $scope_token );
+		return $query;
+	}
+
+	/**
+	 * Invokes run() against a no-op query just so the scope attaches its
+	 * callbacks, captures one of them by hook name, and then cleans up
+	 * by manually firing the cleanup path.
+	 *
+	 * @return callable
+	 */
+	private function grab_callback( RowsQueryScope $scope, string $hook ): callable {
+		$captured = null;
+		$capture  = static function ( $value, $query ) use ( &$captured, $hook ): mixed {
+			global $wp_filter;
+			foreach ( $wp_filter[ $hook ]->callbacks as $priority_callbacks ) {
+				foreach ( $priority_callbacks as $entry ) {
+					$callback = $entry['function'];
+					if ( $callback instanceof \Closure ) {
+						$reflection = new \ReflectionFunction( $callback );
+						if ( str_contains( (string) $reflection->getFileName(), 'RowsQueryScope.php' ) ) {
+							$captured = $callback;
+							return $value;
+						}
+					}
+				}
+			}
+			return $value;
+		};
+
+		add_filter( $hook, $capture, 1, 2 );
+		try {
+			$reflection = new \ReflectionClass( $scope );
+			$method     = $reflection->getMethod( 'run' );
+			$method->setAccessible( true );
+			$method->invoke( $scope, array( 'post_type' => 'crtxt_does_not_exist' ) );
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// run() may throw if WP_Query trips on the unknown CPT; the
+			// scope still attached and detached its callbacks first.
+		}
+		remove_filter( $hook, $capture, 1 );
+
+		$this->assertNotNull( $captured, "Scope did not register a {$hook} callback." );
+		return $captured;
+	}
+
+	private function scope_callback_is_registered( string $hook ): bool {
+		global $wp_filter;
+		if ( ! isset( $wp_filter[ $hook ] ) ) {
+			return false;
+		}
+		foreach ( $wp_filter[ $hook ]->callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $callback_entry ) {
+				$callback = $callback_entry['function'] ?? null;
+				if ( $callback instanceof \Closure ) {
+					$reflection = new \ReflectionFunction( $callback );
+					if ( str_contains( (string) $reflection->getFileName(), 'RowsQueryScope.php' ) ) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	private function unregister_dynamic_collection_post_types(): void {
+		foreach ( get_post_types() as $post_type ) {
+			if (
+				str_starts_with( $post_type, CollectionEntries::CPT_PREFIX ) &&
+				! in_array( $post_type, array( Collection::POST_TYPE, Field::POST_TYPE ), true )
+			) {
+				unregister_post_type( $post_type );
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Closes #102.

Moves common collection row queries onto `GET /cortext/v1/rows`: sorting, field filters, grouped filters, and split-term search. The server now handles the field types we can query reliably, while unsupported query shapes stay on the client instead of being silently sent to the endpoint.

## Why

The table already fetched rows from the rows endpoint, but search and richer filters still depended on client-side behavior. This adds server query support for the normal database-table cases without taking on server pagination changes in this PR.

## How

Server-supported fields:

| Field | Sort | Filter | Search |
| --- | --- | --- | --- |
| Title | Yes | Yes | Yes |
| Text | Yes | Yes | Yes |
| Email | Yes | Yes | Yes |
| URL | Yes | Yes | Yes |
| Number | Yes | Yes | No |
| Date | Yes | Yes | No |
| Datetime | Yes | Yes | No |
| Select | Yes, by stored value | Yes | No |
| Multiselect | No | Yes | No |
| Checkbox | Yes | Yes | No |
| Created / Last edited | Yes | No | No |
| Created by / Last edited by | No | No | No |
| Relation | No | No | No |
| Rollup | No | No | No |

- Uses a local field capability map until WordPress or DataViews exposes a capability contract for custom field types.
- Compiles supported filters through `RowsFilterQuery` and a small `WP_Meta_Query` extension for comparison shapes WP core does not support yet.
- Sends only server-safe DataViews query state, with client fallback when a view contains unsupported query parts.
- Leaves select sorting as stored-value sorting for now, not curated option order.

## Testing Instructions

1. Create a collection with title, text, number, date, datetime, select, multiselect, checkbox, email, URL, relation, and rollup fields.
2. Sort by title, text, number, date, datetime, select, checkbox, and URL. Check that supported fields sort correctly.
3. Add filters for title/text/email/URL contains, number greater than, date before, select is one of, multiselect contains, and checkbox checked. Check that visible rows match.
4. Search for two words where one is in the title and the other is in a text-like field. Check that the row stays visible.
5. Try sorting or filtering relation and rollup fields. They should not be treated as server-supported fields.

## Screen recording

https://github.com/user-attachments/assets/8465d547-1727-4a4a-88b6-2b3efd6fe5c2

