### PR TITLE
Collections: Add field type conversions

### DIFF
--- a/includes/Fields/FieldTypeConverter.php
+++ b/includes/Fields/FieldTypeConverter.php
@@ -2,12 +2,10 @@
 /**
  * Classifies how a row value behaves when a field's type changes.
  *
- * The converter never writes anything. It tells callers, per stored value,
- * whether the cell will render under the target type ("displays"), render
- * empty ("hidden"), or was already empty ("empty"). The commit handler
- * uses these counts for its response; the actual conversion at commit time
- * is just `update_post_meta` on the field's `type` (plus an option-list
- * extension for select / multiselect targets).
+ * The converter does not write row data. It only tells callers whether a
+ * stored value would show under the new type, render empty, or was empty
+ * already. The commit path changes the field type and, for select-like
+ * targets, adds any missing options.
  *
  * @package Cortext
  */
@@ -27,7 +25,7 @@ final class FieldTypeConverter {
 	private const TEXT_LIKE_SOURCES = array( 'text', 'number', 'email', 'url' );
 
 	/**
-	 * Whether a type-change conversion is supported.
+	 * Whether a field can move from one type to another.
 	 *
 	 * @param string $from Source Cortext field type.
 	 * @param string $to   Target Cortext field type.
@@ -49,7 +47,7 @@ final class FieldTypeConverter {
 	}
 
 	/**
-	 * Classifies a stored row value under a type change.
+	 * Classifies one stored row value for a type change.
 	 *
 	 * @param string $from         Source Cortext field type.
 	 * @param string $to           Target Cortext field type.
@@ -63,7 +61,7 @@ final class FieldTypeConverter {
 			return self::STATUS_HIDDEN;
 		}
 
-		// Checkbox target always renders (truthy → checked, falsy → unchecked).
+		// Checkboxes can render any stored value as checked or unchecked.
 		if ( 'checkbox' === $to ) {
 			return self::STATUS_DISPLAYS;
 		}
@@ -80,12 +78,10 @@ final class FieldTypeConverter {
 			return self::STATUS_EMPTY;
 		}
 
-		// text/number/email/url → select / multiselect always displays (commit auto-adds options).
+		// Text-like values become options during the commit.
 		if ( in_array( $to, array( 'select', 'multiselect' ), true ) && in_array( $from, self::TEXT_LIKE_SOURCES, true ) ) {
 			return self::STATUS_DISPLAYS;
 		}
-
-		// select → anything else falls through to the target-specific check below.
 
 		if ( 'number' === $to ) {
 			return is_numeric( $text ) ? self::STATUS_DISPLAYS : self::STATUS_HIDDEN;
@@ -103,16 +99,14 @@ final class FieldTypeConverter {
 			return false !== wp_http_validate_url( $text ) ? self::STATUS_DISPLAYS : self::STATUS_HIDDEN;
 		}
 
-		// text / select target: any non-empty source renders.
+		// Text and select targets can show any non-empty value.
 		return self::STATUS_DISPLAYS;
 	}
 
 	/**
-	 * Splits a text-like value into tokens on `\n`, `,`, `;`.
+	 * Splits text into option tokens.
 	 *
-	 * Used when converting text/number/email/url into select or multiselect:
-	 * a row value like `"Open, Closed"` contributes both `Open` and `Closed`
-	 * as options, and a multiselect cell renders two chips.
+	 * A value like `"Open, Closed"` becomes two options: `Open` and `Closed`.
 	 *
 	 * @param string $value Raw stored value to split.
 	 * @return string[]
@@ -137,7 +131,7 @@ final class FieldTypeConverter {
 	}
 
 	/**
-	 * Whether the conversion auto-extends the field's option list at commit.
+	 * Whether this type change should add options during commit.
 	 *
 	 * @param string $from Source Cortext field type.
 	 * @param string $to   Target Cortext field type.

--- a/includes/Fields/FieldTypeConverter.php
+++ b/includes/Fields/FieldTypeConverter.php
@@ -5,9 +5,9 @@
  * The converter never writes anything. It tells callers, per stored value,
  * whether the cell will render under the target type ("displays"), render
  * empty ("hidden"), or was already empty ("empty"). The commit handler
- * uses these counts to drive the preview UI; the actual conversion at
- * commit time is just `update_post_meta` on the field's `type` (plus an
- * option-list extension for select / multiselect targets).
+ * uses these counts for its response; the actual conversion at commit time
+ * is just `update_post_meta` on the field's `type` (plus an option-list
+ * extension for select / multiselect targets).
  *
  * @package Cortext
  */
@@ -100,7 +100,7 @@ final class FieldTypeConverter {
 		}
 
 		if ( 'url' === $to ) {
-			return '' !== esc_url_raw( $text ) ? self::STATUS_DISPLAYS : self::STATUS_HIDDEN;
+			return false !== wp_http_validate_url( $text ) ? self::STATUS_DISPLAYS : self::STATUS_HIDDEN;
 		}
 
 		// text / select target: any non-empty source renders.

--- a/includes/Fields/FieldTypeConverter.php
+++ b/includes/Fields/FieldTypeConverter.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Classifies how a row value behaves when a field's type changes.
+ *
+ * The converter never writes anything. It tells callers, per stored value,
+ * whether the cell will render under the target type ("displays"), render
+ * empty ("hidden"), or was already empty ("empty"). The commit handler
+ * uses these counts to drive the preview UI; the actual conversion at
+ * commit time is just `update_post_meta` on the field's `type` (plus an
+ * option-list extension for select / multiselect targets).
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Fields;
+
+final class FieldTypeConverter {
+
+	public const STATUS_DISPLAYS = 'displays';
+	public const STATUS_HIDDEN   = 'hidden';
+	public const STATUS_EMPTY    = 'empty';
+
+	private const UNSUPPORTED = array( 'relation', 'rollup', 'formula' );
+
+	private const TEXT_LIKE_SOURCES = array( 'text', 'number', 'email', 'url' );
+
+	/**
+	 * Whether a type-change conversion is supported.
+	 *
+	 * @param string $from Source Cortext field type.
+	 * @param string $to   Target Cortext field type.
+	 */
+	public static function supports( string $from, string $to ): bool {
+		if ( $from === $to ) {
+			return false;
+		}
+		if ( ! FieldTypeRegistry::exists( $from ) || ! FieldTypeRegistry::exists( $to ) ) {
+			return false;
+		}
+		if ( in_array( $from, self::UNSUPPORTED, true ) ) {
+			return false;
+		}
+		if ( in_array( $to, self::UNSUPPORTED, true ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Classifies a stored row value under a type change.
+	 *
+	 * @param string $from         Source Cortext field type.
+	 * @param string $to           Target Cortext field type.
+	 * @param mixed  $stored_value Raw stored meta value. For multiselect
+	 *                             sources, an array of strings (the full
+	 *                             multi-meta-row fetch). Otherwise the single
+	 *                             scalar from `get_post_meta(..., true)`.
+	 */
+	public static function classify( string $from, string $to, mixed $stored_value ): string {
+		if ( ! self::supports( $from, $to ) ) {
+			return self::STATUS_HIDDEN;
+		}
+
+		// Checkbox target always renders (truthy → checked, falsy → unchecked).
+		if ( 'checkbox' === $to ) {
+			return self::STATUS_DISPLAYS;
+		}
+
+		if ( 'multiselect' === $from ) {
+			$values = is_array( $stored_value )
+				? array_values( array_filter( $stored_value, static fn( $v ): bool => '' !== (string) $v ) )
+				: array();
+			return count( $values ) === 0 ? self::STATUS_EMPTY : self::STATUS_DISPLAYS;
+		}
+
+		$text = is_array( $stored_value ) ? '' : trim( (string) $stored_value );
+		if ( '' === $text ) {
+			return self::STATUS_EMPTY;
+		}
+
+		// text/number/email/url → select / multiselect always displays (commit auto-adds options).
+		if ( in_array( $to, array( 'select', 'multiselect' ), true ) && in_array( $from, self::TEXT_LIKE_SOURCES, true ) ) {
+			return self::STATUS_DISPLAYS;
+		}
+
+		// select → anything else falls through to the target-specific check below.
+
+		if ( 'number' === $to ) {
+			return is_numeric( $text ) ? self::STATUS_DISPLAYS : self::STATUS_HIDDEN;
+		}
+
+		if ( 'date' === $to || 'datetime' === $to ) {
+			return false !== strtotime( $text ) ? self::STATUS_DISPLAYS : self::STATUS_HIDDEN;
+		}
+
+		if ( 'email' === $to ) {
+			return false !== is_email( $text ) ? self::STATUS_DISPLAYS : self::STATUS_HIDDEN;
+		}
+
+		if ( 'url' === $to ) {
+			return '' !== esc_url_raw( $text ) ? self::STATUS_DISPLAYS : self::STATUS_HIDDEN;
+		}
+
+		// text / select target: any non-empty source renders.
+		return self::STATUS_DISPLAYS;
+	}
+
+	/**
+	 * Splits a text-like value into tokens on `\n`, `,`, `;`.
+	 *
+	 * Used when converting text/number/email/url into select or multiselect:
+	 * a row value like `"Open, Closed"` contributes both `Open` and `Closed`
+	 * as options, and a multiselect cell renders two chips.
+	 *
+	 * @param string $value Raw stored value to split.
+	 * @return string[]
+	 */
+	public static function split_tokens( string $value ): array {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return array();
+		}
+		$parts  = preg_split( '/[\n,;]/', $value );
+		$tokens = array();
+		if ( false === $parts ) {
+			return array();
+		}
+		foreach ( $parts as $part ) {
+			$token = trim( (string) $part );
+			if ( '' !== $token ) {
+				$tokens[] = $token;
+			}
+		}
+		return $tokens;
+	}
+
+	/**
+	 * Whether the conversion auto-extends the field's option list at commit.
+	 *
+	 * @param string $from Source Cortext field type.
+	 * @param string $to   Target Cortext field type.
+	 */
+	public static function extends_options( string $from, string $to ): bool {
+		if ( ! self::supports( $from, $to ) ) {
+			return false;
+		}
+		if ( ! in_array( $to, array( 'select', 'multiselect' ), true ) ) {
+			return false;
+		}
+		return in_array( $from, self::TEXT_LIKE_SOURCES, true );
+	}
+}

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -315,6 +315,19 @@ final class CollectionEntries {
 		Relations::remove_deleted_row_references( $post_id, $field_ids );
 	}
 
+	/**
+	 * Collection IDs for which an entry CPT has been registered during this
+	 * request. Populated lazily by `register_for_collection` and useful for
+	 * scans that would otherwise need a `WP_Query` over the collections —
+	 * notably the field→collection reverse lookup used by the type-change
+	 * REST endpoints.
+	 *
+	 * @return int[]
+	 */
+	public static function known_collection_ids(): array {
+		return array_values( self::$entry_collection_ids );
+	}
+
 	private function collection_id_for_entry_post_type( string $post_type ): int {
 		if ( isset( self::$entry_collection_ids[ $post_type ] ) ) {
 			return self::$entry_collection_ids[ $post_type ];

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -316,11 +316,9 @@ final class CollectionEntries {
 	}
 
 	/**
-	 * Collection IDs for which an entry CPT has been registered during this
-	 * request. Populated lazily by `register_for_collection` and useful for
-	 * scans that would otherwise need a `WP_Query` over the collections —
-	 * notably the field→collection reverse lookup used by the type-change
-	 * REST endpoints.
+	 * Collection IDs whose entry post types are already registered in this
+	 * request. The type-change endpoints use this for a cheap field→collection
+	 * lookup before falling back to postmeta.
 	 *
 	 * @return int[]
 	 */

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -205,29 +205,6 @@ final class FieldsController {
 
 		register_rest_route(
 			self::NAMESPACE,
-			'/fields/(?P<field_id>\d+)/convert/preview',
-			array(
-				array(
-					'methods'             => 'POST',
-					'callback'            => array( $this, 'convert_preview' ),
-					'permission_callback' => array( $this, 'can_edit_field' ),
-					'args'                => array(
-						'field_id' => array(
-							'type'     => 'integer',
-							'required' => true,
-						),
-						'type'     => array(
-							'type'     => 'string',
-							'required' => true,
-							'enum'     => FieldTypeRegistry::types(),
-						),
-					),
-				),
-			)
-		);
-
-		register_rest_route(
-			self::NAMESPACE,
 			'/fields/(?P<field_id>\d+)/convert',
 			array(
 				array(
@@ -496,26 +473,6 @@ final class FieldsController {
 	}
 
 	/**
-	 * Dry-runs a field type change. Returns the same plan the commit handler
-	 * would apply: counts of rows that will display vs render empty, a small
-	 * sample, and the unique option tokens that would be auto-added for
-	 * text-like → select / multiselect targets.
-	 *
-	 * @param WP_REST_Request $request Request carrying `field_id` and target `type`.
-	 */
-	public function convert_preview( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$field_id    = (int) $request->get_param( 'field_id' );
-		$target_type = (string) $request->get_param( 'type' );
-
-		$plan = $this->build_conversion_plan( $field_id, $target_type );
-		if ( is_wp_error( $plan ) ) {
-			return $plan;
-		}
-
-		return new WP_REST_Response( $plan, 200 );
-	}
-
-	/**
 	 * Commits a field type change. Flips the field's `type` meta in place,
 	 * extends the options list for text-like → select / multiselect targets,
 	 * and stashes the field's prior `date_format` when converting away from a
@@ -580,15 +537,14 @@ final class FieldsController {
 
 	/**
 	 * Iterates the rows of the collection that owns the field and classifies
-	 * each stored value under the proposed target type. Returns counts plus a
-	 * sample for the preview UI and the unique tokens that would be auto-added
-	 * to the field's options list on commit (only for text-like → select /
-	 * multiselect conversions).
+	 * each stored value under the proposed target type. Returns counts plus the
+	 * unique tokens that should be auto-added to the field's options list on
+	 * commit (only for text-like → select / multiselect conversions).
 	 *
 	 * @param int        $field_id         Field post ID being converted.
 	 * @param string     $target_type      Cortext field type to convert into.
 	 * @param int[]|null $row_ids_override Optional row ID list (testing seam).
-	 * @return array{from:string,to:string,total:int,displays:int,hidden:int,empty:int,sample:array<int,array<string,mixed>>,new_options:string[]}|WP_Error
+	 * @return array{from:string,to:string,total:int,displays:int,hidden:int,empty:int,new_options:string[]}|WP_Error
 	 */
 	private function build_conversion_plan( int $field_id, string $target_type, ?array $row_ids_override = null ): array|WP_Error {
 		$source_type = (string) get_post_meta( $field_id, 'type', true );
@@ -634,9 +590,7 @@ final class FieldsController {
 		$displays      = 0;
 		$hidden        = 0;
 		$empty         = 0;
-		$sample        = array();
 		$option_tokens = array();
-		$sample_limit  = 10;
 
 		foreach ( $row_ids as $row_id ) {
 			$row_id = (int) $row_id;
@@ -672,24 +626,6 @@ final class FieldsController {
 					}
 				}
 			}
-
-			if ( count( $sample ) < $sample_limit && FieldTypeConverter::STATUS_EMPTY !== $status ) {
-				$row     = get_post( $row_id );
-				$preview = array(
-					'row_id'    => $row_id,
-					'row_title' => $row instanceof WP_Post ? $row->post_title : '',
-					'old_value' => is_array( $stored ) ? implode( ', ', array_map( 'strval', $stored ) ) : (string) $stored,
-					'status'    => $status,
-				);
-				if ( $extends_opts && FieldTypeConverter::STATUS_DISPLAYS === $status ) {
-					$tokens = FieldTypeConverter::split_tokens( (string) $stored );
-					if ( 'select' === $target_type && count( $tokens ) > 1 ) {
-						$tokens = array_slice( $tokens, 0, 1 );
-					}
-					$preview['new_chips'] = $tokens;
-				}
-				$sample[] = $preview;
-			}
 		}
 
 		return array(
@@ -699,7 +635,6 @@ final class FieldsController {
 			'displays'    => $displays,
 			'hidden'      => $hidden,
 			'empty'       => $empty,
-			'sample'      => $sample,
 			'new_options' => $option_tokens,
 		);
 	}

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -473,11 +473,9 @@ final class FieldsController {
 	}
 
 	/**
-	 * Commits a field type change. Flips the field's `type` meta in place,
-	 * extends the options list for text-like → select / multiselect targets,
-	 * and stashes the field's prior `date_format` when converting away from a
-	 * date type so the text cell can keep rendering values in the format the
-	 * user was already seeing. Row meta is never written.
+	 * Changes a field's type without touching row meta. Text-like values can
+	 * add options when moving to select or multiselect, and date fields keep
+	 * their old display format when moving to text.
 	 *
 	 * @param WP_REST_Request $request Request carrying `field_id` and target `type`.
 	 */
@@ -552,16 +550,12 @@ final class FieldsController {
 	}
 
 	/**
-	 * Walks the rows of the collection that owns the field and harvests the
-	 * unique split-tokens that should seed the target's options list. Only
-	 * called for text-like → select / multiselect conversions; every other
-	 * conversion skips row enumeration entirely and finishes in O(1).
+	 * Collects option tokens from existing rows for text-like → select or
+	 * multiselect conversions. Other type changes skip the row scan.
 	 *
 	 * @param int        $field_id         Field post ID being converted.
 	 * @param string     $target_type      Target field type (`select` or `multiselect`).
-	 * @param int[]|null $row_ids_override Optional row ID list (testing seam for
-	 *                                     environments where `WP_Query` over the
-	 *                                     entry CPT doesn't return rows).
+	 * @param int[]|null $row_ids_override Optional row IDs for tests.
 	 * @return string[]|WP_Error
 	 */
 	private function collect_option_tokens( int $field_id, string $target_type, ?array $row_ids_override = null ): array|WP_Error {
@@ -587,12 +581,8 @@ final class FieldsController {
 		}
 
 		$meta_key = Relations::meta_key( $field_id );
-		// Hash-keyed set for O(1) dedupe — `in_array` over a growing list
-		// scales quadratically once the unique-token count grows past a few
-		// hundred, which is the realistic worst case for a high-cardinality
-		// text column being converted. `array_keys` preserves insertion
-		// order so the first occurrence wins, matching the previous
-		// `in_array` semantics.
+		// Keep the first occurrence of each token without repeatedly scanning
+		// the growing list.
 		$seen = array();
 		foreach ( $row_ids as $row_id ) {
 			$stored = get_post_meta( (int) $row_id, $meta_key, true );
@@ -615,19 +605,15 @@ final class FieldsController {
 	/**
 	 * Finds the entry post type for the collection that owns this field.
 	 *
-	 * Walks every Cortext collection and checks its `fields` meta list for
-	 * the field ID. The collection→fields relation is many-to-one (a field
-	 * belongs to a single collection), so the first match wins.
+	 * A field belongs to one collection, so the first match is enough.
 	 *
 	 * @param int $field_id Field post ID to resolve.
 	 */
 	private function row_post_type_for_field( int $field_id ): ?string {
 		$field_id_str = (string) $field_id;
 
-		// Cache-first: walk collections whose entry CPT has already been
-		// registered this request. Avoids a `WP_Query` over `crtxt_collection`
-		// in the common case and works in test environments that don't fully
-		// back `wp_posts` queries.
+		// Try collections already registered in this request first. This avoids
+		// an extra query in the common path and keeps tests simple.
 		foreach ( CollectionEntries::known_collection_ids() as $collection_id ) {
 			$ids = array_map( 'strval', get_post_meta( (int) $collection_id, 'fields', false ) );
 			if ( in_array( $field_id_str, $ids, true ) ) {
@@ -635,8 +621,7 @@ final class FieldsController {
 			}
 		}
 
-		// Fallback: direct postmeta lookup for collections whose entry CPT
-		// hasn't been registered yet during this request lifecycle.
+		// Fall back to postmeta for collections not registered yet.
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- field→collection reverse lookup; bounded by a single matching row.
 		$collection_id = (int) $wpdb->get_var(
@@ -653,7 +638,7 @@ final class FieldsController {
 	}
 
 	/**
-	 * Reads the field's existing normalized options list.
+	 * Reads the field's current options.
 	 *
 	 * @param int $field_id Field post ID whose options should be read.
 	 * @return array<int,array{value:string,label:string,color?:string}>

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -587,7 +587,13 @@ final class FieldsController {
 		}
 
 		$meta_key = Relations::meta_key( $field_id );
-		$tokens   = array();
+		// Hash-keyed set for O(1) dedupe — `in_array` over a growing list
+		// scales quadratically once the unique-token count grows past a few
+		// hundred, which is the realistic worst case for a high-cardinality
+		// text column being converted. `array_keys` preserves insertion
+		// order so the first occurrence wins, matching the previous
+		// `in_array` semantics.
+		$seen = array();
 		foreach ( $row_ids as $row_id ) {
 			$stored = get_post_meta( (int) $row_id, $meta_key, true );
 			if ( null === $stored || '' === $stored ) {
@@ -598,12 +604,12 @@ final class FieldsController {
 				$row_tokens = array_slice( $row_tokens, 0, 1 );
 			}
 			foreach ( $row_tokens as $token ) {
-				if ( ! in_array( $token, $tokens, true ) ) {
-					$tokens[] = $token;
+				if ( ! isset( $seen[ $token ] ) ) {
+					$seen[ $token ] = true;
 				}
 			}
 		}
-		return $tokens;
+		return array_keys( $seen );
 	}
 
 	/**

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+use Cortext\Fields\FieldTypeConverter;
 use Cortext\Fields\FieldTypeRegistry;
 use Cortext\OptionPalette;
 use Cortext\PostType\Collection;
@@ -196,6 +197,52 @@ final class FieldsController {
 									'to'     => array( 'type' => 'string' ),
 								),
 							),
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/fields/(?P<field_id>\d+)/convert/preview',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'convert_preview' ),
+					'permission_callback' => array( $this, 'can_edit_field' ),
+					'args'                => array(
+						'field_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'type'     => array(
+							'type'     => 'string',
+							'required' => true,
+							'enum'     => FieldTypeRegistry::types(),
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/fields/(?P<field_id>\d+)/convert',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'convert' ),
+					'permission_callback' => array( $this, 'can_edit_field' ),
+					'args'                => array(
+						'field_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'type'     => array(
+							'type'     => 'string',
+							'required' => true,
+							'enum'     => FieldTypeRegistry::types(),
 						),
 					),
 				),
@@ -446,6 +493,273 @@ final class FieldsController {
 			),
 			200
 		);
+	}
+
+	/**
+	 * Dry-runs a field type change. Returns the same plan the commit handler
+	 * would apply: counts of rows that will display vs render empty, a small
+	 * sample, and the unique option tokens that would be auto-added for
+	 * text-like → select / multiselect targets.
+	 *
+	 * @param WP_REST_Request $request Request carrying `field_id` and target `type`.
+	 */
+	public function convert_preview( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$field_id    = (int) $request->get_param( 'field_id' );
+		$target_type = (string) $request->get_param( 'type' );
+
+		$plan = $this->build_conversion_plan( $field_id, $target_type );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		return new WP_REST_Response( $plan, 200 );
+	}
+
+	/**
+	 * Commits a field type change. Flips the field's `type` meta in place,
+	 * extends the options list for text-like → select / multiselect targets,
+	 * and stashes the field's prior `date_format` when converting away from a
+	 * date type so the text cell can keep rendering values in the format the
+	 * user was already seeing. Row meta is never written.
+	 *
+	 * @param WP_REST_Request $request Request carrying `field_id` and target `type`.
+	 */
+	public function convert( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$field_id    = (int) $request->get_param( 'field_id' );
+		$target_type = (string) $request->get_param( 'type' );
+
+		$plan = $this->build_conversion_plan( $field_id, $target_type );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		$source_type = $plan['from'];
+
+		if ( in_array( $source_type, array( 'date', 'datetime' ), true ) && 'text' === $target_type ) {
+			$prior_format = (string) get_post_meta( $field_id, 'date_format', true );
+			if ( '' !== $prior_format ) {
+				update_post_meta( $field_id, 'prior_date_format', $prior_format );
+			} else {
+				update_post_meta( $field_id, 'prior_date_format', $source_type );
+			}
+		}
+
+		if ( count( $plan['new_options'] ) > 0 ) {
+			$existing      = $this->existing_options( $field_id );
+			$existing_vals = array_column( $existing, 'value' );
+			$additions     = array();
+			foreach ( $plan['new_options'] as $value ) {
+				if ( in_array( $value, $existing_vals, true ) ) {
+					continue;
+				}
+				$additions[] = array(
+					'value' => $value,
+					'label' => $value,
+				);
+			}
+			$merged = array_merge( $existing, $additions );
+			update_post_meta( $field_id, 'options', wp_json_encode( $merged ) );
+		}
+
+		update_post_meta( $field_id, 'type', $target_type );
+
+		return new WP_REST_Response(
+			array(
+				'id'          => $field_id,
+				'type'        => $target_type,
+				'from'        => $source_type,
+				'total'       => $plan['total'],
+				'displays'    => $plan['displays'],
+				'hidden'      => $plan['hidden'],
+				'empty'       => $plan['empty'],
+				'new_options' => $plan['new_options'],
+			),
+			200
+		);
+	}
+
+	/**
+	 * Iterates the rows of the collection that owns the field and classifies
+	 * each stored value under the proposed target type. Returns counts plus a
+	 * sample for the preview UI and the unique tokens that would be auto-added
+	 * to the field's options list on commit (only for text-like → select /
+	 * multiselect conversions).
+	 *
+	 * @param int        $field_id         Field post ID being converted.
+	 * @param string     $target_type      Cortext field type to convert into.
+	 * @param int[]|null $row_ids_override Optional row ID list (testing seam).
+	 * @return array{from:string,to:string,total:int,displays:int,hidden:int,empty:int,sample:array<int,array<string,mixed>>,new_options:string[]}|WP_Error
+	 */
+	private function build_conversion_plan( int $field_id, string $target_type, ?array $row_ids_override = null ): array|WP_Error {
+		$source_type = (string) get_post_meta( $field_id, 'type', true );
+		if ( '' === $source_type ) {
+			return new WP_Error(
+				'cortext_field_type_missing',
+				__( 'Field type could not be determined.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! FieldTypeConverter::supports( $source_type, $target_type ) ) {
+			return new WP_Error(
+				'cortext_field_conversion_unsupported',
+				__( 'This type change is not supported.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( null === $row_ids_override ) {
+			$post_type = $this->row_post_type_for_field( $field_id );
+			if ( null === $post_type ) {
+				return new WP_Error(
+					'cortext_field_collection_missing',
+					__( 'Field collection could not be determined.', 'cortext' ),
+					array( 'status' => 400 )
+				);
+			}
+			$row_ids = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit' ),
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				)
+			);
+		} else {
+			$row_ids = $row_ids_override;
+		}
+
+		$meta_key      = Relations::meta_key( $field_id );
+		$extends_opts  = FieldTypeConverter::extends_options( $source_type, $target_type );
+		$displays      = 0;
+		$hidden        = 0;
+		$empty         = 0;
+		$sample        = array();
+		$option_tokens = array();
+		$sample_limit  = 10;
+
+		foreach ( $row_ids as $row_id ) {
+			$row_id = (int) $row_id;
+
+			if ( 'multiselect' === $source_type ) {
+				$stored = get_post_meta( $row_id, $meta_key, false );
+			} else {
+				$stored = get_post_meta( $row_id, $meta_key, true );
+			}
+
+			$status = FieldTypeConverter::classify( $source_type, $target_type, $stored );
+			switch ( $status ) {
+				case FieldTypeConverter::STATUS_DISPLAYS:
+					++$displays;
+					break;
+				case FieldTypeConverter::STATUS_HIDDEN:
+					++$hidden;
+					break;
+				case FieldTypeConverter::STATUS_EMPTY:
+				default:
+					++$empty;
+					break;
+			}
+
+			if ( $extends_opts && FieldTypeConverter::STATUS_DISPLAYS === $status ) {
+				$tokens = FieldTypeConverter::split_tokens( (string) $stored );
+				if ( 'select' === $target_type && count( $tokens ) > 1 ) {
+					$tokens = array_slice( $tokens, 0, 1 );
+				}
+				foreach ( $tokens as $token ) {
+					if ( ! in_array( $token, $option_tokens, true ) ) {
+						$option_tokens[] = $token;
+					}
+				}
+			}
+
+			if ( count( $sample ) < $sample_limit && FieldTypeConverter::STATUS_EMPTY !== $status ) {
+				$row     = get_post( $row_id );
+				$preview = array(
+					'row_id'    => $row_id,
+					'row_title' => $row instanceof WP_Post ? $row->post_title : '',
+					'old_value' => is_array( $stored ) ? implode( ', ', array_map( 'strval', $stored ) ) : (string) $stored,
+					'status'    => $status,
+				);
+				if ( $extends_opts && FieldTypeConverter::STATUS_DISPLAYS === $status ) {
+					$tokens = FieldTypeConverter::split_tokens( (string) $stored );
+					if ( 'select' === $target_type && count( $tokens ) > 1 ) {
+						$tokens = array_slice( $tokens, 0, 1 );
+					}
+					$preview['new_chips'] = $tokens;
+				}
+				$sample[] = $preview;
+			}
+		}
+
+		return array(
+			'from'        => $source_type,
+			'to'          => $target_type,
+			'total'       => count( $row_ids ),
+			'displays'    => $displays,
+			'hidden'      => $hidden,
+			'empty'       => $empty,
+			'sample'      => $sample,
+			'new_options' => $option_tokens,
+		);
+	}
+
+	/**
+	 * Finds the entry post type for the collection that owns this field.
+	 *
+	 * Walks every Cortext collection and checks its `fields` meta list for
+	 * the field ID. The collection→fields relation is many-to-one (a field
+	 * belongs to a single collection), so the first match wins.
+	 *
+	 * @param int $field_id Field post ID to resolve.
+	 */
+	private function row_post_type_for_field( int $field_id ): ?string {
+		$field_id_str = (string) $field_id;
+
+		// Cache-first: walk collections whose entry CPT has already been
+		// registered this request. Avoids a `WP_Query` over `crtxt_collection`
+		// in the common case and works in test environments that don't fully
+		// back `wp_posts` queries.
+		foreach ( CollectionEntries::known_collection_ids() as $collection_id ) {
+			$ids = array_map( 'strval', get_post_meta( (int) $collection_id, 'fields', false ) );
+			if ( in_array( $field_id_str, $ids, true ) ) {
+				return Relations::entry_post_type_for_collection( (int) $collection_id );
+			}
+		}
+
+		// Fallback: direct postmeta lookup for collections whose entry CPT
+		// hasn't been registered yet during this request lifecycle.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- field→collection reverse lookup; bounded by a single matching row.
+		$collection_id = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s LIMIT 1",
+				'fields',
+				$field_id_str
+			)
+		);
+		if ( $collection_id < 1 ) {
+			return null;
+		}
+		return Relations::entry_post_type_for_collection( $collection_id );
+	}
+
+	/**
+	 * Reads the field's existing normalized options list.
+	 *
+	 * @param int $field_id Field post ID whose options should be read.
+	 * @return array<int,array{value:string,label:string,color?:string}>
+	 */
+	private function existing_options( int $field_id ): array {
+		$raw = (string) get_post_meta( $field_id, 'options', true );
+		if ( '' === $raw ) {
+			return array();
+		}
+		$decoded = json_decode( $raw, true );
+		if ( ! is_array( $decoded ) ) {
+			return array();
+		}
+		return $this->normalize_options( $decoded );
 	}
 
 	/**

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -485,68 +485,6 @@ final class FieldsController {
 		$field_id    = (int) $request->get_param( 'field_id' );
 		$target_type = (string) $request->get_param( 'type' );
 
-		$plan = $this->build_conversion_plan( $field_id, $target_type );
-		if ( is_wp_error( $plan ) ) {
-			return $plan;
-		}
-
-		$source_type = $plan['from'];
-
-		if ( in_array( $source_type, array( 'date', 'datetime' ), true ) && 'text' === $target_type ) {
-			$prior_format = (string) get_post_meta( $field_id, 'date_format', true );
-			if ( '' !== $prior_format ) {
-				update_post_meta( $field_id, 'prior_date_format', $prior_format );
-			} else {
-				update_post_meta( $field_id, 'prior_date_format', $source_type );
-			}
-		}
-
-		if ( count( $plan['new_options'] ) > 0 ) {
-			$existing      = $this->existing_options( $field_id );
-			$existing_vals = array_column( $existing, 'value' );
-			$additions     = array();
-			foreach ( $plan['new_options'] as $value ) {
-				if ( in_array( $value, $existing_vals, true ) ) {
-					continue;
-				}
-				$additions[] = array(
-					'value' => $value,
-					'label' => $value,
-				);
-			}
-			$merged = array_merge( $existing, $additions );
-			update_post_meta( $field_id, 'options', wp_json_encode( $merged ) );
-		}
-
-		update_post_meta( $field_id, 'type', $target_type );
-
-		return new WP_REST_Response(
-			array(
-				'id'          => $field_id,
-				'type'        => $target_type,
-				'from'        => $source_type,
-				'total'       => $plan['total'],
-				'displays'    => $plan['displays'],
-				'hidden'      => $plan['hidden'],
-				'empty'       => $plan['empty'],
-				'new_options' => $plan['new_options'],
-			),
-			200
-		);
-	}
-
-	/**
-	 * Iterates the rows of the collection that owns the field and classifies
-	 * each stored value under the proposed target type. Returns counts plus the
-	 * unique tokens that should be auto-added to the field's options list on
-	 * commit (only for text-like → select / multiselect conversions).
-	 *
-	 * @param int        $field_id         Field post ID being converted.
-	 * @param string     $target_type      Cortext field type to convert into.
-	 * @param int[]|null $row_ids_override Optional row ID list (testing seam).
-	 * @return array{from:string,to:string,total:int,displays:int,hidden:int,empty:int,new_options:string[]}|WP_Error
-	 */
-	private function build_conversion_plan( int $field_id, string $target_type, ?array $row_ids_override = null ): array|WP_Error {
 		$source_type = (string) get_post_meta( $field_id, 'type', true );
 		if ( '' === $source_type ) {
 			return new WP_Error(
@@ -564,6 +502,69 @@ final class FieldsController {
 			);
 		}
 
+		$new_options = array();
+		if ( FieldTypeConverter::extends_options( $source_type, $target_type ) ) {
+			$tokens_or_error = $this->collect_option_tokens( $field_id, $target_type );
+			if ( is_wp_error( $tokens_or_error ) ) {
+				return $tokens_or_error;
+			}
+			$new_options = $tokens_or_error;
+			if ( count( $new_options ) > 0 ) {
+				$existing      = $this->existing_options( $field_id );
+				$existing_vals = array_column( $existing, 'value' );
+				$additions     = array();
+				foreach ( $new_options as $value ) {
+					if ( in_array( $value, $existing_vals, true ) ) {
+						continue;
+					}
+					$additions[] = array(
+						'value' => $value,
+						'label' => $value,
+					);
+				}
+				if ( count( $additions ) > 0 ) {
+					$merged = array_merge( $existing, $additions );
+					update_post_meta( $field_id, 'options', wp_json_encode( $merged ) );
+				}
+			}
+		}
+
+		if ( in_array( $source_type, array( 'date', 'datetime' ), true ) && 'text' === $target_type ) {
+			$prior_format = (string) get_post_meta( $field_id, 'date_format', true );
+			update_post_meta(
+				$field_id,
+				'prior_date_format',
+				'' !== $prior_format ? $prior_format : $source_type
+			);
+		}
+
+		update_post_meta( $field_id, 'type', $target_type );
+
+		return new WP_REST_Response(
+			array(
+				'id'          => $field_id,
+				'type'        => $target_type,
+				'from'        => $source_type,
+				'new_options' => $new_options,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Walks the rows of the collection that owns the field and harvests the
+	 * unique split-tokens that should seed the target's options list. Only
+	 * called for text-like → select / multiselect conversions; every other
+	 * conversion skips row enumeration entirely and finishes in O(1).
+	 *
+	 * @param int        $field_id         Field post ID being converted.
+	 * @param string     $target_type      Target field type (`select` or `multiselect`).
+	 * @param int[]|null $row_ids_override Optional row ID list (testing seam for
+	 *                                     environments where `WP_Query` over the
+	 *                                     entry CPT doesn't return rows).
+	 * @return string[]|WP_Error
+	 */
+	private function collect_option_tokens( int $field_id, string $target_type, ?array $row_ids_override = null ): array|WP_Error {
 		if ( null === $row_ids_override ) {
 			$post_type = $this->row_post_type_for_field( $field_id );
 			if ( null === $post_type ) {
@@ -585,58 +586,24 @@ final class FieldsController {
 			$row_ids = $row_ids_override;
 		}
 
-		$meta_key      = Relations::meta_key( $field_id );
-		$extends_opts  = FieldTypeConverter::extends_options( $source_type, $target_type );
-		$displays      = 0;
-		$hidden        = 0;
-		$empty         = 0;
-		$option_tokens = array();
-
+		$meta_key = Relations::meta_key( $field_id );
+		$tokens   = array();
 		foreach ( $row_ids as $row_id ) {
-			$row_id = (int) $row_id;
-
-			if ( 'multiselect' === $source_type ) {
-				$stored = get_post_meta( $row_id, $meta_key, false );
-			} else {
-				$stored = get_post_meta( $row_id, $meta_key, true );
+			$stored = get_post_meta( (int) $row_id, $meta_key, true );
+			if ( null === $stored || '' === $stored ) {
+				continue;
 			}
-
-			$status = FieldTypeConverter::classify( $source_type, $target_type, $stored );
-			switch ( $status ) {
-				case FieldTypeConverter::STATUS_DISPLAYS:
-					++$displays;
-					break;
-				case FieldTypeConverter::STATUS_HIDDEN:
-					++$hidden;
-					break;
-				case FieldTypeConverter::STATUS_EMPTY:
-				default:
-					++$empty;
-					break;
+			$row_tokens = FieldTypeConverter::split_tokens( (string) $stored );
+			if ( 'select' === $target_type && count( $row_tokens ) > 1 ) {
+				$row_tokens = array_slice( $row_tokens, 0, 1 );
 			}
-
-			if ( $extends_opts && FieldTypeConverter::STATUS_DISPLAYS === $status ) {
-				$tokens = FieldTypeConverter::split_tokens( (string) $stored );
-				if ( 'select' === $target_type && count( $tokens ) > 1 ) {
-					$tokens = array_slice( $tokens, 0, 1 );
-				}
-				foreach ( $tokens as $token ) {
-					if ( ! in_array( $token, $option_tokens, true ) ) {
-						$option_tokens[] = $token;
-					}
+			foreach ( $row_tokens as $token ) {
+				if ( ! in_array( $token, $tokens, true ) ) {
+					$tokens[] = $token;
 				}
 			}
 		}
-
-		return array(
-			'from'        => $source_type,
-			'to'          => $target_type,
-			'total'       => count( $row_ids ),
-			'displays'    => $displays,
-			'hidden'      => $hidden,
-			'empty'       => $empty,
-			'new_options' => $option_tokens,
-		);
+		return $tokens;
 	}
 
 	/**

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+use Cortext\Fields\FieldTypeConverter;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\Relations;
@@ -913,9 +914,12 @@ final class RowsController {
 			} elseif ( 'rollup' === $field_type ) {
 				$meta[ $key ] = $this->compute_rollup_value( $post->ID, $field_id );
 			} else {
-				$meta[ $key ] = isset( $multi_field_ids[ $field_id ] )
-					? get_post_meta( $post->ID, $key, false )
-					: get_post_meta( $post->ID, $key, true );
+				$meta[ $key ] = $this->format_typed_value(
+					$post->ID,
+					$field_id,
+					$field_type,
+					isset( $multi_field_ids[ $field_id ] )
+				);
 			}
 		}
 
@@ -939,6 +943,145 @@ final class RowsController {
 			'modified_by' => $this->display_name_for( $modified_by_id > 0 ? $modified_by_id : $created_by_id ),
 			'meta'        => $meta,
 		);
+	}
+
+	/**
+	 * Per-type tolerance pass on a row's stored meta. Returns a value the
+	 * client can render directly; out-of-shape values (text in a number
+	 * field after a type change, etc.) come back as empty so cells render
+	 * blank rather than displaying garbage. The original raw meta is
+	 * preserved on disk and reappears if the field type is reverted.
+	 *
+	 * @param int    $row_id     Row post ID.
+	 * @param int    $field_id   Field post ID.
+	 * @param string $field_type Cortext field type.
+	 * @param bool   $is_multi   Whether the field allows multiple meta rows.
+	 * @return mixed
+	 */
+	private function format_typed_value( int $row_id, int $field_id, string $field_type, bool $is_multi ) {
+		$key = "field-{$field_id}";
+
+		if ( 'multiselect' === $field_type ) {
+			$values = get_post_meta( $row_id, $key, false );
+			if ( ! is_array( $values ) || count( $values ) === 0 ) {
+				return array();
+			}
+			// Single meta row carrying delimited text (data converted from a
+			// text-like field) — split on \n , ; into chips.
+			if ( count( $values ) === 1 ) {
+				$single = (string) $values[0];
+				if ( preg_match( '/[\n,;]/', $single ) ) {
+					return FieldTypeConverter::split_tokens( $single );
+				}
+			}
+			$normalized = array_values( array_map( 'strval', $values ) );
+			$options    = $this->valid_option_values( $field_id );
+			if ( count( $options ) === 0 ) {
+				return $normalized;
+			}
+			return array_values(
+				array_filter( $normalized, static fn( string $v ): bool => in_array( $v, $options, true ) )
+			);
+		}
+
+		$stored = $is_multi
+			? get_post_meta( $row_id, $key, false )
+			: get_post_meta( $row_id, $key, true );
+
+		if ( 'select' === $field_type ) {
+			$value = is_array( $stored ) ? '' : trim( (string) $stored );
+			if ( '' === $value ) {
+				return '';
+			}
+			// A single meta row carrying delimited text comes from a
+			// type-change off text / number / email / url. Mirror the
+			// commit-time split so the cell renders the same first-token
+			// chip the preview promised the user.
+			if ( preg_match( '/[\n,;]/', $value ) ) {
+				$tokens = FieldTypeConverter::split_tokens( $value );
+				$value  = count( $tokens ) > 0 ? $tokens[0] : '';
+				if ( '' === $value ) {
+					return '';
+				}
+			}
+			$options = $this->valid_option_values( $field_id );
+			if ( count( $options ) === 0 ) {
+				return $value;
+			}
+			return in_array( $value, $options, true ) ? $value : '';
+		}
+
+		if ( 'number' === $field_type ) {
+			if ( is_array( $stored ) || null === $stored || '' === $stored ) {
+				return null;
+			}
+			return is_numeric( $stored ) ? (float) $stored : null;
+		}
+
+		if ( 'date' === $field_type || 'datetime' === $field_type ) {
+			$text = is_array( $stored ) ? '' : trim( (string) $stored );
+			if ( '' === $text ) {
+				return '';
+			}
+			$timestamp = strtotime( $text );
+			if ( false === $timestamp ) {
+				return '';
+			}
+			return 'date' === $field_type
+				? gmdate( 'Y-m-d', $timestamp )
+				: gmdate( DATE_RFC3339, $timestamp );
+		}
+
+		if ( 'checkbox' === $field_type ) {
+			if ( is_array( $stored ) || null === $stored || '' === $stored ) {
+				return false;
+			}
+			return Relations::is_truthy( $stored );
+		}
+
+		if ( 'text' === $field_type ) {
+			$prior_format = (string) get_post_meta( $field_id, 'prior_date_format', true );
+			$text         = is_array( $stored ) ? '' : (string) $stored;
+			if ( '' !== $prior_format && '' !== trim( $text ) ) {
+				$timestamp = strtotime( trim( $text ) );
+				if ( false !== $timestamp ) {
+					$format = in_array( $prior_format, array( 'date', 'datetime' ), true )
+						? ( 'date' === $prior_format ? 'Y-m-d' : DATE_RFC3339 )
+						: $prior_format;
+					return wp_date( $format, $timestamp );
+				}
+			}
+			return $text;
+		}
+
+		return $stored;
+	}
+
+	/**
+	 * Reads a select/multiselect field's valid option values.
+	 *
+	 * @param int $field_id Field post ID whose options should be read.
+	 * @return string[]
+	 */
+	private function valid_option_values( int $field_id ): array {
+		$raw = (string) get_post_meta( $field_id, 'options', true );
+		if ( '' === $raw ) {
+			return array();
+		}
+		$decoded = json_decode( $raw, true );
+		if ( ! is_array( $decoded ) ) {
+			return array();
+		}
+		$values = array();
+		foreach ( $decoded as $entry ) {
+			if ( is_array( $entry ) && isset( $entry['value'] ) ) {
+				$value = trim( (string) $entry['value'] );
+				if ( '' !== $value ) {
+					$values[] = $value;
+				}
+			}
+		}
+		return $values;
 	}
 
 	/**

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -491,12 +491,9 @@ final class RowsController {
 			return;
 		}
 
-		// Single-value field types must replace any multi-row residue from a
-		// prior multiselect (or other multi-write path). `update_post_meta`
-		// updates only the first matching row, so without this collapse the
-		// user's edit lands on row 0 while stale rows 1..n persist and
-		// reappear if the field is ever converted back to multiselect or
-		// rendered with the multi-row join.
+		// A single-value edit should clear leftover multi-row values first.
+		// Otherwise `update_post_meta` updates only row 0 and stale chips can
+		// come back after another type change.
 		$existing = get_post_meta( $row_id, $key, false );
 		if ( is_array( $existing ) && count( $existing ) > 1 ) {
 			delete_post_meta( $row_id, $key );
@@ -957,11 +954,9 @@ final class RowsController {
 	}
 
 	/**
-	 * Per-type tolerance pass on a row's stored meta. Returns a value the
-	 * client can render directly; out-of-shape values (text in a number
-	 * field after a type change, etc.) come back as empty so cells render
-	 * blank rather than displaying garbage. The original raw meta is
-	 * preserved on disk and reappears if the field type is reverted.
+	 * Formats stored meta for the field's current type. Values that no longer
+	 * fit the type render empty, but the raw meta stays on disk so changing the
+	 * type back can show it again.
 	 *
 	 * @param int    $row_id     Row post ID.
 	 * @param int    $field_id   Field post ID.
@@ -988,11 +983,8 @@ final class RowsController {
 			if ( count( $matched ) > 0 ) {
 				return $matched;
 			}
-			// No raw value matched. If a single meta row carries delimited
-			// text (residue of a text→multiselect conversion), split it and
-			// keep the tokens that exist in the options list. Native option
-			// values that happen to contain `,` / `;` / `\n` were already
-			// matched above and never hit this branch.
+			// A single unmatched row may be leftover text from a conversion.
+			// Split it, but only keep tokens that are real options.
 			if ( count( $normalized ) === 1 && preg_match( '/[\n,;]/', $normalized[0] ) ) {
 				$tokens = FieldTypeConverter::split_tokens( $normalized[0] );
 				return array_values(
@@ -1018,10 +1010,8 @@ final class RowsController {
 			if ( in_array( $value, $options, true ) ) {
 				return $value;
 			}
-			// Raw value didn't match. Residue of a text-like → select
-			// conversion: take the first split-token if it matches an
-			// option. Pre-existing option values containing `,` / `;` /
-			// `\n` matched above and never reach this branch.
+			// Leftover delimited text from a conversion: use the first token
+			// only if it is now a real option.
 			if ( preg_match( '/[\n,;]/', $value ) ) {
 				$tokens = FieldTypeConverter::split_tokens( $value );
 				if ( count( $tokens ) > 0 && in_array( $tokens[0], $options, true ) ) {
@@ -1076,9 +1066,7 @@ final class RowsController {
 		}
 
 		if ( 'text' === $field_type ) {
-			// Residue from a multiselect field (multi-meta-row storage) the
-			// user edited before converting back: join the chip values so
-			// the cell reflects what was on disk, not just the first row.
+			// If this used to be multiselect, show all remaining meta rows.
 			$all = get_post_meta( $row_id, $key, false );
 			if ( is_array( $all ) && count( $all ) > 1 ) {
 				$text = implode( ', ', array_map( 'strval', $all ) );
@@ -1102,7 +1090,7 @@ final class RowsController {
 	}
 
 	/**
-	 * Reads a select/multiselect field's valid option values.
+	 * Reads valid values for a select or multiselect field.
 	 *
 	 * @param int $field_id Field post ID whose options should be read.
 	 * @return string[]

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -491,6 +491,17 @@ final class RowsController {
 			return;
 		}
 
+		// Single-value field types must replace any multi-row residue from a
+		// prior multiselect (or other multi-write path). `update_post_meta`
+		// updates only the first matching row, so without this collapse the
+		// user's edit lands on row 0 while stale rows 1..n persist and
+		// reappear if the field is ever converted back to multiselect or
+		// rendered with the multi-row join.
+		$existing = get_post_meta( $row_id, $key, false );
+		if ( is_array( $existing ) && count( $existing ) > 1 ) {
+			delete_post_meta( $row_id, $key );
+		}
+
 		if ( 'number' === $field_type ) {
 			update_post_meta( $row_id, $key, is_numeric( $value ) ? (float) $value : $value );
 			return;
@@ -1065,8 +1076,16 @@ final class RowsController {
 		}
 
 		if ( 'text' === $field_type ) {
+			// Residue from a multiselect field (multi-meta-row storage) the
+			// user edited before converting back: join the chip values so
+			// the cell reflects what was on disk, not just the first row.
+			$all = get_post_meta( $row_id, $key, false );
+			if ( is_array( $all ) && count( $all ) > 1 ) {
+				$text = implode( ', ', array_map( 'strval', $all ) );
+			} else {
+				$text = is_array( $stored ) ? '' : (string) $stored;
+			}
 			$prior_format = (string) get_post_meta( $field_id, 'prior_date_format', true );
-			$text         = is_array( $stored ) ? '' : (string) $stored;
 			if ( '' !== $prior_format && '' !== trim( $text ) ) {
 				$timestamp = strtotime( trim( $text ) );
 				if ( false !== $timestamp ) {

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -966,22 +966,29 @@ final class RowsController {
 			if ( ! is_array( $values ) || count( $values ) === 0 ) {
 				return array();
 			}
-			// Single meta row carrying delimited text (data converted from a
-			// text-like field) — split on \n , ; into chips.
-			if ( count( $values ) === 1 ) {
-				$single = (string) $values[0];
-				if ( preg_match( '/[\n,;]/', $single ) ) {
-					return FieldTypeConverter::split_tokens( $single );
-				}
-			}
 			$normalized = array_values( array_map( 'strval', $values ) );
 			$options    = $this->valid_option_values( $field_id );
 			if ( count( $options ) === 0 ) {
 				return $normalized;
 			}
-			return array_values(
+			$matched = array_values(
 				array_filter( $normalized, static fn( string $v ): bool => in_array( $v, $options, true ) )
 			);
+			if ( count( $matched ) > 0 ) {
+				return $matched;
+			}
+			// No raw value matched. If a single meta row carries delimited
+			// text (residue of a text→multiselect conversion), split it and
+			// keep the tokens that exist in the options list. Native option
+			// values that happen to contain `,` / `;` / `\n` were already
+			// matched above and never hit this branch.
+			if ( count( $normalized ) === 1 && preg_match( '/[\n,;]/', $normalized[0] ) ) {
+				$tokens = FieldTypeConverter::split_tokens( $normalized[0] );
+				return array_values(
+					array_filter( $tokens, static fn( string $v ): bool => in_array( $v, $options, true ) )
+				);
+			}
+			return array();
 		}
 
 		$stored = $is_multi
@@ -993,22 +1000,24 @@ final class RowsController {
 			if ( '' === $value ) {
 				return '';
 			}
-			// A single meta row carrying delimited text comes from a
-			// type-change off text / number / email / url. Mirror the
-			// commit-time split so the cell renders the same first-token
-			// chip the preview promised the user.
-			if ( preg_match( '/[\n,;]/', $value ) ) {
-				$tokens = FieldTypeConverter::split_tokens( $value );
-				$value  = count( $tokens ) > 0 ? $tokens[0] : '';
-				if ( '' === $value ) {
-					return '';
-				}
-			}
 			$options = $this->valid_option_values( $field_id );
 			if ( count( $options ) === 0 ) {
 				return $value;
 			}
-			return in_array( $value, $options, true ) ? $value : '';
+			if ( in_array( $value, $options, true ) ) {
+				return $value;
+			}
+			// Raw value didn't match. Residue of a text-like → select
+			// conversion: take the first split-token if it matches an
+			// option. Pre-existing option values containing `,` / `;` /
+			// `\n` matched above and never reach this branch.
+			if ( preg_match( '/[\n,;]/', $value ) ) {
+				$tokens = FieldTypeConverter::split_tokens( $value );
+				if ( count( $tokens ) > 0 && in_array( $tokens[0], $options, true ) ) {
+					return $tokens[0];
+				}
+			}
+			return '';
 		}
 
 		if ( 'number' === $field_type ) {
@@ -1037,6 +1046,22 @@ final class RowsController {
 				return false;
 			}
 			return Relations::is_truthy( $stored );
+		}
+
+		if ( 'email' === $field_type ) {
+			$value = is_array( $stored ) ? '' : trim( (string) $stored );
+			if ( '' === $value ) {
+				return '';
+			}
+			return false !== is_email( $value ) ? $value : '';
+		}
+
+		if ( 'url' === $field_type ) {
+			$value = is_array( $stored ) ? '' : trim( (string) $stored );
+			if ( '' === $value ) {
+				return '';
+			}
+			return false !== wp_http_validate_url( $value ) ? $value : '';
 		}
 
 		if ( 'text' === $field_type ) {

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -287,6 +287,18 @@ function NumberRing( { value, format, text } ) {
 	);
 }
 
+// Splits a delimited string on `\n` `,` `;` and trims each token, dropping
+// empties. Mirrors `FieldTypeConverter::split_tokens` server-side so the
+// transient state right after a text→select / text→multiselect conversion
+// (row meta still raw text, field type already updated) renders the same
+// chips the rows endpoint will return on its next response.
+function splitTokens( value ) {
+	return String( value )
+		.split( /[\n,;]/ )
+		.map( ( token ) => token.trim() )
+		.filter( Boolean );
+}
+
 // Returns either '' (empty cell) or a renderable value (string or JSX).
 // `display === ''` is the consumer's empty-cell signal — see CellShell's
 // `isEmpty` prop. Non-empty values may be JSX (anchor for url, icon for
@@ -349,9 +361,25 @@ export function formatDisplay( value, type, options = {} ) {
 	}
 
 	if ( type === 'select' ) {
-		const single = Array.isArray( value ) ? value[ 0 ] : value;
+		let single = Array.isArray( value ) ? value[ 0 ] : value;
 		if ( single === null || single === undefined || single === '' ) {
 			return '';
+		}
+		// Right after a text→select conversion the row hasn't refetched yet,
+		// so the cell receives the raw text. Mirror the backend's split
+		// fallback when the raw string doesn't match any registered option
+		// so the chip lands on the first token immediately, without the
+		// flash of a one-chip monster covering the whole text.
+		if (
+			typeof single === 'string' &&
+			elements?.length &&
+			! elements.some( ( e ) => e.value === single ) &&
+			/[\n,;]/.test( single )
+		) {
+			const tokens = splitTokens( single );
+			if ( tokens.length > 0 ) {
+				single = tokens[ 0 ];
+			}
 		}
 		const element = elements?.find( ( e ) => e.value === single );
 		return (
@@ -363,7 +391,23 @@ export function formatDisplay( value, type, options = {} ) {
 	}
 
 	if ( type === 'multiselect' ) {
-		const list = Array.isArray( value ) ? value : [ value ];
+		let list;
+		if ( Array.isArray( value ) ) {
+			list = value;
+		} else if (
+			typeof value === 'string' &&
+			/[\n,;]/.test( value ) &&
+			elements?.length &&
+			! elements.some( ( e ) => e.value === value )
+		) {
+			// Pre-refetch state right after a text→multiselect conversion:
+			// the cell receives the raw delimited string. Split client-side
+			// so the chips render immediately, matching what the row endpoint
+			// will return on its next response.
+			list = splitTokens( value );
+		} else {
+			list = [ value ];
+		}
 		const populated = list.filter(
 			( v ) => v !== null && v !== undefined && v !== ''
 		);

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -287,11 +287,8 @@ function NumberRing( { value, format, text } ) {
 	);
 }
 
-// Splits a delimited string on `\n` `,` `;` and trims each token, dropping
-// empties. Mirrors `FieldTypeConverter::split_tokens` server-side so the
-// transient state right after a text→select / text→multiselect conversion
-// (row meta still raw text, field type already updated) renders the same
-// chips the rows endpoint will return on its next response.
+// Keep the first render after a text→select or text→multiselect change in
+// sync with the server: the field type may update before the row data refetches.
 function splitTokens( value ) {
 	return String( value )
 		.split( /[\n,;]/ )
@@ -365,11 +362,8 @@ export function formatDisplay( value, type, options = {} ) {
 		if ( single === null || single === undefined || single === '' ) {
 			return '';
 		}
-		// Right after a text→select conversion the row hasn't refetched yet,
-		// so the cell receives the raw text. Mirror the backend's split
-		// fallback when the raw string doesn't match any registered option
-		// so the chip lands on the first token immediately, without the
-		// flash of a one-chip monster covering the whole text.
+		// The field type can update before the row refetches. If the raw text
+		// is not an option yet, show the first split token for now.
 		if (
 			typeof single === 'string' &&
 			elements?.length &&
@@ -400,10 +394,8 @@ export function formatDisplay( value, type, options = {} ) {
 			elements?.length &&
 			! elements.some( ( e ) => e.value === value )
 		) {
-			// Pre-refetch state right after a text→multiselect conversion:
-			// the cell receives the raw delimited string. Split client-side
-			// so the chips render immediately, matching what the row endpoint
-			// will return on its next response.
+			// Same early-render case as select, but multi-select keeps every
+			// split token.
 			list = splitTokens( value );
 		} else {
 			list = [ value ];

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -67,7 +67,7 @@ const datetimeIcon = (
 	</svg>
 );
 
-const FIELD_TYPES = [
+export const FIELD_TYPES = [
 	{ value: 'text', label: __( 'Text', 'cortext' ), icon: typography },
 	{ value: 'number', label: __( 'Number', 'cortext' ), icon: numberIcon },
 	{

--- a/src/components/fields/ChangeFieldTypePopover.js
+++ b/src/components/fields/ChangeFieldTypePopover.js
@@ -1,0 +1,88 @@
+import { __ } from '@wordpress/i18n';
+import { Icon, Notice, Popover } from '@wordpress/components';
+import { useMemo, useState } from '@wordpress/element';
+
+import { FIELD_TYPES } from './AddFieldPopover';
+import { useChangeFieldType } from '../../hooks/useFieldMutations';
+
+// Types we never offer as conversion source or target. Relation and rollup
+// involve cross-collection data that can't be safely reinterpreted; formula
+// will follow the same rule once it ships.
+const UNCONVERTIBLE = new Set( [ 'relation', 'rollup', 'formula' ] );
+
+function pickTargetTypes( currentType ) {
+	return FIELD_TYPES.filter(
+		( option ) =>
+			option.value !== currentType && ! UNCONVERTIBLE.has( option.value )
+	);
+}
+
+export default function ChangeFieldTypePopover( {
+	anchor,
+	collectionId,
+	recordId,
+	currentType,
+	onClose,
+} ) {
+	const [ pending, setPending ] = useState( null );
+	const commit = useChangeFieldType( collectionId );
+
+	const targets = useMemo(
+		() => pickTargetTypes( currentType ),
+		[ currentType ]
+	);
+
+	const handlePick = async ( targetType ) => {
+		if ( commit.isBusy ) {
+			return;
+		}
+		setPending( targetType );
+		try {
+			await commit.run( recordId, targetType );
+			onClose?.();
+		} catch {
+			// Error rendered inline; popover stays open so the user can retry.
+			setPending( null );
+		}
+	};
+
+	return (
+		<Popover
+			anchor={ anchor }
+			placement="bottom-start"
+			onClose={ commit.isBusy ? () => {} : onClose }
+			className="cortext-change-field-type-popover"
+			focusOnMount="firstElement"
+		>
+			<div className="cortext-change-field-type-popover__body">
+				<span className="cortext-change-field-type-popover__title">
+					{ __( 'Change type', 'cortext' ) }
+				</span>
+				<div className="cortext-change-field-type-popover__grid">
+					{ targets.map( ( option ) => (
+						<button
+							key={ option.value }
+							type="button"
+							className="cortext-change-field-type-popover__type-button"
+							onClick={ () => handlePick( option.value ) }
+							disabled={ commit.isBusy }
+							aria-busy={ pending === option.value }
+						>
+							<Icon
+								icon={ option.icon }
+								className="cortext-change-field-type-popover__type-icon"
+							/>
+							<span>{ option.label }</span>
+						</button>
+					) ) }
+				</div>
+				{ commit.error && (
+					<Notice status="error" isDismissible={ false }>
+						{ commit.error?.message ??
+							__( 'Could not change type.', 'cortext' ) }
+					</Notice>
+				) }
+			</div>
+		</Popover>
+	);
+}

--- a/src/components/fields/ChangeFieldTypePopover.js
+++ b/src/components/fields/ChangeFieldTypePopover.js
@@ -5,9 +5,8 @@ import { useMemo, useState } from '@wordpress/element';
 import { FIELD_TYPES } from './AddFieldPopover';
 import { useChangeFieldType } from '../../hooks/useFieldMutations';
 
-// Types we never offer as conversion source or target. Relation and rollup
-// involve cross-collection data that can't be safely reinterpreted; formula
-// will follow the same rule once it ships.
+// These types depend on other fields or collections, so we do not offer them
+// as conversion targets.
 const UNCONVERTIBLE = new Set( [ 'relation', 'rollup', 'formula' ] );
 
 function pickTargetTypes( currentType ) {
@@ -41,7 +40,7 @@ export default function ChangeFieldTypePopover( {
 			await commit.run( recordId, targetType );
 			onClose?.();
 		} catch {
-			// Error rendered inline; popover stays open so the user can retry.
+			// Keep the popover open so the inline error stays visible.
 			setPending( null );
 		}
 	};

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -50,9 +50,7 @@ const { Menu } = unlock( componentsPrivateApis );
 
 const FORMATTABLE_TYPES = new Set( [ 'number', 'date', 'datetime' ] );
 
-// Conversion is not offered for these source types (the converter rejects
-// any pair that touches them server-side; hide the menu item so we don't
-// invite a click that always errors).
+// The server rejects conversions for these types, so hide the action up front.
 const UNCONVERTIBLE_SOURCE_TYPES = new Set( [
 	'relation',
 	'rollup',

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -31,6 +31,7 @@ import {
 } from '@wordpress/icons';
 
 import AddFieldPopover from './AddFieldPopover';
+import ChangeFieldTypePopover from './ChangeFieldTypePopover';
 import EditOptionsPopover from './EditOptionsPopover';
 import FieldFormatPopover from './FieldFormatPopover';
 import RenameFieldInline from './RenameFieldInline';
@@ -48,6 +49,15 @@ const TYPES_WITH_OPTIONS = new Set( [ 'select', 'multiselect' ] );
 const { Menu } = unlock( componentsPrivateApis );
 
 const FORMATTABLE_TYPES = new Set( [ 'number', 'date', 'datetime' ] );
+
+// Conversion is not offered for these source types (the converter rejects
+// any pair that touches them server-side; hide the menu item so we don't
+// invite a click that always errors).
+const UNCONVERTIBLE_SOURCE_TYPES = new Set( [
+	'relation',
+	'rollup',
+	'formula',
+] );
 
 // Projects two kinds of triggers into the DataViews table header:
 //
@@ -184,6 +194,7 @@ function FieldActions( {
 	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
 	const [ isFormatting, setIsFormatting ] = useState( false );
 	const [ isEditingOptions, setIsEditingOptions ] = useState( false );
+	const [ isChangingType, setIsChangingType ] = useState( false );
 	const [ isCalculating, setIsCalculating ] = useState( false );
 	const [ shouldFocusFormat, setShouldFocusFormat ] = useState( false );
 	const [ shouldFocusCalculation, setShouldFocusCalculation ] =
@@ -200,6 +211,8 @@ function FieldActions( {
 	const fieldType = record?.meta?.type;
 	const canFormat = FORMATTABLE_TYPES.has( fieldType );
 	const supportsOptions = TYPES_WITH_OPTIONS.has( fieldType );
+	const canChangeType =
+		Boolean( fieldType ) && ! UNCONVERTIBLE_SOURCE_TYPES.has( fieldType );
 	const initialOptions = useMemo(
 		() =>
 			supportsOptions
@@ -550,6 +563,15 @@ function FieldActions( {
 								</Menu.ItemLabel>
 							</Menu.Item>
 						) : null }
+						{ canChangeType ? (
+							<Menu.Item
+								onClick={ () => setIsChangingType( true ) }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Change type…', 'cortext' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) : null }
 					</Menu.Group>
 					<Menu.Separator />
 					{ /* View group: keep sort/hide actions together. */ }
@@ -735,6 +757,18 @@ function FieldActions( {
 						onRequestClose={ () => setIsEditingOptions( false ) }
 					/>
 				</Popover>
+			) : null }
+			{ isChangingType && canChangeType ? (
+				<ChangeFieldTypePopover
+					anchor={ optionsAnchorRef.current }
+					collectionId={ collectionId }
+					recordId={ recordId }
+					currentType={ fieldType }
+					onClose={ () => {
+						setIsChangingType( false );
+						onRowsChanged?.();
+					} }
+				/>
 			) : null }
 		</span>
 	);

--- a/src/hooks/useFieldMutations.js
+++ b/src/hooks/useFieldMutations.js
@@ -267,12 +267,8 @@ export function useOptionUsage() {
 	return { run };
 }
 
-// Commits a field type change. The server flips the `type` meta on the
-// field (plus extends `options` for text-like → select / multiselect),
-// leaves all row meta untouched, and returns the post-commit counts.
-// Hook callers must pass `collectionId` so the field list invalidates
-// after the type changes and the column rerenders with the new cell
-// editor and renderer.
+// Changes the field type on the server, then refreshes the field record and
+// list so the column gets the right renderer and editor.
 export function useChangeFieldType( collectionId ) {
 	const { isBusy, setIsBusy, error, setError } = useMutationState();
 	const invalidate = useFieldListInvalidation();

--- a/src/hooks/useFieldMutations.js
+++ b/src/hooks/useFieldMutations.js
@@ -267,35 +267,6 @@ export function useOptionUsage() {
 	return { run };
 }
 
-// Dry-runs a field type change. Returns counts of rows that will display
-// vs render empty after the change, plus the unique tokens that would be
-// added as new select/multiselect options for text-like → option-list
-// targets. The popover calls this whenever the user picks a different
-// target type so it can show the preview before the user confirms.
-export function usePreviewFieldTypeChange() {
-	const { isBusy, setIsBusy, error, setError } = useMutationState();
-	const run = useCallback(
-		async ( recordId, targetType ) => {
-			setIsBusy( true );
-			setError( null );
-			try {
-				return await apiFetch( {
-					path: `/cortext/v1/fields/${ recordId }/convert/preview`,
-					method: 'POST',
-					data: { type: targetType },
-				} );
-			} catch ( apiError ) {
-				setError( apiError );
-				throw apiError;
-			} finally {
-				setIsBusy( false );
-			}
-		},
-		[ setIsBusy, setError ]
-	);
-	return { run, isBusy, error };
-}
-
 // Commits a field type change. The server flips the `type` meta on the
 // field (plus extends `options` for text-like → select / multiselect),
 // leaves all row meta untouched, and returns the post-commit counts.

--- a/src/hooks/useFieldMutations.js
+++ b/src/hooks/useFieldMutations.js
@@ -267,6 +267,70 @@ export function useOptionUsage() {
 	return { run };
 }
 
+// Dry-runs a field type change. Returns counts of rows that will display
+// vs render empty after the change, plus the unique tokens that would be
+// added as new select/multiselect options for text-like → option-list
+// targets. The popover calls this whenever the user picks a different
+// target type so it can show the preview before the user confirms.
+export function usePreviewFieldTypeChange() {
+	const { isBusy, setIsBusy, error, setError } = useMutationState();
+	const run = useCallback(
+		async ( recordId, targetType ) => {
+			setIsBusy( true );
+			setError( null );
+			try {
+				return await apiFetch( {
+					path: `/cortext/v1/fields/${ recordId }/convert/preview`,
+					method: 'POST',
+					data: { type: targetType },
+				} );
+			} catch ( apiError ) {
+				setError( apiError );
+				throw apiError;
+			} finally {
+				setIsBusy( false );
+			}
+		},
+		[ setIsBusy, setError ]
+	);
+	return { run, isBusy, error };
+}
+
+// Commits a field type change. The server flips the `type` meta on the
+// field (plus extends `options` for text-like → select / multiselect),
+// leaves all row meta untouched, and returns the post-commit counts.
+// Hook callers must pass `collectionId` so the field list invalidates
+// after the type changes and the column rerenders with the new cell
+// editor and renderer.
+export function useChangeFieldType( collectionId ) {
+	const { isBusy, setIsBusy, error, setError } = useMutationState();
+	const invalidate = useFieldListInvalidation();
+	const flush = useFlushFieldRecord();
+	const run = useCallback(
+		async ( recordId, targetType ) => {
+			setIsBusy( true );
+			setError( null );
+			try {
+				const result = await apiFetch( {
+					path: `/cortext/v1/fields/${ recordId }/convert`,
+					method: 'POST',
+					data: { type: targetType },
+				} );
+				await flush( recordId );
+				invalidate( collectionId );
+				return result;
+			} catch ( apiError ) {
+				setError( apiError );
+				throw apiError;
+			} finally {
+				setIsBusy( false );
+			}
+		},
+		[ collectionId, flush, invalidate, setIsBusy, setError ]
+	);
+	return { run, isBusy, error };
+}
+
 export function useDeleteField( collectionId ) {
 	const { deleteEntityRecord, invalidateResolution } = useDispatch( 'core' );
 	const { isBusy, setIsBusy, error, setError } = useMutationState();

--- a/src/index.scss
+++ b/src/index.scss
@@ -1511,6 +1511,69 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 	}
 }
 
+// "Change type" popover. Quick action: pick a target type from a 2-column
+// grid and the field flips immediately. No confirmation — the change is
+// fully reversible by switching the type back, so adding an "Are you sure"
+// step is friction without payoff.
+.cortext-change-field-type-popover {
+
+	&__body {
+		display: grid;
+		gap: $grid-unit-10;
+		padding: $grid-unit-15;
+		width: 320px;
+	}
+
+	&__title {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		color: $gray-700;
+	}
+
+	&__grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: $grid-unit-05;
+	}
+
+	&__type-button {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+		padding: $grid-unit-10;
+		border: $border-width solid $gray-200;
+		border-radius: 4px;
+		background: transparent;
+		text-align: start;
+		font-size: 13px;
+		color: $gray-900;
+		cursor: pointer;
+		transition: background-color 0.1s ease, border-color 0.1s ease;
+
+		&:disabled {
+			cursor: not-allowed;
+			opacity: 0.5;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline-offset: -1px;
+		}
+
+		&:hover:not(:disabled) {
+			background: $gray-100;
+			border-color: $gray-700;
+		}
+	}
+
+	&__type-icon {
+		flex: 0 0 auto;
+		color: $gray-700;
+	}
+}
+
 // Cascading format submenu. The outer popover sits beside the column
 // dropdown; each row is a button that anchors a third-level flyout for
 // picking a value. The visual is intentionally tight (240px panel) so it

--- a/src/index.scss
+++ b/src/index.scss
@@ -1511,10 +1511,8 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 	}
 }
 
-// "Change type" popover. Quick action: pick a target type from a 2-column
-// grid and the field flips immediately. No confirmation — the change is
-// fully reversible by switching the type back, so adding an "Are you sure"
-// step is friction without payoff.
+// "Change type" popover. The action commits immediately because row values
+// stay on disk and switching back restores what the user had before.
 .cortext-change-field-type-popover {
 
 	&__body {

--- a/tests/js/components/EditableCell.test.js
+++ b/tests/js/components/EditableCell.test.js
@@ -356,7 +356,7 @@ describe( 'formatDisplay', () => {
 			);
 		} );
 
-		it( 'splits a delimited string when the value is not a known option (post-conversion transient)', () => {
+		it( 'splits a delimited string when it is not a known option yet', () => {
 			const elements = [
 				{ value: 'CD', label: 'CD' },
 				{ value: 'LP', label: 'LP' },
@@ -370,7 +370,7 @@ describe( 'formatDisplay', () => {
 			);
 		} );
 
-		it( 'preserves a known option that legitimately contains commas', () => {
+		it( 'preserves a known option that contains commas', () => {
 			const elements = [ { value: 'ACME, Inc.', label: 'ACME, Inc.' } ];
 			renderDisplay( 'ACME, Inc.', 'multiselect', { elements } );
 			expect( screen.getByText( 'ACME, Inc.' ) ).toHaveClass(

--- a/tests/js/components/EditableCell.test.js
+++ b/tests/js/components/EditableCell.test.js
@@ -355,6 +355,37 @@ describe( 'formatDisplay', () => {
 				''
 			);
 		} );
+
+		it( 'splits a delimited string when the value is not a known option (post-conversion transient)', () => {
+			const elements = [
+				{ value: 'CD', label: 'CD' },
+				{ value: 'LP', label: 'LP' },
+				{ value: 'Record', label: 'Record' },
+			];
+			renderDisplay( 'CD, LP, Record', 'multiselect', { elements } );
+			expect( screen.getByText( 'CD' ) ).toHaveClass( 'cortext-chip' );
+			expect( screen.getByText( 'LP' ) ).toHaveClass( 'cortext-chip' );
+			expect( screen.getByText( 'Record' ) ).toHaveClass(
+				'cortext-chip'
+			);
+		} );
+
+		it( 'preserves a known option that legitimately contains commas', () => {
+			const elements = [ { value: 'ACME, Inc.', label: 'ACME, Inc.' } ];
+			renderDisplay( 'ACME, Inc.', 'multiselect', { elements } );
+			expect( screen.getByText( 'ACME, Inc.' ) ).toHaveClass(
+				'cortext-chip'
+			);
+		} );
+	} );
+
+	describe( 'select post-conversion transient', () => {
+		it( 'renders the first split-token when the value is not a known option', () => {
+			const elements = [ { value: 'CD', label: 'CD' } ];
+			renderDisplay( 'CD, LP, Record', 'select', { elements } );
+			expect( screen.getByText( 'CD' ) ).toHaveClass( 'cortext-chip' );
+			expect( screen.queryByText( 'LP' ) ).toBeNull();
+		} );
 	} );
 } );
 

--- a/tests/php/test-field-type-converter.php
+++ b/tests/php/test-field-type-converter.php
@@ -70,7 +70,8 @@ final class Test_Field_Type_Converter extends BaseTestCase {
 
 	public function test_classify_text_to_url(): void {
 		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'url', 'https://example.com' ) );
-		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'url', 'example.com' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_HIDDEN, FieldTypeConverter::classify( 'text', 'url', 'abc' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_HIDDEN, FieldTypeConverter::classify( 'text', 'url', 'example.com' ) );
 	}
 
 	public function test_classify_to_checkbox_always_displays(): void {

--- a/tests/php/test-field-type-converter.php
+++ b/tests/php/test-field-type-converter.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for Cortext\Fields\FieldTypeConverter.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Fields\FieldTypeConverter;
+use WorDBless\BaseTestCase;
+
+final class Test_Field_Type_Converter extends BaseTestCase {
+
+	public function test_supports_rejects_same_type(): void {
+		$this->assertFalse( FieldTypeConverter::supports( 'text', 'text' ) );
+	}
+
+	public function test_supports_rejects_unknown_types(): void {
+		$this->assertFalse( FieldTypeConverter::supports( 'text', 'unknown' ) );
+		$this->assertFalse( FieldTypeConverter::supports( 'unknown', 'text' ) );
+	}
+
+	public function test_supports_rejects_relation_rollup_formula(): void {
+		$this->assertFalse( FieldTypeConverter::supports( 'text', 'relation' ) );
+		$this->assertFalse( FieldTypeConverter::supports( 'relation', 'text' ) );
+		$this->assertFalse( FieldTypeConverter::supports( 'text', 'rollup' ) );
+		$this->assertFalse( FieldTypeConverter::supports( 'rollup', 'text' ) );
+		$this->assertFalse( FieldTypeConverter::supports( 'text', 'formula' ) );
+		$this->assertFalse( FieldTypeConverter::supports( 'formula', 'text' ) );
+	}
+
+	public function test_supports_accepts_common_pairs(): void {
+		$this->assertTrue( FieldTypeConverter::supports( 'text', 'number' ) );
+		$this->assertTrue( FieldTypeConverter::supports( 'number', 'text' ) );
+		$this->assertTrue( FieldTypeConverter::supports( 'text', 'select' ) );
+		$this->assertTrue( FieldTypeConverter::supports( 'select', 'multiselect' ) );
+		$this->assertTrue( FieldTypeConverter::supports( 'multiselect', 'select' ) );
+		$this->assertTrue( FieldTypeConverter::supports( 'date', 'text' ) );
+		$this->assertTrue( FieldTypeConverter::supports( 'checkbox', 'number' ) );
+	}
+
+	public function test_classify_empty_is_empty(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_EMPTY, FieldTypeConverter::classify( 'text', 'number', '' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_EMPTY, FieldTypeConverter::classify( 'text', 'number', null ) );
+		$this->assertSame( FieldTypeConverter::STATUS_EMPTY, FieldTypeConverter::classify( 'multiselect', 'select', array() ) );
+		$this->assertSame( FieldTypeConverter::STATUS_EMPTY, FieldTypeConverter::classify( 'multiselect', 'text', array( '' ) ) );
+	}
+
+	public function test_classify_text_to_number(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'number', '42' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'number', '3.14' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'number', '-7' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_HIDDEN, FieldTypeConverter::classify( 'text', 'number', 'abc' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_HIDDEN, FieldTypeConverter::classify( 'text', 'number', '12 cats' ) );
+	}
+
+	public function test_classify_text_to_date(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'date', '2026-05-13' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'date', 'May 13, 2026' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_HIDDEN, FieldTypeConverter::classify( 'text', 'date', 'not a date' ) );
+	}
+
+	public function test_classify_text_to_email(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'email', 'user@example.com' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_HIDDEN, FieldTypeConverter::classify( 'text', 'email', 'not-an-email' ) );
+	}
+
+	public function test_classify_text_to_url(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'url', 'https://example.com' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'url', 'example.com' ) );
+	}
+
+	public function test_classify_to_checkbox_always_displays(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'checkbox', '' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'checkbox', 'anything' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'number', 'checkbox', '0' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'multiselect', 'checkbox', array() ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'multiselect', 'checkbox', array( 'a' ) ) );
+	}
+
+	public function test_classify_text_to_select_always_displays(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'select', 'Open' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'text', 'multiselect', 'Open, Closed' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'number', 'select', '42' ) );
+	}
+
+	public function test_classify_multiselect_to_select_first_value_displays(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'multiselect', 'select', array( 'A', 'B', 'C' ) ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'multiselect', 'text', array( 'A' ) ) );
+		$this->assertSame( FieldTypeConverter::STATUS_EMPTY, FieldTypeConverter::classify( 'multiselect', 'select', array() ) );
+	}
+
+	public function test_classify_select_to_multiselect_displays_single(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'select', 'multiselect', 'Open' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_EMPTY, FieldTypeConverter::classify( 'select', 'multiselect', '' ) );
+	}
+
+	public function test_classify_number_to_text_displays(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'number', 'text', '42' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'number', 'text', 3.14 ) );
+	}
+
+	public function test_classify_date_to_text_displays(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'date', 'text', '2026-05-13' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_DISPLAYS, FieldTypeConverter::classify( 'datetime', 'text', '2026-05-13T10:00:00+00:00' ) );
+	}
+
+	public function test_classify_unsupported_returns_hidden(): void {
+		$this->assertSame( FieldTypeConverter::STATUS_HIDDEN, FieldTypeConverter::classify( 'text', 'relation', 'anything' ) );
+		$this->assertSame( FieldTypeConverter::STATUS_HIDDEN, FieldTypeConverter::classify( 'rollup', 'text', '42' ) );
+	}
+
+	public function test_split_tokens_splits_on_delimiters(): void {
+		$this->assertSame( array( 'Open', 'Closed' ), FieldTypeConverter::split_tokens( 'Open, Closed' ) );
+		$this->assertSame( array( 'Open', 'Closed' ), FieldTypeConverter::split_tokens( 'Open; Closed' ) );
+		$this->assertSame( array( 'Open', 'Closed' ), FieldTypeConverter::split_tokens( "Open\nClosed" ) );
+		$this->assertSame( array( 'A', 'B', 'C' ), FieldTypeConverter::split_tokens( 'A, B; C' ) );
+	}
+
+	public function test_split_tokens_drops_empty_tokens_and_trims(): void {
+		$this->assertSame( array( 'A', 'B' ), FieldTypeConverter::split_tokens( ' A , , B ' ) );
+		$this->assertSame( array(), FieldTypeConverter::split_tokens( ' , ; ' ) );
+		$this->assertSame( array(), FieldTypeConverter::split_tokens( '' ) );
+	}
+
+	public function test_split_tokens_returns_single_token_when_no_delimiter(): void {
+		$this->assertSame( array( 'Single value' ), FieldTypeConverter::split_tokens( 'Single value' ) );
+	}
+
+	public function test_extends_options_only_for_text_like_to_select_pairs(): void {
+		$this->assertTrue( FieldTypeConverter::extends_options( 'text', 'select' ) );
+		$this->assertTrue( FieldTypeConverter::extends_options( 'text', 'multiselect' ) );
+		$this->assertTrue( FieldTypeConverter::extends_options( 'number', 'select' ) );
+		$this->assertTrue( FieldTypeConverter::extends_options( 'email', 'multiselect' ) );
+		$this->assertTrue( FieldTypeConverter::extends_options( 'url', 'select' ) );
+
+		$this->assertFalse( FieldTypeConverter::extends_options( 'multiselect', 'select' ) );
+		$this->assertFalse( FieldTypeConverter::extends_options( 'select', 'multiselect' ) );
+		$this->assertFalse( FieldTypeConverter::extends_options( 'text', 'number' ) );
+		$this->assertFalse( FieldTypeConverter::extends_options( 'text', 'relation' ) );
+	}
+}

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -1189,6 +1189,116 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		return $method->invoke( $controller, $row_id, $field_id, $field_type, $is_multi );
 	}
 
+	public function test_format_typed_value_preserves_select_option_with_delimiters(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Vendors', 'vendors-sel' );
+
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Vendor',
+				'meta_input'  => array(
+					'type'    => 'select',
+					'options' => wp_json_encode(
+						array(
+							array(
+								'value' => 'ACME, Inc.',
+								'label' => 'ACME, Inc.',
+							),
+						)
+					),
+				),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+		( new CollectionEntries() )->register_for_collection( get_post( $collection_id ) );
+
+		$row_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_vendors-sel',
+				'post_status' => 'publish',
+				'post_title'  => 'Row',
+			)
+		);
+		update_post_meta( $row_id, "field-{$field_id}", 'ACME, Inc.' );
+
+		$this->assertSame(
+			'ACME, Inc.',
+			$this->invoke_format_typed_value( $row_id, $field_id, 'select', false )
+		);
+	}
+
+	public function test_format_typed_value_preserves_multiselect_option_with_delimiters(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Tags', 'tags-multi' );
+
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Vendors',
+				'meta_input'  => array(
+					'type'    => 'multiselect',
+					'options' => wp_json_encode(
+						array(
+							array(
+								'value' => 'ACME, Inc.',
+								'label' => 'ACME, Inc.',
+							),
+						)
+					),
+				),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+		( new CollectionEntries() )->register_for_collection( get_post( $collection_id ) );
+
+		$row_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_tags-multi',
+				'post_status' => 'publish',
+				'post_title'  => 'Row',
+			)
+		);
+		add_post_meta( $row_id, "field-{$field_id}", 'ACME, Inc.' );
+
+		$this->assertSame(
+			array( 'ACME, Inc.' ),
+			$this->invoke_format_typed_value( $row_id, $field_id, 'multiselect', true )
+		);
+	}
+
+	public function test_format_typed_value_hides_invalid_email(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'email-invalid',
+			array( 'user@example.com', 'not-an-email', '' )
+		);
+		update_post_meta( $field_id, 'type', 'email' );
+
+		$rendered = array();
+		foreach ( $row_ids as $row_id ) {
+			$rendered[] = $this->invoke_format_typed_value( $row_id, $field_id, 'email', false );
+		}
+		$this->assertSame( array( 'user@example.com', '', '' ), $rendered );
+	}
+
+	public function test_format_typed_value_hides_invalid_url(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'url-invalid',
+			array( 'https://example.com', 'abc', '' )
+		);
+		update_post_meta( $field_id, 'type', 'url' );
+
+		$rendered = array();
+		foreach ( $row_ids as $row_id ) {
+			$rendered[] = $this->invoke_format_typed_value( $row_id, $field_id, 'url', false );
+		}
+		$this->assertSame( array( 'https://example.com', '', '' ), $rendered );
+	}
+
 	public function test_convert_round_trip_preserves_stored_text(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
@@ -1219,13 +1329,6 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$method     = new \ReflectionMethod( $controller, 'build_conversion_plan' );
 		$method->setAccessible( true );
 		return $method->invoke( $controller, $field_id, $target_type, $row_ids );
-	}
-
-	private function convert_preview( int $field_id, string $target_type ) {
-		$request = new WP_REST_Request( 'POST', "/cortext/v1/fields/{$field_id}/convert/preview" );
-		$request->set_param( 'field_id', $field_id );
-		$request->set_param( 'type', $target_type );
-		return rest_do_request( $request );
 	}
 
 	private function convert_field( int $field_id, string $target_type ) {

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -1053,8 +1053,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
-		// Non-option conversions skip the row scan entirely, so the response
-		// carries no preview counts and `new_options` is always empty.
+		// Non-option conversions do not scan rows, so the response stays small.
 		$this->assertSame(
 			array( 'id', 'type', 'from', 'new_options' ),
 			array_keys( $data )
@@ -1114,11 +1113,8 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 			array( 'Open', 'Closed', 'Open' )
 		);
 
-		// Mirror what the REST handler does: collect option tokens, write
-		// options, flip type. Kept inline so the test can verify what the row
-		// endpoint will return immediately after, without the WorDBless-
-		// incompatible `WP_Query` row enumeration that the real handler also
-		// performs.
+		// Mirror the commit path inline so the test can inspect the row output
+		// without depending on WorDBless row queries.
 		$tokens    = $this->collect_option_tokens( $field_id, 'select', $row_ids );
 		$additions = array();
 		foreach ( $tokens as $value ) {
@@ -1151,8 +1147,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		);
 
 		$tokens = $this->collect_option_tokens( $field_id, 'select', $row_ids );
-		// For select targets each row contributes only its first split-token,
-		// so the option list mirrors what the cell will render.
+		// Select keeps only the first token from each row.
 		sort( $tokens );
 		$this->assertSame( array( 'Done', 'In Progress', 'Open' ), $tokens );
 
@@ -1288,7 +1283,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 				'post_title'  => 'Row',
 			)
 		);
-		// Simulate post-multiselect residue: two meta rows under the same key.
+		// Simulate leftover multiselect storage: two meta rows under one key.
 		add_post_meta( $row_id, "field-{$field_id}", 'CD' );
 		add_post_meta( $row_id, "field-{$field_id}", 'Record' );
 
@@ -1300,7 +1295,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$this->assertSame(
 			array( 'vinyl' ),
 			get_post_meta( $row_id, "field-{$field_id}", false ),
-			'Single-value write must collapse the multiselect residue, not stack on top of it.'
+			'Single-value writes should replace leftover multiselect rows.'
 		);
 	}
 
@@ -1313,9 +1308,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 				'post_type'   => Field::POST_TYPE,
 				'post_status' => 'private',
 				'post_title'  => 'Formats',
-				// Simulates the after-state of a text→multiselect conversion
-				// followed by a chip deselect: type is back to `text`, but the
-				// row meta carries the surviving chip values as multiple rows.
+				// Back to `text`, but the row still has multiple chip values.
 				'meta_input'  => array( 'type' => 'text' ),
 			)
 		);
@@ -1375,11 +1368,10 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 			array( '42', 'abc' )
 		);
 
-		// Non-option conversion: flip the type without touching row values,
-		// mirroring `convert()` (which writes only `type` here).
+		// Non-option conversion: only the field type changes.
 		update_post_meta( $field_id, 'type', 'number' );
 
-		// Round-trip the type back to text — row meta is still the original.
+		// Change back to text; row meta is still the original.
 		update_post_meta( $field_id, 'type', 'text' );
 
 		$values = array();

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -1269,6 +1269,78 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		);
 	}
 
+	public function test_write_field_value_replaces_multiselect_residue(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Edits', 'edits-collapse' );
+
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Format',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+		( new CollectionEntries() )->register_for_collection( get_post( $collection_id ) );
+
+		$row_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_edits-collapse',
+				'post_status' => 'publish',
+				'post_title'  => 'Row',
+			)
+		);
+		// Simulate post-multiselect residue: two meta rows under the same key.
+		add_post_meta( $row_id, "field-{$field_id}", 'CD' );
+		add_post_meta( $row_id, "field-{$field_id}", 'Record' );
+
+		$controller = new \Cortext\Rest\RowsController();
+		$method     = new \ReflectionMethod( $controller, 'write_field_value' );
+		$method->setAccessible( true );
+		$method->invoke( $controller, $row_id, $field_id, 'text', 'vinyl' );
+
+		$this->assertSame(
+			array( 'vinyl' ),
+			get_post_meta( $row_id, "field-{$field_id}", false ),
+			'Single-value write must collapse the multiselect residue, not stack on top of it.'
+		);
+	}
+
+	public function test_format_typed_value_joins_multiselect_residue_for_text(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Formats', 'formats-join' );
+
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Formats',
+				// Simulates the after-state of a text→multiselect conversion
+				// followed by a chip deselect: type is back to `text`, but the
+				// row meta carries the surviving chip values as multiple rows.
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+		( new CollectionEntries() )->register_for_collection( get_post( $collection_id ) );
+
+		$row_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_formats-join',
+				'post_status' => 'publish',
+				'post_title'  => 'Row',
+			)
+		);
+		add_post_meta( $row_id, "field-{$field_id}", 'CD' );
+		add_post_meta( $row_id, "field-{$field_id}", 'Record' );
+
+		$this->assertSame(
+			'CD, Record',
+			$this->invoke_format_typed_value( $row_id, $field_id, 'text', false )
+		);
+	}
+
 	public function test_format_typed_value_hides_invalid_email(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -1007,63 +1007,62 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$this->assertSame( 0, $response->get_data()['count'] );
 	}
 
-	public function test_convert_plan_classifies_text_to_number(): void {
+	public function test_collect_option_tokens_for_text_to_select_dedupes_and_keeps_first(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
-			'plan-num',
-			array( '42', '3.14', '-7', 'abc', '12 cats' )
-		);
-
-		$plan = $this->build_plan( $field_id, 'number', $row_ids );
-
-		$this->assertSame( 'text', $plan['from'] );
-		$this->assertSame( 'number', $plan['to'] );
-		$this->assertSame( 5, $plan['total'] );
-		$this->assertSame( 3, $plan['displays'] );
-		$this->assertSame( 2, $plan['hidden'] );
-		$this->assertSame( 0, $plan['empty'] );
-		$this->assertSame( array(), $plan['new_options'] );
-	}
-
-	public function test_convert_plan_classifies_empty_and_partial(): void {
-		wp_set_current_user( $this->create_user( 'editor' ) );
-		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
-			'plan-empty',
-			array( '42', '', 'abc', '' )
-		);
-
-		$plan = $this->build_plan( $field_id, 'number', $row_ids );
-
-		$this->assertSame( 4, $plan['total'] );
-		$this->assertSame( 1, $plan['displays'] );
-		$this->assertSame( 1, $plan['hidden'] );
-		$this->assertSame( 2, $plan['empty'] );
-	}
-
-	public function test_convert_plan_extends_options_for_text_to_select(): void {
-		wp_set_current_user( $this->create_user( 'editor' ) );
-		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
-			'plan-sel',
+			'tokens-sel',
 			array( 'Open', 'Closed', 'Open', 'In Progress' )
 		);
 
-		$plan = $this->build_plan( $field_id, 'select', $row_ids );
+		$tokens = $this->collect_option_tokens( $field_id, 'select', $row_ids );
 
-		sort( $plan['new_options'] );
-		$this->assertSame( array( 'Closed', 'In Progress', 'Open' ), $plan['new_options'] );
+		sort( $tokens );
+		$this->assertSame( array( 'Closed', 'In Progress', 'Open' ), $tokens );
 	}
 
-	public function test_convert_plan_splits_delimiters_for_text_to_multiselect(): void {
+	public function test_collect_option_tokens_for_text_to_multiselect_splits_delimiters(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
-			'plan-multi',
+			'tokens-multi',
 			array( 'Open, Closed', 'In Progress', 'Open; Pending' )
 		);
 
-		$plan = $this->build_plan( $field_id, 'multiselect', $row_ids );
+		$tokens = $this->collect_option_tokens( $field_id, 'multiselect', $row_ids );
 
-		sort( $plan['new_options'] );
-		$this->assertSame( array( 'Closed', 'In Progress', 'Open', 'Pending' ), $plan['new_options'] );
+		sort( $tokens );
+		$this->assertSame( array( 'Closed', 'In Progress', 'Open', 'Pending' ), $tokens );
+	}
+
+	public function test_collect_option_tokens_for_text_to_select_keeps_only_first_token(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'tokens-sel-first',
+			array( 'Open, Closed, Pending' )
+		);
+
+		$tokens = $this->collect_option_tokens( $field_id, 'select', $row_ids );
+
+		$this->assertSame( array( 'Open' ), $tokens );
+	}
+
+	public function test_convert_text_to_number_returns_lean_response_without_scanning_rows(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id ] = $this->fixture_text_field_with_rows( 'lean', array( '42', 'abc' ) );
+
+		$response = $this->convert_field( $field_id, 'number' );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		// Non-option conversions skip the row scan entirely, so the response
+		// carries no preview counts and `new_options` is always empty.
+		$this->assertSame(
+			array( 'id', 'type', 'from', 'new_options' ),
+			array_keys( $data )
+		);
+		$this->assertSame( 'number', $data['type'] );
+		$this->assertSame( 'text', $data['from'] );
+		$this->assertSame( array(), $data['new_options'] );
+		$this->assertSame( 'number', get_post_meta( $field_id, 'type', true ) );
 	}
 
 	public function test_convert_rejects_unsupported_pair(): void {
@@ -1115,25 +1114,23 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 			array( 'Open', 'Closed', 'Open' )
 		);
 
-		$plan = $this->build_plan( $field_id, 'select', $row_ids );
-		$this->assertSame( array( 'Open', 'Closed' ), $plan['new_options'] );
-
-		// Apply commit the same way the REST handler does: write options
-		// first, then flip the type. This is exactly what `convert()` runs;
-		// keeping it inline here lets the test verify what the row endpoint
-		// will return immediately after, without the WorDBless-incompatible
-		// `WP_Query` row enumeration that the real handler also performs.
+		// Mirror what the REST handler does: collect option tokens, write
+		// options, flip type. Kept inline so the test can verify what the row
+		// endpoint will return immediately after, without the WorDBless-
+		// incompatible `WP_Query` row enumeration that the real handler also
+		// performs.
+		$tokens    = $this->collect_option_tokens( $field_id, 'select', $row_ids );
 		$additions = array();
-		foreach ( $plan['new_options'] as $value ) {
+		foreach ( $tokens as $value ) {
 			$additions[] = array(
 				'value' => $value,
 				'label' => $value,
 			);
 		}
+		$this->assertSame( array( 'Open', 'Closed' ), $tokens );
 		update_post_meta( $field_id, 'options', wp_json_encode( $additions ) );
 		update_post_meta( $field_id, 'type', 'select' );
 
-		// Now what would the rows endpoint return for each row's value?
 		$rendered = array();
 		foreach ( $row_ids as $row_id ) {
 			$rendered[] = $this->invoke_format_typed_value( $row_id, $field_id, 'select', false );
@@ -1153,14 +1150,14 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 			)
 		);
 
-		$plan = $this->build_plan( $field_id, 'select', $row_ids );
-		// For select targets the plan keeps only the first split-token per
-		// row, so the option list mirrors what the cell will render.
-		sort( $plan['new_options'] );
-		$this->assertSame( array( 'Done', 'In Progress', 'Open' ), $plan['new_options'] );
+		$tokens = $this->collect_option_tokens( $field_id, 'select', $row_ids );
+		// For select targets each row contributes only its first split-token,
+		// so the option list mirrors what the cell will render.
+		sort( $tokens );
+		$this->assertSame( array( 'Done', 'In Progress', 'Open' ), $tokens );
 
 		$additions = array();
-		foreach ( $plan['new_options'] as $value ) {
+		foreach ( $tokens as $value ) {
 			$additions[] = array(
 				'value' => $value,
 				'label' => $value,
@@ -1378,11 +1375,8 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 			array( '42', 'abc' )
 		);
 
-		$plan_forward = $this->build_plan( $field_id, 'number', $row_ids );
-		$this->assertSame( 1, $plan_forward['displays'] );
-		$this->assertSame( 1, $plan_forward['hidden'] );
-
-		// Flip the type without touching row values, mirroring `convert`.
+		// Non-option conversion: flip the type without touching row values,
+		// mirroring `convert()` (which writes only `type` here).
 		update_post_meta( $field_id, 'type', 'number' );
 
 		// Round-trip the type back to text — row meta is still the original.
@@ -1396,9 +1390,9 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$this->assertSame( array( '42', 'abc' ), $values );
 	}
 
-	private function build_plan( int $field_id, string $target_type, array $row_ids ): array {
+	private function collect_option_tokens( int $field_id, string $target_type, array $row_ids ): array {
 		$controller = new FieldsController();
-		$method     = new \ReflectionMethod( $controller, 'build_conversion_plan' );
+		$method     = new \ReflectionMethod( $controller, 'collect_option_tokens' );
 		$method->setAccessible( true );
 		return $method->invoke( $controller, $field_id, $target_type, $row_ids );
 	}

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -1007,6 +1007,268 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$this->assertSame( 0, $response->get_data()['count'] );
 	}
 
+	public function test_convert_plan_classifies_text_to_number(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'plan-num',
+			array( '42', '3.14', '-7', 'abc', '12 cats' )
+		);
+
+		$plan = $this->build_plan( $field_id, 'number', $row_ids );
+
+		$this->assertSame( 'text', $plan['from'] );
+		$this->assertSame( 'number', $plan['to'] );
+		$this->assertSame( 5, $plan['total'] );
+		$this->assertSame( 3, $plan['displays'] );
+		$this->assertSame( 2, $plan['hidden'] );
+		$this->assertSame( 0, $plan['empty'] );
+		$this->assertSame( array(), $plan['new_options'] );
+	}
+
+	public function test_convert_plan_classifies_empty_and_partial(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'plan-empty',
+			array( '42', '', 'abc', '' )
+		);
+
+		$plan = $this->build_plan( $field_id, 'number', $row_ids );
+
+		$this->assertSame( 4, $plan['total'] );
+		$this->assertSame( 1, $plan['displays'] );
+		$this->assertSame( 1, $plan['hidden'] );
+		$this->assertSame( 2, $plan['empty'] );
+	}
+
+	public function test_convert_plan_extends_options_for_text_to_select(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'plan-sel',
+			array( 'Open', 'Closed', 'Open', 'In Progress' )
+		);
+
+		$plan = $this->build_plan( $field_id, 'select', $row_ids );
+
+		sort( $plan['new_options'] );
+		$this->assertSame( array( 'Closed', 'In Progress', 'Open' ), $plan['new_options'] );
+	}
+
+	public function test_convert_plan_splits_delimiters_for_text_to_multiselect(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'plan-multi',
+			array( 'Open, Closed', 'In Progress', 'Open; Pending' )
+		);
+
+		$plan = $this->build_plan( $field_id, 'multiselect', $row_ids );
+
+		sort( $plan['new_options'] );
+		$this->assertSame( array( 'Closed', 'In Progress', 'Open', 'Pending' ), $plan['new_options'] );
+	}
+
+	public function test_convert_rejects_unsupported_pair(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id ] = $this->fixture_text_field_with_rows( 'reject', array( 'a' ) );
+
+		$response = $this->convert_field( $field_id, 'relation' );
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_field_conversion_unsupported', $response->as_error()->get_error_code() );
+		$this->assertSame( 'text', get_post_meta( $field_id, 'type', true ) );
+	}
+
+	public function test_convert_rejects_same_type(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id ] = $this->fixture_text_field_with_rows( 'same', array( 'a' ) );
+
+		$response = $this->convert_field( $field_id, 'text' );
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_convert_date_to_text_stashes_prior_format(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Dates', 'datestash' );
+
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Due',
+				'meta_input'  => array(
+					'type'        => 'date',
+					'date_format' => 'F j, Y',
+				),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+		( new CollectionEntries() )->register_for_collection( get_post( $collection_id ) );
+
+		$response = $this->convert_field( $field_id, 'text' );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'F j, Y', get_post_meta( $field_id, 'prior_date_format', true ) );
+		$this->assertSame( 'text', get_post_meta( $field_id, 'type', true ) );
+	}
+
+	public function test_convert_text_to_select_makes_format_typed_value_return_chip(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'select-render',
+			array( 'Open', 'Closed', 'Open' )
+		);
+
+		$plan = $this->build_plan( $field_id, 'select', $row_ids );
+		$this->assertSame( array( 'Open', 'Closed' ), $plan['new_options'] );
+
+		// Apply commit the same way the REST handler does: write options
+		// first, then flip the type. This is exactly what `convert()` runs;
+		// keeping it inline here lets the test verify what the row endpoint
+		// will return immediately after, without the WorDBless-incompatible
+		// `WP_Query` row enumeration that the real handler also performs.
+		$additions = array();
+		foreach ( $plan['new_options'] as $value ) {
+			$additions[] = array(
+				'value' => $value,
+				'label' => $value,
+			);
+		}
+		update_post_meta( $field_id, 'options', wp_json_encode( $additions ) );
+		update_post_meta( $field_id, 'type', 'select' );
+
+		// Now what would the rows endpoint return for each row's value?
+		$rendered = array();
+		foreach ( $row_ids as $row_id ) {
+			$rendered[] = $this->invoke_format_typed_value( $row_id, $field_id, 'select', false );
+		}
+
+		$this->assertSame( array( 'Open', 'Closed', 'Open' ), $rendered );
+	}
+
+	public function test_convert_text_to_select_renders_first_token_for_delimited_values(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'select-split',
+			array(
+				'Open, Closed, Pending',
+				'In Progress',
+				'Done; Archived',
+			)
+		);
+
+		$plan = $this->build_plan( $field_id, 'select', $row_ids );
+		// For select targets the plan keeps only the first split-token per
+		// row, so the option list mirrors what the cell will render.
+		sort( $plan['new_options'] );
+		$this->assertSame( array( 'Done', 'In Progress', 'Open' ), $plan['new_options'] );
+
+		$additions = array();
+		foreach ( $plan['new_options'] as $value ) {
+			$additions[] = array(
+				'value' => $value,
+				'label' => $value,
+			);
+		}
+		update_post_meta( $field_id, 'options', wp_json_encode( $additions ) );
+		update_post_meta( $field_id, 'type', 'select' );
+
+		$rendered = array();
+		foreach ( $row_ids as $row_id ) {
+			$rendered[] = $this->invoke_format_typed_value( $row_id, $field_id, 'select', false );
+		}
+
+		$this->assertSame( array( 'Open', 'In Progress', 'Done' ), $rendered );
+	}
+
+	private function invoke_format_typed_value(
+		int $row_id,
+		int $field_id,
+		string $field_type,
+		bool $is_multi
+	) {
+		$controller = new \Cortext\Rest\RowsController();
+		$method     = new \ReflectionMethod( $controller, 'format_typed_value' );
+		$method->setAccessible( true );
+		return $method->invoke( $controller, $row_id, $field_id, $field_type, $is_multi );
+	}
+
+	public function test_convert_round_trip_preserves_stored_text(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'round-trip',
+			array( '42', 'abc' )
+		);
+
+		$plan_forward = $this->build_plan( $field_id, 'number', $row_ids );
+		$this->assertSame( 1, $plan_forward['displays'] );
+		$this->assertSame( 1, $plan_forward['hidden'] );
+
+		// Flip the type without touching row values, mirroring `convert`.
+		update_post_meta( $field_id, 'type', 'number' );
+
+		// Round-trip the type back to text — row meta is still the original.
+		update_post_meta( $field_id, 'type', 'text' );
+
+		$values = array();
+		foreach ( $row_ids as $row_id ) {
+			$values[] = (string) get_post_meta( $row_id, "field-{$field_id}", true );
+		}
+		sort( $values );
+		$this->assertSame( array( '42', 'abc' ), $values );
+	}
+
+	private function build_plan( int $field_id, string $target_type, array $row_ids ): array {
+		$controller = new FieldsController();
+		$method     = new \ReflectionMethod( $controller, 'build_conversion_plan' );
+		$method->setAccessible( true );
+		return $method->invoke( $controller, $field_id, $target_type, $row_ids );
+	}
+
+	private function convert_preview( int $field_id, string $target_type ) {
+		$request = new WP_REST_Request( 'POST', "/cortext/v1/fields/{$field_id}/convert/preview" );
+		$request->set_param( 'field_id', $field_id );
+		$request->set_param( 'type', $target_type );
+		return rest_do_request( $request );
+	}
+
+	private function convert_field( int $field_id, string $target_type ) {
+		$request = new WP_REST_Request( 'POST', "/cortext/v1/fields/{$field_id}/convert" );
+		$request->set_param( 'field_id', $field_id );
+		$request->set_param( 'type', $target_type );
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * @return array{0:int,1:int,2:int[]} Collection id, field id, row ids.
+	 */
+	private function fixture_text_field_with_rows( string $slug, array $values ): array {
+		$collection_id = $this->create_collection_with_slug( ucfirst( $slug ), $slug );
+
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Status',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+		( new CollectionEntries() )->register_for_collection( get_post( $collection_id ) );
+
+		$row_post_type = 'crtxt_' . $slug;
+		$row_ids       = array();
+		foreach ( $values as $idx => $value ) {
+			$row_id = (int) wp_insert_post(
+				array(
+					'post_type'   => $row_post_type,
+					'post_status' => 'publish',
+					'post_title'  => "Row {$idx}",
+				)
+			);
+			update_post_meta( $row_id, "field-{$field_id}", $value );
+			$row_ids[] = $row_id;
+		}
+
+		return array( $collection_id, $field_id, $row_ids );
+	}
+
 	private function update_options( int $field_id, array $body ) {
 		$request = new WP_REST_Request(
 			'POST',


### PR DESCRIPTION
## What

Closes #124.

Adds a `Change type…` action for collection fields. Users can switch a field to another supported type without rewriting row values: values that fit the new type keep showing, values that do not fit show as empty, and switching back brings the original data back. Text values converted to select or multi-select also create matching options and chips.

## How

- Leave row meta in place during type changes.
- Validate row values when they render under the current field type.
- Scan rows only when a type change needs to derive select or multi-select options.
- Clean up leftover multi-select meta when a converted field is edited as a single-value field.
- Split delimited text into select or multi-select chips only when it is not already a real option value.

## Testing Instructions

1. Open a collection with a text field that has numeric, empty, and non-numeric values.
2. Change the field to `Number` from the column header menu.
3. Confirm numeric values still show and incompatible text values show as empty.
4. Change the field back to `Text` and confirm the original values return.
5. Change a text field with comma- or semicolon-separated values to `Multi-select` and confirm matching chips/options appear.
6. Confirm select or multi-select options with commas still render as one chip.
7. Confirm relation and rollup fields do not show `Change type…`.

## Screen recording

https://github.com/user-attachments/assets/02510ef8-0047-43c8-b3ad-b3d6740548dc
