### PR TITLE
Bugfix: Keep nested table menus on screen

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -410,3 +410,11 @@ The user-facing placeholder is still Core's generic "Search commands and setting
 **Where.** `RowsMetaQuery` in `includes/Rest/RowsMetaQuery.php`, called from `RowsFilterQuery::meta_query_sql()`.
 
 **Solution.** Upstream `WP_Meta_Query` could grow one-sided `LIKE` compares and value-bearing negative `NOT EXISTS` compares. A structured title-query helper in `WP_Query` would cover the title sentinel separately. If those land, `RowsMetaQuery` shrinks back toward a thin adapter or disappears.
+
+## 47. Cascading Popovers need manual fallback placement `[upstream, soft]`
+
+**What.** `@wordpress/components` `Popover` can shift a submenu along the cross axis, but it does not try a left-side fallback when a `right-start` cascading submenu runs past the viewport edge. Cortext now measures the outer menu and the portaled submenu, starts on the side that keeps the submenu away from the column dropdown, then switches to `left-start` or `bottom-start` if the first placement clips. This keeps Format and Calculate submenus usable near the right side of the table, but it is still a local placement policy layered on top of Popover.
+
+**Where.** `useSubmenuPlacement` in `src/hooks/useSubmenuPlacement.js`, wired into `src/components/fields/FieldFormatPopover.js` and `src/components/TableCalculationMenu.js`.
+
+**Solution.** WordPress Popover could expose fallback placements, or pass enough Floating UI middleware through for consumers to say "try right, then left, then bottom" without measuring after render. If that lands, Cortext can drop `useSubmenuPlacement` and let the Popover own cascading-menu collision handling.

--- a/src/components/TableCalculationMenu.js
+++ b/src/components/TableCalculationMenu.js
@@ -1,8 +1,9 @@
 import { Icon, Popover } from '@wordpress/components';
-import { useMemo, useRef, useState } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { check, chevronRight } from '@wordpress/icons';
 
+import { useSubmenuPlacement } from '../hooks/useSubmenuPlacement';
 import {
 	CALCULATION_LABELS,
 	CALCULATION_NONE,
@@ -156,6 +157,7 @@ export default function TableCalculationMenu( {
 	onClose,
 	onMouseEnter,
 	onMouseLeave,
+	anchor,
 } ) {
 	const validSelected = isCalculationAvailable( field, selected )
 		? selected
@@ -164,9 +166,15 @@ export default function TableCalculationMenu( {
 		() => calculationGroupsForField( field ),
 		[ field ]
 	);
-	const [ openGroup, setOpenGroup ] = useState( null );
 	const groupRefs = useRef( {} );
+	const panelRef = useRef( null );
 	const noneSelected = ! validSelected;
+	const {
+		submenuRef,
+		placement: submenuPlacement,
+		openKey: openGroup,
+		open: openGroupAt,
+	} = useSubmenuPlacement( anchor, panelRef );
 
 	const pick = ( calculation ) => {
 		onPick( calculation === CALCULATION_NONE ? null : calculation );
@@ -201,6 +209,7 @@ export default function TableCalculationMenu( {
 
 	return (
 		<div
+			ref={ panelRef }
 			className="cortext-format-submenu__panel cortext-table-calculation-menu"
 			role="menu"
 			tabIndex={ -1 }
@@ -232,7 +241,7 @@ export default function TableCalculationMenu( {
 						<CalculationGroupRow
 							group={ group }
 							isOpen={ isOpen }
-							onOpen={ () => setOpenGroup( group.id ) }
+							onOpen={ () => openGroupAt( group.id ) }
 							rowRef={ ( element ) => {
 								groupRefs.current[ group.id ] = element;
 							} }
@@ -240,20 +249,34 @@ export default function TableCalculationMenu( {
 						{ isOpen ? (
 							<Popover
 								anchor={ groupRefs.current[ group.id ] }
-								placement="right-start"
+								placement={ submenuPlacement }
 								offset={ 8 }
-								onClose={ () => setOpenGroup( null ) }
+								shift
+								resize={ false }
+								onClose={ () => openGroupAt( null ) }
 								className="cortext-format-submenu__flyout cortext-table-calculation-submenu__flyout"
 							>
-								<CalculationChoiceList
-									options={ group.options }
-									selected={ validSelected }
-									onPick={ pick }
-									onClose={ () => setOpenGroup( null ) }
-									returnFocusRef={ {
-										current: groupRefs.current[ group.id ],
-									} }
-								/>
+								{ /* This submenu is portaled out of the
+								     panel, so the panel's mouseLeave fires
+								     as soon as the cursor crosses into here.
+								     Re-bind the hover-grace handlers so the
+								     parent's close timer keeps pausing. */ }
+								<div
+									ref={ submenuRef }
+									onMouseEnter={ onMouseEnter }
+									onMouseLeave={ onMouseLeave }
+								>
+									<CalculationChoiceList
+										options={ group.options }
+										selected={ validSelected }
+										onPick={ pick }
+										onClose={ () => openGroupAt( null ) }
+										returnFocusRef={ {
+											current:
+												groupRefs.current[ group.id ],
+										} }
+									/>
+								</div>
 							</Popover>
 						) : null }
 					</div>
@@ -278,6 +301,8 @@ export function TableCalculationPopover( {
 			anchor={ anchor }
 			placement="right-start"
 			offset={ 8 }
+			shift
+			resize={ false }
 			onClose={ onClose }
 			focusOnMount={ focusOnMount }
 			className="cortext-format-submenu cortext-table-calculation-submenu"
@@ -289,6 +314,7 @@ export function TableCalculationPopover( {
 				onClose={ onClose }
 				onMouseEnter={ onMouseEnter }
 				onMouseLeave={ onMouseLeave }
+				anchor={ anchor }
 			/>
 		</Popover>
 	);

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -8,10 +8,11 @@ import {
 } from '@wordpress/components';
 import { useEntityRecord } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { forwardRef, useMemo, useRef, useState } from '@wordpress/element';
+import { forwardRef, useMemo, useRef } from '@wordpress/element';
 import { check, chevronRight } from '@wordpress/icons';
 
 import { parseFormat } from '../../hooks/fieldMapping';
+import { useSubmenuPlacement } from '../../hooks/useSubmenuPlacement';
 import { FORMAT_COLORS, findFormatColor } from './formatColors';
 
 const FOCUSABLE_CONTROL_SELECTOR = [
@@ -470,8 +471,20 @@ function SubmenuToggleRow( { label, checked, onChange } ) {
 	);
 }
 
-function NumberFormBody( { config, onChange } ) {
-	const [ openRow, setOpenRow ] = useState( null );
+function NumberFormBody( {
+	config,
+	onChange,
+	anchor,
+	panelRef,
+	onMouseEnter,
+	onMouseLeave,
+} ) {
+	const {
+		submenuRef,
+		placement: submenuPlacement,
+		openKey: openRow,
+		open: setOpenRow,
+	} = useSubmenuPlacement( anchor, panelRef );
 	const formatRowRef = useRef( null );
 	const decimalsRowRef = useRef( null );
 	const colorRowRef = useRef( null );
@@ -597,59 +610,96 @@ function NumberFormBody( { config, onChange } ) {
 			{ openRow === 'format' ? (
 				<Popover
 					anchor={ formatRowRef.current }
-					placement="right-start"
+					placement={ submenuPlacement }
 					offset={ 8 }
+					shift
+					resize={ false }
 					onClose={ () => setOpenRow( null ) }
 					className="cortext-format-submenu__flyout"
 				>
-					<ChoiceList
-						items={ NUMBER_FORMATS }
-						isSelected={ ( item ) => item.id === current.id }
-						onPick={ pickFormat }
-						onClose={ () => setOpenRow( null ) }
-						returnFocusRef={ formatRowRef }
-					/>
+					<div
+						ref={ submenuRef }
+						onMouseEnter={ onMouseEnter }
+						onMouseLeave={ onMouseLeave }
+					>
+						<ChoiceList
+							items={ NUMBER_FORMATS }
+							isSelected={ ( item ) => item.id === current.id }
+							onPick={ pickFormat }
+							onClose={ () => setOpenRow( null ) }
+							returnFocusRef={ formatRowRef }
+						/>
+					</div>
 				</Popover>
 			) : null }
 			{ openRow === 'decimals' ? (
 				<Popover
 					anchor={ decimalsRowRef.current }
-					placement="right-start"
+					placement={ submenuPlacement }
 					offset={ 8 }
+					shift
+					resize={ false }
 					onClose={ () => setOpenRow( null ) }
 					className="cortext-format-submenu__flyout"
 				>
-					<ChoiceList
-						items={ DECIMAL_OPTIONS }
-						isSelected={ ( item ) => item.value === decimals }
-						onPick={ ( item ) => pickDecimals( item.value ) }
-						onClose={ () => setOpenRow( null ) }
-						returnFocusRef={ decimalsRowRef }
-					/>
+					<div
+						ref={ submenuRef }
+						onMouseEnter={ onMouseEnter }
+						onMouseLeave={ onMouseLeave }
+					>
+						<ChoiceList
+							items={ DECIMAL_OPTIONS }
+							isSelected={ ( item ) => item.value === decimals }
+							onPick={ ( item ) => pickDecimals( item.value ) }
+							onClose={ () => setOpenRow( null ) }
+							returnFocusRef={ decimalsRowRef }
+						/>
+					</div>
 				</Popover>
 			) : null }
 			{ openRow === 'color' ? (
 				<Popover
 					anchor={ colorRowRef.current }
-					placement="right-start"
+					placement={ submenuPlacement }
 					offset={ 8 }
+					shift
+					resize={ false }
 					onClose={ () => setOpenRow( null ) }
 					className="cortext-format-submenu__flyout"
 				>
-					<ColorList
-						value={ colorId }
-						onPick={ pickColor }
-						onClose={ () => setOpenRow( null ) }
-						returnFocusRef={ colorRowRef }
-					/>
+					<div
+						ref={ submenuRef }
+						onMouseEnter={ onMouseEnter }
+						onMouseLeave={ onMouseLeave }
+					>
+						<ColorList
+							value={ colorId }
+							onPick={ pickColor }
+							onClose={ () => setOpenRow( null ) }
+							returnFocusRef={ colorRowRef }
+						/>
+					</div>
 				</Popover>
 			) : null }
 		</>
 	);
 }
 
-function DateFormBody( { type, config, onChange } ) {
-	const [ openRow, setOpenRow ] = useState( null );
+function DateFormBody( {
+	type,
+	config,
+	onChange,
+	anchor,
+	panelRef,
+	onMouseEnter,
+	onMouseLeave,
+} ) {
+	const {
+		submenuRef,
+		placement: submenuPlacement,
+		openKey: openRow,
+		open: setOpenRow,
+	} = useSubmenuPlacement( anchor, panelRef );
 	const formatRowRef = useRef( null );
 	const timeRowRef = useRef( null );
 	// `date` fields store dates without a time component, the inline
@@ -708,37 +758,55 @@ function DateFormBody( { type, config, onChange } ) {
 			{ openRow === 'format' ? (
 				<Popover
 					anchor={ formatRowRef.current }
-					placement="right-start"
+					placement={ submenuPlacement }
 					offset={ 8 }
+					shift
+					resize={ false }
 					onClose={ () => setOpenRow( null ) }
 					className="cortext-format-submenu__flyout"
 				>
-					<ChoiceList
-						items={ DATE_FORMATS }
-						isSelected={ ( item ) =>
-							item.id === currentDateFormat.id
-						}
-						onPick={ pickFormat }
-						onClose={ () => setOpenRow( null ) }
-						returnFocusRef={ formatRowRef }
-					/>
+					<div
+						ref={ submenuRef }
+						onMouseEnter={ onMouseEnter }
+						onMouseLeave={ onMouseLeave }
+					>
+						<ChoiceList
+							items={ DATE_FORMATS }
+							isSelected={ ( item ) =>
+								item.id === currentDateFormat.id
+							}
+							onPick={ pickFormat }
+							onClose={ () => setOpenRow( null ) }
+							returnFocusRef={ formatRowRef }
+						/>
+					</div>
 				</Popover>
 			) : null }
 			{ supportsTime && openRow === 'time' ? (
 				<Popover
 					anchor={ timeRowRef.current }
-					placement="right-start"
+					placement={ submenuPlacement }
 					offset={ 8 }
+					shift
+					resize={ false }
 					onClose={ () => setOpenRow( null ) }
 					className="cortext-format-submenu__flyout"
 				>
-					<ChoiceList
-						items={ TIME_OPTIONS }
-						isSelected={ ( item ) => item.id === currentTime.id }
-						onPick={ pickTime }
-						onClose={ () => setOpenRow( null ) }
-						returnFocusRef={ timeRowRef }
-					/>
+					<div
+						ref={ submenuRef }
+						onMouseEnter={ onMouseEnter }
+						onMouseLeave={ onMouseLeave }
+					>
+						<ChoiceList
+							items={ TIME_OPTIONS }
+							isSelected={ ( item ) =>
+								item.id === currentTime.id
+							}
+							onPick={ pickTime }
+							onClose={ () => setOpenRow( null ) }
+							returnFocusRef={ timeRowRef }
+						/>
+					</div>
 				</Popover>
 			) : null }
 		</>
@@ -761,6 +829,7 @@ export default function FieldFormatPopover( {
 	onMouseEnter,
 	onMouseLeave,
 } ) {
+	const panelRef = useRef( null );
 	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
@@ -855,17 +924,29 @@ export default function FieldFormatPopover( {
 			onKeyDown={ onPopoverKeyDown }
 		>
 			<div
+				ref={ panelRef }
 				className="cortext-format-submenu__panel"
 				onMouseEnter={ onMouseEnter }
 				onMouseLeave={ onMouseLeave }
 			>
 				{ isNumber ? (
-					<NumberFormBody config={ initial } onChange={ persist } />
+					<NumberFormBody
+						config={ initial }
+						onChange={ persist }
+						anchor={ anchor }
+						panelRef={ panelRef }
+						onMouseEnter={ onMouseEnter }
+						onMouseLeave={ onMouseLeave }
+					/>
 				) : (
 					<DateFormBody
 						type={ type }
 						config={ initial }
 						onChange={ persist }
+						anchor={ anchor }
+						panelRef={ panelRef }
+						onMouseEnter={ onMouseEnter }
+						onMouseLeave={ onMouseLeave }
 					/>
 				) }
 				<p className="cortext-format-submenu__note">

--- a/src/hooks/useSubmenuPlacement.js
+++ b/src/hooks/useSubmenuPlacement.js
@@ -1,0 +1,71 @@
+import {
+	useCallback,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
+
+// Picks a `Popover` placement for a row submenu inside a cascading menu,
+// adjusting after render if the chosen side overflows the viewport.
+// `@wordpress/components` `Popover` only flips on the main axis and shifts
+// on the cross axis, so a `right-start` submenu that overflows past the
+// viewport's right edge wouldn't be pulled back into view on its own.
+//
+// Strategy (recomputed every time a submenu opens):
+//   1. If the outer panel landed to the right of its anchor (normal), start
+//      with `right-start`. If it flipped to the left of the anchor (column
+//      near right edge), start with `left-start` to keep the submenu clear
+//      of the column dropdown.
+//   2. After paint, measure the submenu rect. If it clipped right, switch
+//      to `left-start`. If left-start clips left, fall back to `bottom-start`.
+//
+// `outerAnchor` is the element the outer popover is anchored to (e.g. the
+// "Calculate" / "Format" menu item in the column header). `panelRef`
+// points at the outer panel div whose horizontal position decides
+// whether the inner submenu starts on the right or the left.
+//
+// Returns the inner submenu wrapper ref, the current open key, the
+// placement to pass to `Popover`, and an `open(key)` setter.
+export function useSubmenuPlacement( outerAnchor, panelRef ) {
+	const [ placement, setPlacement ] = useState( 'right-start' );
+	const [ openKey, setOpenKey ] = useState( null );
+	const submenuRef = useRef( null );
+
+	const open = useCallback(
+		( key ) => {
+			if ( key === null ) {
+				setOpenKey( null );
+				return;
+			}
+			const panel = panelRef.current;
+			if ( panel && outerAnchor ) {
+				const panelLeft = panel.getBoundingClientRect().left;
+				const anchorRight = outerAnchor.getBoundingClientRect().right;
+				const outerFlipped = panelLeft + 1 < anchorRight;
+				setPlacement( outerFlipped ? 'left-start' : 'right-start' );
+			}
+			setOpenKey( key );
+		},
+		[ outerAnchor, panelRef ]
+	);
+
+	useLayoutEffect( () => {
+		if ( ! openKey ) {
+			return;
+		}
+		const submenu = submenuRef.current;
+		if ( ! submenu ) {
+			return;
+		}
+		const rect = submenu.getBoundingClientRect();
+		if ( placement === 'right-start' && rect.right > window.innerWidth ) {
+			setPlacement( 'left-start' );
+			return;
+		}
+		if ( placement === 'left-start' && rect.left < 0 ) {
+			setPlacement( 'bottom-start' );
+		}
+	}, [ openKey, placement ] );
+
+	return { submenuRef, placement, openKey, open };
+}

--- a/src/hooks/useSubmenuPlacement.js
+++ b/src/hooks/useSubmenuPlacement.js
@@ -7,6 +7,7 @@ import {
 
 // Picks a `Popover` placement for a row submenu inside a cascading menu,
 // adjusting after render if the chosen side overflows the viewport.
+// See docs/tech-debt.md#47.
 // `@wordpress/components` `Popover` only flips on the main axis and shifts
 // on the cross axis, so a `right-start` submenu that overflows past the
 // viewport's right edge wouldn't be pulled back into view on its own.


### PR DESCRIPTION
## What

Fixes nested Format and Calculate menus that could open off-screen near the right edge of a table. The flyouts now pick a better side when space is tight, and they stay open while the cursor moves into the nested menu.

## How

Reusing one placement helper for Format and Calculate flyouts.

## Testing Instructions

1. Open a table with a number or date field near the right edge of the viewport.
2. Open the column menu, choose Format, and hover through the nested options.
3. Confirm the nested menu stays visible and selectable.
4. Open Calculate from the same column menu and hover through the grouped options.
5. Confirm the nested menu stays visible and does not close while moving into it.
6. Repeat with a field away from the right edge and confirm the nested menus still open normally.

## Screenshots
| Before | After |
| --- | --- |
| <img width="652" height="755" alt="image" src="https://github.com/user-attachments/assets/5c9e9338-98b7-449f-859d-83b23e47b2a1" /> | <img width="642" height="725" alt="image" src="https://github.com/user-attachments/assets/94d59d32-1888-404a-9c90-63da8a9d0e0a" /> |