### PR TITLE
Collections: Add single-row actions menu (open, duplicate, delete)

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -165,17 +165,17 @@ Double-click autofit is the trickiest piece. With no measurement hook upstream, 
 
 **Solution.** A `field.menuItems` (array or render-prop) on DataViews fields, appended to the built-in dropdown. Other consumers (Pattern Manager, Pages, Site Editor) would benefit too. File as a Gutenberg feature request.
 
-## 17. Ghost `+` column is a synthetic field pinned in `view.fields` `[internal]`
+## 17. Add-field header piggybacks on the DataViews actions column `[upstream, soft]`
 
-**What.** The `+ add field` column is a synthetic DataViews field (`__add_field`) — no data, no label, pinned last in `view.fields` for table layout. We rely on `enableHiding: false` to keep it out of the column-visibility menu. If DataViews stops honoring that flag, the synthetic leaks into the menu and confuses the column list.
+**What.** The table's `+ add field` button now sits in DataViews' row-actions column header. `ColumnHeaderActions` finds `th.dataviews-view-table__actions-column` and portals the button there; CSS hides the built-in "Actions" label and keeps the header cell sticky on the right. This is cleaner than the old synthetic `__add_field` column because it no longer leaks into `view.fields`, but it still leans on DataViews internals. If the class name, header rendering, or sticky-column markup changes, the button can disappear or stop lining up with the row kebabs.
 
-**Where.** `GHOST_FIELD` and the view-sync effect in `src/components/CollectionDataViews.js`.
+**Where.** `src/components/fields/ColumnHeaderActions.js` (actions-column lookup and portal), `src/index.scss` (`.dataviews-view-table__actions-column` overrides), and the legacy `__add_field` cleanup in `src/components/CollectionDataViews.js`.
 
-**Solution.** If `enableHiding` ever stops working, fork the field list in `CollectionDataViews.js` — pass the synthetic to the table layout but hide it from the visibility menu.
+**Solution.** DataViews exposes a trailing table-header slot, an add-column slot, or a header action area separate from per-row actions. Then the portal targets a real extension point, the sticky/header-label CSS disappears, and `__add_field` stays only as migration cleanup for old saved views.
 
 ## 18. Field management is table-layout only `[internal]`
 
-**What.** Rename / Duplicate / Delete only show up in the table-layout column-header kebab. Grid and list layouts have no schema actions and no ghost `+`. Users there can still create fields via the toolbar Add field button, but they have to switch to table to manage existing fields.
+**What.** Rename / Duplicate / Delete only show up in the table-layout column-header kebab. Grid and list layouts have no schema actions. Users there can still create fields via the toolbar Add field button, but they have to switch to table to manage existing fields.
 
 **Where.** `ColumnHeaderActions` mounts only when `view.type === 'table'` (`src/components/CollectionDataViews.js`).
 
@@ -191,7 +191,7 @@ Double-click autofit is the trickiest piece. With no measurement hook upstream, 
 
 ## 20. Table layout overrides couple to DataViews internals `[upstream, soft]`
 
-**What.** DataViews ships `table-layout: auto; width: 100%` plus per-cell padding rules. We flip to `table-layout: fixed; width: max-content` with explicit per-cell widths so adding or removing a field doesn't reflow every other column, and match DataViews' selector specificity to override the last-cell padding so the ghost column stays slim. Result: a content-sized table that scrolls horizontally on overflow. Depends on DataViews' class names and selector specificity staying put.
+**What.** DataViews ships `table-layout: auto; width: 100%` plus per-cell padding rules. We flip to `table-layout: fixed; width: max-content` with explicit per-cell widths so adding or removing a field doesn't reflow every other column. We also override the actions-column header so the add-field button stays pinned beside the row kebabs. The table sizes to its content and scrolls horizontally on overflow. Depends on DataViews' class names and selector specificity staying put.
 
 **Where.** `src/index.scss`, around the `.dataviews-view-table` block.
 

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -200,8 +200,8 @@ final class RowsController {
 	}
 
 	/**
-	 * Permission gate for duplicating a row: must be able to read the source
-	 * row and to create new rows in the same collection.
+	 * Allows duplication only when the user can edit the source row and add
+	 * rows to the collection.
 	 *
 	 * @param WP_REST_Request $request Incoming REST request.
 	 * @return bool|WP_Error
@@ -429,11 +429,10 @@ final class RowsController {
 	}
 
 	/**
-	 * Creates a new row that mirrors an existing one. Copies the title (with a
-	 * "Copy of …" prefix), content, status, document icon, featured media, and
-	 * every stored field value. Relations sync to the new row only when their
-	 * reverse side is multi-valued; single-valued reverses would otherwise
-	 * displace the source row's pointer, mutating the original.
+	 * Duplicates a row. Copies the title as "Copy of %s", plus content, status,
+	 * document icon, featured media, and stored field values. Relation values
+	 * are copied only when the reverse field accepts more than one row; copying
+	 * a single reverse would move the relation away from the source row.
 	 *
 	 * @param WP_REST_Request $request Incoming REST request.
 	 * @return WP_REST_Response|WP_Error

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -138,6 +138,28 @@ final class RowsController {
 				),
 			)
 		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/collections/(?P<collection_id>\d+)/rows/(?P<row_id>\d+)/duplicate',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'duplicate_row' ),
+					'permission_callback' => array( $this, 'can_duplicate_row' ),
+					'args'                => array(
+						'collection_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'row_id'        => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+					),
+				),
+			)
+		);
 	}
 
 	public function can_read(): bool {
@@ -175,6 +197,24 @@ final class RowsController {
 		}
 
 		return current_user_can( 'edit_post', $row_id );
+	}
+
+	/**
+	 * Permission gate for duplicating a row: must be able to read the source
+	 * row and to create new rows in the same collection.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 * @return bool|WP_Error
+	 */
+	public function can_duplicate_row( WP_REST_Request $request ): bool|WP_Error {
+		$edit_check = $this->can_edit_row( $request );
+		if ( is_wp_error( $edit_check ) ) {
+			return $edit_check;
+		}
+		if ( ! $edit_check ) {
+			return false;
+		}
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**
@@ -385,6 +425,114 @@ final class RowsController {
 		return new WP_REST_Response(
 			$this->format_row( get_post( $row_id ), $field_ids, $multi_field_ids ),
 			200
+		);
+	}
+
+	/**
+	 * Creates a new row that mirrors an existing one. Copies the title (with a
+	 * "Copy of …" prefix), content, status, document icon, featured media, and
+	 * every stored field value. Relations sync to the new row only when their
+	 * reverse side is multi-valued; single-valued reverses would otherwise
+	 * displace the source row's pointer, mutating the original.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function duplicate_row( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$collection_id = (int) $request->get_param( 'collection_id' );
+		$row_id        = (int) $request->get_param( 'row_id' );
+
+		$collection = $this->validate_collection( $collection_id );
+		if ( is_wp_error( $collection ) ) {
+			return $collection;
+		}
+
+		$slug   = (string) get_post_meta( $collection_id, 'slug', true );
+		$source = get_post( $row_id );
+		if ( ! $source instanceof WP_Post || CollectionEntries::CPT_PREFIX . $slug !== $source->post_type ) {
+			return new WP_Error(
+				'cortext_row_not_found',
+				__( 'Row not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$copy_title = sprintf(
+			/* translators: %s: original row title. */
+			__( 'Copy of %s', 'cortext' ),
+			$source->post_title
+		);
+
+		$new_id = wp_insert_post(
+			array(
+				'post_type'    => $source->post_type,
+				'post_status'  => $source->post_status,
+				'post_title'   => $copy_title,
+				'post_content' => $source->post_content,
+				'post_excerpt' => $source->post_excerpt,
+			),
+			true
+		);
+		if ( is_wp_error( $new_id ) ) {
+			return $new_id;
+		}
+
+		$new_id    = (int) $new_id;
+		$field_ids = $this->collection_field_ids( $collection_id );
+
+		foreach ( $field_ids as $field_id ) {
+			$field_type = (string) get_post_meta( $field_id, 'type', true );
+
+			if ( 'rollup' === $field_type ) {
+				continue;
+			}
+
+			if ( 'relation' === $field_type ) {
+				$reverse_id = (int) get_post_meta( $field_id, 'relation_reverse_field_id', true );
+				if ( $reverse_id < 1 || ! Relations::relation_is_multiple( $reverse_id ) ) {
+					continue;
+				}
+				$values = Relations::relation_values( $row_id, $field_id );
+				if ( count( $values ) === 0 ) {
+					continue;
+				}
+				$synced = Relations::sync_relation_value( $new_id, $field_id, $values );
+				if ( is_wp_error( $synced ) ) {
+					return $synced;
+				}
+				continue;
+			}
+
+			$key = Relations::meta_key( $field_id );
+			if ( 'multiselect' === $field_type ) {
+				foreach ( get_post_meta( $row_id, $key, false ) as $value ) {
+					if ( '' !== $value && null !== $value ) {
+						add_post_meta( $new_id, $key, $value );
+					}
+				}
+				continue;
+			}
+
+			$value = get_post_meta( $row_id, $key, true );
+			if ( '' !== $value && null !== $value ) {
+				update_post_meta( $new_id, $key, $value );
+			}
+		}
+
+		$icon = (string) get_post_meta( $row_id, 'cortext_document_icon', true );
+		if ( '' !== $icon ) {
+			update_post_meta( $new_id, 'cortext_document_icon', $icon );
+		}
+
+		$thumbnail_id = (int) get_post_thumbnail_id( $row_id );
+		if ( $thumbnail_id > 0 ) {
+			set_post_thumbnail( $new_id, $thumbnail_id );
+		}
+
+		$multi_field_ids = $this->multi_value_field_ids( $field_ids );
+		return new WP_REST_Response(
+			$this->format_row( get_post( $new_id ), $field_ids, $multi_field_ids ),
+			201
 		);
 	}
 

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1,5 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Notice } from '@wordpress/components';
+import {
+	Button,
+	Notice,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import {
 	createContext,
@@ -10,9 +15,10 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { copy, plus, trash } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
+import { addQueryArgs } from '@wordpress/url';
 
 import DataViewColumnInteractions from './DataViewColumnInteractions';
 import EditableCell, { RowMutationContext } from './EditableCell';
@@ -20,7 +26,10 @@ import PageIcon from './PageIcon';
 import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
 import ColumnHeaderActions from './fields/ColumnHeaderActions';
-import RowDetailView, { ROW_DETAIL_MODE_ICONS } from './RowDetailView';
+import RowDetailView, {
+	ROW_DETAIL_MODE_ICONS,
+	ROW_DETAIL_MODE_LABELS,
+} from './RowDetailView';
 import { RowDetailSidebar } from './RowDetailSidebarSlot';
 import {
 	GHOST_FIELD_ID,
@@ -162,37 +171,6 @@ const TITLE_FIELD = {
 	// reorders and resizes like any other column. `normalizeView` re-adds
 	// the id to `view.fields` if something corrupts the saved state.
 	enableHiding: false,
-};
-
-// Synthetic "ghost column" rendered at the right edge of the table layout.
-// Its `header` carries an aria-hidden marker that `ColumnHeaderActions`
-// portals a `+` button into; the row cells render `null`, leaving an
-// empty column that visually echoes an "add column" affordance.
-// Pinned visible (and last) by the view-sync effect when
-// `view.type === 'table'`, dropped from `view.fields` for grid/list.
-const GHOST_FIELD = {
-	id: GHOST_FIELD_ID,
-	type: 'text',
-	cortextType: 'ghost',
-	label: '',
-	sortable: false,
-	filterable: false,
-	operators: [],
-	filterBy: false,
-	enableSorting: false,
-	enableHiding: false,
-	editable: false,
-	getValue: () => '',
-	render: () => (
-		<span className="cortext-data-view__ghost-cell" aria-hidden="true" />
-	),
-	header: (
-		<span
-			className="cortext-column-header-marker cortext-column-header-marker--add"
-			data-cortext-add-field-marker="true"
-			aria-hidden="true"
-		/>
-	),
 };
 
 // Pulls a "single equality" prefill out of the active filters: only filters
@@ -350,13 +328,7 @@ export default function CollectionDataViews( {
 
 	const isTableLayout = view?.type === 'table';
 	const isServerPaginated = queryMode === 'server';
-	const dataViewFields = useMemo(
-		() =>
-			isTableLayout
-				? [ ...availableFields, GHOST_FIELD ]
-				: availableFields,
-		[ availableFields, isTableLayout ]
-	);
+	const dataViewFields = availableFields;
 
 	const tableWrapperRef = useRef( null );
 	// editRequest is the "open this cell for editing" channel: cells that
@@ -737,24 +709,146 @@ export default function CollectionDataViews( {
 		[ isTableLayout, openRowId, requestOpenRow, savedRowDetailMode ]
 	);
 
-	const rowActions = useMemo(
-		() => [
-			{
-				id: 'open-row',
-				label: __( 'Open row', 'cortext' ),
-				icon: ROW_DETAIL_MODE_ICONS[ savedRowDetailMode ],
-				isPrimary: true,
-				context: 'single',
-				callback: ( items ) => requestOpenRow( items?.[ 0 ] ),
-			},
-		],
-		[ requestOpenRow, savedRowDetailMode ]
+	const [ pendingDeleteRow, setPendingDeleteRow ] = useState( null );
+	const [ rowActionError, setRowActionError ] = useState( null );
+
+	const openRowInMode = useCallback(
+		( row, mode ) => {
+			if ( ! row?.id ) {
+				return;
+			}
+			if ( mode === 'full' ) {
+				runDetailTransition( { type: 'full', rowId: row.id } );
+				return;
+			}
+			// Persist the chosen mode so the surface renders side vs modal
+			// correctly, then open the row. Matches the existing in-detail
+			// mode toggle: an explicit choice updates the user's preference.
+			if ( savedRowDetailMode !== mode ) {
+				onChangeView( withRowDetailMode( view, mode ) );
+			}
+			runDetailTransition( { type: 'row', rowId: row.id } );
+		},
+		[ onChangeView, runDetailTransition, savedRowDetailMode, view ]
 	);
 
-	const dataViewActions = useMemo(
-		() => ( isTableLayout ? undefined : rowActions ),
-		[ isTableLayout, rowActions ]
+	const duplicateRow = useCallback(
+		async ( row ) => {
+			if ( ! collectionId || ! row?.id ) {
+				return;
+			}
+			setRowActionError( null );
+			try {
+				const created = await apiFetch( {
+					path: `/cortext/v1/collections/${ collectionId }/rows/${ row.id }/duplicate`,
+					method: 'POST',
+				} );
+				if ( created?.id ) {
+					touchRecent( {
+						kind: 'row',
+						id: created.id,
+						collectionId,
+					} );
+				}
+				refresh();
+			} catch ( apiError ) {
+				setRowActionError(
+					apiError?.message ??
+						__( 'Could not duplicate row.', 'cortext' )
+				);
+			}
+		},
+		[ collectionId, refresh, touchRecent ]
 	);
+
+	const requestDeleteRow = useCallback( ( row ) => {
+		if ( ! row?.id ) {
+			return;
+		}
+		setRowActionError( null );
+		setPendingDeleteRow( row );
+	}, [] );
+
+	const cancelDeleteRow = useCallback( () => {
+		setPendingDeleteRow( null );
+	}, [] );
+
+	const confirmDeleteRow = useCallback( async () => {
+		const row = pendingDeleteRow;
+		setPendingDeleteRow( null );
+		if ( ! row?.id || ! postType ) {
+			return;
+		}
+		try {
+			await apiFetch( {
+				path: addQueryArgs( `/wp/v2/${ postType }/${ row.id }`, {
+					force: true,
+				} ),
+				method: 'DELETE',
+			} );
+			if ( String( row.id ) === String( openRowId ) ) {
+				runDetailTransition( { type: 'close' } );
+			}
+			refresh();
+		} catch ( apiError ) {
+			setRowActionError(
+				apiError?.message ?? __( 'Could not delete row.', 'cortext' )
+			);
+		}
+	}, [
+		openRowId,
+		pendingDeleteRow,
+		postType,
+		refresh,
+		runDetailTransition,
+	] );
+
+	const rowActions = useMemo( () => {
+		const actions = [];
+		// Three explicit "Open in" entries (side / modal / full). The one
+		// matching the saved mode is primary on list and grid layouts, so
+		// it surfaces as an inline icon button next to the kebab. Table
+		// layout has its own title-cell inline Open button, so none of the
+		// "Open in" actions is primary there.
+		for ( const mode of [ 'side', 'modal', 'full' ] ) {
+			actions.push( {
+				id: `open-in-${ mode }`,
+				label: sprintf(
+					/* translators: %s: row detail mode (Side peek, Center modal, Full page). */
+					__( 'Open in %s', 'cortext' ),
+					ROW_DETAIL_MODE_LABELS[ mode ]
+				),
+				icon: ROW_DETAIL_MODE_ICONS[ mode ],
+				isPrimary: ! isTableLayout && mode === savedRowDetailMode,
+				context: 'single',
+				callback: ( items ) => openRowInMode( items?.[ 0 ], mode ),
+			} );
+		}
+		actions.push( {
+			id: 'duplicate-row',
+			label: __( 'Duplicate', 'cortext' ),
+			icon: copy,
+			context: 'single',
+			callback: ( items ) => duplicateRow( items?.[ 0 ] ),
+		} );
+		actions.push( {
+			id: 'delete-row',
+			label: __( 'Delete', 'cortext' ),
+			icon: trash,
+			isDestructive: true,
+			context: 'single',
+			callback: ( items ) => requestDeleteRow( items?.[ 0 ] ),
+		} );
+		return actions;
+	}, [
+		duplicateRow,
+		isTableLayout,
+		openRowInMode,
+		requestDeleteRow,
+		savedRowDetailMode,
+	] );
+
+	const dataViewActions = rowActions;
 
 	const requestCloseDetail = useCallback(
 		() => runDetailTransition( { type: 'close' } ),
@@ -919,23 +1013,16 @@ export default function CollectionDataViews( {
 			}
 		}
 
-		// Pin the ghost "+ add field" column last whenever the table
-		// layout is active. In grid/list layouts the synthetic field
-		// isn't part of `availableFields`, so `normalizeView` already
-		// dropped any stale reference.
-		if ( isTableLayout ) {
-			const stripped = ( normalized.fields ?? [] ).filter(
-				( id ) => id !== GHOST_FIELD_ID
-			);
-			const nextFields = [ ...stripped, GHOST_FIELD_ID ];
-			const fieldsChanged =
-				nextFields.length !== ( normalized.fields ?? [] ).length ||
-				nextFields.some(
-					( id, i ) => id !== ( normalized.fields ?? [] )[ i ]
-				);
-			if ( fieldsChanged ) {
-				normalized = { ...normalized, fields: nextFields };
-			}
+		// Strip any legacy ghost-column id from saved views; the "+ add
+		// field" affordance now lives in the dataviews actions column
+		// header, not a synthetic table column.
+		if ( ( normalized.fields ?? [] ).includes( GHOST_FIELD_ID ) ) {
+			normalized = {
+				...normalized,
+				fields: ( normalized.fields ?? [] ).filter(
+					( id ) => id !== GHOST_FIELD_ID
+				),
+			};
 		}
 
 		knownFieldIdsRef.current = validIds;
@@ -1085,6 +1172,15 @@ export default function CollectionDataViews( {
 					data-row-detail-open={ openRowId ? 'true' : 'false' }
 				>
 					<div className="cortext-data-view" ref={ tableWrapperRef }>
+						{ rowActionError && (
+							<Notice
+								status="error"
+								isDismissible
+								onRemove={ () => setRowActionError( null ) }
+							>
+								{ rowActionError }
+							</Notice>
+						) }
 						<DataViews
 							data={ dataFiltered }
 							fields={ dataViewFields }
@@ -1137,6 +1233,24 @@ export default function CollectionDataViews( {
 					</div>
 					{ detailSurface }
 				</div>
+				{ pendingDeleteRow && (
+					<ConfirmDialog
+						onConfirm={ confirmDeleteRow }
+						onCancel={ cancelDeleteRow }
+						confirmButtonText={ __( 'Delete', 'cortext' ) }
+					>
+						{ sprintf(
+							/* translators: %s: row title. */
+							__(
+								'Delete "%s"? This cannot be undone.',
+								'cortext'
+							),
+							pendingDeleteRow?.title?.rendered ||
+								pendingDeleteRow?.title?.raw ||
+								__( '(untitled)', 'cortext' )
+						) }
+					</ConfirmDialog>
+				) }
 			</OpenRowActionContext.Provider>
 		</RowMutationContext.Provider>
 	);

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -721,9 +721,9 @@ export default function CollectionDataViews( {
 				runDetailTransition( { type: 'full', rowId: row.id } );
 				return;
 			}
-			// Persist the chosen mode so the surface renders side vs modal
-			// correctly, then open the row. Matches the existing in-detail
-			// mode toggle: an explicit choice updates the user's preference.
+			// Store the chosen side/modal mode before opening. This matches
+			// the in-detail mode toggle: an explicit choice updates the
+			// user's preference.
 			if ( savedRowDetailMode !== mode ) {
 				onChangeView( withRowDetailMode( view, mode ) );
 			}
@@ -805,11 +805,9 @@ export default function CollectionDataViews( {
 
 	const rowActions = useMemo( () => {
 		const actions = [];
-		// Three explicit "Open in" entries (side / modal / full). The one
-		// matching the saved mode is primary on list and grid layouts, so
-		// it surfaces as an inline icon button next to the kebab. Table
-		// layout has its own title-cell inline Open button, so none of the
-		// "Open in" actions is primary there.
+		// List and grid get one primary Open action, matching the saved
+		// detail mode. Table already has the inline Open button in the title
+		// cell, so these actions stay inside the menu there.
 		for ( const mode of [ 'side', 'modal', 'full' ] ) {
 			actions.push( {
 				id: `open-in-${ mode }`,
@@ -1013,9 +1011,8 @@ export default function CollectionDataViews( {
 			}
 		}
 
-		// Strip any legacy ghost-column id from saved views; the "+ add
-		// field" affordance now lives in the dataviews actions column
-		// header, not a synthetic table column.
+		// Drop `__add_field` from older saved views. The add-field button now
+		// uses the DataViews actions header instead of a synthetic column.
 		if ( ( normalized.fields ?? [] ).includes( GHOST_FIELD_ID ) ) {
 			normalized = {
 				...normalized,

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -109,19 +109,21 @@ export default function ColumnHeaderActions( {
 						th,
 					} );
 				} );
-			wrapper
-				.querySelectorAll( '[data-cortext-add-field-marker]' )
-				.forEach( ( marker ) => {
-					const th = marker.closest( 'th' );
-					if ( ! th ) {
-						return;
-					}
-					next.push( {
-						key: 'add-field',
-						kind: 'add',
-						th,
-					} );
+			// `+ add field` lives in the dataviews actions column header
+			// (`<th class="dataviews-view-table__actions-column">`).
+			// That column is rendered whenever the table has row actions,
+			// which we always do, so we don't need a separate ghost column
+			// for this affordance. See `tech-debt.md#16`.
+			const actionsTh = wrapper.querySelector(
+				'th.dataviews-view-table__actions-column'
+			);
+			if ( actionsTh ) {
+				next.push( {
+					key: 'add-field',
+					kind: 'add',
+					th: actionsTh,
 				} );
+			}
 
 			setTargets( ( prev ) => {
 				if ( prev.length !== next.length ) {
@@ -750,7 +752,7 @@ function AddFieldTrigger( { collectionId } ) {
 					<Button
 						icon={ plus }
 						label={ __( 'Add field', 'cortext' ) }
-						size="small"
+						size="compact"
 						onClick={ onToggle }
 						isPressed={ isOpen }
 					/>

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -49,24 +49,19 @@ const { Menu } = unlock( componentsPrivateApis );
 
 const FORMATTABLE_TYPES = new Set( [ 'number', 'date', 'datetime' ] );
 
-// Projects two kinds of triggers into the DataViews table header:
+// Projects Cortext controls into DataViews' table header:
 //
-// - `[data-cortext-field-marker="<recordId>"]` — combined column-header
-//   dropdown for custom fields. Replaces DataViews' built-in trigger
-//   (hidden via CSS, see `tech-debt.md#16`) with a single menu owning
-//   Sort / Move / Hide *plus* Rename / Duplicate / Delete. The marker
-//   sits inside DataViews' (hidden) trigger and serves only as a portal
-//   anchor; the actual button is rendered as a sibling of the trigger,
-//   inheriting the same class so main's drag handle click-forward
-//   resolves to it.
-// - `[data-cortext-add-field-marker]` — `+` button on the ghost column
-//   that opens the same `AddFieldPopover` as the toolbar Add field
-//   trigger.
+// - `[data-cortext-field-marker="<recordId>"]` marks custom fields. We hide
+//   DataViews' trigger (see `tech-debt.md#16`) and portal in one menu with
+//   Sort / Move / Hide plus Rename / Duplicate / Delete. The marker is only
+//   the anchor; the real button is a sibling so the column drag handle can
+//   still forward clicks to it.
+// - `th.dataviews-view-table__actions-column` — `+` button in the
+//   row-actions column header that opens the same `AddFieldPopover`
+//   as the toolbar Add field trigger. See `tech-debt.md#17`.
 //
-// Renders an invisible anchor element so the component finds its own
-// position in DOM and walks up to the wrapping `.cortext-data-view`.
-// A MutationObserver re-syncs portals whenever DataViews mutates its
-// header markup (column toggles, sorting, resizing).
+// The invisible anchor lets this component find its wrapper. A
+// MutationObserver re-syncs portals after DataViews rewrites the header.
 export default function ColumnHeaderActions( {
 	collectionId,
 	view,
@@ -109,11 +104,9 @@ export default function ColumnHeaderActions( {
 						th,
 					} );
 				} );
-			// `+ add field` lives in the dataviews actions column header
-			// (`<th class="dataviews-view-table__actions-column">`).
-			// That column is rendered whenever the table has row actions,
-			// which we always do, so we don't need a separate ghost column
-			// for this affordance. See `tech-debt.md#16`.
+			// The add-field button lives in DataViews' actions column header.
+			// Row actions keep that column rendered, so we no longer need a
+			// synthetic table column for it. See `tech-debt.md#17`.
 			const actionsTh = wrapper.querySelector(
 				'th.dataviews-view-table__actions-column'
 			);
@@ -406,9 +399,8 @@ function FieldActions( {
 		[ fields, recordId ]
 	);
 
-	// Title is pinned at index 0 (PR A's normalizeView) and the ghost
-	// column at the end. Move only operates on the data-field region in
-	// between, so a sideways swap can't displace either.
+	// Move only touches data fields. Title stays pinned, and the legacy
+	// ghost id is ignored if an older saved view still has it.
 	const movableFields = useMemo(
 		() =>
 			visibleFields.filter(
@@ -444,8 +436,8 @@ function FieldActions( {
 			}
 			order.splice( from, 1 );
 			order.splice( to, 0, dataViewId );
-			// Re-stitch with title first and ghost last so neither can
-			// be displaced by a sideways swap.
+			// Put title back first. Preserve the legacy ghost id for now;
+			// CollectionDataViews strips it on the next normalization pass.
 			const ordered = [];
 			if ( visibleFields.includes( TITLE_FIELD_ID ) ) {
 				ordered.push( TITLE_FIELD_ID );

--- a/src/index.scss
+++ b/src/index.scss
@@ -1918,6 +1918,15 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 	}
 }
 
+// Regular cells get vertical centering from DataViews' inner wrapper.
+// The row-actions cell skips that wrapper, so center the kebab on the td.
+.cortext-data-view
+.dataviews-view-table
+tbody
+td.dataviews-view-table__actions-column {
+	vertical-align: middle;
+}
+
 // Custom field columns carry a marker that `ColumnHeaderActions`
 // portals our trigger into. We hide DataViews' built-in trigger on
 // those <th>s and replace it with a single combined dropdown (Sort /

--- a/src/index.scss
+++ b/src/index.scss
@@ -1841,18 +1841,11 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 	width: 280px;
 }
 
-// `+ add field` is portaled into the dataviews actions column header.
-// Hide the built-in "Actions" label so the column reads as a single
-// `+` affordance; the kebab in each row body already conveys the
-// per-row actions meaning. The header `<th>` should be sticky-right
-// like its body siblings, but `<thead>` itself is sticky-top, and the
-// double-sticky combination misbehaves in some browsers — the inner
-// horizontal sticky stops engaging once the outer vertical sticky
-// kicks in. Promote the `<th>`'s stacking and reaffirm sticky-right
-// so the `+` stays pinned alongside the row kebab during horizontal
-// scroll. `!important` is here because dataviews ships an identical
-// declaration whose specificity ties ours; the duplicate keeps the
-// rule from losing to any later cascade rewrite.
+// The add-field button is portaled into DataViews' actions column header.
+// Hide the built-in "Actions" label; the row kebabs already explain the
+// column. The header cell needs its own sticky-right rule because the sticky
+// `<thead>` can otherwise break horizontal stickiness in some browsers.
+// `!important` matches DataViews' own tied-specificity sticky rule.
 .dataviews-view-table thead th.dataviews-view-table__actions-column {
 	position: sticky !important;
 	right: 0 !important;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1841,29 +1841,34 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 	width: 280px;
 }
 
-// Ghost column is just the `+` icon button. DataViews uses
-// `.dataviews-view-table tr td:last-child { padding-right: 48px }`
-// for the last column, plus `min-width: 15ch` on the cell content
-// wrapper. Match DataViews' selector specificity so our overrides
-// win, then size the column to the button's natural width with a
-// tight right padding.
-.dataviews-view-table tr th:has(.cortext-column-header-marker--add),
-.dataviews-view-table tr td:has(.cortext-data-view__ghost-cell) {
-	width: 0;
-	padding-right: $grid-unit-10;
+// `+ add field` is portaled into the dataviews actions column header.
+// Hide the built-in "Actions" label so the column reads as a single
+// `+` affordance; the kebab in each row body already conveys the
+// per-row actions meaning. The header `<th>` should be sticky-right
+// like its body siblings, but `<thead>` itself is sticky-top, and the
+// double-sticky combination misbehaves in some browsers — the inner
+// horizontal sticky stops engaging once the outer vertical sticky
+// kicks in. Promote the `<th>`'s stacking and reaffirm sticky-right
+// so the `+` stays pinned alongside the row kebab during horizontal
+// scroll. `!important` is here because dataviews ships an identical
+// declaration whose specificity ties ours; the duplicate keeps the
+// rule from losing to any later cascade rewrite.
+.dataviews-view-table thead th.dataviews-view-table__actions-column {
+	position: sticky !important;
+	right: 0 !important;
+	z-index: 3;
+	background-color: #fff;
 
-	.dataviews-view-table__cell-content-wrapper,
-	.dataviews-view-table__primary-column-content {
-		min-width: 0;
+	> .dataviews-view-table-header {
+		display: none;
 	}
 }
 
-// Custom field columns and the ghost column carry a marker that
-// `ColumnHeaderActions` portals our trigger into. We hide DataViews'
-// built-in trigger on those <th>s and replace it with a single combined
-// dropdown (Sort / Move / Hide / Rename / Duplicate / Delete) for data
-// columns, or a `+` button for the ghost column. Title and system
-// fields don't have a marker, so their built-in triggers stay visible.
+// Custom field columns carry a marker that `ColumnHeaderActions`
+// portals our trigger into. We hide DataViews' built-in trigger on
+// those <th>s and replace it with a single combined dropdown (Sort /
+// Move / Hide / Rename / Duplicate / Delete). Title and system fields
+// don't have a marker, so their built-in triggers stay visible.
 // `tech-debt.md#16` covers the upstream gap that forces this takeover.
 .dataviews-view-table
 th:has(.cortext-column-header-marker)

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -126,9 +126,7 @@ function Harness( { collectionId, recordId } ) {
 								<span data-cortext-field-marker={ recordId } />
 							</th>
 						) : null }
-						<th>
-							<span data-cortext-add-field-marker="true" />
-						</th>
+						<th className="dataviews-view-table__actions-column" />
 					</tr>
 				</thead>
 			</table>

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -51,6 +51,10 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 			'/cortext/v1/collections/(?P<collection_id>\d+)/rows/(?P<row_id>\d+)',
 			$routes
 		);
+		$this->assertArrayHasKey(
+			'/cortext/v1/collections/(?P<collection_id>\d+)/rows/(?P<row_id>\d+)/duplicate',
+			$routes
+		);
 	}
 
 	public function test_create_row_creates_formatted_collection_entry(): void {
@@ -1002,6 +1006,194 @@ public function test_build_query_args_with_title_sort(): void {
 		$this->assertSame( 'ASC', $args['order'] );
 	}
 
+	// -- Duplicate tests ------------------------------------------------
+
+	public function test_duplicate_row_creates_copy_with_prefixed_title(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$fixture = $this->create_collection_fixture( 'dup', 'text' );
+		$source_id = $this->create_entry( 'crtxt_dup', 'My Row' );
+		update_post_meta( $source_id, "field-{$fixture['field_id']}", 'hello' );
+
+		$response = $this->duplicate_row( $fixture['collection_id'], $source_id );
+
+		$this->assertSame( 201, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertNotSame( $source_id, $data['id'] );
+		$this->assertSame( 'Copy of My Row', $data['title']['raw'] );
+		$this->assertSame( 'crtxt_dup', get_post_type( $data['id'] ) );
+		$this->assertSame( 'hello', $data['meta']["field-{$fixture['field_id']}"] );
+
+		// Source row stays untouched.
+		$this->assertSame( 'My Row', get_post( $source_id )->post_title );
+		$this->assertSame( 'hello', get_post_meta( $source_id, "field-{$fixture['field_id']}", true ) );
+	}
+
+	public function test_duplicate_row_copies_content_and_status(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$fixture = $this->create_collection_fixture( 'dupc', 'text' );
+
+		$source_id = (int) wp_insert_post(
+			array(
+				'post_type'    => 'crtxt_dupc',
+				'post_status'  => 'private',
+				'post_title'   => 'Original',
+				'post_content' => '<p>Body text.</p>',
+				'post_excerpt' => 'short summary',
+			)
+		);
+
+		$response = $this->duplicate_row( $fixture['collection_id'], $source_id );
+
+		$this->assertSame( 201, $response->get_status() );
+		$copy = get_post( $response->get_data()['id'] );
+		$this->assertSame( '<p>Body text.</p>', $copy->post_content );
+		$this->assertSame( 'short summary', $copy->post_excerpt );
+		$this->assertSame( 'private', $copy->post_status );
+	}
+
+	public function test_duplicate_row_copies_multiselect_values(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$collection_id = $this->create_collection_with_slug( 'Tagged', 'dupms' );
+		$field_id      = $this->create_collection_field( $collection_id, 'Tags', 'multiselect' );
+		$source_id     = $this->create_entry( 'crtxt_dupms', 'Tagged row' );
+		add_post_meta( $source_id, "field-{$field_id}", 'alpha' );
+		add_post_meta( $source_id, "field-{$field_id}", 'beta' );
+
+		$response = $this->duplicate_row( $collection_id, $source_id );
+
+		$this->assertSame( 201, $response->get_status() );
+		$new_id = $response->get_data()['id'];
+		$values = get_post_meta( $new_id, "field-{$field_id}", false );
+		$this->assertContains( 'alpha', $values );
+		$this->assertContains( 'beta', $values );
+		$this->assertCount( 2, $values );
+	}
+
+	public function test_duplicate_row_skips_rollups(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$projects_id = $this->create_collection_with_slug( 'Projects', 'dup-proj' );
+		$invoices_id = $this->create_collection_with_slug( 'Invoices', 'dup-inv' );
+		$relation    = $this->create_relation_pair( $projects_id, $invoices_id );
+		$count_id    = $this->create_rollup_field( $projects_id, 'Count', $relation['source_id'], 0, 'count' );
+
+		$project_id = $this->create_entry( 'crtxt_dup-proj', 'Project A' );
+		$invoice_id = $this->create_entry( 'crtxt_dup-inv', 'Invoice 1' );
+		\Cortext\Relations::sync_relation_value(
+			$project_id,
+			$relation['source_id'],
+			array( $invoice_id )
+		);
+
+		$response = $this->duplicate_row( $projects_id, $project_id );
+
+		$this->assertSame( 201, $response->get_status() );
+		$new_id = $response->get_data()['id'];
+		// Rollup values are computed on read; no stored meta to copy.
+		$this->assertSame( '', get_post_meta( $new_id, "field-{$count_id}", true ) );
+	}
+
+	public function test_duplicate_row_copies_relation_when_reverse_is_multiple(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$tasks_id  = $this->create_collection_with_slug( 'Tasks', 'dup-task' );
+		$people_id = $this->create_collection_with_slug( 'People', 'dup-people' );
+		$relation  = $this->create_relation_pair( $tasks_id, $people_id, true, true );
+
+		$task_id   = $this->create_entry( 'crtxt_dup-task', 'Original task' );
+		$person_id = $this->create_entry( 'crtxt_dup-people', 'Ada' );
+		\Cortext\Relations::sync_relation_value(
+			$task_id,
+			$relation['source_id'],
+			array( $person_id )
+		);
+
+		$response = $this->duplicate_row( $tasks_id, $task_id );
+
+		$this->assertSame( 201, $response->get_status() );
+		$new_id = $response->get_data()['id'];
+
+		// New row points at the same person.
+		$this->assertSame(
+			array( (string) $person_id ),
+			get_post_meta( $new_id, "field-{$relation['source_id']}", false )
+		);
+		// Source row still points at the person; reverse list contains both.
+		$this->assertSame(
+			array( (string) $person_id ),
+			get_post_meta( $task_id, "field-{$relation['source_id']}", false )
+		);
+		$reverse_values = get_post_meta( $person_id, "field-{$relation['reverse_id']}", false );
+		$this->assertContains( (string) $task_id, $reverse_values );
+		$this->assertContains( (string) $new_id, $reverse_values );
+	}
+
+	public function test_duplicate_row_skips_relation_when_reverse_is_single(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$tasks_id  = $this->create_collection_with_slug( 'Tasks', 'dup-tsng' );
+		$people_id = $this->create_collection_with_slug( 'People', 'dup-psng' );
+		// Reverse is single-valued: each person can be tied to only one task.
+		$relation = $this->create_relation_pair( $tasks_id, $people_id, true, false );
+
+		$task_id   = $this->create_entry( 'crtxt_dup-tsng', 'Original task' );
+		$person_id = $this->create_entry( 'crtxt_dup-psng', 'Ada' );
+		\Cortext\Relations::sync_relation_value(
+			$task_id,
+			$relation['source_id'],
+			array( $person_id )
+		);
+
+		$response = $this->duplicate_row( $tasks_id, $task_id );
+
+		$this->assertSame( 201, $response->get_status() );
+		$new_id = $response->get_data()['id'];
+
+		// Source row keeps its relation; new row has no relation.
+		$this->assertSame(
+			array( (string) $person_id ),
+			get_post_meta( $task_id, "field-{$relation['source_id']}", false )
+		);
+		$this->assertSame(
+			array(),
+			get_post_meta( $new_id, "field-{$relation['source_id']}", false )
+		);
+		$this->assertSame(
+			array( (string) $task_id ),
+			get_post_meta( $person_id, "field-{$relation['reverse_id']}", false )
+		);
+	}
+
+	public function test_duplicate_row_copies_document_icon(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$fixture   = $this->create_collection_fixture( 'dupic', 'text' );
+		$source_id = $this->create_entry( 'crtxt_dupic', 'Iconified' );
+		$icon      = wp_json_encode( array( 'type' => 'wp', 'name' => 'home' ) );
+		update_post_meta( $source_id, 'cortext_document_icon', $icon );
+
+		$response = $this->duplicate_row( $fixture['collection_id'], $source_id );
+
+		$this->assertSame( 201, $response->get_status() );
+		$new_id = $response->get_data()['id'];
+		$this->assertSame( $icon, get_post_meta( $new_id, 'cortext_document_icon', true ) );
+	}
+
+	public function test_duplicate_row_returns_404_for_unknown_row(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		$fixture = $this->create_collection_fixture( 'dupnf' );
+
+		$response = $this->duplicate_row( $fixture['collection_id'], 999999 );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	public function test_duplicate_row_requires_edit_caps(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+		$fixture   = $this->create_collection_fixture( 'dupperm' );
+		$source_id = $this->create_entry( 'crtxt_dupperm', 'Original' );
+
+		$response = $this->duplicate_row( $fixture['collection_id'], $source_id );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
 	// -- Helpers --------------------------------------------------------
 
 	private function invoke_format_row( int $post_id, int $field_id ): array {
@@ -1080,6 +1272,17 @@ public function test_build_query_args_with_title_sort(): void {
 		$request->set_param( 'row_id', $row_id );
 		$request->set_param( 'field', $field );
 		$request->set_param( 'value', $value );
+
+		return rest_do_request( $request );
+	}
+
+	private function duplicate_row( int $collection_id, int $row_id ): \WP_REST_Response {
+		$request = new WP_REST_Request(
+			'POST',
+			"/cortext/v1/collections/{$collection_id}/rows/{$row_id}/duplicate"
+		);
+		$request->set_param( 'collection_id', $collection_id );
+		$request->set_param( 'row_id', $row_id );
 
 		return rest_do_request( $request );
 	}


### PR DESCRIPTION
## What

Closes #107.

Adds row actions to open rows on a selected detail surface, duplicate rows, and delete rows from collection views. Row duplication creates a new copy with the copied field values, document icon, featured media, and relation handling, while deletion prompts confirmation before permanently removing the row (will change to send to trash in #179).

## How

- Adding a REST endpoint for duplicating collection rows.
- Moving the table `+` add-field control into the DataViews actions column instead of using a synthetic ghost column.
- Documenting the remaining DataViews actions-column dependency in tech debt.
- Preserving existing row-detail save/transition behavior when opening, deleting, or refreshing rows.

## Testing Instructions

1. Open a collection in table, grid, and list views.
2. Use a row action to open a row in side peek, center modal, and full page.
3. Duplicate a row and confirm the new row appears with copied values and a `Copy of` title.
4. Delete a row and confirm it is removed after accepting the confirmation dialog.
5. In table view, verify the `+` add-field button appears in the right-side actions column and opens the add-field popover.
6. Open a custom field header menu and verify field actions like rename, duplicate, delete, and move still appear.

## Screen recording

https://github.com/user-attachments/assets/901afeb9-4b31-472f-9b2c-94459cbe7357

