### PR TITLE
Collections: polish UX when adding new/duplicated columns

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -169,9 +169,11 @@ Double-click autofit is the trickiest piece. With no measurement hook upstream, 
 
 **What.** The table's `+ add field` button now sits in DataViews' row-actions column header. `ColumnHeaderActions` finds `th.dataviews-view-table__actions-column` and portals the button there; CSS hides the built-in "Actions" label and keeps the header cell sticky on the right. This is cleaner than the old synthetic `__add_field` column because it no longer leaks into `view.fields`, but it still leans on DataViews internals. If the class name, header rendering, or sticky-column markup changes, the button can disappear or stop lining up with the row kebabs.
 
-**Where.** `src/components/fields/ColumnHeaderActions.js` (actions-column lookup and portal), `src/index.scss` (`.dataviews-view-table__actions-column` overrides), and the legacy `__add_field` cleanup in `src/components/CollectionDataViews.js`.
+The create-field flow also has to reveal the new trailing column itself. It carries the created field ID back to `CollectionDataViews`, waits until the field marker exists in the rendered header, then scrolls `.dataviews-wrapper` to the right edge. The interaction feels right, but it still depends on DataViews' DOM shape.
 
-**Solution.** DataViews exposes a trailing table-header slot, an add-column slot, or a header action area separate from per-row actions. Then the portal targets a real extension point, the sticky/header-label CSS disappears, and `__add_field` stays only as migration cleanup for old saved views.
+**Where.** `src/components/fields/ColumnHeaderActions.js` (actions-column lookup and portal), `src/components/CollectionDataViews.js` and `src/components/dataViewScroll.js` (created-field reveal and `.dataviews-wrapper` scroll), `src/index.scss` (`.dataviews-view-table__actions-column` overrides), and the legacy `__add_field` cleanup in `src/components/CollectionDataViews.js`.
+
+**Solution.** DataViews exposes a trailing table-header slot, an add-column slot, or a header action area separate from per-row actions, plus refs for the table scroll wrapper and rendered headers. Then the portal targets a real extension point, the reveal code stops querying DataViews DOM, the sticky/header-label CSS disappears, and `__add_field` stays only as migration cleanup for old saved views.
 
 ## 18. Field management is table-layout only `[internal]`
 

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -32,6 +32,7 @@ import { cog, plus, replace } from '@wordpress/icons';
 import CollectionDataViews from '../../components/CollectionDataViews';
 import AddFieldPopover from '../../components/fields/AddFieldPopover';
 import { COLLECTION_QUERY } from '../../collections';
+import { toDataViewId } from '../../hooks/fieldIds';
 import {
 	CollectionFieldsProvider,
 	useCollectionFieldsContext,
@@ -200,7 +201,11 @@ function CollectionCreator( { onCreate } ) {
 	);
 }
 
-function CollectionToolbarControl( { collectionId, onSelect } ) {
+function CollectionToolbarControl( {
+	collectionId,
+	onSelect,
+	onFieldCreated,
+} ) {
 	const { collection, isResolving } = useCollectionFieldsContext();
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
@@ -247,7 +252,10 @@ function CollectionToolbarControl( { collectionId, onSelect } ) {
 						<div className="cortext-data-view-toolbar-popover__content">
 							<AddFieldPopover
 								collectionId={ collectionId }
-								onCreate={ onClose }
+								onCreate={ ( created ) => {
+									onFieldCreated?.( created );
+									onClose();
+								} }
 							/>
 						</div>
 					) }
@@ -274,6 +282,7 @@ function CollectionInspectorControls( {
 	onSelect,
 	onChangeView,
 	onChangeAlign,
+	onFieldCreated,
 } ) {
 	const {
 		fields: availableFields,
@@ -393,7 +402,10 @@ function CollectionInspectorControls( {
 								<div className="cortext-data-view-toolbar-popover__content">
 									<AddFieldPopover
 										collectionId={ collectionId }
-										onCreate={ onClose }
+										onCreate={ ( created ) => {
+											onFieldCreated?.( created );
+											onClose();
+										} }
 									/>
 								</div>
 							) }
@@ -504,6 +516,7 @@ function CollectionInspectorControls( {
 export default function Edit( { attributes, setAttributes } ) {
 	const { collectionId, view, align } = attributes;
 	const blockProps = useBlockProps();
+	const [ revealFieldId, setRevealFieldId ] = useState( null );
 
 	const setView = useCallback(
 		( next ) => setAttributes( { view: next } ),
@@ -523,9 +536,23 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	const onSelectCollection = ( id ) => {
 		if ( id !== collectionId ) {
+			setRevealFieldId( null );
 			selectCollection( id );
 		}
 	};
+
+	const onFieldCreated = useCallback( ( created ) => {
+		const fieldId = toDataViewId( created?.id );
+		if ( fieldId ) {
+			setRevealFieldId( fieldId );
+		}
+	}, [] );
+
+	const onFieldRevealed = useCallback( ( fieldId ) => {
+		setRevealFieldId( ( current ) =>
+			current === fieldId ? null : current
+		);
+	}, [] );
 
 	if ( ! collectionId ) {
 		return (
@@ -561,6 +588,7 @@ export default function Edit( { attributes, setAttributes } ) {
 				<CollectionToolbarControl
 					collectionId={ collectionId }
 					onSelect={ onSelectCollection }
+					onFieldCreated={ onFieldCreated }
 				/>
 				<CollectionInspectorControls
 					collectionId={ collectionId }
@@ -569,11 +597,14 @@ export default function Edit( { attributes, setAttributes } ) {
 					onSelect={ onSelectCollection }
 					onChangeView={ setView }
 					onChangeAlign={ setAlign }
+					onFieldCreated={ onFieldCreated }
 				/>
 				<CollectionDataViews
 					collectionId={ collectionId }
 					view={ view }
 					onChangeView={ setView }
+					revealFieldId={ revealFieldId }
+					onFieldRevealed={ onFieldRevealed }
 					loading={ <Spinner /> }
 					invalid={
 						<Notice status="warning" isDismissible={ false }>

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -11,6 +11,7 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -37,7 +38,9 @@ import {
 	isDefaultVisibleField,
 	normalizeView,
 	pruneFiltersForFields,
+	withNewlyVisibleFields,
 } from './dataViewColumns';
+import { scrollToEndQuickly } from './dataViewScroll';
 import {
 	adjacentRowId,
 	getRowDetailMode,
@@ -45,6 +48,7 @@ import {
 } from './rowDetailUtils';
 import { useCollectionFieldsContext } from './CollectionFieldsContext';
 import { dataViewsFilterByForType } from '../hooks/fieldMapping';
+import { toDataViewId, toRecordId } from '../hooks/fieldIds';
 import useCollectionRows from '../hooks/useCollectionRows';
 import { useRecents } from '../hooks/useRecents';
 import { elementsFromOptions } from '../hooks/optionElements';
@@ -284,6 +288,8 @@ export default function CollectionDataViews( {
 	invalid,
 	error,
 	onReady,
+	revealFieldId = null,
+	onFieldRevealed,
 } ) {
 	const navigate = useNavigate();
 	const { fields, collection, slug, isResolving, fieldsResolved } =
@@ -331,6 +337,19 @@ export default function CollectionDataViews( {
 	const dataViewFields = availableFields;
 
 	const tableWrapperRef = useRef( null );
+	const [ localRevealFieldId, setLocalRevealFieldId ] = useState( null );
+	const pendingRevealFieldId = revealFieldId ?? localRevealFieldId;
+	const requestRevealCreatedField = useCallback( ( created ) => {
+		const fieldId = toDataViewId( created?.id );
+		if ( fieldId ) {
+			const wrapper =
+				tableWrapperRef.current?.querySelector( '.dataviews-wrapper' );
+			if ( wrapper ) {
+				scrollToEndQuickly( wrapper, { snapIfAtEnd: true } );
+			}
+			setLocalRevealFieldId( fieldId );
+		}
+	}, [] );
 	// editRequest is the "open this cell for editing" channel: cells that
 	// match its `{ rowId, fieldId }` flip to edit mode and clear it. Used
 	// for both the title-cell auto-open on a fresh row and Tab-driven
@@ -969,47 +988,16 @@ export default function CollectionDataViews( {
 			fields: availableFields,
 		} );
 
-		// Splice any editable field that just appeared in the schema
-		// (wasn't present on the previous sync) into its schema position
-		// in `view.fields`. The first render — `previouslyKnown` is
-		// `null` — leaves saved views alone; from then on, the diff
-		// detects fields the user just created via toolbar Add field
-		// or duplicate. Honors user-driven hides because the toggled-off
-		// field IS in `previouslyKnown` and gets skipped here. Inserting
-		// at the schema position (rather than appending) keeps a
-		// duplicated field next to its source instead of jumping to the
-		// end of the visible columns.
-		if ( previouslyKnown && currentFields.length > 0 ) {
-			const next = [ ...( normalized.fields ?? [] ) ];
-			let inserted = false;
-			for (
-				let schemaIdx = 0;
-				schemaIdx < availableFields.length;
-				schemaIdx++
-			) {
-				const f = availableFields[ schemaIdx ];
-				if (
-					! isDefaultVisibleField( f ) ||
-					previouslyKnown.has( f.id ) ||
-					next.includes( f.id )
-				) {
-					continue;
-				}
-				let insertAt = next.length;
-				for ( let i = schemaIdx - 1; i >= 0; i-- ) {
-					const idx = next.indexOf( availableFields[ i ].id );
-					if ( idx >= 0 ) {
-						insertAt = idx + 1;
-						break;
-					}
-				}
-				next.splice( insertAt, 0, f.id );
-				inserted = true;
-			}
-			if ( inserted ) {
-				normalized = { ...normalized, fields: next };
-			}
-		}
+		// Add fields that just appeared in the schema to `view.fields`.
+		// The first run leaves saved views alone. Fields created through
+		// Add field go at the end; duplicates and outside schema changes
+		// keep the old placement rule.
+		normalized = withNewlyVisibleFields(
+			normalized,
+			availableFields,
+			previouslyKnown,
+			pendingRevealFieldId
+		);
 
 		// Drop `__add_field` from older saved views. The add-field button now
 		// uses the DataViews actions header instead of a synthetic column.
@@ -1044,7 +1032,68 @@ export default function CollectionDataViews( {
 				filters: nextFilters,
 			} );
 		}
-	}, [ availableFields, isTableLayout, isResolving, fieldsResolved ] );
+	}, [
+		availableFields,
+		isTableLayout,
+		isResolving,
+		fieldsResolved,
+		pendingRevealFieldId,
+	] );
+
+	useLayoutEffect( () => {
+		if (
+			! isTableLayout ||
+			! pendingRevealFieldId ||
+			isResolving ||
+			! fieldsResolved
+		) {
+			return undefined;
+		}
+		if ( ! ( view?.fields ?? [] ).includes( pendingRevealFieldId ) ) {
+			return undefined;
+		}
+
+		const recordId = toRecordId( pendingRevealFieldId );
+		const reveal = () => {
+			const wrapper =
+				tableWrapperRef.current?.querySelector( '.dataviews-wrapper' );
+			if ( ! wrapper ) {
+				return false;
+			}
+			if ( recordId ) {
+				const marker = tableWrapperRef.current?.querySelector(
+					`[data-cortext-field-marker="${ recordId }"]`
+				);
+				if ( ! marker ) {
+					return false;
+				}
+			}
+			scrollToEndQuickly( wrapper );
+			if ( localRevealFieldId === pendingRevealFieldId ) {
+				setLocalRevealFieldId( null );
+			}
+			onFieldRevealed?.( pendingRevealFieldId );
+			return true;
+		};
+
+		if ( reveal() ) {
+			return undefined;
+		}
+
+		const frame = window.requestAnimationFrame( reveal );
+
+		return () => {
+			window.cancelAnimationFrame( frame );
+		};
+	}, [
+		fieldsResolved,
+		isResolving,
+		isTableLayout,
+		localRevealFieldId,
+		onFieldRevealed,
+		pendingRevealFieldId,
+		view?.fields,
+	] );
 
 	useEffect( () => {
 		if ( ! isResolving && rowsResolved ) {
@@ -1213,6 +1262,7 @@ export default function CollectionDataViews( {
 								view={ view }
 								onChangeView={ onChangeView }
 								onFieldOptionsSaved={ updateFieldOptions }
+								onFieldCreated={ requestRevealCreatedField }
 								onRowsChanged={ refresh }
 							/>
 						) }

--- a/src/components/dataViewColumns.js
+++ b/src/components/dataViewColumns.js
@@ -205,6 +205,57 @@ export function normalizeView( view, validIds, options = {} ) {
 	return nextView;
 }
 
+// Adds fields that just appeared in the schema to the saved column order.
+// Add field flows can push the new column to the end. Everything else keeps
+// the old placement rule, so duplicated fields still stay near their source.
+export function withNewlyVisibleFields(
+	view,
+	availableFields,
+	previouslyKnown,
+	explicitAppendFieldId = null
+) {
+	const currentFields = Array.isArray( view?.fields ) ? view.fields : [];
+	if ( ! previouslyKnown || currentFields.length === 0 ) {
+		return view;
+	}
+
+	const next = currentFields.slice();
+	let inserted = false;
+	const appendId =
+		typeof explicitAppendFieldId === 'string'
+			? explicitAppendFieldId
+			: null;
+
+	for ( let schemaIdx = 0; schemaIdx < availableFields.length; schemaIdx++ ) {
+		const field = availableFields[ schemaIdx ];
+		if (
+			! isDefaultVisibleField( field ) ||
+			previouslyKnown.has( field.id ) ||
+			next.includes( field.id )
+		) {
+			continue;
+		}
+		if ( field.id === appendId ) {
+			next.push( field.id );
+			inserted = true;
+			continue;
+		}
+
+		let insertAt = next.length;
+		for ( let i = schemaIdx - 1; i >= 0; i-- ) {
+			const idx = next.indexOf( availableFields[ i ].id );
+			if ( idx >= 0 ) {
+				insertAt = idx + 1;
+				break;
+			}
+		}
+		next.splice( insertAt, 0, field.id );
+		inserted = true;
+	}
+
+	return inserted ? { ...view, fields: next } : view;
+}
+
 // Applies a width to a single column. Always returns through the layout shape
 // the library reads. We pin `maxWidth` to the user's chosen width too, so the
 // saved shape remains defensive if DataViews changes its table sizing again.

--- a/src/components/dataViewScroll.js
+++ b/src/components/dataViewScroll.js
@@ -1,0 +1,54 @@
+function prefersReducedMotion() {
+	return (
+		typeof window !== 'undefined' &&
+		window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches
+	);
+}
+
+function isAtScrollEnd( scrollLeft, target ) {
+	return Math.abs( scrollLeft - target ) <= 2;
+}
+
+export function scrollToEndQuickly( wrapper, options = {} ) {
+	const maxScroll = wrapper.scrollWidth - wrapper.clientWidth;
+	if ( maxScroll <= 0 ) {
+		return;
+	}
+	const isRtl = window.getComputedStyle( wrapper ).direction === 'rtl';
+	const target = isRtl ? -maxScroll : maxScroll;
+	const start = wrapper.scrollLeft;
+	if ( options.snapIfAtEnd ) {
+		if ( isAtScrollEnd( start, target ) ) {
+			wrapper.scrollLeft = target;
+			wrapper.dataset.cortextRevealAtEnd = 'true';
+		}
+		return;
+	}
+	if ( wrapper.dataset.cortextRevealAtEnd === 'true' ) {
+		delete wrapper.dataset.cortextRevealAtEnd;
+		wrapper.scrollLeft = target;
+		return;
+	}
+	if ( prefersReducedMotion() ) {
+		wrapper.scrollLeft = target;
+		return;
+	}
+
+	const distance = target - start;
+	if ( distance === 0 ) {
+		return;
+	}
+
+	const duration = 180;
+	const startedAt = window.performance.now();
+	const easeOutCubic = ( t ) => 1 - Math.pow( 1 - t, 3 );
+
+	const animate = ( now ) => {
+		const progress = Math.min( 1, ( now - startedAt ) / duration );
+		wrapper.scrollLeft = start + distance * easeOutCubic( progress );
+		if ( progress < 1 ) {
+			window.requestAnimationFrame( animate );
+		}
+	};
+	window.requestAnimationFrame( animate );
+}

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -75,6 +75,7 @@ export default function ColumnHeaderActions( {
 	view,
 	onChangeView,
 	onFieldOptionsSaved,
+	onFieldCreated,
 	onRowsChanged,
 } ) {
 	const anchorRef = useRef( null );
@@ -166,7 +167,10 @@ export default function ColumnHeaderActions( {
 					);
 				}
 				return createPortal(
-					<AddFieldTrigger collectionId={ collectionId } />,
+					<AddFieldTrigger
+						collectionId={ collectionId }
+						onFieldCreated={ onFieldCreated }
+					/>,
 					target.th,
 					`${ target.key }-${ collectionId }`
 				);
@@ -766,7 +770,7 @@ function FieldActions( {
 	);
 }
 
-function AddFieldTrigger( { collectionId } ) {
+function AddFieldTrigger( { collectionId, onFieldCreated } ) {
 	return (
 		<span className="cortext-column-header-actions cortext-column-header-actions--add">
 			<Dropdown
@@ -785,7 +789,10 @@ function AddFieldTrigger( { collectionId } ) {
 					<div className="cortext-data-view-toolbar-popover__content">
 						<AddFieldPopover
 							collectionId={ collectionId }
-							onCreate={ onClose }
+							onCreate={ ( created ) => {
+								onFieldCreated?.( created );
+								onClose();
+							} }
 						/>
 					</div>
 				) }

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -19,6 +19,19 @@ async function deleteIfCreated( requestUtils, path ) {
 	}
 }
 
+async function expectTableScrolledToEnd( canvas ) {
+	const wrapper = canvas
+		.locator( '.cortext-data-view > .dataviews-wrapper' )
+		.first();
+	await expect
+		.poll( async () =>
+			wrapper.evaluate(
+				( el ) => el.scrollLeft + el.clientWidth >= el.scrollWidth - 2
+			)
+		)
+		.toBe( true );
+}
+
 async function createCollectionFixture( requestUtils ) {
 	const suffix = Date.now().toString( 36 ).slice( -4 );
 	const slug = `e2ebooks${ suffix }`;
@@ -2998,6 +3011,7 @@ test.describe( 'Collection view block', () => {
 				name: /Notes/,
 			} );
 			await expect( notesHeader ).toBeVisible();
+			await expectTableScrolledToEnd( canvas );
 
 			// `getByRole('button', { name })` would match both the visible
 			// combined-dropdown trigger (text label) and the transparent
@@ -3073,6 +3087,7 @@ test.describe( 'Collection view block', () => {
 			await expect(
 				canvas.getByRole( 'columnheader', { name: /Tags/ } )
 			).toBeVisible();
+			await expectTableScrolledToEnd( canvas );
 
 			// 6. Title's column doesn't get the schema-action takeover —
 			//    its `<th>` keeps DataViews' built-in trigger and has no

--- a/tests/js/components/CollectionDataViews.test.js
+++ b/tests/js/components/CollectionDataViews.test.js
@@ -1,0 +1,88 @@
+import { scrollToEndQuickly } from '../../../src/components/dataViewScroll';
+
+function makeScroller( { direction = 'ltr', scrollLeft = 0 } = {} ) {
+	const wrapper = document.createElement( 'div' );
+	Object.defineProperty( wrapper, 'clientWidth', {
+		value: 200,
+		configurable: true,
+	} );
+	Object.defineProperty( wrapper, 'scrollWidth', {
+		value: 800,
+		configurable: true,
+	} );
+	wrapper.scrollLeft = scrollLeft;
+	wrapper.style.direction = direction;
+	document.body.appendChild( wrapper );
+	return wrapper;
+}
+
+describe( 'scrollToEndQuickly', () => {
+	let matchMedia;
+	let requestAnimationFrame;
+
+	beforeEach( () => {
+		matchMedia = window.matchMedia;
+		window.matchMedia = jest.fn( () => ( { matches: true } ) );
+		requestAnimationFrame = window.requestAnimationFrame;
+	} );
+
+	afterEach( () => {
+		window.matchMedia = matchMedia;
+		window.requestAnimationFrame = requestAnimationFrame;
+		document.body.innerHTML = '';
+	} );
+
+	it( 'uses positive scrollLeft for LTR tables', () => {
+		const wrapper = makeScroller();
+
+		scrollToEndQuickly( wrapper );
+
+		expect( wrapper.scrollLeft ).toBe( 600 );
+	} );
+
+	it( 'uses negative scrollLeft for RTL tables', () => {
+		const wrapper = makeScroller( { direction: 'rtl' } );
+
+		scrollToEndQuickly( wrapper );
+
+		expect( wrapper.scrollLeft ).toBe( -600 );
+	} );
+
+	it( 'marks the scroller when the create starts at the end', () => {
+		const wrapper = makeScroller( { scrollLeft: 600 } );
+
+		scrollToEndQuickly( wrapper, { snapIfAtEnd: true } );
+
+		expect( wrapper.dataset.cortextRevealAtEnd ).toBe( 'true' );
+		expect( wrapper.scrollLeft ).toBe( 600 );
+	} );
+
+	it( 'does not pre-scroll when the user is away from the end', () => {
+		window.matchMedia = jest.fn( () => ( { matches: false } ) );
+		window.requestAnimationFrame = jest.fn();
+		const wrapper = makeScroller( { scrollLeft: 200 } );
+
+		scrollToEndQuickly( wrapper, { snapIfAtEnd: true } );
+
+		expect( wrapper.scrollLeft ).toBe( 200 );
+		expect( wrapper.dataset.cortextRevealAtEnd ).toBeUndefined();
+		expect( window.requestAnimationFrame ).not.toHaveBeenCalled();
+	} );
+
+	it( 'snaps to the new end without animating when already marked', () => {
+		window.matchMedia = jest.fn( () => ( { matches: false } ) );
+		window.requestAnimationFrame = jest.fn();
+		const wrapper = makeScroller( { scrollLeft: 600 } );
+		Object.defineProperty( wrapper, 'scrollWidth', {
+			value: 1000,
+			configurable: true,
+		} );
+		wrapper.dataset.cortextRevealAtEnd = 'true';
+
+		scrollToEndQuickly( wrapper );
+
+		expect( wrapper.scrollLeft ).toBe( 800 );
+		expect( wrapper.dataset.cortextRevealAtEnd ).toBeUndefined();
+		expect( window.requestAnimationFrame ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/js/components/dataViewColumns.test.js
+++ b/tests/js/components/dataViewColumns.test.js
@@ -10,6 +10,7 @@ import {
 	pruneFiltersForFields,
 	withColumnOrder,
 	withColumnWidth,
+	withNewlyVisibleFields,
 } from '../../../src/components/dataViewColumns';
 
 describe( 'getMinWidth', () => {
@@ -173,6 +174,18 @@ describe( 'normalizeView', () => {
 		expect( next.fields ).toEqual( [ TITLE_FIELD_ID, 'field-1' ] );
 	} );
 
+	it( 'drops the legacy add-field ghost column', () => {
+		const view = {
+			...baseView(),
+			fields: [ TITLE_FIELD_ID, 'field-1', '__add_field' ],
+		};
+		const next = normalizeView(
+			view,
+			new Set( [ TITLE_FIELD_ID, 'field-1' ] )
+		);
+		expect( next.fields ).toEqual( [ TITLE_FIELD_ID, 'field-1' ] );
+	} );
+
 	it( 'prepends the title id when fields filtered it out', () => {
 		const view = { ...baseView(), fields: [ 'field-1', 'field-2' ] };
 		const next = normalizeView(
@@ -321,6 +334,45 @@ describe( 'normalizeView', () => {
 			}
 		);
 		expect( next.calculations ).toEqual( { 'field-2': 'max' } );
+	} );
+} );
+
+describe( 'withNewlyVisibleFields', () => {
+	const fields = [
+		{ id: TITLE_FIELD_ID, editable: true },
+		{ id: 'field-1', recordId: 1, editable: true },
+		{ id: 'field-99', recordId: 99, editable: true },
+		{ id: 'field-2', recordId: 2, editable: true },
+	];
+	const known = new Set( [ TITLE_FIELD_ID, 'field-1', 'field-2' ] );
+
+	it( 'puts fields created from Add field at the end', () => {
+		const view = { fields: [ TITLE_FIELD_ID, 'field-1', 'field-2' ] };
+		const next = withNewlyVisibleFields( view, fields, known, 'field-99' );
+		expect( next.fields ).toEqual( [
+			TITLE_FIELD_ID,
+			'field-1',
+			'field-2',
+			'field-99',
+		] );
+	} );
+
+	it( 'keeps other schema additions near their schema neighbors', () => {
+		const view = { fields: [ TITLE_FIELD_ID, 'field-1', 'field-2' ] };
+		const next = withNewlyVisibleFields( view, fields, known );
+		expect( next.fields ).toEqual( [
+			TITLE_FIELD_ID,
+			'field-1',
+			'field-99',
+			'field-2',
+		] );
+	} );
+
+	it( 'leaves first-render saved views alone', () => {
+		const view = { fields: [ TITLE_FIELD_ID, 'field-1', 'field-2' ] };
+		expect( withNewlyVisibleFields( view, fields, null, 'field-99' ) ).toBe(
+			view
+		);
 	} );
 } );
 

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -106,8 +106,13 @@ jest.mock( '../../../../src/components/CollectionFieldsContext', () => ( {
 
 jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
 	__esModule: true,
-	default: ( { collectionId } ) => (
-		<div>{ `Add field for collection ${ collectionId }` }</div>
+	default: ( { collectionId, onCreate } ) => (
+		<div>
+			<div>{ `Add field for collection ${ collectionId }` }</div>
+			<button type="button" onClick={ () => onCreate?.( { id: 123 } ) }>
+				Create mock field
+			</button>
+		</div>
 	),
 } ) );
 
@@ -115,7 +120,7 @@ import ColumnHeaderActions from '../../../../src/components/fields/ColumnHeaderA
 import { useEntityRecord } from '@wordpress/core-data';
 import { useCollectionFieldsContext } from '../../../../src/components/CollectionFieldsContext';
 
-function Harness( { collectionId, recordId } ) {
+function Harness( { collectionId, recordId, onFieldCreated = jest.fn() } ) {
 	return (
 		<div className="cortext-data-view">
 			<table>
@@ -134,6 +139,7 @@ function Harness( { collectionId, recordId } ) {
 				collectionId={ collectionId }
 				view={ { fields: [] } }
 				onChangeView={ jest.fn() }
+				onFieldCreated={ onFieldCreated }
 			/>
 		</div>
 	);
@@ -164,6 +170,27 @@ describe( 'ColumnHeaderActions', () => {
 
 		rerender( <Harness collectionId={ 6 } /> );
 
+		await waitFor( () =>
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
+		);
+	} );
+
+	it( 'passes the created field out of the add-field dropdown', async () => {
+		const onFieldCreated = jest.fn();
+		render(
+			<Harness collectionId={ 5 } onFieldCreated={ onFieldCreated } />
+		);
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Add field' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'button', {
+				name: 'Create mock field',
+			} )
+		);
+
+		expect( onFieldCreated ).toHaveBeenCalledWith( { id: 123 } );
 		await waitFor( () =>
 			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
 		);


### PR DESCRIPTION
## What
Closes #95.

When you add a field to a table, the new column now lands at the end and the table scrolls over to show it right away. This works from the table `+` button, the block toolbar, and the inspector. 

## How

- Keeps duplicated fields near the original field.
- Appends fields created through Add field.
- Handles the table reveal in both LTR and RTL layouts.

## Testing Instructions

1. Open a collection table with enough columns to scroll sideways.
2. Add a field from the table `+` button and confirm the new column appears at the far end and is visible right away.
3. Add a field from the block toolbar or inspector and confirm the same behavior.
4. Switch to an RTL admin/content context, add a field, and confirm the table scrolls to the new column.

## Screen recording

https://github.com/user-attachments/assets/87e767a8-004c-4bd1-bcad-d69525311f3b

