### PR TITLE
Try: Compare PR benchmarks against main

### DIFF
--- a/.github/scripts/write-perf-bench-summary.php
+++ b/.github/scripts/write-perf-bench-summary.php
@@ -240,6 +240,11 @@ function comparison_lines( array $current, string $base_path, string $base_label
 		return $lines;
 	}
 
+	if ( ! reports_share_config( $current, $base['report'] ) ) {
+		$lines[] = 'Baseline stale: seed args or budget changed.';
+		return $lines;
+	}
+
 	$current_scenarios = is_array( $current['scenarios'] ?? null ) ? $current['scenarios'] : array();
 	$base_scenarios    = is_array( $base['report']['scenarios'] ?? null ) ? $base['report']['scenarios'] : array();
 	$rows              = array();
@@ -272,6 +277,16 @@ function comparison_lines( array $current, string $base_path, string $base_label
 			$rows
 		)
 	);
+}
+
+/**
+ * @param array<string,mixed> $current
+ * @param array<string,mixed> $base
+ */
+function reports_share_config( array $current, array $base ): bool {
+	return is_string( $current['seed_config_hash'] ?? null )
+		&& is_string( $base['seed_config_hash'] ?? null )
+		&& hash_equals( $base['seed_config_hash'], $current['seed_config_hash'] );
 }
 
 function escape_cell( mixed $value ): string {

--- a/.github/scripts/write-perf-bench-summary.php
+++ b/.github/scripts/write-perf-bench-summary.php
@@ -241,7 +241,7 @@ function comparison_lines( array $current, string $base_path, string $base_label
 	}
 
 	if ( ! reports_share_config( $current, $base['report'] ) ) {
-		$lines[] = 'Baseline stale: seed args or budget changed.';
+		$lines[] = 'Baseline stale: seed args or budget path changed.';
 		return $lines;
 	}
 
@@ -269,7 +269,7 @@ function comparison_lines( array $current, string $base_path, string $base_label
 		return $lines;
 	}
 
-	return array_merge(
+	$lines = array_merge(
 		$lines,
 		markdown_table(
 			array( 'Scenario', 'p50 ms', 'p95 ms', 'SQL p95', 'Memory p95' ),
@@ -277,6 +277,11 @@ function comparison_lines( array $current, string $base_path, string $base_label
 			$rows
 		)
 	);
+
+	$lines[] = '';
+	$lines[] = '_Deltas <10% on p50/p95 may be runner noise; SQL counts and memory are deterministic._';
+
+	return $lines;
 }
 
 /**

--- a/.github/scripts/write-perf-bench-summary.php
+++ b/.github/scripts/write-perf-bench-summary.php
@@ -1,0 +1,391 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+$args         = parse_args( $argv );
+$current_path = $args['current'] ?? 'artifacts/perf-bench.json';
+$base_path    = $args['base'] ?? '';
+$base_label   = $args['base-label'] ?? 'base';
+$summary_path = $args['summary'] ?? getenv( 'GITHUB_STEP_SUMMARY' );
+$comparison_only = isset( $args['comparison-only'] ) && '0' !== $args['comparison-only'];
+
+$output = build_output( $current_path, $base_path, $base_label, $comparison_only );
+echo $output;
+
+if ( is_string( $summary_path ) && '' !== $summary_path ) {
+	file_put_contents( $summary_path, $output, FILE_APPEND );
+}
+
+/**
+ * @param array<int,string> $argv
+ * @return array<string,string>
+ */
+function parse_args( array $argv ): array {
+	$args = array();
+
+	foreach ( array_slice( $argv, 1 ) as $arg ) {
+		if ( ! str_starts_with( $arg, '--' ) ) {
+			continue;
+		}
+
+		$parts = explode( '=', substr( $arg, 2 ), 2 );
+		$key   = $parts[0] ?? '';
+		if ( '' === $key ) {
+			continue;
+		}
+
+		$args[ $key ] = $parts[1] ?? '1';
+	}
+
+	return $args;
+}
+
+function build_output( string $current_path, string $base_path, string $base_label, bool $comparison_only ): string {
+	$current = load_report( $current_path, 'benchmark' );
+	if ( null === $current['report'] ) {
+		return $current['message'];
+	}
+
+	if ( $comparison_only ) {
+		if ( '' === $base_path ) {
+			return "Base benchmark produced no output.\n";
+		}
+
+		return implode( "\n", comparison_lines( $current['report'], $base_path, $base_label ) ) . "\n";
+	}
+
+	$lines = benchmark_summary_lines( $current['report'] );
+
+	if ( '' !== $base_path ) {
+		$lines[] = '';
+		$lines   = array_merge( $lines, comparison_lines( $current['report'], $base_path, $base_label ) );
+	}
+
+	return implode( "\n", $lines ) . "\n";
+}
+
+/**
+ * @return array{report:?array<string,mixed>,message:string}
+ */
+function load_report( string $path, string $label ): array {
+	if ( ! is_file( $path ) || 0 === filesize( $path ) ) {
+		return array(
+			'report'  => null,
+			'message' => ucfirst( $label ) . " produced no output.\n",
+		);
+	}
+
+	$raw = file_get_contents( $path );
+	if ( false === $raw ) {
+		return array(
+			'report'  => null,
+			'message' => "Could not read {$label} output.\n",
+		);
+	}
+
+	$json = extract_json_object( $raw );
+	if ( null === $json ) {
+		return array(
+			'report'  => null,
+			'message' => ucfirst( $label ) . " output had no JSON.\n",
+		);
+	}
+
+	$report = json_decode( $json, true );
+	if ( ! is_array( $report ) ) {
+		return array(
+			'report'  => null,
+			'message' => "Could not parse {$label} JSON: " . json_last_error_msg() . "\n",
+		);
+	}
+
+	return array(
+		'report'  => $report,
+		'message' => '',
+	);
+}
+
+function extract_json_object( string $raw ): ?string {
+	$json_start = strpos( $raw, '{' );
+	if ( false === $json_start ) {
+		return null;
+	}
+
+	$depth     = 0;
+	$in_string = false;
+	$escaped   = false;
+	$length    = strlen( $raw );
+
+	for ( $index = $json_start; $index < $length; $index++ ) {
+		$char = $raw[ $index ];
+
+		if ( $in_string ) {
+			if ( $escaped ) {
+				$escaped = false;
+			} elseif ( '\\' === $char ) {
+				$escaped = true;
+			} elseif ( '"' === $char ) {
+				$in_string = false;
+			}
+			continue;
+		}
+
+		if ( '"' === $char ) {
+			$in_string = true;
+		} elseif ( '{' === $char ) {
+			$depth++;
+		} elseif ( '}' === $char ) {
+			$depth--;
+			if ( 0 === $depth ) {
+				return substr( $raw, $json_start, $index - $json_start + 1 );
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
+ * @param array<string,mixed> $report
+ * @return array<int,string>
+ */
+function benchmark_summary_lines( array $report ): array {
+	$iterations = is_array( $report['iterations'] ?? null ) ? $report['iterations'] : array();
+	$lines      = array(
+		'## Performance benchmark',
+		'',
+		'- Result: ' . ( ! empty( $report['passed'] ) ? 'passed' : 'failed' ),
+		'- Total time: ' . number_value( $report['elapsedMs'] ?? null ) . ' ms',
+		'- Runs: ' . integer_value( $iterations['measured'] ?? null ) . ' measured, ' . integer_value( $iterations['warmup'] ?? null ) . ' warm-up',
+		'',
+	);
+
+	$scenario_rows = array();
+	foreach ( (array) ( $report['scenarios'] ?? array() ) as $scenario ) {
+		if ( ! is_array( $scenario ) ) {
+			continue;
+		}
+
+		$budget          = is_array( $scenario['budget'] ?? null ) ? $scenario['budget'] : array();
+		$scenario_rows[] = array(
+			! empty( $scenario['passed'] ) ? 'pass' : 'fail',
+			escape_cell( $scenario['label'] ?? '' ),
+			number_value( $scenario['p50_ms'] ?? null ),
+			number_value( $scenario['p95_ms'] ?? null ),
+			number_value( $budget['p95_ms'] ?? null ),
+			integer_value( $scenario['sql_queries_p50'] ?? null ),
+			integer_value( $scenario['sql_queries_p95'] ?? null ),
+			integer_value( $budget['sql_queries_p95'] ?? null ),
+			memory_value( $scenario['memory_bytes_p95'] ?? null ),
+			memory_value( $budget['memory_bytes_p95'] ?? null ),
+		);
+	}
+
+	$lines = array_merge(
+		$lines,
+		markdown_table(
+			array( 'Status', 'Scenario', 'p50 ms', 'p95 ms', 'p95 limit', 'SQL p50', 'SQL p95', 'SQL limit', 'Memory p95', 'Memory limit' ),
+			array( 'left', 'left', 'right', 'right', 'right', 'right', 'right', 'right', 'right', 'right' ),
+			$scenario_rows
+		)
+	);
+
+	if ( ! empty( $report['failures'] ) ) {
+		$lines[] = '';
+		$lines[] = '### Budget misses';
+		$lines[] = '';
+
+		$failure_rows = array();
+		foreach ( (array) $report['failures'] as $failure ) {
+			if ( ! is_array( $failure ) ) {
+				continue;
+			}
+
+			$metric         = (string) ( $failure['metric'] ?? '' );
+			$failure_rows[] = array(
+				escape_cell( $failure['scenario'] ?? '' ),
+				escape_cell( $metric ),
+				failure_value( $metric, $failure['actual'] ?? null ),
+				failure_value( $metric, $failure['budget'] ?? null ),
+			);
+		}
+
+		$lines = array_merge(
+			$lines,
+			markdown_table(
+				array( 'Scenario', 'Metric', 'Actual', 'Budget' ),
+				array( 'left', 'left', 'right', 'right' ),
+				$failure_rows
+			)
+		);
+	}
+
+	return $lines;
+}
+
+/**
+ * @param array<string,mixed> $current
+ * @return array<int,string>
+ */
+function comparison_lines( array $current, string $base_path, string $base_label ): array {
+	$base = load_report( $base_path, "{$base_label} benchmark" );
+	$escaped_base_label = escape_cell( $base_label );
+	$lines = array(
+		'## Performance vs ' . $escaped_base_label,
+		'',
+	);
+
+	if ( null === $base['report'] ) {
+		$lines[] = trim( $base['message'] );
+		return $lines;
+	}
+
+	$current_scenarios = is_array( $current['scenarios'] ?? null ) ? $current['scenarios'] : array();
+	$base_scenarios    = is_array( $base['report']['scenarios'] ?? null ) ? $base['report']['scenarios'] : array();
+	$rows              = array();
+
+	foreach ( $current_scenarios as $scenario_id => $scenario ) {
+		if ( ! is_array( $scenario ) || ! isset( $base_scenarios[ $scenario_id ] ) || ! is_array( $base_scenarios[ $scenario_id ] ) ) {
+			continue;
+		}
+
+		$base_scenario = $base_scenarios[ $scenario_id ];
+		$rows[]        = array(
+			escape_cell( $scenario['label'] ?? $scenario_id ),
+			comparison_value( $scenario['p50_ms'] ?? null, $base_scenario['p50_ms'] ?? null, 'number' ),
+			comparison_value( $scenario['p95_ms'] ?? null, $base_scenario['p95_ms'] ?? null, 'number' ),
+			comparison_value( $scenario['sql_queries_p95'] ?? null, $base_scenario['sql_queries_p95'] ?? null, 'integer' ),
+			comparison_value( $scenario['memory_bytes_p95'] ?? null, $base_scenario['memory_bytes_p95'] ?? null, 'memory' ),
+		);
+	}
+
+	if ( count( $rows ) === 0 ) {
+		$lines[] = 'No shared scenarios to compare.';
+		return $lines;
+	}
+
+	return array_merge(
+		$lines,
+		markdown_table(
+			array( 'Scenario', 'p50 ms', 'p95 ms', 'SQL p95', 'Memory p95' ),
+			array( 'left', 'right', 'right', 'right', 'right' ),
+			$rows
+		)
+	);
+}
+
+function escape_cell( mixed $value ): string {
+	return str_replace( array( '|', "\n", "\r" ), array( '\\|', ' ', ' ' ), (string) $value );
+}
+
+function number_value( mixed $value, int $decimals = 3 ): string {
+	return is_numeric( $value ) ? number_format( (float) $value, $decimals, '.', '' ) : 'n/a';
+}
+
+function integer_value( mixed $value ): string {
+	return is_numeric( $value ) ? (string) (int) $value : 'n/a';
+}
+
+function memory_value( mixed $value ): string {
+	return is_numeric( $value ) ? number_format( (float) $value / 1048576, 1, '.', '' ) . ' MiB' : 'n/a';
+}
+
+function failure_value( string $metric, mixed $value ): string {
+	if ( 'memory_bytes_p95' === $metric ) {
+		return memory_value( $value );
+	}
+
+	if ( str_starts_with( $metric, 'sql_queries_' ) ) {
+		return integer_value( $value );
+	}
+
+	return number_value( $value );
+}
+
+function comparison_value( mixed $current, mixed $base, string $type ): string {
+	if ( ! is_numeric( $current ) || ! is_numeric( $base ) ) {
+		return 'n/a';
+	}
+
+	return formatted_value( $current, $type ) . ' (Δ ' . delta_value( $current, $base, $type ) . ')';
+}
+
+function formatted_value( mixed $value, string $type ): string {
+	return match ( $type ) {
+		'integer' => integer_value( $value ),
+		'memory'  => memory_value( $value ),
+		default   => number_value( $value ),
+	};
+}
+
+function delta_value( mixed $current, mixed $base, string $type ): string {
+	if ( ! is_numeric( $current ) || ! is_numeric( $base ) ) {
+		return 'n/a';
+	}
+
+	$current_float = (float) $current;
+	$base_float    = (float) $base;
+	$delta         = $current_float - $base_float;
+	$percent       = 0.0 !== $base_float ? $delta / $base_float * 100 : null;
+	$delta_text    = match ( $type ) {
+		'integer' => signed_number( $delta, 0 ),
+		'memory'  => signed_number( $delta / 1048576, 1 ) . ' MiB',
+		default   => signed_number( $delta, 3 ) . ' ms',
+	};
+
+	if ( null === $percent ) {
+		return $delta_text;
+	}
+
+	return $delta_text . ', ' . signed_number( $percent, 1 ) . '%';
+}
+
+function signed_number( float $value, int $decimals ): string {
+	$formatted = number_format( $value, $decimals, '.', '' );
+	if ( $value > 0 ) {
+		return '+' . $formatted;
+	}
+
+	return $formatted;
+}
+
+/**
+ * @param array<int,string> $headers
+ * @param array<int,string> $alignments
+ * @param array<int,array<int,string>> $rows
+ * @return array<int,string>
+ */
+function markdown_table( array $headers, array $alignments, array $rows ): array {
+	$widths = array_map( 'strlen', $headers );
+
+	foreach ( $rows as $row ) {
+		foreach ( $row as $index => $cell ) {
+			$widths[ $index ] = max( $widths[ $index ] ?? 0, strlen( $cell ) );
+		}
+	}
+
+	foreach ( $widths as $index => $width ) {
+		$widths[ $index ] = max( 3, $width );
+	}
+
+	$format_row = static function ( array $row ) use ( $alignments, $widths ): string {
+		foreach ( $row as $index => $cell ) {
+			$pad_type      = 'right' === ( $alignments[ $index ] ?? 'left' ) ? STR_PAD_LEFT : STR_PAD_RIGHT;
+			$row[ $index ] = str_pad( $cell, $widths[ $index ], ' ', $pad_type );
+		}
+
+		return '| ' . implode( ' | ', $row ) . ' |';
+	};
+
+	$separator = array();
+	foreach ( $widths as $index => $width ) {
+		$separator[] = 'right' === ( $alignments[ $index ] ?? 'left' )
+			? str_repeat( '-', $width - 1 ) . ':'
+			: str_repeat( '-', $width );
+	}
+
+	return array_merge(
+		array( $format_row( $headers ), '| ' . implode( ' | ', $separator ) . ' |' ),
+		array_map( $format_row, $rows )
+	);
+}

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -3,12 +3,28 @@ name: Performance benchmark
 on:
     push:
         branches: [main]
+        paths:
+            - includes/CLI/**
+            - src/**
+            - tests/e2e/specs/perf-ui.spec.js
+            - .github/workflows/perf-bench.yml
+            - .github/scripts/write-perf-bench-summary.php
     pull_request:
         branches: [main]
+        paths:
+            - includes/CLI/**
+            - src/**
+            - tests/e2e/specs/perf-ui.spec.js
+            - .github/workflows/perf-bench.yml
+            - .github/scripts/write-perf-bench-summary.php
+    workflow_dispatch:
 
 permissions:
     contents: read
     issues: write
+
+env:
+    CORTEXT_PERF_UI: ${{ vars.CORTEXT_PERF_UI || '0' }}
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -111,6 +127,22 @@ jobs:
                     --fail-on-budget \
                     --pretty | tee artifacts/perf-bench.json
 
+            - name: Run UI performance benchmark
+              if: github.event_name == 'workflow_dispatch' || env.CORTEXT_PERF_UI == '1'
+              env:
+                  WP_BASE_URL: http://localhost:8888
+              run: |
+                  set -euo pipefail
+
+                  if [ ! -f tests/e2e/specs/perf-ui.spec.js ]; then
+                    echo "No UI performance spec found."
+                    exit 0
+                  fi
+
+                  pnpm exec playwright install --with-deps chromium
+                  pnpm run build
+                  pnpm exec wp-scripts test-playwright --config playwright.config.js tests/e2e/specs/perf-ui.spec.js
+
             - name: Write benchmark summaries
               if: always()
               env:
@@ -172,5 +204,7 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: perf-bench
-                  path: artifacts/perf-bench*.json
+                  path: |
+                      artifacts/perf-bench*.json
+                      playwright-report/
                   retention-days: 7

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -20,6 +20,7 @@ on:
     workflow_dispatch:
 
 permissions:
+    actions: read
     contents: read
     issues: write
 
@@ -34,9 +35,49 @@ jobs:
     performance-bench:
         name: Performance benchmark
         runs-on: ubuntu-latest
-        timeout-minutes: 40
+        timeout-minutes: 20
         steps:
             - uses: actions/checkout@v4
+
+            - name: Download main benchmark baseline
+              if: github.event_name == 'pull_request'
+              continue-on-error: true
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPOSITORY: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  mkdir -p artifacts/main-baseline
+                  run_id="$(gh run list \
+                    --repo "$REPOSITORY" \
+                    --workflow perf-bench.yml \
+                    --branch main \
+                    --status completed \
+                    --limit 1 \
+                    --json databaseId \
+                    --jq '.[0].databaseId // ""')"
+
+                  if [ -z "$run_id" ]; then
+                    echo "No completed main benchmark run found."
+                    exit 0
+                  fi
+
+                  if ! gh run download "$run_id" \
+                    --repo "$REPOSITORY" \
+                    --name perf-bench-main \
+                    --dir artifacts/main-baseline; then
+                    echo "No main benchmark artifact found."
+                    exit 0
+                  fi
+
+                  base_json="$(find artifacts/main-baseline -name 'perf-bench.json' -type f | head -n 1)"
+                  if [ -z "$base_json" ]; then
+                    echo "Main benchmark artifact had no perf-bench.json."
+                    exit 0
+                  fi
+
+                  cp "$base_json" artifacts/perf-bench-base.json
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -58,45 +99,6 @@ jobs:
               with:
                   node-version: '24.15'
                   cache: 'pnpm'
-
-            - name: Benchmark main
-              if: github.event_name == 'pull_request'
-              continue-on-error: true
-              env:
-                  BASE_REF: main
-                  HEAD_SHA: ${{ github.sha }}
-              run: |
-                  set -euo pipefail
-
-                  restore_head() {
-                    git checkout --force "$HEAD_SHA"
-                  }
-                  trap restore_head EXIT
-
-                  mkdir -p artifacts
-                  git fetch --no-tags --depth=1 origin "$BASE_REF"
-                  git checkout --force FETCH_HEAD
-
-                  composer install --no-interaction --prefer-dist --no-dev
-                  pnpm install --frozen-lockfile
-
-                  pnpm run env:start
-                  pnpm exec wp-env run cli wp cortext perf-seed \
-                    --reset \
-                    --force \
-                    --collections=3 \
-                    --rows=1250 \
-                    --fields=8 \
-                    --wide-fields=40 \
-                    --relations=1 \
-                    --rollups=1
-
-                  set -o pipefail
-                  pnpm exec wp-env run cli wp cortext perf-bench \
-                    --iterations=5 \
-                    --warmup=1 \
-                    --budget=includes/CLI/perf-budgets.json \
-                    --pretty | tee artifacts/perf-bench-base.json
 
             - run: composer install --no-interaction --prefer-dist --no-dev
 
@@ -165,6 +167,15 @@ jobs:
                       --comparison-only \
                       --summary= > artifacts/perf-bench-comment-body.md
                   fi
+
+            - name: Upload main benchmark baseline
+              if: always() && github.event_name == 'push'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: perf-bench-main
+                  path: artifacts/perf-bench.json
+                  if-no-files-found: ignore
+                  retention-days: 90
 
             - name: Post PR benchmark comment
               if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -132,6 +132,7 @@ jobs:
             - name: Run UI performance benchmark
               if: github.event_name == 'workflow_dispatch' || env.CORTEXT_PERF_UI == '1'
               env:
+                  # The benchmark workflow starts the dev wp-env, which serves WordPress on 8888.
                   WP_BASE_URL: http://localhost:8888
               run: |
                   set -euo pipefail

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -4,6 +4,11 @@ on:
     push:
         branches: [main]
     pull_request:
+        branches: [main]
+
+permissions:
+    contents: read
+    issues: write
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,7 +18,7 @@ jobs:
     performance-bench:
         name: Performance benchmark
         runs-on: ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: 40
         steps:
             - uses: actions/checkout@v4
 
@@ -28,8 +33,6 @@ jobs:
                   path: ~/.composer/cache
                   key: composer-${{ hashFiles('composer.lock') }}
 
-            - run: composer install --no-interaction --prefer-dist --no-dev
-
             - uses: pnpm/action-setup@v4
               with:
                   version: 11.0.8
@@ -39,6 +42,47 @@ jobs:
               with:
                   node-version: '24.15'
                   cache: 'pnpm'
+
+            - name: Benchmark main
+              if: github.event_name == 'pull_request'
+              continue-on-error: true
+              env:
+                  BASE_REF: main
+                  HEAD_SHA: ${{ github.sha }}
+              run: |
+                  set -euo pipefail
+
+                  restore_head() {
+                    git checkout --force "$HEAD_SHA"
+                  }
+                  trap restore_head EXIT
+
+                  mkdir -p artifacts
+                  git fetch --no-tags --depth=1 origin "$BASE_REF"
+                  git checkout --force FETCH_HEAD
+
+                  composer install --no-interaction --prefer-dist --no-dev
+                  pnpm install --frozen-lockfile
+
+                  pnpm run env:start
+                  pnpm exec wp-env run cli wp cortext perf-seed \
+                    --reset \
+                    --force \
+                    --collections=3 \
+                    --rows=1250 \
+                    --fields=8 \
+                    --wide-fields=40 \
+                    --relations=1 \
+                    --rollups=1
+
+                  set -o pipefail
+                  pnpm exec wp-env run cli wp cortext perf-bench \
+                    --iterations=5 \
+                    --warmup=1 \
+                    --budget=includes/CLI/perf-budgets.json \
+                    --pretty | tee artifacts/perf-bench-base.json
+
+            - run: composer install --no-interaction --prefer-dist --no-dev
 
             - run: pnpm install --frozen-lockfile
 
@@ -67,198 +111,66 @@ jobs:
                     --fail-on-budget \
                     --pretty | tee artifacts/perf-bench.json
 
-            - name: Write benchmark summary
+            - name: Write benchmark summaries
               if: always()
+              env:
+                  BASE_REF: main
               run: |
-                  if [ ! -s artifacts/perf-bench.json ]; then
-                    echo "The benchmark did not write any output."
-                    echo "The benchmark did not write any output." >> "$GITHUB_STEP_SUMMARY"
+                  mkdir -p artifacts
+
+                  args=(--current=artifacts/perf-bench.json)
+                  if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+                    args+=(--base=artifacts/perf-bench-base.json --base-label="${BASE_REF:-base}")
+                  fi
+
+                  php .github/scripts/write-perf-bench-summary.php "${args[@]}" | tee artifacts/perf-bench-summary.md
+
+                  if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+                    php .github/scripts/write-perf-bench-summary.php \
+                      --current=artifacts/perf-bench.json \
+                      --base=artifacts/perf-bench-base.json \
+                      --base-label=main \
+                      --comparison-only \
+                      --summary= > artifacts/perf-bench-comment-body.md
+                  fi
+
+            - name: Post PR benchmark comment
+              if: always() && github.event_name == 'pull_request'
+              continue-on-error: true
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPOSITORY: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  if [ ! -s artifacts/perf-bench-comment-body.md ]; then
                     exit 0
                   fi
 
-                  php <<'PHP'
-                  <?php
-                  $summary_path = getenv( 'GITHUB_STEP_SUMMARY' );
-                  $raw          = file_get_contents( 'artifacts/perf-bench.json' );
-                  $json_start   = strpos( $raw, '{' );
+                  marker='<!-- cortext-perf-bench-comment -->'
+                  comment_file='artifacts/perf-bench-comment.md'
+                  {
+                    echo "$marker"
+                    cat artifacts/perf-bench-comment-body.md
+                  } > "$comment_file"
 
-                  if ( false === $json_start ) {
-                      $message = "The benchmark output did not include JSON.\n";
-                      echo $message;
-                      file_put_contents( $summary_path, $message, FILE_APPEND );
-                      exit( 0 );
-                  }
+                  comment_id="$(gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+                    --paginate \
+                    --jq '.[] | select(.user.type == "Bot" and (.body | contains("<!-- cortext-perf-bench-comment -->"))) | .id' \
+                    | tail -n 1)"
 
-                  $json      = null;
-                  $depth     = 0;
-                  $in_string = false;
-                  $escaped   = false;
-                  $length    = strlen( $raw );
-                  for ( $index = $json_start; $index < $length; $index++ ) {
-                      $char = $raw[ $index ];
-
-                      if ( $in_string ) {
-                          if ( $escaped ) {
-                              $escaped = false;
-                          } elseif ( '\\' === $char ) {
-                              $escaped = true;
-                          } elseif ( '"' === $char ) {
-                              $in_string = false;
-                          }
-                          continue;
-                      }
-
-                      if ( '"' === $char ) {
-                          $in_string = true;
-                      } elseif ( '{' === $char ) {
-                          $depth++;
-                      } elseif ( '}' === $char ) {
-                          $depth--;
-                          if ( 0 === $depth ) {
-                              $json = substr( $raw, $json_start, $index - $json_start + 1 );
-                              break;
-                          }
-                      }
-                  }
-
-                  if ( null === $json ) {
-                      $message = "The benchmark JSON could not be found in the wp-env output.\n";
-                      echo $message;
-                      file_put_contents( $summary_path, $message, FILE_APPEND );
-                      exit( 0 );
-                  }
-
-                  $report = json_decode( $json, true );
-                  if ( ! is_array( $report ) ) {
-                      $message = "The benchmark JSON could not be parsed: " . json_last_error_msg() . "\n";
-                      echo $message;
-                      file_put_contents( $summary_path, $message, FILE_APPEND );
-                      exit( 0 );
-                  }
-
-                  $escape = static function ( mixed $value ): string {
-                      return str_replace( array( '|', "\n", "\r" ), array( '\\|', ' ', ' ' ), (string) $value );
-                  };
-                  $number = static function ( mixed $value, int $decimals = 3 ): string {
-                      return is_numeric( $value ) ? number_format( (float) $value, $decimals, '.', '' ) : 'n/a';
-                  };
-                  $integer = static function ( mixed $value ): string {
-                      return is_numeric( $value ) ? (string) (int) $value : 'n/a';
-                  };
-                  $memory = static function ( mixed $value ): string {
-                      return is_numeric( $value ) ? number_format( (float) $value / 1048576, 1, '.', '' ) . ' MiB' : 'n/a';
-                  };
-                  $failure_value = static function ( string $metric, mixed $value ) use ( $number, $integer, $memory ): string {
-                      if ( 'memory_bytes_p95' === $metric ) {
-                          return $memory( $value );
-                      }
-                      if ( str_starts_with( $metric, 'sql_queries_' ) ) {
-                          return $integer( $value );
-                      }
-                      return $number( $value );
-                  };
-                  $markdown_table = static function ( array $headers, array $alignments, array $rows ): array {
-                      $widths = array_map( 'strlen', $headers );
-
-                      foreach ( $rows as $row ) {
-                          foreach ( $row as $index => $cell ) {
-                              $widths[ $index ] = max( $widths[ $index ] ?? 0, strlen( $cell ) );
-                          }
-                      }
-
-                      foreach ( $widths as $index => $width ) {
-                          $widths[ $index ] = max( 3, $width );
-                      }
-
-                      $format_row = static function ( array $row ) use ( $alignments, $widths ): string {
-                          foreach ( $row as $index => $cell ) {
-                              $pad_type      = 'right' === ( $alignments[ $index ] ?? 'left' ) ? STR_PAD_LEFT : STR_PAD_RIGHT;
-                              $row[ $index ] = str_pad( $cell, $widths[ $index ], ' ', $pad_type );
-                          }
-
-                          return '| ' . implode( ' | ', $row ) . ' |';
-                      };
-
-                      $separator = array();
-                      foreach ( $widths as $index => $width ) {
-                          $separator[] = 'right' === ( $alignments[ $index ] ?? 'left' )
-                              ? str_repeat( '-', $width - 1 ) . ':'
-                              : str_repeat( '-', $width );
-                      }
-
-                      return array_merge(
-                          array( $format_row( $headers ), '| ' . implode( ' | ', $separator ) . ' |' ),
-                          array_map( $format_row, $rows )
-                      );
-                  };
-
-                  $iterations = is_array( $report['iterations'] ?? null ) ? $report['iterations'] : array();
-                  $lines      = array(
-                      '## Performance benchmark',
-                      '',
-                      '- Result: ' . ( ! empty( $report['passed'] ) ? 'passed' : 'failed' ),
-                      '- Total time: ' . $number( $report['elapsedMs'] ?? null ) . ' ms',
-                      '- Runs: ' . $integer( $iterations['measured'] ?? null ) . ' measured, ' . $integer( $iterations['warmup'] ?? null ) . ' warm-up',
-                      '',
-                  );
-
-                  $scenario_rows = array();
-                  foreach ( (array) ( $report['scenarios'] ?? array() ) as $scenario ) {
-                      $budget          = is_array( $scenario['budget'] ?? null ) ? $scenario['budget'] : array();
-                      $scenario_rows[] = array(
-                          ! empty( $scenario['passed'] ) ? 'pass' : 'fail',
-                          $escape( $scenario['label'] ?? '' ),
-                          $number( $scenario['p50_ms'] ?? null ),
-                          $number( $scenario['p95_ms'] ?? null ),
-                          $number( $budget['p95_ms'] ?? null ),
-                          $integer( $scenario['sql_queries_p50'] ?? null ),
-                          $integer( $scenario['sql_queries_p95'] ?? null ),
-                          $integer( $budget['sql_queries_p95'] ?? null ),
-                          $memory( $scenario['memory_bytes_p95'] ?? null ),
-                          $memory( $budget['memory_bytes_p95'] ?? null )
-                      );
-                  }
-                  $lines = array_merge(
-                      $lines,
-                      $markdown_table(
-                          array( 'Status', 'Scenario', 'p50 ms', 'p95 ms', 'p95 limit', 'SQL p50', 'SQL p95', 'SQL limit', 'Memory p95', 'Memory limit' ),
-                          array( 'left', 'left', 'right', 'right', 'right', 'right', 'right', 'right', 'right', 'right' ),
-                          $scenario_rows
-                      )
-                  );
-
-                  if ( ! empty( $report['failures'] ) ) {
-                      $lines[] = '';
-                      $lines[] = '### Budget misses';
-                      $lines[] = '';
-
-                      $failure_rows = array();
-                      foreach ( (array) $report['failures'] as $failure ) {
-                          $failure_rows[] = array(
-                              $escape( $failure['scenario'] ?? '' ),
-                              $escape( $failure['metric'] ?? '' ),
-                              $failure_value( (string) ( $failure['metric'] ?? '' ), $failure['actual'] ?? null ),
-                              $failure_value( (string) ( $failure['metric'] ?? '' ), $failure['budget'] ?? null )
-                          );
-                      }
-                      $lines = array_merge(
-                          $lines,
-                          $markdown_table(
-                              array( 'Scenario', 'Metric', 'Actual', 'Budget' ),
-                              array( 'left', 'left', 'right', 'right' ),
-                              $failure_rows
-                          )
-                      );
-                  }
-
-                  $output = implode( "\n", $lines ) . "\n";
-                  echo $output;
-                  file_put_contents( $summary_path, $output, FILE_APPEND );
-                  PHP
+                  if [ -n "$comment_id" ]; then
+                    gh api --method PATCH "repos/$REPOSITORY/issues/comments/$comment_id" \
+                      --field "body=@$comment_file" >/dev/null
+                  else
+                    gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+                      --field "body=@$comment_file" >/dev/null
+                  fi
 
             - if: failure()
               uses: actions/upload-artifact@v4
               with:
                   name: perf-bench
-                  path: artifacts/perf-bench.json
+                  path: artifacts/perf-bench*.json
                   retention-days: 7

--- a/includes/CLI/PerfBench.php
+++ b/includes/CLI/PerfBench.php
@@ -359,7 +359,7 @@ final class PerfBench {
 
 		return array(
 			'version'          => 1,
-			'seed_config_hash' => self::benchmark_config_hash( $manifest, $budget, $budget_path ),
+			'seed_config_hash' => self::benchmark_config_hash( $manifest, $budget_path ),
 			'elapsedMs'        => self::elapsed_ms( $started_at ),
 			'dataset'          => self::public_dataset_summary( $manifest ),
 			'iterations'       => array(
@@ -1501,10 +1501,9 @@ final class PerfBench {
 	 * Hashes the benchmark config that has to match before comparing runs.
 	 *
 	 * @param array<string,mixed> $manifest    Dataset manifest.
-	 * @param array<string,mixed> $budget      Budget config.
 	 * @param string              $budget_path Budget file path.
 	 */
-	private static function benchmark_config_hash( array $manifest, array $budget, string $budget_path ): string {
+	private static function benchmark_config_hash( array $manifest, string $budget_path ): string {
 		$config = isset( $manifest['config'] ) && is_array( $manifest['config'] )
 			? self::normalize_int_map( $manifest['config'] )
 			: array();
@@ -1515,7 +1514,6 @@ final class PerfBench {
 					'seed'        => (string) ( $manifest['seed'] ?? self::DATASET_SEED ),
 					'seed_args'   => $config,
 					'budget_path' => self::relative_local_path( $budget_path ),
-					'budget'      => $budget,
 				),
 				JSON_UNESCAPED_SLASHES
 			)

--- a/includes/CLI/PerfBench.php
+++ b/includes/CLI/PerfBench.php
@@ -151,15 +151,16 @@ final class PerfBench {
 	public static function bench( array $args, array $assoc_args ): void {
 		unset( $args );
 
-		$bench      = new self();
-		$iterations = self::flag_int( $assoc_args, 'iterations', self::DEFAULT_ITERATIONS, 1 );
-		$warmup     = self::flag_int( $assoc_args, 'warmup', self::DEFAULT_WARMUP, 0 );
-		$budget     = $bench->load_budget(
+		$bench       = new self();
+		$iterations  = self::flag_int( $assoc_args, 'iterations', self::DEFAULT_ITERATIONS, 1 );
+		$warmup      = self::flag_int( $assoc_args, 'warmup', self::DEFAULT_WARMUP, 0 );
+		$budget_path = self::normalize_local_path(
 			(string) ( $assoc_args['budget'] ?? CORTEXT_PATH . 'includes/CLI/perf-budgets.json' )
 		);
+		$budget      = $bench->load_budget( $budget_path );
 
 		try {
-			$result = $bench->run_benchmark( $iterations, $warmup, $budget );
+			$result = $bench->run_benchmark( $iterations, $warmup, $budget, $budget_path );
 		} catch ( RuntimeException $exception ) {
 			\WP_CLI::error( $exception->getMessage() );
 			return;
@@ -305,10 +306,11 @@ final class PerfBench {
 	 * @param int                 $iterations Measured iterations.
 	 * @param int                 $warmup     Warm-up iterations.
 	 * @param array<string,mixed> $budget     Budget config.
+	 * @param string              $budget_path Budget file path.
 	 * @return array<string,mixed> Benchmark report.
 	 * @throws RuntimeException When the dataset is missing or a scenario fails.
 	 */
-	public function run_benchmark( int $iterations, int $warmup, array $budget ): array {
+	public function run_benchmark( int $iterations, int $warmup, array $budget, string $budget_path = 'includes/CLI/perf-budgets.json' ): array {
 		$started_at = hrtime( true );
 		$manifest   = get_option( self::DATASET_OPTION );
 		if ( ! is_array( $manifest ) || ! $this->manifest_is_usable( $manifest ) ) {
@@ -356,16 +358,17 @@ final class PerfBench {
 		$budget_result = self::apply_budgets( $summaries, $budget );
 
 		return array(
-			'version'    => 1,
-			'elapsedMs'  => self::elapsed_ms( $started_at ),
-			'dataset'    => self::public_dataset_summary( $manifest ),
-			'iterations' => array(
+			'version'          => 1,
+			'seed_config_hash' => self::benchmark_config_hash( $manifest, $budget, $budget_path ),
+			'elapsedMs'        => self::elapsed_ms( $started_at ),
+			'dataset'          => self::public_dataset_summary( $manifest ),
+			'iterations'       => array(
 				'warmup'   => $warmup,
 				'measured' => $iterations,
 			),
-			'passed'     => $budget_result['passed'],
-			'failures'   => $budget_result['failures'],
-			'scenarios'  => $budget_result['scenarios'],
+			'passed'           => $budget_result['passed'],
+			'failures'         => $budget_result['failures'],
+			'scenarios'        => $budget_result['scenarios'],
 		);
 	}
 
@@ -1425,9 +1428,7 @@ final class PerfBench {
 	 * @throws RuntimeException When the budget file cannot be loaded.
 	 */
 	private function load_budget( string $path ): array {
-		if ( ! str_starts_with( $path, '/' ) ) {
-			$path = CORTEXT_PATH . ltrim( $path, '/' );
-		}
+		$path = self::normalize_local_path( $path );
 		if ( ! file_exists( $path ) ) {
 			throw new RuntimeException( esc_html( "Budget file not found: {$path}" ) );
 		}
@@ -1494,6 +1495,48 @@ final class PerfBench {
 			'rollups'             => (int) ( $config['rollups'] ?? 0 ),
 			'collectionRows'      => $collections,
 		);
+	}
+
+	/**
+	 * Hashes the benchmark config that has to match before comparing runs.
+	 *
+	 * @param array<string,mixed> $manifest    Dataset manifest.
+	 * @param array<string,mixed> $budget      Budget config.
+	 * @param string              $budget_path Budget file path.
+	 */
+	private static function benchmark_config_hash( array $manifest, array $budget, string $budget_path ): string {
+		$config = isset( $manifest['config'] ) && is_array( $manifest['config'] )
+			? self::normalize_int_map( $manifest['config'] )
+			: array();
+
+		return sha1(
+			(string) wp_json_encode(
+				array(
+					'seed'        => (string) ( $manifest['seed'] ?? self::DATASET_SEED ),
+					'seed_args'   => $config,
+					'budget_path' => self::relative_local_path( $budget_path ),
+					'budget'      => $budget,
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+	}
+
+	private static function normalize_local_path( string $path ): string {
+		if ( str_starts_with( $path, '/' ) ) {
+			return $path;
+		}
+
+		return CORTEXT_PATH . ltrim( $path, '/' );
+	}
+
+	private static function relative_local_path( string $path ): string {
+		$path = self::normalize_local_path( $path );
+		if ( str_starts_with( $path, CORTEXT_PATH ) ) {
+			return ltrim( substr( $path, strlen( CORTEXT_PATH ) ), '/' );
+		}
+
+		return $path;
 	}
 
 	/**


### PR DESCRIPTION
## What

PRs now get a benchmark comment that compares the branch against the latest `main` run. That gives reviewers the numbers in context instead of making them read raw timings on their own. The workflow also saves `main` results for future PRs, skips unrelated file changes, and can run the UI performance spec when that check is enabled.

The comparison comment includes a short note that small p50/p95 deltas can just be runner noise.

## How

- Downloads the latest `main` benchmark artifact during PR runs.
- Uses the same PHP summary script for the workflow summary and PR comment.
- Compares runs when the seed config and budget file path match, so budget threshold tweaks do not make the baseline stale.

## Testing Instructions

1. Open a PR that changes a performance-related path.
2. Confirm the Performance benchmark workflow runs.
3. Confirm the workflow summary shows the benchmark table.
4. Confirm the PR gets a benchmark comparison comment, or updates the existing one.
