### PR TITLE
Polish DataView block layout

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -219,11 +219,11 @@ The create-field flow also has to reveal the new trailing column itself. It carr
 
 ## 23. Embedded data-view block has no width/height controls `[internal]`
 
-**What.** The `cortext/data-view` block exposes `align` (default / wide / full) for width but nothing for height. A freshly inserted block needs a usable viewport and long tables need to stay bounded inside the page, so we set `height` from `var(--cortext-data-view-block-min-height, 640px)` and let DataViews scroll internally. The number is a guess: roughly fits a header, ~10 compact rows, footer, and pagination. It doesn't track the block's density or `perPage`, so a comfortable block with `perPage: 25` shows the same default viewport as a compact block with 5 rows.
+**What.** The `cortext/data-view` block exposes `align` (default / wide / full) for width but nothing for height. For now the block sizes to its content: short tables fit their rows, long tables grow with the page, and empty blocks fall back to DataViews' no-results state. That default is easy to understand, but authors still can't say "show 10 rows and scroll the rest." A long table stretches the document.
 
-**Where.** `--cortext-data-view-block-min-height` in `src/styles/_tokens.scss`, the `.wp-block-cortext-data-view .cortext-data-view` rule in `src/index.scss`, `src/blocks/data-view/block.json` (no `height` attribute today).
+**Where.** `src/blocks/data-view/block.json` (no `height` attribute today). The block-mode size rule lives in `src/index.scss` next to the `.wp-block-cortext-data-view .cortext-data-view > .dataviews-wrapper` override.
 
-**Solution.** Add a `height` (or "rows visible") attribute to the block with an inspector control, fall back to the variable when unset, and let the variable stay as a theme-overridable default. Computing the default from `density × perPage` is a smaller win; once the per-block control exists, the default rarely matters.
+**Solution.** Add a `height` (or "rows visible") attribute to the block with an inspector control, and clamp the shell to that value when set. A density-aware default would help, but the per-block control is the part that matters.
 
 ## 24. Workspace notices filtered by id prefix `[upstream, soft]`
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -4208,7 +4208,9 @@ body.cortext-row-detail-sidebar-resizing {
 	z-index: auto;
 }
 
+.block-editor-block-list__layout
 .block-editor-block-list__block[data-type="cortext/data-view"].is-selected::after,
+.block-editor-block-list__layout
 .block-editor-block-list__block[data-type="cortext/data-view"]:focus::after {
 	z-index: 10;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1895,6 +1895,18 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 	width: 200px;
 }
 
+// Keep the actions column only as wide as its kebab/`+` icon. Otherwise it
+// inherits the generic 200px cell width and pushes the last data column under
+// the sticky-right overlay. The `tr` keeps specificity tied with DataViews'
+// own `tr td:last-child` rule, which also sets `padding-right: 48px`.
+.dataviews-view-table tr th.dataviews-view-table__actions-column,
+.dataviews-view-table tr td.dataviews-view-table__actions-column {
+	width: $grid-unit-50 + $grid-unit-05;
+	min-width: $grid-unit-50 + $grid-unit-05;
+	max-width: $grid-unit-50 + $grid-unit-05;
+	padding-right: $grid-unit-05;
+}
+
 // Title carries the post name and tends to be longer than other
 // fields; give it more breathing room.
 .dataviews-view-table th:first-child,
@@ -1916,15 +1928,6 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 	> .dataviews-view-table-header {
 		display: none;
 	}
-}
-
-// Regular cells get vertical centering from DataViews' inner wrapper.
-// The row-actions cell skips that wrapper, so center the kebab on the td.
-.cortext-data-view
-.dataviews-view-table
-tbody
-td.dataviews-view-table__actions-column {
-	vertical-align: middle;
 }
 
 // Custom field columns carry a marker that `ColumnHeaderActions`
@@ -4020,6 +4023,7 @@ body.cortext-row-detail-sidebar-resizing {
 		tr td {
 			overflow: hidden;
 			padding-block: 0;
+			vertical-align: middle;
 		}
 
 		// DataViews wraps each cell's render in a flex container that
@@ -4035,6 +4039,7 @@ body.cortext-row-detail-sidebar-resizing {
 			width: 100%;
 			min-width: 0;
 			max-width: 100%;
+			align-items: center;
 		}
 
 		tfoot.cortext-table-calculations {
@@ -4178,12 +4183,12 @@ body.cortext-row-detail-sidebar-resizing {
 	height: 100%;
 }
 
-// tech-debt.md#23: embedded block has no per-instance height attribute. Use
-// the shared token as a min-height so short collections still get a comfortable
-// viewport while long ones grow the block (and keep the footer in view) instead
-// of clipping. Width comes from Gutenberg's alignment.
+// Embedded blocks do not have a fixed-height parent. With the shared
+// `height: 100%`, the shell collapses and the table disappears. In block
+// mode, let content set the height until #23 gives authors an explicit
+// per-instance viewport.
 .wp-block-cortext-data-view .cortext-data-view-shell {
-	min-height: var(--cortext-data-view-block-min-height);
+	height: auto;
 }
 
 // Full-page mode wants the wrapper to fill a fixed-height parent and scroll
@@ -4192,6 +4197,20 @@ body.cortext-row-detail-sidebar-resizing {
 // shared `flex: 1 1 0` only here.
 .wp-block-cortext-data-view .cortext-data-view > .dataviews-wrapper {
 	flex: 0 0 auto;
+}
+
+// DataViews keeps pagination sticky for fixed-height surfaces. Embedded blocks
+// grow with their content, and the sticky layer can cover Gutenberg's selected
+// block outline, so keep the footer in normal flow here.
+.wp-block-cortext-data-view .dataviews-footer {
+	background-color: transparent;
+	position: static;
+	z-index: auto;
+}
+
+.block-editor-block-list__block[data-type="cortext/data-view"].is-selected::after,
+.block-editor-block-list__block[data-type="cortext/data-view"]:focus::after {
+	z-index: 10;
 }
 
 // Embedded blocks are width-constrained by the editor canvas. Letting relation

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -17,11 +17,6 @@
 	--cortext-scrollbar-thumb: rgba(0, 0, 0, 0.12);
 	--cortext-scrollbar-thumb-hover: rgba(0, 0, 0, 0.28);
 
-	// Default viewport height for the embedded data-view block. Fits a header,
-	// pagination row, footer, and roughly 10 compact rows; override this to
-	// give the block a different default.
-	--cortext-data-view-block-min-height: 640px;
-
 	// Option chip palette. Backgrounds are muted tints; foregrounds are a
 	// matching hue dark enough to read on the background. Names mirror
 	// `Cortext\OptionPalette::names()` and the JS `OPTION_COLOR_NAMES`


### PR DESCRIPTION
## What

Polishes the embedded data-view block layout. Short tables now hug their content instead of sitting inside a fixed 640px box, and long tables can keep growing with the document. The block selection outline also stays visible around the table, pagination, and New row button.

This also tightens the actions column so it only takes the space needed for the kebab / `+` controls, and keeps shorter cells centered when another cell makes the row taller.

## Why

Small embedded tables looked oddly tall, and the pagination footer could cut through Gutenberg's blue selection outline. The actions column had a similar polish issue: it inherited the generic table-cell width, which wasted space and could push real data under the sticky-right edge.

## Testing Instructions

1. Add or select a `cortext/data-view` block with a short collection.
2. Check that the block height fits the visible rows without a large empty area.
3. Select the block and check that the blue outline stays continuous around the table, pagination, and New row button.
4. Check that the actions column is only wide enough for the kebab / `+` controls.
5. Use a row with taller wrapped content and check that shorter cells and row controls stay vertically centered.
6. Open a full collection view and check that the table still scrolls normally there.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1408" height="742" alt="image" src="https://github.com/user-attachments/assets/6c61ba69-a9cd-40e7-ae3a-a7e7f5a1a4cd" /> | <img width="1400" height="516" alt="image" src="https://github.com/user-attachments/assets/1fb74aee-ee16-4ae7-afd4-821ee573eefd" /> |
| <img width="1379" height="248" alt="image" src="https://github.com/user-attachments/assets/b5e91e5e-2ec8-4c78-b91c-b260e57509cb" /> | <img width="1355" height="240" alt="image" src="https://github.com/user-attachments/assets/ad5dda2e-ab9a-4053-9de1-9475c0504cfd" /> |
| <img width="820" height="588" alt="image" src="https://github.com/user-attachments/assets/84775651-9de6-41ba-b429-85becae39015" /> | <img width="779" height="569" alt="image" src="https://github.com/user-attachments/assets/cacc2dbc-c510-45dd-8a9c-c26ea954da90" /> |
