### PR TITLE
Performance: Add UI perf scenarios and row detail timing

### DIFF
--- a/.github/scripts/write-perf-bench-summary.php
+++ b/.github/scripts/write-perf-bench-summary.php
@@ -8,6 +8,11 @@ $base_path    = $args['base'] ?? '';
 $base_label   = $args['base-label'] ?? 'base';
 $summary_path = $args['summary'] ?? getenv( 'GITHUB_STEP_SUMMARY' );
 $comparison_only = isset( $args['comparison-only'] ) && '0' !== $args['comparison-only'];
+$failures_only_metric = $args['failures-only-metric'] ?? '';
+
+if ( '' !== $failures_only_metric ) {
+	exit( failures_are_only_metric( $current_path, $failures_only_metric ) ? 0 : 1 );
+}
 
 $output = build_output( $current_path, $base_path, $base_label, $comparison_only );
 echo $output;
@@ -62,6 +67,26 @@ function build_output( string $current_path, string $base_path, string $base_lab
 	}
 
 	return implode( "\n", $lines ) . "\n";
+}
+
+function failures_are_only_metric( string $current_path, string $metric ): bool {
+	$current = load_report( $current_path, 'benchmark' );
+	if ( null === $current['report'] ) {
+		return false;
+	}
+
+	$failures = $current['report']['failures'] ?? null;
+	if ( ! is_array( $failures ) || count( $failures ) === 0 ) {
+		return false;
+	}
+
+	foreach ( $failures as $failure ) {
+		if ( ! is_array( $failure ) || ( $failure['metric'] ?? '' ) !== $metric ) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 /**

--- a/.github/scripts/write-perf-ui-summary.php
+++ b/.github/scripts/write-perf-ui-summary.php
@@ -18,9 +18,11 @@ $current_path = $args['current'] ?? 'artifacts/perf-ui.json';
 $summary_path = $args['summary'] ?? getenv( 'GITHUB_STEP_SUMMARY' );
 
 $output = build_output( $current_path );
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CLI markdown output for GitHub summaries should stay unescaped.
 echo $output;
 
 if ( is_string( $summary_path ) && '' !== $summary_path ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Standalone CI helper writes to GitHub's summary file outside WordPress.
 	file_put_contents( $summary_path, $output, FILE_APPEND );
 }
 
@@ -50,6 +52,7 @@ function build_output( string $current_path ): string {
 	if ( ! is_file( $current_path ) || 0 === filesize( $current_path ) ) {
 		return "UI performance run produced no output.\n";
 	}
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads a local artifact path in a standalone CI helper.
 	$raw = file_get_contents( $current_path );
 	if ( false === $raw ) {
 		return "Could not read UI performance output.\n";

--- a/.github/scripts/write-perf-ui-summary.php
+++ b/.github/scripts/write-perf-ui-summary.php
@@ -1,0 +1,184 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Renders the UI performance benchmark JSON as a markdown table grouped by
+ * scenario category. Writes to stdout and appends to the GitHub step summary
+ * when $GITHUB_STEP_SUMMARY is set.
+ *
+ * Usage:
+ *   php .github/scripts/write-perf-ui-summary.php --current=artifacts/perf-ui.json
+ *
+ * @package Cortext
+ */
+
+declare(strict_types=1);
+
+$args         = parse_args( $argv );
+$current_path = $args['current'] ?? 'artifacts/perf-ui.json';
+$summary_path = $args['summary'] ?? getenv( 'GITHUB_STEP_SUMMARY' );
+
+$output = build_output( $current_path );
+echo $output;
+
+if ( is_string( $summary_path ) && '' !== $summary_path ) {
+	file_put_contents( $summary_path, $output, FILE_APPEND );
+}
+
+/**
+ * Parses `--name=value` flags out of $argv.
+ *
+ * @param array<int,string> $argv Raw argv.
+ * @return array<string,string>
+ */
+function parse_args( array $argv ): array {
+	$args = array();
+	foreach ( array_slice( $argv, 1 ) as $arg ) {
+		if ( ! str_starts_with( $arg, '--' ) ) {
+			continue;
+		}
+		$parts = explode( '=', substr( $arg, 2 ), 2 );
+		$key   = $parts[0] ?? '';
+		if ( '' === $key ) {
+			continue;
+		}
+		$args[ $key ] = $parts[1] ?? '1';
+	}
+	return $args;
+}
+
+function build_output( string $current_path ): string {
+	if ( ! is_file( $current_path ) || 0 === filesize( $current_path ) ) {
+		return "UI performance run produced no output.\n";
+	}
+	$raw = file_get_contents( $current_path );
+	if ( false === $raw ) {
+		return "Could not read UI performance output.\n";
+	}
+	$report = json_decode( $raw, true );
+	if ( ! is_array( $report ) ) {
+		return 'Could not parse UI performance JSON: ' . json_last_error_msg() . "\n";
+	}
+
+	// Categories are ordered from broadest (collection-level) down to the
+	// most localized surfaces. The category id is the tag the spec writes;
+	// the label is what shows up in the table section header.
+	$category_order = array(
+		'collection_read' => 'Collection',
+		'row'             => 'Row',
+		'column'          => 'Column',
+		'navigation'      => 'Navigation',
+		'surface'         => 'Surface',
+	);
+
+	$scenario_labels = array(
+		'collection_ready_basic'   => 'Open collection (cold)',
+		'collection_ready_rollups' => 'Paginate to rollups',
+		'sort_apply'               => 'Sort apply',
+		'search_rows_ready'        => 'Search rows',
+		'row_detail_ready'         => 'Open row detail',
+		'row_create_ready'         => 'Create row',
+		'row_navigate_next'        => 'Navigate to next row',
+		'column_actions_open'      => 'Open column actions',
+		'column_rename_inline'     => 'Rename column inline',
+		'workspace_home_ready'     => 'Open workspace home',
+		'shell_navigation_warm'    => 'Warm shell navigation',
+		'page_edit_ready'          => 'Open page in editor',
+		'command_palette_open'     => 'Open command palette',
+	);
+
+	$scenarios = is_array( $report['scenarios'] ?? null ) ? $report['scenarios'] : array();
+
+	$grouped = array_fill_keys( array_keys( $category_order ), array() );
+	$unknown = array();
+	foreach ( $scenarios as $name => $data ) {
+		if ( ! is_array( $data ) ) {
+			continue;
+		}
+		$category = (string) ( $data['category'] ?? '' );
+		if ( isset( $grouped[ $category ] ) ) {
+			$grouped[ $category ][ $name ] = $data;
+		} else {
+			$unknown[ $name ] = $data;
+		}
+	}
+	if ( count( $unknown ) > 0 ) {
+		$grouped['_uncategorized']        = $unknown;
+		$category_order['_uncategorized'] = 'Uncategorized';
+	}
+
+	$headers    = array( 'Scenario', 'ready ms', 'rows API ms', 'REST', 'longtask total' );
+	$alignments = array( 'left', 'right', 'right', 'right', 'right' );
+	$rows       = array();
+	foreach ( $category_order as $category_id => $category_label ) {
+		if ( empty( $grouped[ $category_id ] ) ) {
+			continue;
+		}
+		$rows[] = array( '**' . $category_label . '**', '', '', '', '' );
+		foreach ( $grouped[ $category_id ] as $name => $data ) {
+			$label  = $scenario_labels[ $name ] ?? $name;
+			$rows[] = array(
+				$label,
+				integer_value( $data['ready_ms'] ?? null ),
+				integer_value( $data['rows_api_ms'] ?? null ),
+				integer_value( $data['rest_request_count'] ?? null ),
+				integer_value( $data['long_task_total_ms'] ?? null ),
+			);
+		}
+	}
+
+	if ( count( $rows ) === 0 ) {
+		return "UI performance run had no scenarios.\n";
+	}
+
+	$lines = array( '## UI performance', '' );
+	$lines = array_merge( $lines, markdown_table( $headers, $alignments, $rows ) );
+
+	return implode( "\n", $lines ) . "\n";
+}
+
+function integer_value( mixed $value ): string {
+	if ( is_numeric( $value ) ) {
+		return (string) (int) round( (float) $value );
+	}
+	return 'n/a';
+}
+
+/**
+ * Builds an aligned GitHub-flavored markdown table.
+ *
+ * @param array<int,string>            $headers    Column headers.
+ * @param array<int,string>            $alignments One of `left` or `right` per column.
+ * @param array<int,array<int,string>> $rows       Pre-stringified cell values.
+ * @return array<int,string>
+ */
+function markdown_table( array $headers, array $alignments, array $rows ): array {
+	$widths = array_map( 'strlen', $headers );
+	foreach ( $rows as $row ) {
+		foreach ( $row as $index => $cell ) {
+			$widths[ $index ] = max( $widths[ $index ] ?? 0, strlen( $cell ) );
+		}
+	}
+	foreach ( $widths as $index => $width ) {
+		$widths[ $index ] = max( 3, $width );
+	}
+
+	$format_row = static function ( array $row ) use ( $alignments, $widths ): string {
+		foreach ( $row as $index => $cell ) {
+			$pad_type      = 'right' === ( $alignments[ $index ] ?? 'left' ) ? STR_PAD_LEFT : STR_PAD_RIGHT;
+			$row[ $index ] = str_pad( $cell, $widths[ $index ], ' ', $pad_type );
+		}
+		return '| ' . implode( ' | ', $row ) . ' |';
+	};
+
+	$separator = array();
+	foreach ( $widths as $index => $width ) {
+		$separator[] = 'right' === ( $alignments[ $index ] ?? 'left' )
+			? str_repeat( '-', $width - 1 ) . ':'
+			: str_repeat( '-', $width );
+	}
+
+	return array_merge(
+		array( $format_row( $headers ), '| ' . implode( ' | ', $separator ) . ' |' ),
+		array_map( $format_row, $rows )
+	);
+}

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -123,18 +123,13 @@ jobs:
             - name: Run benchmark
               run: |
                   set -o pipefail
-                  fail_args=()
-                  if [ "$GITHUB_EVENT_NAME" = "push" ]; then
-                    fail_args+=(--fail-on-budget)
-                  fi
-
                   mkdir -p artifacts
                   pnpm exec wp-env run cli wp cortext perf-bench \
                     --iterations=5 \
                     --warmup=1 \
                     --budget=includes/CLI/perf-budgets.json \
-                    --pretty \
-                    "${fail_args[@]}" | tee artifacts/perf-bench.json
+                    --fail-on-budget \
+                    --pretty | tee artifacts/perf-bench.json
 
             - name: Run UI performance benchmark
               if: github.event_name == 'workflow_dispatch' || env.CORTEXT_PERF_UI == '1'

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -122,14 +122,38 @@ jobs:
 
             - name: Run benchmark
               run: |
-                  set -o pipefail
+                  set -euo pipefail
                   mkdir -p artifacts
-                  pnpm exec wp-env run cli wp cortext perf-bench \
-                    --iterations=5 \
-                    --warmup=1 \
-                    --budget=includes/CLI/perf-budgets.json \
-                    --fail-on-budget \
-                    --pretty | tee artifacts/perf-bench.json
+
+                  run_benchmark() {
+                    local output_path="$1"
+
+                    pnpm exec wp-env run cli wp cortext perf-bench \
+                      --iterations=10 \
+                      --warmup=1 \
+                      --budget=includes/CLI/perf-budgets.json \
+                      --fail-on-budget \
+                      --pretty | tee "$output_path"
+                    local status="${PIPESTATUS[0]}"
+
+                    return "$status"
+                  }
+
+                  set +e
+                  run_benchmark artifacts/perf-bench.json
+                  status="$?"
+                  set -e
+
+                  if [ "$status" -ne 0 ] && php .github/scripts/write-perf-bench-summary.php --current=artifacts/perf-bench.json --failures-only-metric=p95_ms; then
+                    echo "Only p95 latency budgets missed; retrying the benchmark once."
+                    cp artifacts/perf-bench.json artifacts/perf-bench-first.json
+                    set +e
+                    run_benchmark artifacts/perf-bench.json
+                    status="$?"
+                    set -e
+                  fi
+
+                  exit "$status"
 
             - name: Run UI performance benchmark
               if: github.event_name == 'workflow_dispatch' || env.CORTEXT_PERF_UI == '1'

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -9,6 +9,7 @@ on:
             - tests/e2e/specs/perf-ui.spec.js
             - .github/workflows/perf-bench.yml
             - .github/scripts/write-perf-bench-summary.php
+            - .github/scripts/write-perf-ui-summary.php
     pull_request:
         branches: [main]
         paths:
@@ -17,6 +18,7 @@ on:
             - tests/e2e/specs/perf-ui.spec.js
             - .github/workflows/perf-bench.yml
             - .github/scripts/write-perf-bench-summary.php
+            - .github/scripts/write-perf-ui-summary.php
     workflow_dispatch:
 
 permissions:
@@ -121,13 +123,18 @@ jobs:
             - name: Run benchmark
               run: |
                   set -o pipefail
+                  fail_args=()
+                  if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+                    fail_args+=(--fail-on-budget)
+                  fi
+
                   mkdir -p artifacts
                   pnpm exec wp-env run cli wp cortext perf-bench \
                     --iterations=5 \
                     --warmup=1 \
                     --budget=includes/CLI/perf-budgets.json \
-                    --fail-on-budget \
-                    --pretty | tee artifacts/perf-bench.json
+                    --pretty \
+                    "${fail_args[@]}" | tee artifacts/perf-bench.json
 
             - name: Run UI performance benchmark
               if: github.event_name == 'workflow_dispatch' || env.CORTEXT_PERF_UI == '1'
@@ -169,6 +176,11 @@ jobs:
                       --summary= > artifacts/perf-bench-comment-body.md
                   fi
 
+                  if [ -s artifacts/perf-ui.json ]; then
+                    php .github/scripts/write-perf-ui-summary.php \
+                      --current=artifacts/perf-ui.json | tee artifacts/perf-ui-summary.md
+                  fi
+
             - name: Upload main benchmark baseline
               if: always() && github.event_name == 'push'
               uses: actions/upload-artifact@v4
@@ -199,17 +211,24 @@ jobs:
                     cat artifacts/perf-bench-comment-body.md
                   } > "$comment_file"
 
-                  comment_id="$(gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+                  if ! comment_id="$(gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
                     --paginate \
                     --jq '.[] | select(.user.type == "Bot" and (.body | contains("<!-- cortext-perf-bench-comment -->"))) | .id' \
-                    | tail -n 1)"
+                    | tail -n 1)"; then
+                    echo "Could not read existing PR benchmark comments; skipping comment."
+                    exit 0
+                  fi
 
                   if [ -n "$comment_id" ]; then
-                    gh api --method PATCH "repos/$REPOSITORY/issues/comments/$comment_id" \
-                      --field "body=@$comment_file" >/dev/null
+                    if ! gh api --method PATCH "repos/$REPOSITORY/issues/comments/$comment_id" \
+                      --field "body=@$comment_file" >/dev/null; then
+                      echo "Could not update PR benchmark comment; skipping comment."
+                    fi
                   else
-                    gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
-                      --field "body=@$comment_file" >/dev/null
+                    if ! gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+                      --field "body=@$comment_file" >/dev/null; then
+                      echo "Could not create PR benchmark comment; skipping comment."
+                    fi
                   fi
 
             - if: failure()

--- a/includes/CLI/PerfBench.php
+++ b/includes/CLI/PerfBench.php
@@ -334,6 +334,11 @@ final class PerfBench {
 		$summaries = array();
 
 		foreach ( $scenarios as $name => $scenario ) {
+			if ( isset( $scenario['steps'] ) && is_array( $scenario['steps'] ) ) {
+				$summaries[ $name ] = $this->run_stepped_scenario( $scenario, $warmup, $iterations );
+				continue;
+			}
+
 			$samples = array();
 			$total   = $warmup + $iterations;
 			for ( $index = 0; $index < $total; $index++ ) {
@@ -1036,11 +1041,13 @@ final class PerfBench {
 	/**
 	 * Builds the scenario callbacks.
 	 *
-	 * Labels stay short so the JSON is easy to scan. The comments carry the
-	 * why; otherwise budget reviews lose that context fast.
+	 * Labels stay short so the JSON is easy to scan. Put the reasoning in
+	 * comments; budget reviews go stale fast without it. Each scenario uses
+	 * either `run` for one measured callback or `steps` for named callbacks
+	 * that are measured separately and then rolled up.
 	 *
 	 * @param array<string,mixed> $manifest Dataset manifest.
-	 * @return array<string,array{label:string,prepare?:callable,run:callable}>
+	 * @return array<string,array{label:string,prepare?:callable,run?:callable,steps?:array<string,callable>}>
 	 * @throws RuntimeException When relation scenario data is missing.
 	 */
 	private function scenario_callbacks( array $manifest ): array {
@@ -1071,6 +1078,11 @@ final class PerfBench {
 		// Keep writes off the pages read below. Otherwise a second benchmark run
 		// would change the rows used by the read scenarios.
 		$relation_row_id = $primary_row_ids[ self::PAGE_SIZE * 4 ] ?? $primary_row_ids[0];
+		// Page 3 starts in the heavy-rollup zone. Opening that row covers
+		// relation and rollup hydration while staying away from rows touched by
+		// write scenarios.
+		$row_detail_row_id = $primary_row_ids[ self::PAGE_SIZE * 2 ] ?? $primary_row_ids[0];
+		$row_rest_base     = CollectionEntries::CPT_PREFIX . (string) $manifest['primary_slug'];
 
 		return array(
 			// This is the first thing users hit when opening a collection:
@@ -1226,6 +1238,28 @@ final class PerfBench {
 					)
 				),
 			),
+			// Opening a single row takes two REST calls: the locator maps an id
+			// to a rest_base, then core REST returns the record with
+			// cortext_hydrated_meta. Keep both timings so resolver cost does
+			// not hide inside hydrate if it grows.
+			'row_detail_open'         => array(
+				'label' => 'Open a row detail (resolve and hydrate)',
+				'steps' => array(
+					'resolve' => fn() => $this->rest_request(
+						'GET',
+						"/cortext/v1/documents/{$row_detail_row_id}",
+						array()
+					),
+					'hydrate' => fn() => $this->rest_request(
+						'GET',
+						"/wp/v2/{$row_rest_base}/{$row_detail_row_id}",
+						array(
+							'context' => 'edit',
+							'_fields' => 'id,slug,parent,type,created_at,created_by,modified_at,modified_by,cortext_hydrated_meta',
+						)
+					),
+				),
+			),
 			// The third collection is wide on purpose. It measures field loading
 			// and per-row meta formatting with many columns.
 			'rows_wide_schema'        => array(
@@ -1298,6 +1332,85 @@ final class PerfBench {
 				'run'     => fn() => $this->migrate_options( (int) $manifest['migration_field_id'], 'old-many', 'new-many' ),
 			),
 		);
+	}
+
+	/**
+	 * Builds the summary for a scenario split into steps. User-facing latency
+	 * is the sum of step latencies, SQL queries are summed, and memory uses the
+	 * highest step peak. Per-step fields only expose latency; SQL and memory
+	 * would make the report noisy without adding much.
+	 *
+	 * @param string                                                                            $label         Scenario label.
+	 * @param array<int,array{latency_ms:float,sql_queries:int,memory_bytes:int}>               $total_samples Aggregate samples per iteration.
+	 * @param array<string,array<int,array{latency_ms:float,sql_queries:int,memory_bytes:int}>> $step_samples Per-step samples per iteration, keyed by step name.
+	 * @return array<string,mixed>
+	 */
+	public static function summarize_stepped_samples( string $label, array $total_samples, array $step_samples ): array {
+		$aggregate = self::summarize_samples( $total_samples );
+
+		$summary = array_merge(
+			array( 'label' => $label ),
+			$aggregate,
+			array(
+				'total_p50_ms' => $aggregate['p50_ms'],
+				'total_p95_ms' => $aggregate['p95_ms'],
+			)
+		);
+
+		foreach ( $step_samples as $step_name => $samples ) {
+			$step_summary                     = self::summarize_samples( $samples );
+			$summary[ "{$step_name}_p50_ms" ] = $step_summary['p50_ms'];
+			$summary[ "{$step_name}_p95_ms" ] = $step_summary['p95_ms'];
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Runs a scenario split into named steps.
+	 *
+	 * @param array{label:string,steps:array<string,callable>,prepare?:callable} $scenario   Scenario config.
+	 * @param int                                                                $warmup     Warm-up iterations.
+	 * @param int                                                                $iterations Measured iterations.
+	 * @return array<string,mixed>
+	 */
+	private function run_stepped_scenario( array $scenario, int $warmup, int $iterations ): array {
+		$steps         = $scenario['steps'];
+		$step_samples  = array_fill_keys( array_keys( $steps ), array() );
+		$total_samples = array();
+
+		$total = $warmup + $iterations;
+		for ( $index = 0; $index < $total; $index++ ) {
+			if ( isset( $scenario['prepare'] ) && is_callable( $scenario['prepare'] ) ) {
+				$scenario['prepare']();
+			}
+
+			$iteration_latency = 0.0;
+			$iteration_sql     = 0;
+			$iteration_memory  = 0;
+			$per_step          = array();
+
+			foreach ( $steps as $step_name => $step_callback ) {
+				$sample                 = $this->measure( $step_callback );
+				$per_step[ $step_name ] = $sample;
+				$iteration_latency     += $sample['latency_ms'];
+				$iteration_sql         += $sample['sql_queries'];
+				$iteration_memory       = max( $iteration_memory, $sample['memory_bytes'] );
+			}
+
+			if ( $index >= $warmup ) {
+				foreach ( $per_step as $step_name => $sample ) {
+					$step_samples[ $step_name ][] = $sample;
+				}
+				$total_samples[] = array(
+					'latency_ms'   => $iteration_latency,
+					'sql_queries'  => $iteration_sql,
+					'memory_bytes' => $iteration_memory,
+				);
+			}
+		}
+
+		return self::summarize_stepped_samples( (string) $scenario['label'], $total_samples, $step_samples );
 	}
 
 	/**

--- a/tests/e2e/perf-fixtures.js
+++ b/tests/e2e/perf-fixtures.js
@@ -1,0 +1,34 @@
+/**
+ * Helpers shared by the UI perf specs. Collections are resolved by meta.slug,
+ * not post_name, so the helper lists the small seed set and picks the matching
+ * meta value.
+ */
+
+async function resolveCollectionAdminUrl( requestUtils, slug ) {
+	const collections = await requestUtils.rest( {
+		path: '/wp/v2/crtxt_collections',
+		params: {
+			context: 'edit',
+			per_page: 100,
+			status: 'private,publish,draft',
+			_fields: 'id,meta',
+		},
+	} );
+
+	const match = ( Array.isArray( collections ) ? collections : [] ).find(
+		( entry ) => entry?.meta?.slug === slug
+	);
+
+	if ( ! match ) {
+		throw new Error(
+			`Could not find a collection with slug "${ slug }". Run \`wp cortext perf-seed --reset --force\` first.`
+		);
+	}
+
+	return {
+		id: match.id,
+		adminQuery: `page=cortext&p=/collection/${ slug }-${ match.id }`,
+	};
+}
+
+module.exports = { resolveCollectionAdminUrl };

--- a/tests/e2e/specs/perf-ui.spec.js
+++ b/tests/e2e/specs/perf-ui.spec.js
@@ -1,0 +1,618 @@
+/**
+ * UI perf checks for Cortext.
+ *
+ * Skipped by default. Set CORTEXT_PERF_UI=1 to run them. At the end, the suite
+ * writes `artifacts/perf-ui.json` so CI can save it for comparison runs.
+ *
+ * Scenarios:
+ *   - collection_ready_basic: seeded collection open to first painted rows.
+ *   - collection_ready_rollups: page 3 of the same collection, where rollups
+ *     are heavier.
+ *   - row_detail_ready: first row's Open button to detail view ready.
+ *   - row_create_ready: New row click through POST and rendered row.
+ *   - sort_apply: open the first column header menu, choose "Sort
+ *     ascending", wait for sorted rows.
+ *   - page_edit_ready: crtxt_page in Gutenberg until the editor is mounted.
+ *   - command_palette_open: shell event to command palette mount.
+ *   - column_actions_open: column header trigger to visible menu.
+ *   - column_rename_inline: open the column menu, choose "Rename", type a new
+ *     name, press Enter, then wait for the save to finish.
+ *   - workspace_home_ready: root Cortext URL until sidebar and home content render.
+ *   - shell_navigation_warm: sidebar navigation from one loaded collection to another.
+ *   - search_rows_ready: DataView search input to filtered rows.
+ *   - row_navigate_next: "Row below" click in full row detail to the next row.
+ */
+
+const { test } = require( '@wordpress/e2e-test-utils-playwright' );
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+const { resolveCollectionAdminUrl } = require( '../perf-fixtures' );
+
+const COLLECTION_SLUG = 'perfmain';
+const READY_TIMEOUT_MS = 30_000;
+const ROWS_API_SEGMENT = '/cortext/v1/rows';
+const REST_SEGMENTS = [ '/cortext/v1/', '/wp/v2/', '/wp-json/' ];
+
+// Tag a measured scenario with the category the renderer groups it under.
+// Categories: collection_read, row, column, navigation, surface.
+const tag = ( category, metrics ) => ( { category, ...metrics } );
+
+const PERF_PAGE_CONTENT =
+	'<!-- wp:heading -->\n<h2>Cortext perf page</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Filler paragraph one.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Filler paragraph two.</p>\n<!-- /wp:paragraph -->';
+
+test.describe( 'Cortext UI performance', () => {
+	test.skip(
+		process.env.CORTEXT_PERF_UI !== '1',
+		'Set CORTEXT_PERF_UI=1 to run the UI performance specs.'
+	);
+
+	// Keep this file serial. The shared `scenarios` object is written once in
+	// `afterAll`; parallel workers would each write their own partial artifact.
+	test.describe.configure( { mode: 'serial' } );
+
+	const scenarios = {};
+	let collection;
+	let perfPage;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		collection = await resolveCollectionAdminUrl(
+			requestUtils,
+			COLLECTION_SLUG
+		);
+
+		perfPage = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/crtxt_pages',
+			data: {
+				title: 'Cortext perf page',
+				status: 'private',
+				content: PERF_PAGE_CONTENT,
+			},
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		if ( perfPage?.id ) {
+			try {
+				await requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/crtxt_pages/${ perfPage.id }`,
+					params: { force: true },
+				} );
+			} catch {
+				// Cleanup is best effort. A failed DELETE should not hide the
+				// perf numbers.
+			}
+		}
+
+		const outDir = path.resolve( process.cwd(), 'artifacts' );
+		fs.mkdirSync( outDir, { recursive: true } );
+		fs.writeFileSync(
+			path.join( outDir, 'perf-ui.json' ),
+			JSON.stringify(
+				{
+					version: 1,
+					collection: collection
+						? { slug: COLLECTION_SLUG, id: collection.id }
+						: null,
+					scenarios,
+				},
+				null,
+				2
+			),
+			'utf-8'
+		);
+	} );
+
+	test( 'collection_ready_basic', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		const startedAt = Date.now();
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		scenarios.collection_ready_basic = tag(
+			'collection_read',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'collection_ready_rollups', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		const previousFirstRow = await readFirstRowText( page );
+
+		await probe.reset();
+		const responsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( ROWS_API_SEGMENT ) &&
+				response.url().includes( 'page=3' ),
+			{ timeout: READY_TIMEOUT_MS }
+		);
+		const startedAt = Date.now();
+
+		await page.getByLabel( 'Current page' ).selectOption( '3' );
+		await responsePromise;
+		await waitForFirstRowChanged( page, previousFirstRow );
+		await waitForPaint( page );
+
+		scenarios.collection_ready_rollups = tag(
+			'collection_read',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'row_detail_ready', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		await probe.reset();
+		const startedAt = Date.now();
+
+		await page.getByLabel( 'Open row' ).first().click( { force: true } );
+		await waitForRowDetailReady( page );
+
+		scenarios.row_detail_ready = tag(
+			'row',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'row_create_ready', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		const previousCount = await readRowCount( page );
+
+		await probe.reset();
+		const createPromise = page.waitForResponse(
+			( response ) =>
+				response.request().method() === 'POST' &&
+				response.url().includes( `/wp/v2/crtxt_${ COLLECTION_SLUG }` ),
+			{ timeout: READY_TIMEOUT_MS }
+		);
+		const startedAt = Date.now();
+
+		await page.locator( '.cortext-data-view__new-row' ).click();
+		await createPromise;
+		await waitForRowCountChanged( page, previousCount );
+		await waitForPaint( page );
+
+		scenarios.row_create_ready = tag(
+			'row',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'sort_apply', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		const previousFirstRow = await readFirstRowText( page );
+
+		await probe.reset();
+		const responsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( ROWS_API_SEGMENT ) &&
+				response.url().includes( 'sort' ),
+			{ timeout: READY_TIMEOUT_MS }
+		);
+		const startedAt = Date.now();
+
+		await page
+			.locator( 'button.dataviews-view-table-header-button' )
+			.first()
+			.click( { force: true } );
+		// Title rows are zero-padded "Perf Primary Row NNNNN", so ascending
+		// matches the default oldest-first order; descending swaps the first
+		// row from 00001 to 01250 and gives a stable readiness signal.
+		await page
+			.getByRole( 'menuitemradio', { name: 'Sort descending' } )
+			.click();
+		await responsePromise;
+		await waitForFirstRowChanged( page, previousFirstRow );
+		await waitForPaint( page );
+
+		scenarios.sort_apply = tag(
+			'collection_read',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'page_edit_ready', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		const startedAt = Date.now();
+		await admin.visitAdminPage(
+			'admin.php',
+			`page=cortext&p=/${ perfPage.id }`
+		);
+		await waitForEditorReady( page, perfPage.id );
+
+		scenarios.page_edit_ready = tag(
+			'surface',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'column_actions_open', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		await probe.reset();
+		const startedAt = Date.now();
+
+		await page
+			.locator( 'button.cortext-column-header-trigger' )
+			.first()
+			.click( { force: true } );
+		await page
+			.getByRole( 'menu' )
+			.first()
+			.waitFor( { state: 'visible', timeout: READY_TIMEOUT_MS } );
+
+		scenarios.column_actions_open = tag(
+			'column',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'column_rename_inline', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		await page
+			.locator( 'button.cortext-column-header-trigger' )
+			.first()
+			.click( { force: true } );
+		await page.getByRole( 'menuitem', { name: 'Rename' } ).click();
+		const renameInput = page.locator(
+			'.cortext-rename-field-inline input'
+		);
+		await renameInput.waitFor( {
+			state: 'visible',
+			timeout: READY_TIMEOUT_MS,
+		} );
+
+		await probe.reset();
+		const startedAt = Date.now();
+
+		await renameInput.fill( `Perf renamed ${ Date.now() }` );
+		await renameInput.press( 'Enter' );
+		await page
+			.locator( '.cortext-rename-field-inline' )
+			.waitFor( { state: 'hidden', timeout: READY_TIMEOUT_MS } );
+		await waitForPaint( page );
+
+		scenarios.column_rename_inline = tag(
+			'column',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'command_palette_open', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		await probe.reset();
+		const startedAt = Date.now();
+
+		await page.evaluate( () => {
+			window.dispatchEvent( new Event( 'cortext:open-command-palette' ) );
+		} );
+		await waitForCommandPaletteReady( page );
+
+		scenarios.command_palette_open = tag(
+			'surface',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'workspace_home_ready', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		const responsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( '/cortext/v1/workspace-home' ),
+			{ timeout: READY_TIMEOUT_MS }
+		);
+		const startedAt = Date.now();
+
+		await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+		await responsePromise;
+		await page
+			.locator( '.cortext-sidebar' )
+			.first()
+			.waitFor( { state: 'visible', timeout: READY_TIMEOUT_MS } );
+		await waitForPaint( page );
+
+		scenarios.workspace_home_ready = tag(
+			'navigation',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'shell_navigation_warm', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		const previousFirstRow = await readFirstRowText( page );
+
+		await probe.reset();
+		const responsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( ROWS_API_SEGMENT ) &&
+				! response.url().includes( `collection=${ collection.id }` ),
+			{ timeout: READY_TIMEOUT_MS }
+		);
+		const startedAt = Date.now();
+
+		await page
+			.locator( '.cortext-sidebar' )
+			.getByRole( 'button', { name: 'Perf Target 1', exact: true } )
+			.click();
+		await responsePromise;
+		await waitForFirstRowChanged( page, previousFirstRow );
+		await waitForPaint( page );
+
+		scenarios.shell_navigation_warm = tag(
+			'navigation',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'search_rows_ready', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		const previousFirstRow = await readFirstRowText( page );
+
+		await probe.reset();
+		const responsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( ROWS_API_SEGMENT ) &&
+				response.url().includes( 'search=' ),
+			{ timeout: READY_TIMEOUT_MS }
+		);
+		const startedAt = Date.now();
+
+		// Search for the last seeded row's suffix so the result set shrinks
+		// to one entry whose title differs from the unfiltered first row.
+		// 'Perf' would match every row and leave the first row unchanged.
+		await page.locator( '.dataviews-search input' ).fill( '01250' );
+		await responsePromise;
+		await waitForFirstRowChanged( page, previousFirstRow );
+		await waitForPaint( page );
+
+		scenarios.search_rows_ready = tag(
+			'collection_read',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'row_navigate_next', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+		await page.getByLabel( 'Open row' ).first().click( { force: true } );
+		await waitForRowDetailReady( page );
+
+		const previousTitle = await page
+			.locator( '.cortext-row-detail__title' )
+			.first()
+			.textContent();
+
+		await probe.reset();
+		const startedAt = Date.now();
+
+		await page.getByLabel( 'Row below' ).click();
+		await page.waitForFunction(
+			( prev ) => {
+				const el = document.querySelector(
+					'.cortext-row-detail__title'
+				);
+				return Boolean( el ) && el.textContent !== prev;
+			},
+			previousTitle,
+			{ timeout: READY_TIMEOUT_MS }
+		);
+		await waitForPaint( page );
+
+		scenarios.row_navigate_next = tag(
+			'row',
+			await probe.snapshot( startedAt )
+		);
+	} );
+} );
+
+async function setupProbe( page ) {
+	await page.addInitScript( () => {
+		window.__cortextPerfLongTasks = [];
+		try {
+			new PerformanceObserver( ( list ) => {
+				for ( const entry of list.getEntries() ) {
+					window.__cortextPerfLongTasks.push( entry.duration );
+				}
+			} ).observe( { entryTypes: [ 'longtask' ] } );
+		} catch {
+			// Some browsers do not expose `longtask` entries. An empty array
+			// reports this as 0 below.
+		}
+	} );
+
+	const requests = [];
+	// Track request and response timestamps with the request object. In this
+	// wp-env setup, `request.timing()` often returns -1 for cached or kept-alive
+	// requests.
+	const requestStarts = new WeakMap();
+	page.on( 'request', ( request ) => {
+		requestStarts.set( request, Date.now() );
+	} );
+	page.on( 'response', ( response ) => {
+		const url = response.url();
+		if ( ! REST_SEGMENTS.some( ( segment ) => url.includes( segment ) ) ) {
+			return;
+		}
+		const start = requestStarts.get( response.request() );
+		const duration = start ? Date.now() - start : null;
+		requests.push( { url, duration } );
+	} );
+
+	const resetLongTasks = async () => {
+		try {
+			await page.evaluate( () => {
+				window.__cortextPerfLongTasks = [];
+			} );
+		} catch {
+			// Before first navigation, there may not be a document yet. The init
+			// script sets the array on the next one.
+		}
+	};
+
+	return {
+		async reset() {
+			requests.length = 0;
+			await resetLongTasks();
+		},
+		async snapshot( startedAt ) {
+			const readyMs = Date.now() - startedAt;
+			const rowsCall = requests.find( ( entry ) =>
+				entry.url.includes( ROWS_API_SEGMENT )
+			);
+			const tasks = await page.evaluate(
+				() => window.__cortextPerfLongTasks ?? []
+			);
+			const longTasks = Array.isArray( tasks ) ? tasks : [];
+
+			return {
+				ready_ms: readyMs,
+				rows_api_ms: rowsCall?.duration ?? null,
+				rest_request_count: requests.length,
+				long_task_total_ms: longTasks.reduce(
+					( total, duration ) => total + duration,
+					0
+				),
+				long_task_max_ms: longTasks.reduce(
+					( max, duration ) => Math.max( max, duration ),
+					0
+				),
+			};
+		},
+	};
+}
+
+async function waitForCollectionReady( page ) {
+	await page
+		.locator( '.cortext-data-view .dataviews-wrapper' )
+		.first()
+		.waitFor( { state: 'visible', timeout: READY_TIMEOUT_MS } );
+	await page
+		.locator( 'tbody tr.dataviews-view-table__row' )
+		.first()
+		.waitFor( { state: 'visible', timeout: READY_TIMEOUT_MS } );
+	await waitForPaint( page );
+}
+
+async function readFirstRowText( page ) {
+	return page.evaluate(
+		() =>
+			document.querySelector( 'tbody tr.dataviews-view-table__row' )
+				?.textContent ?? null
+	);
+}
+
+async function readRowCount( page ) {
+	return page.evaluate(
+		() =>
+			document.querySelectorAll( 'tbody tr.dataviews-view-table__row' )
+				.length
+	);
+}
+
+async function waitForFirstRowChanged( page, previousText ) {
+	await page.waitForFunction(
+		( prev ) => {
+			const row = document.querySelector(
+				'tbody tr.dataviews-view-table__row'
+			);
+			return Boolean( row ) && row.textContent !== prev;
+		},
+		previousText,
+		{ timeout: READY_TIMEOUT_MS }
+	);
+}
+
+async function waitForRowCountChanged( page, previousCount ) {
+	await page.waitForFunction(
+		( prev ) => {
+			const count = document.querySelectorAll(
+				'tbody tr.dataviews-view-table__row'
+			).length;
+			return count !== prev && count > 0;
+		},
+		previousCount,
+		{ timeout: READY_TIMEOUT_MS }
+	);
+}
+
+async function waitForRowDetailReady( page ) {
+	await page
+		.locator( '.cortext-row-detail__frame' )
+		.first()
+		.waitFor( { state: 'visible', timeout: READY_TIMEOUT_MS } );
+	await page
+		.locator( '.cortext-row-detail__title' )
+		.first()
+		.waitFor( { state: 'visible', timeout: READY_TIMEOUT_MS } );
+	await waitForPaint( page );
+}
+
+async function waitForCommandPaletteReady( page ) {
+	await page
+		.locator( '.commands-command-menu' )
+		.first()
+		.waitFor( { state: 'visible', timeout: READY_TIMEOUT_MS } );
+	await waitForPaint( page );
+}
+
+async function waitForEditorReady( page, postId ) {
+	await page.waitForFunction(
+		( id ) =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ===
+			id,
+		postId,
+		{ timeout: READY_TIMEOUT_MS }
+	);
+	await waitForPaint( page );
+}
+
+async function waitForPaint( page ) {
+	await page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				window.requestAnimationFrame( () =>
+					window.requestAnimationFrame( resolve )
+				);
+			} )
+	);
+}

--- a/tests/php/test-cli-perf-bench.php
+++ b/tests/php/test-cli-perf-bench.php
@@ -73,6 +73,89 @@ final class Test_CLI_Perf_Bench extends BaseTestCase {
 		$this->assertSame( 12, $summary['sql_queries_p95'] );
 	}
 
+	public function test_summarize_stepped_samples_exposes_total_and_per_step_metrics(): void {
+		$total_samples = array(
+			array(
+				'latency_ms'   => 12.0,
+				'sql_queries'  => 8,
+				'memory_bytes' => 2000,
+			),
+			array(
+				'latency_ms'   => 18.0,
+				'sql_queries'  => 12,
+				'memory_bytes' => 2400,
+			),
+			array(
+				'latency_ms'   => 15.0,
+				'sql_queries'  => 10,
+				'memory_bytes' => 2200,
+			),
+		);
+
+		$step_samples = array(
+			'resolve' => array(
+				array(
+					'latency_ms'   => 2.0,
+					'sql_queries'  => 1,
+					'memory_bytes' => 500,
+				),
+				array(
+					'latency_ms'   => 3.0,
+					'sql_queries'  => 2,
+					'memory_bytes' => 600,
+				),
+				array(
+					'latency_ms'   => 2.5,
+					'sql_queries'  => 1,
+					'memory_bytes' => 550,
+				),
+			),
+			'hydrate' => array(
+				array(
+					'latency_ms'   => 10.0,
+					'sql_queries'  => 7,
+					'memory_bytes' => 2000,
+				),
+				array(
+					'latency_ms'   => 15.0,
+					'sql_queries'  => 10,
+					'memory_bytes' => 2400,
+				),
+				array(
+					'latency_ms'   => 12.5,
+					'sql_queries'  => 9,
+					'memory_bytes' => 2200,
+				),
+			),
+		);
+
+		$summary = PerfBench::summarize_stepped_samples( 'Open a row detail', $total_samples, $step_samples );
+
+		$this->assertSame( 'Open a row detail', $summary['label'] );
+		$this->assertSame(
+			array(
+				'label',
+				'runs',
+				'p50_ms',
+				'p95_ms',
+				'sql_queries_p50',
+				'sql_queries_p95',
+				'memory_bytes_p50',
+				'memory_bytes_p95',
+				'total_p50_ms',
+				'total_p95_ms',
+				'resolve_p50_ms',
+				'resolve_p95_ms',
+				'hydrate_p50_ms',
+				'hydrate_p95_ms',
+			),
+			array_keys( $summary )
+		);
+		$this->assertSame( $summary['p50_ms'], $summary['total_p50_ms'] );
+		$this->assertSame( $summary['p95_ms'], $summary['total_p95_ms'] );
+		$this->assertGreaterThan( $summary['resolve_p50_ms'], $summary['hydrate_p50_ms'] );
+	}
+
 	public function test_apply_budgets_marks_failures(): void {
 		$result = PerfBench::apply_budgets(
 			array(


### PR DESCRIPTION
## What

Adds a Playwright perf run for Cortext, plus one missing row-detail case in the existing WP-CLI benchmark.

The browser run uses the seeded perf dataset and writes `artifacts/perf-ui.json`. The workflow also keeps the benchmark gate required, but makes it less flaky: it now runs more samples and retries once when the only budget miss is `p95_ms`.

## Why

The server benchmark was already in place, but we still had no data around row detail and browser-visible flows.

Latency in GitHub runners can spike hard without any SQL or memory change, so the retry keeps the gate useful without turning runner noise into a failing PR.

## How

Adds perf checks for:

- `row_detail_open` in WP-CLI, split into resolve, hydrate, and total timings.
- Collections: open, paginate into rollup-heavy rows, sort, and search.
- Rows: open detail, create a row, and move to the next row.
- Columns: open column actions and rename a column inline.
- Shell: workspace home, warm sidebar navigation, page editor load, and command palette open.

Updates the benchmark workflow to:

- Run 10 measured iterations instead of 5.
- Keep `--fail-on-budget` enabled.
- Retry once only when all budget misses are `p95_ms`.
- Still fail immediately for SQL or memory budget misses.

## Testing Instructions

1. Seed the perf dataset with `wp cortext perf-seed --reset --force`.
2. Run `wp cortext perf-bench --pretty` and check that `row_detail_open` reports total, resolve, and hydrate timings.
3. Run the UI perf suite with `CORTEXT_PERF_UI=1` and check that it writes `artifacts/perf-ui.json`.
4. Run `.github/scripts/write-perf-ui-summary.php --current=artifacts/perf-ui.json` and check that the output is grouped by category.