### PR TITLE
Exploration: Add a standalone Cortext desktop app via Playground

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,9 +10,48 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changes:
+        name: Detect changed paths
+        runs-on: ubuntu-latest
+        outputs:
+            e2e_changed: ${{ steps.changed_paths.outputs.e2e_changed }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - id: changed_paths
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                    base="${{ github.event.pull_request.base.sha }}"
+                    head="${{ github.event.pull_request.head.sha }}"
+                  else
+                    base="${{ github.event.before }}"
+                    head="${{ github.sha }}"
+                  fi
+
+                  if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+                    changed_files="$(git diff-tree --no-commit-id --name-only -r "$head")"
+                  else
+                    changed_files="$(git diff --name-only "$base" "$head")"
+                  fi
+
+                  e2e_paths='^(\.github/workflows/e2e\.yml|composer\.(json|lock)|package\.json|pnpm-lock\.yaml|playwright\.config\.js|\.wp-env\.json|cortext\.php|includes/|templates/|src/|build/|tests/e2e/|seed-assets/|scripts/wp-env-seed\.mjs)'
+
+                  if [ -n "$changed_files" ] && grep -Eq "$e2e_paths" <<< "$changed_files"; then
+                    echo "e2e_changed=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "e2e_changed=false" >> "$GITHUB_OUTPUT"
+                  fi
+
     playwright:
         name: Playwright
         runs-on: ubuntu-latest
+        needs: changes
+        if: needs.changes.outputs.e2e_changed == 'true'
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,9 +10,56 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changes:
+        name: Detect changed paths
+        runs-on: ubuntu-latest
+        outputs:
+            php_changed: ${{ steps.changed_paths.outputs.php_changed }}
+            js_changed: ${{ steps.changed_paths.outputs.js_changed }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - id: changed_paths
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                    base="${{ github.event.pull_request.base.sha }}"
+                    head="${{ github.event.pull_request.head.sha }}"
+                  else
+                    base="${{ github.event.before }}"
+                    head="${{ github.sha }}"
+                  fi
+
+                  if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+                    changed_files="$(git diff-tree --no-commit-id --name-only -r "$head")"
+                  else
+                    changed_files="$(git diff --name-only "$base" "$head")"
+                  fi
+
+                  php_paths='^(\.github/workflows/unit-tests\.yml|composer\.(json|lock)|phpunit\.xml\.dist|cortext\.php|includes/|templates/|tests/php/)'
+                  js_paths='^(\.github/workflows/unit-tests\.yml|package\.json|pnpm-lock\.yaml|jest\.config\.js|src/|tests/js/)'
+
+                  if [ -n "$changed_files" ] && grep -Eq "$php_paths" <<< "$changed_files"; then
+                    echo "php_changed=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "php_changed=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+                  if [ -n "$changed_files" ] && grep -Eq "$js_paths" <<< "$changed_files"; then
+                    echo "js_changed=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "js_changed=false" >> "$GITHUB_OUTPUT"
+                  fi
+
     php:
         name: PHP
         runs-on: ubuntu-latest
+        needs: changes
+        if: needs.changes.outputs.php_changed == 'true'
         steps:
             - uses: actions/checkout@v4
 
@@ -34,6 +81,8 @@ jobs:
     js:
         name: JavaScript
         runs-on: ubuntu-latest
+        needs: changes
+        if: needs.changes.outputs.js_changed == 'true'
         steps:
             - uses: actions/checkout@v4
 

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+out
+snapshot.zip
+.snapshot-work

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,11 +1,11 @@
 # Cortext desktop
 
-Electron wrapper for Cortext. WordPress runs inside the app via Playground
-(PHP-WASM), so there's no external WordPress install to provision.
+Cortext, packaged as an Electron app. WordPress lives inside, served by
+Playground (PHP-WASM), so you don't have to set up a server to try it.
 
 ## Run it
 
-From the repo root, one-time setup:
+First time, from the repo root:
 
 ```sh
 npm install
@@ -13,39 +13,41 @@ npm --prefix apps/desktop install
 npm --prefix apps/desktop run snapshot
 ```
 
-The snapshot script builds the plugin, runs `wp-playground-cli build-snapshot`
-against `blueprint.json`, and writes `apps/desktop/snapshot.zip` (~40 MB). The
-blueprint defines `CORTEXT_DESKTOP`, activates Cortext, and seeds demo data
-with `wp cortext seed`. Re-run it after plugin changes or when you want a
-fresh seed.
+The one to remember is `snapshot`. It builds the plugin, hands
+`blueprint.json` to `wp-playground-cli build-snapshot`, and produces
+`apps/desktop/snapshot.zip` (~40 MB). That zip is a baked WordPress site:
+Cortext installed, `CORTEXT_DESKTOP` defined, `wp cortext seed` already
+run. Re-run after changing plugin code, or when you want the seed back to a
+clean state.
 
-Launch:
+Start the app with:
 
 ```sh
 npm --prefix apps/desktop start
 ```
 
-On first launch the app unzips the snapshot into
+The first launch unzips the snapshot into
 `~/Library/Application Support/cortext-desktop/site/` and boots Playground
-without re-running install.
+without re-installing anything.
 
 ## What it does
 
-Electron's main process spawns `wp-playground-cli server` against the
-unzipped site (WP 6.9) on port 9410. In front of it, a small Node proxy
-listens on 9402: any `/wp-content/uploads/*` image is served straight from
-disk, everything else is forwarded to Playground. Skipping PHP-WASM for
-thumbnails saves a round-trip per image, which adds up fast in a grid view.
+There are two processes at play. Electron spawns `wp-playground-cli server`
+on port 9410 against the unzipped site (WP 6.9). Sitting in front of it, a
+small Node proxy listens on 9402 and routes per-request: anything matching
+`/wp-content/uploads/*` is served straight from disk, the rest goes to
+Playground. The image shortcut isn't decorative; every PHP-WASM round-trip
+costs real time, and a grid view full of thumbnails feels it fast.
 
-When Playground reports ready, Electron loads
-`http://127.0.0.1:9402/wp-admin/admin.php?page=cortext`. DevTools open by
-default; pass `CORTEXT_DEVTOOLS=0` to turn them off. Closing the window
-shuts Playground down.
+Once Playground reports ready, Electron loads
+`http://127.0.0.1:9402/wp-admin/admin.php?page=cortext`. DevTools are open
+by default; pass `CORTEXT_DEVTOOLS=0` to turn them off. Closing the window
+kills the Playground process.
 
 ## Performance
 
-A cold launch (snapshot extract + boot) takes ~5-10 seconds. Warm launches
-get to "Ready!" in ~1-2 seconds, with another second or so before the shell
-paints. Inside the app, navigation is noticeably slower than `wp-env` or a
-real WordPress: every PHP request still runs through PHP-WASM, and there's
-no way around that without leaving Playground.
+A cold launch (extract + boot) takes about 5-10 seconds. Warm launches
+reach "Ready!" in 1-2 seconds, with the shell paint coming a beat after
+that. Once you're in, navigation is noticeably slower than `wp-env` or a
+real WordPress: every PHP request still goes through PHP-WASM, and that's
+the deal until we leave Playground.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,0 +1,51 @@
+# Cortext desktop
+
+Electron wrapper for Cortext. WordPress runs inside the app via Playground
+(PHP-WASM), so there's no external WordPress install to provision.
+
+## Run it
+
+From the repo root, one-time setup:
+
+```sh
+npm install
+npm --prefix apps/desktop install
+npm --prefix apps/desktop run snapshot
+```
+
+The snapshot script builds the plugin, runs `wp-playground-cli build-snapshot`
+against `blueprint.json`, and writes `apps/desktop/snapshot.zip` (~40 MB). The
+blueprint defines `CORTEXT_DESKTOP`, activates Cortext, and seeds demo data
+with `wp cortext seed`. Re-run it after plugin changes or when you want a
+fresh seed.
+
+Launch:
+
+```sh
+npm --prefix apps/desktop start
+```
+
+On first launch the app unzips the snapshot into
+`~/Library/Application Support/cortext-desktop/site/` and boots Playground
+without re-running install.
+
+## What it does
+
+Electron's main process spawns `wp-playground-cli server` against the
+unzipped site (WP 6.9) on port 9410. In front of it, a small Node proxy
+listens on 9402: any `/wp-content/uploads/*` image is served straight from
+disk, everything else is forwarded to Playground. Skipping PHP-WASM for
+thumbnails saves a round-trip per image, which adds up fast in a grid view.
+
+When Playground reports ready, Electron loads
+`http://127.0.0.1:9402/wp-admin/admin.php?page=cortext`. DevTools open by
+default; pass `CORTEXT_DEVTOOLS=0` to turn them off. Closing the window
+shuts Playground down.
+
+## Performance
+
+A cold launch (snapshot extract + boot) takes ~5-10 seconds. Warm launches
+get to "Ready!" in ~1-2 seconds, with another second or so before the shell
+paints. Inside the app, navigation is noticeably slower than `wp-env` or a
+real WordPress: every PHP request still runs through PHP-WASM, and there's
+no way around that without leaving Playground.

--- a/apps/desktop/blueprint.json
+++ b/apps/desktop/blueprint.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/admin.php?page=cortext",
+	"login": true,
+	"steps": [
+		{
+			"step": "defineWpConfigConsts",
+			"consts": {
+				"CORTEXT_DESKTOP": true
+			}
+		},
+		{
+			"step": "login",
+			"username": "admin"
+		},
+		{
+			"step": "activatePlugin",
+			"pluginPath": "/wordpress/wp-content/plugins/cortext/cortext.php"
+		},
+		{
+			"step": "wp-cli",
+			"command": "wp cortext seed"
+		}
+	]
+}

--- a/apps/desktop/error.html
+++ b/apps/desktop/error.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Cortext</title>
+		<style>
+			html,
+			body {
+				margin: 0;
+				padding: 0;
+				height: 100%;
+				background: #1d1d1d;
+				color: #f4f4f4;
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+			.wrap {
+				text-align: center;
+				max-width: 420px;
+				padding: 24px;
+			}
+			h1 {
+				font-weight: 500;
+				font-size: 20px;
+				margin: 0 0 8px;
+			}
+			p {
+				color: #9c9c9c;
+				margin: 0 0 8px;
+				font-size: 13px;
+				line-height: 1.5;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wrap">
+			<h1>Cortext could not start</h1>
+			<p>The local WordPress runtime did not become ready in time.</p>
+			<p>Quit the app and check the terminal output for details.</p>
+		</div>
+	</body>
+</html>

--- a/apps/desktop/loading.html
+++ b/apps/desktop/loading.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Cortext</title>
+		<style>
+			html,
+			body {
+				margin: 0;
+				padding: 0;
+				height: 100%;
+				background: #1d1d1d;
+				color: #f4f4f4;
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+			.wrap {
+				text-align: center;
+			}
+			h1 {
+				font-weight: 500;
+				font-size: 22px;
+				margin: 0 0 8px;
+			}
+			p {
+				color: #9c9c9c;
+				margin: 0;
+				font-size: 13px;
+			}
+			.dot {
+				display: inline-block;
+				width: 8px;
+				height: 8px;
+				margin: 0 3px;
+				border-radius: 50%;
+				background: #5a5a5a;
+				animation: pulse 1.2s infinite ease-in-out;
+			}
+			.dot:nth-child(2) {
+				animation-delay: 0.15s;
+			}
+			.dot:nth-child(3) {
+				animation-delay: 0.3s;
+			}
+			@keyframes pulse {
+				0%, 80%, 100% {
+					transform: scale(0.6);
+					opacity: 0.5;
+				}
+				40% {
+					transform: scale(1);
+					opacity: 1;
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wrap">
+			<h1>Starting Cortext</h1>
+			<p>Booting the local WordPress runtime.</p>
+			<div style="margin-top: 24px;">
+				<span class="dot"></span>
+				<span class="dot"></span>
+				<span class="dot"></span>
+			</div>
+		</div>
+	</body>
+</html>

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -1,0 +1,266 @@
+const { app, BrowserWindow } = require( 'electron' );
+const { spawn, spawnSync } = require( 'child_process' );
+const path = require( 'path' );
+const fs = require( 'fs' );
+const http = require( 'http' );
+
+const PUBLIC_PORT = 9402;
+const PLAYGROUND_PORT = 9410;
+const PLUGIN_ROOT = path.resolve( __dirname, '..', '..' );
+const SNAPSHOT_ZIP = path.resolve( __dirname, 'snapshot.zip' );
+const CLI_BIN = path.resolve( PLUGIN_ROOT, 'node_modules', '.bin', 'wp-playground-cli' );
+
+// Extensions we serve straight from disk, bypassing PHP-WASM. Every request
+// that goes through Playground costs ~50-100ms because it boots PHP and
+// WordPress per request; for a thumbnail that's a static byte stream, that
+// cost has no upside. Limiting the list to image MIME types keeps the
+// fast-path safe from anything that needs WordPress's redirect/auth/router
+// machinery (PHP files, admin endpoints, REST, etc.).
+const STATIC_EXTENSIONS = new Set( [
+	'.jpg',
+	'.jpeg',
+	'.png',
+	'.gif',
+	'.webp',
+	'.svg',
+	'.ico',
+	'.avif',
+] );
+
+const MIME_TYPES = {
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.png': 'image/png',
+	'.gif': 'image/gif',
+	'.webp': 'image/webp',
+	'.svg': 'image/svg+xml',
+	'.ico': 'image/x-icon',
+	'.avif': 'image/avif',
+};
+
+let playgroundProcess = null;
+let playgroundReady = null;
+let proxyServer = null;
+let quitting = false;
+
+function getSiteRoot() {
+	return path.join( app.getPath( 'userData' ), 'site' );
+}
+
+function ensureSiteFromSnapshot() {
+	const siteRoot = getSiteRoot();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	if ( fs.existsSync( wordpressDir ) ) {
+		return wordpressDir;
+	}
+	if ( ! fs.existsSync( SNAPSHOT_ZIP ) ) {
+		throw new Error(
+			`Snapshot not found at ${ SNAPSHOT_ZIP }. Run 'npm run snapshot' from apps/desktop/.`
+		);
+	}
+	console.log( `[cortext-desktop] extracting snapshot to ${ siteRoot }` );
+	fs.mkdirSync( siteRoot, { recursive: true } );
+	spawnSync(
+		'unzip',
+		[ '-q', '-o', SNAPSHOT_ZIP, '-d', siteRoot ],
+		{ stdio: [ 'ignore', 'ignore', 'ignore' ] }
+	);
+	if ( ! fs.existsSync( path.join( wordpressDir, 'index.php' ) ) ) {
+		throw new Error( `Snapshot extraction failed: ${ wordpressDir } is empty.` );
+	}
+	return wordpressDir;
+}
+
+function startPlayground( wordpressDir ) {
+	playgroundProcess = spawn(
+		CLI_BIN,
+		[
+			'server',
+			'--mount', `${ wordpressDir }:/wordpress`,
+			'--wordpress-install-mode', 'do-not-attempt-installing',
+			'--login',
+			'--port', String( PLAYGROUND_PORT ),
+			'--site-url', `http://127.0.0.1:${ PUBLIC_PORT }`,
+			'--wp', '6.9',
+		],
+		{
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+			cwd: PLUGIN_ROOT,
+		}
+	);
+
+	// Wait for the cli's "Ready!" line on stdout before letting the renderer
+	// navigate. The cli binds the TCP port well before WordPress is wired up,
+	// and any request that hits it during that window gets a 502 with body
+	// "WordPress is not ready yet". Waiting on the explicit signal avoids
+	// landing the user on that intermediate response.
+	playgroundReady = new Promise( ( resolve, reject ) => {
+		const timer = setTimeout( () => {
+			reject( new Error( 'Playground startup timed out (120s)' ) );
+		}, 120000 );
+		let stdoutBuffer = '';
+		playgroundProcess.stdout.on( 'data', ( chunk ) => {
+			const text = chunk.toString();
+			process.stdout.write( text );
+			stdoutBuffer += text;
+			if ( stdoutBuffer.includes( 'Ready! WordPress is running' ) ) {
+				clearTimeout( timer );
+				resolve();
+			}
+		} );
+		playgroundProcess.stderr.on( 'data', ( chunk ) => {
+			process.stderr.write( chunk );
+		} );
+		playgroundProcess.once( 'exit', () => {
+			clearTimeout( timer );
+			reject( new Error( 'Playground exited before reporting ready' ) );
+		} );
+	} );
+
+	playgroundProcess.on( 'exit', ( code ) => {
+		console.log( `[cortext-desktop] playground exited (code=${ code })` );
+		if ( ! quitting ) {
+			app.quit();
+		}
+	} );
+}
+
+function stopPlayground() {
+	if ( playgroundProcess && ! playgroundProcess.killed ) {
+		playgroundProcess.kill( 'SIGTERM' );
+	}
+}
+
+function tryServeStaticUpload( req, res, wordpressDir ) {
+	const url = new URL( req.url, `http://127.0.0.1:${ PUBLIC_PORT }` );
+	if ( ! url.pathname.startsWith( '/wp-content/uploads/' ) ) {
+		return false;
+	}
+	const ext = path.extname( url.pathname ).toLowerCase();
+	if ( ! STATIC_EXTENSIONS.has( ext ) ) {
+		return false;
+	}
+	const uploadsRoot = path.join( wordpressDir, 'wp-content', 'uploads' );
+	const relative = url.pathname.slice( '/wp-content/uploads/'.length );
+	const resolved = path.resolve( uploadsRoot, relative );
+	// Reject any path that escapes the uploads dir via `..` or symlink
+	// trickery. `path.resolve` collapses traversal, so the prefix check is
+	// the actual safety guard.
+	if ( ! resolved.startsWith( uploadsRoot + path.sep ) ) {
+		res.writeHead( 403 );
+		res.end();
+		return true;
+	}
+	fs.stat( resolved, ( err, stat ) => {
+		if ( err || ! stat.isFile() ) {
+			// Fall through to PHP-WASM. WordPress may know how to serve
+			// (or generate) this file even though it's not on disk where we
+			// expect it.
+			proxyToPlayground( req, res );
+			return;
+		}
+		res.writeHead( 200, {
+			'Content-Type': MIME_TYPES[ ext ] ?? 'application/octet-stream',
+			'Content-Length': stat.size,
+			'Cache-Control': 'public, max-age=31536000, immutable',
+		} );
+		fs.createReadStream( resolved ).pipe( res );
+	} );
+	return true;
+}
+
+function proxyToPlayground( req, res ) {
+	const upstream = http.request(
+		{
+			host: '127.0.0.1',
+			port: PLAYGROUND_PORT,
+			path: req.url,
+			method: req.method,
+			headers: req.headers,
+		},
+		( upstreamRes ) => {
+			res.writeHead( upstreamRes.statusCode, upstreamRes.headers );
+			upstreamRes.pipe( res );
+		}
+	);
+	upstream.on( 'error', ( err ) => {
+		console.error( '[cortext-desktop] upstream error:', err.message );
+		if ( ! res.headersSent ) {
+			res.writeHead( 502 );
+		}
+		res.end();
+	} );
+	req.pipe( upstream );
+}
+
+function startProxy( wordpressDir ) {
+	proxyServer = http.createServer( ( req, res ) => {
+		// Static image fast-path. Anything that isn't an image upload, or
+		// fails to resolve on disk, falls through to the cli on the
+		// internal port (which still runs the full WordPress request cycle
+		// in PHP-WASM).
+		if ( ! tryServeStaticUpload( req, res, wordpressDir ) ) {
+			proxyToPlayground( req, res );
+		}
+	} );
+	proxyServer.listen( PUBLIC_PORT, '127.0.0.1' );
+}
+
+function stopProxy() {
+	if ( proxyServer ) {
+		proxyServer.close();
+		proxyServer = null;
+	}
+}
+
+async function createWindow() {
+	const win = new BrowserWindow( {
+		width: 1280,
+		height: 800,
+		title: 'Cortext',
+		backgroundColor: '#1d1d1d',
+		webPreferences: {
+			contextIsolation: true,
+		},
+	} );
+
+	await win.loadFile( path.resolve( __dirname, 'loading.html' ) );
+
+	try {
+		await playgroundReady;
+		await win.loadURL( `http://127.0.0.1:${ PUBLIC_PORT }/wp-admin/admin.php?page=cortext` );
+		if ( process.env.CORTEXT_DEVTOOLS !== '0' ) {
+			win.webContents.openDevTools( { mode: 'detach' } );
+		}
+	} catch ( err ) {
+		console.error( '[cortext-desktop] failed to reach Playground:', err );
+		await win.loadFile( path.resolve( __dirname, 'error.html' ) );
+	}
+}
+
+app.whenReady().then( () => {
+	try {
+		const wordpressDir = ensureSiteFromSnapshot();
+		startPlayground( wordpressDir );
+		startProxy( wordpressDir );
+		createWindow();
+	} catch ( err ) {
+		console.error( '[cortext-desktop]', err );
+		app.quit();
+	}
+} );
+
+app.on( 'window-all-closed', () => {
+	quitting = true;
+	stopProxy();
+	stopPlayground();
+	if ( process.platform !== 'darwin' ) {
+		app.quit();
+	}
+} );
+
+app.on( 'before-quit', () => {
+	quitting = true;
+	stopProxy();
+	stopPlayground();
+} );

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,0 +1,872 @@
+{
+	"name": "cortext-desktop",
+	"version": "0.0.1",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "cortext-desktop",
+			"version": "0.0.1",
+			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"electron": "^33.2.0"
+			}
+		},
+		"node_modules/@electron/get": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
+			}
+		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "20.19.41",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+			"integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/boolean": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
+		"node_modules/cacheable-request": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decompress-response/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/defer-to-connect": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/electron": {
+			"version": "33.4.11",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+			"integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/get": "^2.0.0",
+				"@types/node": "^20.9.0",
+				"extract-zip": "^2.0.1"
+			},
+			"bin": {
+				"electron": "cli.js"
+			},
+			"engines": {
+				"node": ">= 12.20.55"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/global-agent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"es6-error": "^4.1.1",
+				"matcher": "^3.0.0",
+				"roarr": "^2.15.3",
+				"semver": "^7.3.2",
+				"serialize-error": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=10.0"
+			}
+		},
+		"node_modules/global-agent/node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/got": {
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			}
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/matcher": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/roarr": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"detect-node": "^2.0.4",
+				"globalthis": "^1.0.1",
+				"json-stringify-safe": "^5.0.1",
+				"semver-compare": "^1.0.0",
+				"sprintf-js": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/serialize-error": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"type-fest": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
+		"node_modules/sumchecker": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+			"integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.1.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		}
+	}
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,8 @@
 	"license": "GPL-2.0-or-later",
 	"main": "main.js",
 	"scripts": {
-		"start": "electron ."
+		"start": "electron .",
+		"snapshot": "node scripts/build-snapshot.mjs"
 	},
 	"devDependencies": {
 		"electron": "^33.2.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "cortext-desktop",
+	"version": "0.0.1",
+	"description": "Cortext desktop app, Electron shell hosting the Cortext plugin via WordPress Playground.",
+	"private": true,
+	"license": "GPL-2.0-or-later",
+	"main": "main.js",
+	"scripts": {
+		"start": "electron ."
+	},
+	"devDependencies": {
+		"electron": "^33.2.0"
+	}
+}

--- a/apps/desktop/scripts/build-snapshot.mjs
+++ b/apps/desktop/scripts/build-snapshot.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { rmSync, mkdirSync, cpSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+const DESKTOP_DIR = resolve( __dirname, '..' );
+const REPO_ROOT = resolve( DESKTOP_DIR, '..', '..' );
+const WORK_DIR = resolve( DESKTOP_DIR, '.snapshot-work' );
+const STAGED_PLUGIN = resolve( WORK_DIR, 'cortext' );
+const OUTFILE = resolve( DESKTOP_DIR, 'snapshot.zip' );
+const BLUEPRINT = resolve( DESKTOP_DIR, 'blueprint.json' );
+const CLI = resolve( REPO_ROOT, 'node_modules', '.bin', 'wp-playground-cli' );
+
+const PLUGIN_INCLUDES = [
+	'cortext.php',
+	'readme.txt',
+	'LICENSE',
+	'includes',
+	'build',
+	'templates',
+	'src/blocks',
+	'seed-assets',
+	'vendor',
+];
+
+function run( cmd, opts = {} ) {
+	execSync( cmd, { stdio: 'inherit', ...opts } );
+}
+
+console.log( '[snapshot] Building plugin assets' );
+run( 'npm run build', { cwd: REPO_ROOT } );
+
+console.log( '[snapshot] Staging plugin files' );
+rmSync( WORK_DIR, { recursive: true, force: true } );
+mkdirSync( STAGED_PLUGIN, { recursive: true } );
+for ( const entry of PLUGIN_INCLUDES ) {
+	const src = resolve( REPO_ROOT, entry );
+	if ( ! existsSync( src ) ) {
+		continue;
+	}
+	const dest = resolve( STAGED_PLUGIN, entry );
+	mkdirSync( dirname( dest ), { recursive: true } );
+	cpSync( src, dest, { recursive: true } );
+}
+
+console.log( '[snapshot] Running wp-playground-cli build-snapshot' );
+rmSync( OUTFILE, { force: true } );
+run(
+	[
+		CLI,
+		'build-snapshot',
+		`--blueprint=${ BLUEPRINT }`,
+		'--wp=6.9',
+		`--mount=${ STAGED_PLUGIN }:/wordpress/wp-content/plugins/cortext`,
+		`--outfile=${ OUTFILE }`,
+	].join( ' ' )
+);
+
+console.log( '[snapshot] Cleaning staging dir' );
+rmSync( WORK_DIR, { recursive: true, force: true } );
+
+console.log( `[snapshot] Done. Output: ${ OUTFILE }` );


### PR DESCRIPTION
## What

Part of #196

Exploration to add a desktop wrapper for Cortext. The app starts a local WordPress Playground site, waits for it to be ready, and opens the Cortext admin screen in Electron. It also includes basic loading and startup error screens.

It's quite slow, but it validates the point and we can iterate from here.

## Why

This makes it possible to try Cortext without setting up a separate WordPress install.

## How

- Building a seeded Playground snapshot with Cortext already activated.
- Extracting that snapshot into Electron user data on first launch.
- Routing app traffic through a local proxy and serving uploaded images from disk when possible.

## Testing Instructions

1. Build a fresh desktop snapshot using the README instructions.
2. Launch the desktop app.
3. Confirm the loading screen appears, then the Cortext admin page opens.
4. Confirm seeded media appears in the Cortext UI.
5. Quit the app and confirm the local runtime shuts down.

## Screen recording

https://github.com/user-attachments/assets/6c0a8e2f-c00e-426b-bf57-ef869f4f0014
