### PR TITLE
Add bulk row selection and delete

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -321,15 +321,19 @@ The create-field flow also has to reveal the new trailing column itself. It carr
 
 **Solution.** `Popover` needs a parent/child dismissal story: either close the whole stack when a click lands outside all related popovers, or expose enough event detail for a host popover to opt into that behavior without a document-level listener.
 
-## 36. Table calculations sit outside DataViews' table contract `[upstream, internal]`
+## 36. Table footer content sits outside DataViews' table contract `[upstream, internal]`
 
-**What.** DataViews renders the table, but it doesn't expose a table footer row, a per-column summary cell, or a "filtered rows before pagination" result. The calculation footer therefore finds the rendered `.dataviews-view-table`, watches for it with a `MutationObserver`, and portals a `<tfoot>` into the table after DataViews has already rendered. To keep results aligned with the current search/filter state but not the current page, `CollectionDataViews` also runs DataViews' `filterSortAndPaginate` helper a second time with `page` and `perPage` removed.
+**What.** DataViews owns the table markup, but it gives us nowhere inside that table to put footer content. It has no footer-row slot, no per-column summary cell, no table-aligned bulk-action area, and no "filtered rows before pagination" result. The calculation footer has to find the rendered `.dataviews-view-table`, watch for it with a `MutationObserver`, and portal a `<tfoot>` into the table after DataViews has finished rendering.
 
-The state is ours too. `view.calculations` lives on the DataViews view object because embedded data-view blocks already persist that object, and named saved views do not exist yet. `normalizeView` prunes stale calculation entries when fields disappear or their type changes. That keeps the saved shape honest, but it is still Cortext state attached to a DataViews object that upstream knows nothing about.
+For table layout, bulk row actions use that same footer row. It looks right: selected-row controls and column summaries sit on one line. That leaves some awkward plumbing. `CollectionDataViews` passes the table bulk controls into the portaled footer, and `index.scss` manages the checkbox-width spacer, overflow, and stacking so the buttons stay clickable without painting over the block selection outline. Grid still uses the composed DataViews footer because there is no table summary row to align with.
 
-**Where.** `src/components/TableCalculationsFooter.js` (table lookup, observer, `<tfoot>` portal), `src/components/CollectionDataViews.js` (second filtering pass and footer mount), `src/components/tableCalculations.js` (operation matrix and result formatting), and `src/components/dataViewColumns.js` (view cleanup).
+For calculations, we also need rows after search/filter but before pagination. DataViews does not hand that list back to consumers, so `CollectionDataViews` runs DataViews' `filterSortAndPaginate` helper a second time with `page` and `perPage` removed.
 
-**Solution.** Upstream DataViews could expose one of two shapes: a table `renderFooter` / `renderSummaryRow` slot, or a column-level summary API that receives the filtered, unpaginated rows. Either would let us drop the DOM lookup and portal. A separate helper that returns filtered rows before pagination would remove the second `filterSortAndPaginate` pass. Internally, saved named views should eventually make `calculations` part of Cortext's own saved view schema instead of just an extra key on embedded block state.
+Calculation state also stays in Cortext. `view.calculations` lives on the DataViews view object because embedded data-view blocks already persist that object, and named saved views do not exist yet. `normalizeView` prunes stale calculation entries when fields disappear or their type changes. That keeps the saved shape honest, but it is still Cortext state attached to a DataViews object that upstream knows nothing about.
+
+**Where.** `src/components/TableCalculationsFooter.js` (table lookup, observer, `<tfoot>` portal), `src/components/CollectionDataViews.js` (second filtering pass, table bulk controls, and footer mount), `src/index.scss` (footer-row alignment and overflow rules), `src/components/tableCalculations.js` (operation matrix and result formatting), and `src/components/dataViewColumns.js` (view cleanup).
+
+**Solution.** DataViews needs either a table `renderFooter` / `renderSummaryRow` slot, or a column-level summary API that gets the filtered, unpaginated rows and leaves space for table-level selection controls. Then we can drop the DOM lookup and portal. A helper that returns filtered rows before pagination would remove the second `filterSortAndPaginate` pass. Internally, saved named views should eventually make `calculations` part of Cortext's own saved view schema instead of just an extra key on embedded block state.
 
 ## 37. DataViews has no relation/reference field primitive `[upstream]`
 
@@ -448,3 +452,13 @@ Trash is the clearest example. The endpoint is document-first, but the client st
 **Where.** `includes/Block/DataView.php` (render callback enqueue), `includes/Frontend/Assets.php` (page-level enqueue), `src/frontend.js` (single entry point for both concerns).
 
 **Solution.** Split `src/frontend.js` into two entry points: one for page chrome (`cortext-frontend`) and one for the DataView block (`cortext-data-view-view`). The block entry handles hydration and declares its own dependencies. The page entry stays minimal. Update `webpack.config.js` with the new entry point, and update `DataView.php` to enqueue the block-specific handle.
+
+## 51. DataViews selection is page-local `[upstream, internal]`
+
+**What.** DataViews accepts a controlled `selection`, but the value layouts receive is filtered to the rows in the current `data` array. Its built-in clicks are page-local as well: table rows handle plain and modifier clicks, grid cards handle modifier clicks, and neither layout gives us shift-range selection across the rendered page. Cortext needs selected row IDs to survive pagination. It also needs the selected row objects later for bulk Trash actions and partial-failure cleanup.
+
+`CollectionDataViews` owns the real selection state instead: selected IDs, a cache of selected row objects seen on previous pages, a shift-click anchor, and a capture-phase click-intent layer. That layer translates DataViews' visible-page selection changes into Cortext's persistent selection. The pure helpers in `dataViewSelection.js` keep the merge behavior testable. This works, but it leans on DataViews layout class names and event order.
+
+**Where.** Selection state and `captureSelectionIntent` in `src/components/CollectionDataViews.js`, helper functions in `src/components/dataViewSelection.js`, and coverage in `tests/js/components/dataViewSelection.test.js` plus `tests/e2e/specs/data-view-block.spec.js`.
+
+**Solution.** DataViews could treat selection as a persistent ID set, with range selection and consistent modifier behavior across table and grid. It should not filter hidden IDs out of the controlled value before handing it to layouts. Bulk actions also need either all selected items, or an item resolver for selected IDs that are not on the current page. With that, Cortext can drop the row cache, click-intent capture, and most of `dataViewSelection.js`.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -321,11 +321,11 @@ The create-field flow also has to reveal the new trailing column itself. It carr
 
 **Solution.** `Popover` needs a parent/child dismissal story: either close the whole stack when a click lands outside all related popovers, or expose enough event detail for a host popover to opt into that behavior without a document-level listener.
 
-## 36. Table footer content sits outside DataViews' table contract `[upstream, internal]`
+## 36. Table footer content lives outside DataViews' table contract `[upstream, internal]`
 
-**What.** DataViews owns the table markup, but it gives us nowhere inside that table to put footer content. It has no footer-row slot, no per-column summary cell, no table-aligned bulk-action area, and no "filtered rows before pagination" result. The calculation footer has to find the rendered `.dataviews-view-table`, watch for it with a `MutationObserver`, and portal a `<tfoot>` into the table after DataViews has finished rendering.
+**What.** DataViews owns the table markup, but it has no place for footer content: no footer-row slot, no per-column summary cell, no table-aligned bulk-action area, and no "filtered rows before pagination" result. The calculation footer has to find the rendered `.dataviews-view-table`, watch for it with a `MutationObserver`, and portal a `<tfoot>` into the table after DataViews renders.
 
-For table layout, bulk row actions use that same footer row. It looks right: selected-row controls and column summaries sit on one line. That leaves some awkward plumbing. `CollectionDataViews` passes the table bulk controls into the portaled footer, and `index.scss` manages the checkbox-width spacer, overflow, and stacking so the buttons stay clickable without painting over the block selection outline. Grid still uses the composed DataViews footer because there is no table summary row to align with.
+In table layout, bulk row actions use that same footer row. Selected-row controls and column summaries sit on one line, which is the right layout, but the plumbing is awkward. `CollectionDataViews` passes the table bulk controls into the portaled footer, and `index.scss` manages the checkbox-width spacer, overflow, and stacking so the buttons stay clickable without painting over the block selection outline. Grid still uses the composed DataViews footer because there is no table summary row to align with.
 
 For calculations, we also need rows after search/filter but before pagination. DataViews does not hand that list back to consumers, so `CollectionDataViews` runs DataViews' `filterSortAndPaginate` helper a second time with `page` and `perPage` removed.
 
@@ -455,20 +455,20 @@ Trash is the clearest example. The endpoint is document-first, but the client st
 
 ## 51. DataViews selection is page-local `[upstream, internal]`
 
-**What.** DataViews accepts a controlled `selection`, but the value layouts receive is filtered to the rows in the current `data` array. Its built-in clicks are page-local as well: table rows handle plain and modifier clicks, grid cards handle modifier clicks, and neither layout gives us shift-range selection across the rendered page. Cortext needs selected row IDs to survive pagination. It also needs the selected row objects later for bulk Trash actions and partial-failure cleanup.
+**What.** DataViews accepts a controlled `selection`, but layouts only receive the IDs for rows in the current `data` array. Its built-in clicks are page-local too: table rows handle plain and modifier clicks, grid cards handle modifier clicks, and neither layout gives us shift-range selection across the rendered page. Cortext needs selected row IDs to survive pagination. It also needs the selected row objects later for bulk Trash actions and partial-failure cleanup.
 
-`CollectionDataViews` owns the real selection state instead: selected IDs, a cache of selected row objects seen on previous pages, a shift-click anchor, and a capture-phase click-intent layer. That layer translates DataViews' visible-page selection changes into Cortext's persistent selection. The pure helpers in `dataViewSelection.js` keep the merge behavior testable. This works, but it leans on DataViews layout class names and event order.
+`CollectionDataViews` keeps the real selection state: selected IDs, a cache of selected row objects seen on previous pages, a shift-click anchor, and a capture-phase click-intent layer. That layer translates DataViews' visible-page selection changes into Cortext's persistent selection. The pure helpers in `dataViewSelection.js` keep the merge behavior testable. This works, but it is tied to DataViews layout class names and event order.
 
 **Where.** Selection state and `captureSelectionIntent` in `src/components/CollectionDataViews.js`, helper functions in `src/components/dataViewSelection.js`, and coverage in `tests/js/components/dataViewSelection.test.js` plus `tests/e2e/specs/data-view-block.spec.js`.
 
 **Solution.** DataViews could treat selection as a persistent ID set, with range selection and consistent modifier behavior across table and grid. It should not filter hidden IDs out of the controlled value before handing it to layouts. Bulk actions also need either all selected items, or an item resolver for selected IDs that are not on the current page. With that, Cortext can drop the row cache, click-intent capture, and most of `dataViewSelection.js`.
 
-## 49. Bulk row delete fans out through per-row REST calls `[internal, soft]`
+## 52. Bulk row trash fans out through per-row REST calls `[internal, soft]`
 
-**What.** Bulk row delete still uses the same row REST delete endpoint as the single-row action. The client sends one `DELETE /wp/v2/<row post type>/<id>?force=true` per selected row, capped at four concurrent requests by `allSettledWithConcurrency`. That cap keeps a large selection from flooding the server, and the all-settled result shape lets us keep partial-failure behavior simple.
+**What.** Bulk row trash still calls the same row REST delete endpoint as the single-row action. The client sends one `DELETE /wp/v2/<row post type>/<id>` request per selected row, capped at four concurrent requests by `allSettledWithConcurrency`. That cap keeps a large selection from flooding the server, and the `Promise.allSettled`-style result list keeps partial failures easy to handle.
 
-This is fine for the current DataView scale. It is not a real bulk operation, though. A 100-row delete still means 100 REST writes, just in a small queue. There is no atomic all-or-nothing behavior, no server-side progress state, and no way to resume if the browser goes away mid-run.
+That is acceptable for the current DataView scale. It is not a real bulk operation, though. Moving 100 rows to Trash still means 100 REST writes, just in a small queue. There is no atomic all-or-nothing behavior, no server-side progress state, and no way to resume if the browser goes away mid-run.
 
-**Where.** `confirmDeleteRows` in `src/components/CollectionDataViews.js`, the queue helper in `src/components/allSettledWithConcurrency.js`, and coverage in `tests/js/components/allSettledWithConcurrency.test.js`.
+**Where.** `requestDeleteRows` in `src/components/CollectionDataViews.js`, the queue helper in `src/components/allSettledWithConcurrency.js`, and coverage in `tests/js/components/allSettledWithConcurrency.test.js`.
 
-**Solution.** If collections start handling large row sets, add a collection-row bulk delete endpoint or an async job endpoint with progress polling. That endpoint should own permission checks, deletion order, partial-failure reporting, and cleanup. Then the DataView action can send selected IDs once instead of managing a client-side queue.
+**Solution.** If collections start moving large row sets to Trash, add a collection-row bulk trash endpoint or an async job endpoint with progress polling. That endpoint should own permission checks, trash order, partial-failure reporting, and cleanup. Then the DataView action can send selected IDs once instead of managing a client-side queue.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -462,3 +462,13 @@ Trash is the clearest example. The endpoint is document-first, but the client st
 **Where.** Selection state and `captureSelectionIntent` in `src/components/CollectionDataViews.js`, helper functions in `src/components/dataViewSelection.js`, and coverage in `tests/js/components/dataViewSelection.test.js` plus `tests/e2e/specs/data-view-block.spec.js`.
 
 **Solution.** DataViews could treat selection as a persistent ID set, with range selection and consistent modifier behavior across table and grid. It should not filter hidden IDs out of the controlled value before handing it to layouts. Bulk actions also need either all selected items, or an item resolver for selected IDs that are not on the current page. With that, Cortext can drop the row cache, click-intent capture, and most of `dataViewSelection.js`.
+
+## 49. Bulk row delete fans out through per-row REST calls `[internal, soft]`
+
+**What.** Bulk row delete still uses the same row REST delete endpoint as the single-row action. The client sends one `DELETE /wp/v2/<row post type>/<id>?force=true` per selected row, capped at four concurrent requests by `allSettledWithConcurrency`. That cap keeps a large selection from flooding the server, and the all-settled result shape lets us keep partial-failure behavior simple.
+
+This is fine for the current DataView scale. It is not a real bulk operation, though. A 100-row delete still means 100 REST writes, just in a small queue. There is no atomic all-or-nothing behavior, no server-side progress state, and no way to resume if the browser goes away mid-run.
+
+**Where.** `confirmDeleteRows` in `src/components/CollectionDataViews.js`, the queue helper in `src/components/allSettledWithConcurrency.js`, and coverage in `tests/js/components/allSettledWithConcurrency.test.js`.
+
+**Solution.** If collections start handling large row sets, add a collection-row bulk delete endpoint or an async job endpoint with progress polling. That endpoint should own permission checks, deletion order, partial-failure reporting, and cleanup. Then the DataView action can send selected IDs once instead of managing a client-side queue.

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1265,13 +1265,7 @@ export default function CollectionDataViews( {
 				setRowActionError( deleteErrorMessage );
 			}
 		},
-		[
-			forgetDeletedRows,
-			openRowId,
-			postType,
-			refresh,
-			runDetailTransition,
-		]
+		[ forgetDeletedRows, openRowId, postType, refresh, runDetailTransition ]
 	);
 
 	const requestDeleteSelectedRows = useCallback( () => {
@@ -1782,8 +1776,8 @@ export default function CollectionDataViews( {
 						</div>
 					</div>
 					{ detailSurface }
-					</div>
-				</OpenRowActionContext.Provider>
-			</RowMutationContext.Provider>
+				</div>
+			</OpenRowActionContext.Provider>
+		</RowMutationContext.Provider>
 	);
 }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1,5 +1,11 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Notice } from '@wordpress/components';
+import {
+	Button,
+	CheckboxControl,
+	Notice,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import {
 	createContext,
@@ -11,8 +17,8 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { copy, plus, trash } from '@wordpress/icons';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { closeSmall, copy, plus, trash } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
 
 import DataViewColumnInteractions from './DataViewColumnInteractions';
@@ -40,6 +46,16 @@ import {
 	getRowDetailMode,
 	withRowDetailMode,
 } from './rowDetailUtils';
+import {
+	applyVisibleSelectionChange,
+	mergeVisibleSelection,
+	normalizeRowId,
+	rangeSelection,
+	removeDeletedSelection,
+	rowIds,
+	rowsInDataViewRenderOrder,
+	toggleVisibleSelection,
+} from './dataViewSelection';
 import { useCollectionFieldsContext } from './CollectionFieldsContext';
 import { dataViewsFilterByForType } from '../hooks/fieldMapping';
 import { toDataViewId, toRecordId } from '../hooks/fieldIds';
@@ -275,6 +291,190 @@ function NewRowButton( { slug, view, fields, onCreated, disabled } ) {
 	);
 }
 
+const TABLE_ROW_SELECTOR =
+	'.dataviews-view-table tbody > tr:not(.dataviews-view-table__group-header-row)';
+const GRID_CARD_SELECTOR = '.dataviews-view-grid__card';
+const INTERACTIVE_SELECTION_IGNORE_SELECTOR =
+	'button, a, input, textarea, select, [contenteditable="true"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], .components-button';
+
+function findDataViewItemFromEvent( event, wrapper, layout, rows ) {
+	const target = event.target;
+	if ( ! target || ! wrapper ) {
+		return null;
+	}
+
+	const selector =
+		layout === 'grid' ? GRID_CARD_SELECTOR : TABLE_ROW_SELECTOR;
+	const itemElement = target.closest?.( selector );
+	if ( ! itemElement || ! wrapper.contains( itemElement ) ) {
+		return null;
+	}
+
+	const renderedItems = Array.from( wrapper.querySelectorAll( selector ) );
+	const index = renderedItems.indexOf( itemElement );
+	if ( index < 0 || ! rows[ index ]?.id ) {
+		return null;
+	}
+
+	return {
+		id: normalizeRowId( rows[ index ].id ),
+		row: rows[ index ],
+	};
+}
+
+function DataViewsChrome( { footer } ) {
+	return (
+		<>
+			<HStack
+				alignment="top"
+				justify="space-between"
+				className="dataviews__view-actions"
+				spacing={ 1 }
+			>
+				<HStack
+					justify="start"
+					expanded={ false }
+					className="dataviews__search"
+				>
+					<DataViews.Search />
+					<DataViews.FiltersToggle />
+				</HStack>
+				<HStack
+					spacing={ 1 }
+					expanded={ false }
+					style={ { flexShrink: 0 } }
+				>
+					<DataViews.LayoutSwitcher />
+					<DataViews.ViewConfig />
+				</HStack>
+			</HStack>
+			<DataViews.Filters className="dataviews-filters__container" />
+			<DataViews.Layout />
+			{ footer }
+		</>
+	);
+}
+
+function DataViewsBulkSelectionControls( {
+	className = 'dataviews-bulk-actions-footer__container',
+	selectedIds,
+	visibleIds,
+	onClearSelection,
+	onDeleteSelected,
+	onToggleVisibleSelection,
+} ) {
+	const selectedSet = useMemo(
+		() => new Set( selectedIds ),
+		[ selectedIds ]
+	);
+	const selectedCount = selectedIds.length;
+	const visibleCount = visibleIds.length;
+	const selectedVisibleCount = visibleIds.filter( ( id ) =>
+		selectedSet.has( id )
+	).length;
+	const allVisibleSelected =
+		visibleCount > 0 && selectedVisibleCount === visibleCount;
+	const hasVisibleSelection = selectedVisibleCount > 0;
+
+	const countLabel =
+		selectedCount > 0
+			? sprintf(
+					/* translators: %d: number of selected rows. */
+					_n(
+						'%d row selected',
+						'%d rows selected',
+						selectedCount,
+						'cortext'
+					),
+					selectedCount
+			  )
+			: sprintf(
+					/* translators: %d: number of visible rows. */
+					_n( '%d row', '%d rows', visibleCount, 'cortext' ),
+					visibleCount
+			  );
+
+	return (
+		<HStack expanded={ false } className={ className } spacing={ 3 }>
+			<CheckboxControl
+				className="dataviews-view-table-selection-checkbox"
+				__nextHasNoMarginBottom
+				checked={ allVisibleSelected }
+				indeterminate={ ! allVisibleSelected && hasVisibleSelection }
+				onChange={ onToggleVisibleSelection }
+				aria-label={
+					allVisibleSelected
+						? __( 'Deselect visible rows', 'cortext' )
+						: __( 'Select visible rows', 'cortext' )
+				}
+			/>
+			<span className="dataviews-bulk-actions-footer__item-count">
+				{ countLabel }
+			</span>
+			<HStack
+				className="dataviews-bulk-actions-footer__action-buttons"
+				expanded={ false }
+				spacing={ 1 }
+			>
+				{ selectedCount > 0 && (
+					<Button
+						icon={ trash }
+						isDestructive
+						label={ __( 'Trash selected rows', 'cortext' ) }
+						onClick={ onDeleteSelected }
+						size="compact"
+						showTooltip
+						tooltipPosition="top"
+					/>
+				) }
+				{ selectedCount > 0 && (
+					<Button
+						icon={ closeSmall }
+						label={ __( 'Clear selection', 'cortext' ) }
+						onClick={ onClearSelection }
+						size="compact"
+						showTooltip
+						tooltipPosition="top"
+					/>
+				) }
+			</HStack>
+		</HStack>
+	);
+}
+
+function DataViewsSelectionFooter( {
+	enabled,
+	selectedIds,
+	visibleIds,
+	totalItems,
+	totalPages,
+	onClearSelection,
+	onDeleteSelected,
+	onToggleVisibleSelection,
+} ) {
+	const showBulkControls = enabled && totalItems > 0;
+	const showPagination = totalItems > 0 && totalPages > 1;
+
+	if ( ! showBulkControls && ! showPagination ) {
+		return null;
+	}
+
+	return (
+		<HStack expanded={ false } justify="end" className="dataviews-footer">
+			{ showBulkControls ? (
+				<DataViewsBulkSelectionControls
+					selectedIds={ selectedIds }
+					visibleIds={ visibleIds }
+					onClearSelection={ onClearSelection }
+					onDeleteSelected={ onDeleteSelected }
+					onToggleVisibleSelection={ onToggleVisibleSelection }
+				/>
+			) : null }
+			<DataViews.Pagination />
+		</HStack>
+	);
+}
+
 export default function CollectionDataViews( {
 	collectionId,
 	view,
@@ -329,6 +529,8 @@ export default function CollectionDataViews( {
 	);
 
 	const isTableLayout = view?.type === 'table';
+	const isGridLayout = view?.type === 'grid';
+	const supportsRowSelection = isTableLayout || isGridLayout;
 	const isServerPaginated = queryMode === 'server';
 	const dataViewFields = availableFields;
 
@@ -412,6 +614,194 @@ export default function CollectionDataViews( {
 	const activePaginationInfo = isServerPaginated
 		? serverPaginationInfo
 		: clientPaginationInfo;
+
+	const dataFilteredInRenderOrder = useMemo(
+		() => rowsInDataViewRenderOrder( dataFiltered, view, dataViewFields ),
+		[ dataFiltered, view, dataViewFields ]
+	);
+	const visibleRowIds = useMemo(
+		() => rowIds( dataFilteredInRenderOrder ),
+		[ dataFilteredInRenderOrder ]
+	);
+	const visibleRowsById = useMemo(
+		() =>
+			new Map(
+				dataFiltered.map( ( row ) => [ normalizeRowId( row.id ), row ] )
+			),
+		[ dataFiltered ]
+	);
+	const [ selectedRowIds, setSelectedRowIds ] = useState( [] );
+	const [ selectedRowsById, setSelectedRowsById ] = useState( {} );
+	const [ selectionAnchorId, setSelectionAnchorId ] = useState( null );
+	// tech-debt.md#48: DataViews only gives layouts the current-page
+	// selection, so Cortext owns off-page ids and click-intent merging.
+	const selectionInteractionRef = useRef( null );
+
+	const cacheSelectedRows = useCallback(
+		( ids ) => {
+			setSelectedRowsById( ( current ) => {
+				let next = current;
+				ids.forEach( ( id ) => {
+					const row = visibleRowsById.get( normalizeRowId( id ) );
+					if ( ! row ) {
+						return;
+					}
+					if ( next === current ) {
+						next = { ...current };
+					}
+					next[ normalizeRowId( id ) ] = row;
+				} );
+				return next;
+			} );
+		},
+		[ visibleRowsById ]
+	);
+
+	const selectedRows = useMemo(
+		() =>
+			selectedRowIds
+				.map(
+					( id ) =>
+						selectedRowsById[ id ] ?? visibleRowsById.get( id )
+				)
+				.filter( Boolean ),
+		[ selectedRowIds, selectedRowsById, visibleRowsById ]
+	);
+
+	const updateSelectedRowIds = useCallback(
+		( updater ) => {
+			setSelectedRowIds( ( current ) => {
+				const next =
+					typeof updater === 'function'
+						? updater( current )
+						: updater;
+				cacheSelectedRows( next );
+				return next;
+			} );
+		},
+		[ cacheSelectedRows ]
+	);
+
+	const onChangeSelection = useCallback(
+		( nextVisibleSelection ) => {
+			if ( ! supportsRowSelection ) {
+				return;
+			}
+			const interaction = selectionInteractionRef.current ?? {};
+			selectionInteractionRef.current = null;
+			if ( ! interaction.type ) {
+				return;
+			}
+			updateSelectedRowIds( ( current ) =>
+				applyVisibleSelectionChange(
+					current,
+					nextVisibleSelection,
+					visibleRowIds,
+					interaction
+				)
+			);
+			if ( interaction.targetId ) {
+				setSelectionAnchorId( interaction.targetId );
+			}
+		},
+		[ supportsRowSelection, updateSelectedRowIds, visibleRowIds ]
+	);
+
+	const clearSelection = useCallback( () => {
+		setSelectedRowIds( [] );
+		setSelectedRowsById( {} );
+		setSelectionAnchorId( null );
+	}, [] );
+
+	const toggleVisibleRows = useCallback( () => {
+		updateSelectedRowIds( ( current ) =>
+			toggleVisibleSelection( current, visibleRowIds )
+		);
+	}, [ updateSelectedRowIds, visibleRowIds ] );
+
+	const captureSelectionIntent = useCallback(
+		( event ) => {
+			if ( ! supportsRowSelection ) {
+				return;
+			}
+			selectionInteractionRef.current = null;
+			const target = event.target;
+			if ( ! target?.closest ) {
+				return;
+			}
+			if ( target.closest( '.dataviews-footer' ) ) {
+				return;
+			}
+
+			if (
+				target.closest( '.dataviews-view-table-selection-checkbox' )
+			) {
+				selectionInteractionRef.current = { type: 'merge' };
+				return;
+			}
+
+			const rowInfo = findDataViewItemFromEvent(
+				event,
+				tableWrapperRef.current,
+				isGridLayout ? 'grid' : 'table',
+				dataFilteredInRenderOrder
+			);
+
+			if ( target.closest( '.dataviews-selection-checkbox' ) ) {
+				selectionInteractionRef.current = {
+					type: 'merge',
+					source: 'checkbox',
+					targetId: rowInfo?.id,
+				};
+				return;
+			}
+
+			if ( target.closest( INTERACTIVE_SELECTION_IGNORE_SELECTOR ) ) {
+				return;
+			}
+
+			if ( ! rowInfo ) {
+				return;
+			}
+
+			if ( event.shiftKey ) {
+				event.preventDefault();
+				event.stopPropagation();
+				const nextVisibleSelection = rangeSelection(
+					visibleRowIds,
+					selectionAnchorId,
+					rowInfo.id
+				);
+				updateSelectedRowIds( ( current ) =>
+					mergeVisibleSelection(
+						current,
+						nextVisibleSelection,
+						visibleRowIds
+					)
+				);
+				setSelectionAnchorId( rowInfo.id );
+				return;
+			}
+
+			if ( event.metaKey || event.ctrlKey ) {
+				selectionInteractionRef.current = {
+					type: 'merge',
+					targetId: rowInfo.id,
+				};
+				return;
+			}
+
+			setSelectionAnchorId( rowInfo.id );
+		},
+		[
+			dataFilteredInRenderOrder,
+			isGridLayout,
+			selectionAnchorId,
+			supportsRowSelection,
+			updateSelectedRowIds,
+			visibleRowIds,
+		]
+	);
 
 	const requestNext = useCallback(
 		( rowId, fieldId, direction ) => {
@@ -775,32 +1165,115 @@ export default function CollectionDataViews( {
 		[ collectionId, refresh, touchRecent ]
 	);
 
-	const trashRow = useCallback(
-		async ( row ) => {
-			if ( ! row?.id || ! postType ) {
+	const forgetDeletedRows = useCallback(
+		( deletedIds, options = {} ) => {
+			if ( options.clearSelection ) {
+				clearSelection();
 				return;
 			}
-			setRowActionError( null );
-			try {
-				await apiFetch( {
-					path: `/wp/v2/${ postType }/${ row.id }`,
-					method: 'DELETE',
+			setSelectedRowIds( ( current ) =>
+				removeDeletedSelection( current, deletedIds )
+			);
+			setSelectedRowsById( ( current ) => {
+				const deleted = new Set( deletedIds.map( normalizeRowId ) );
+				let next = current;
+				deleted.forEach( ( id ) => {
+					if ( Object.prototype.hasOwnProperty.call( next, id ) ) {
+						if ( next === current ) {
+							next = { ...current };
+						}
+						delete next[ id ];
+					}
 				} );
-				if ( String( row.id ) === String( openRowId ) ) {
+				return next;
+			} );
+		},
+		[ clearSelection ]
+	);
+
+	const requestDeleteRows = useCallback(
+		async ( rows, options = {} ) => {
+			const nextRows = ( rows ?? [] ).filter( ( row ) => row?.id );
+			if ( nextRows.length === 0 || ! postType ) {
+				return;
+			}
+
+			setRowActionError( null );
+			const results = await Promise.allSettled(
+				nextRows.map( ( row ) =>
+					apiFetch( {
+						path: `/wp/v2/${ postType }/${ row.id }`,
+						method: 'DELETE',
+					} )
+				)
+			);
+
+			const deletedIds = [];
+			const failedRows = [];
+			results.forEach( ( result, index ) => {
+				const row = nextRows[ index ];
+				if ( result.status === 'fulfilled' ) {
+					deletedIds.push( normalizeRowId( row.id ) );
+				} else {
+					failedRows.push( row );
+				}
+			} );
+
+			if ( deletedIds.length > 0 ) {
+				const deleted = new Set( deletedIds );
+				if ( openRowId && deleted.has( normalizeRowId( openRowId ) ) ) {
 					runDetailTransition( { type: 'close' } );
 				}
+				forgetDeletedRows( deletedIds, {
+					clearSelection:
+						failedRows.length === 0 &&
+						( options.clearSelectionOnSuccess ??
+							nextRows.length > 1 ),
+				} );
 				refresh();
 				notifyDocumentTrashChanged();
 				notifyCollectionRowsChanged();
-			} catch ( apiError ) {
-				setRowActionError(
-					apiError?.message ??
-						__( 'Could not move row to Trash.', 'cortext' )
-				);
+			}
+
+			if ( failedRows.length > 0 ) {
+				let deleteErrorMessage;
+				if ( nextRows.length === 1 ) {
+					deleteErrorMessage = __(
+						'Could not move row to Trash.',
+						'cortext'
+					);
+				} else if ( failedRows.length === nextRows.length ) {
+					deleteErrorMessage = __(
+						'Could not move selected rows to Trash.',
+						'cortext'
+					);
+				} else {
+					deleteErrorMessage = sprintf(
+						/* translators: %d: number of rows that failed to move to Trash. */
+						_n(
+							'%d row could not be moved to Trash.',
+							'%d rows could not be moved to Trash.',
+							failedRows.length,
+							'cortext'
+						),
+						failedRows.length
+					);
+				}
+				setRowActionError( deleteErrorMessage );
 			}
 		},
-		[ openRowId, postType, refresh, runDetailTransition ]
+		[
+			forgetDeletedRows,
+			openRowId,
+			postType,
+			refresh,
+			runDetailTransition,
+		]
 	);
+
+	const requestDeleteSelectedRows = useCallback( () => {
+		requestDeleteRows( selectedRows, { clearSelectionOnSuccess: true } );
+	}, [ requestDeleteRows, selectedRows ] );
 
 	const rowActions = useMemo( () => {
 		const actions = [];
@@ -833,16 +1306,20 @@ export default function CollectionDataViews( {
 			label: __( 'Trash', 'cortext' ),
 			icon: trash,
 			isDestructive: true,
+			supportsBulk: true,
 			context: 'single',
-			callback: ( items ) => trashRow( items?.[ 0 ] ),
+			callback: ( items ) =>
+				requestDeleteRows( items, {
+					clearSelectionOnSuccess: ( items?.length ?? 0 ) > 1,
+				} ),
 		} );
 		return actions;
 	}, [
 		duplicateRow,
 		isTableLayout,
 		openRowInMode,
+		requestDeleteRows,
 		savedRowDetailMode,
-		trashRow,
 	] );
 
 	const dataViewActions = rowActions;
@@ -928,7 +1405,9 @@ export default function CollectionDataViews( {
 		setDetailSaveError( null );
 		setPendingDetailTransition( null );
 		detailApiRef.current = null;
-	}, [ clearModeSurfaceTransition, collectionId ] );
+		selectionInteractionRef.current = null;
+		clearSelection();
+	}, [ clearModeSurfaceTransition, clearSelection, collectionId ] );
 
 	// Reconcile saved view state with the live schema whenever the field
 	// set changes: seed defaults on first render, then hand off to
@@ -1157,6 +1636,33 @@ export default function CollectionDataViews( {
 	const previousRowId = adjacentRowId( dataFiltered, openRowId, -1 );
 	const nextRowId = adjacentRowId( dataFiltered, openRowId, 1 );
 	let detailSurface = null;
+	const hasSelectionColumn = isTableLayout && dataFiltered.length > 0;
+	const hasVisibleRows = visibleRowIds.length > 0;
+	// tech-debt.md#36: DataViews has no table footer slot, so table bulk
+	// controls share the same portaled footer row as calculations.
+	const tableBulkActions =
+		isTableLayout && hasVisibleRows && selectedRowIds.length > 0 ? (
+			<DataViewsBulkSelectionControls
+				className="dataviews-bulk-actions-footer__container cortext-table-calculations__bulk-actions"
+				selectedIds={ selectedRowIds }
+				visibleIds={ visibleRowIds }
+				onClearSelection={ clearSelection }
+				onDeleteSelected={ requestDeleteSelectedRows }
+				onToggleVisibleSelection={ toggleVisibleRows }
+			/>
+		) : null;
+	const dataViewsFooter = (
+		<DataViewsSelectionFooter
+			enabled={ supportsRowSelection && ! isTableLayout }
+			selectedIds={ selectedRowIds }
+			visibleIds={ visibleRowIds }
+			totalItems={ activePaginationInfo?.totalItems ?? 0 }
+			totalPages={ activePaginationInfo?.totalPages ?? 0 }
+			onClearSelection={ clearSelection }
+			onDeleteSelected={ requestDeleteSelectedRows }
+			onToggleVisibleSelection={ toggleVisibleRows }
+		/>
+	);
 
 	if ( openRowId && postType && renderedRowDetailMode ) {
 		const detailView = (
@@ -1197,7 +1703,11 @@ export default function CollectionDataViews( {
 					data-row-detail-mode={ rowDetailMode }
 					data-row-detail-open={ openRowId ? 'true' : 'false' }
 				>
-					<div className="cortext-data-view" ref={ tableWrapperRef }>
+					<div
+						className="cortext-data-view"
+						ref={ tableWrapperRef }
+						onClickCapture={ captureSelectionIntent }
+					>
 						{ rowActionError && (
 							<Notice
 								status="error"
@@ -1218,7 +1728,15 @@ export default function CollectionDataViews( {
 							isLoading={ isLoading }
 							empty={ empty }
 							actions={ dataViewActions }
-						/>
+							{ ...( supportsRowSelection
+								? {
+										selection: selectedRowIds,
+										onChangeSelection,
+								  }
+								: {} ) }
+						>
+							<DataViewsChrome footer={ dataViewsFooter } />
+						</DataViews>
 						{ isTableLayout && (
 							<TableCalculationsFooter
 								wrapperRef={ tableWrapperRef }
@@ -1226,6 +1744,8 @@ export default function CollectionDataViews( {
 								fields={ availableFields }
 								data={ dataFilteredForCalculations }
 								onChangeView={ onChangeView }
+								hasSelectionColumn={ hasSelectionColumn }
+								bulkActions={ tableBulkActions }
 							/>
 						) }
 						{ isTableLayout && (
@@ -1259,8 +1779,8 @@ export default function CollectionDataViews( {
 						</div>
 					</div>
 					{ detailSurface }
-				</div>
-			</OpenRowActionContext.Provider>
-		</RowMutationContext.Provider>
+					</div>
+				</OpenRowActionContext.Provider>
+			</RowMutationContext.Provider>
 	);
 }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -24,6 +24,7 @@ import { useNavigate } from '@wordpress/route';
 import DataViewColumnInteractions from './DataViewColumnInteractions';
 import EditableCell, { RowMutationContext } from './EditableCell';
 import PageIcon from './PageIcon';
+import allSettledWithConcurrency from './allSettledWithConcurrency';
 import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
 import ColumnHeaderActions from './fields/ColumnHeaderActions';
@@ -296,6 +297,7 @@ const TABLE_ROW_SELECTOR =
 const GRID_CARD_SELECTOR = '.dataviews-view-grid__card';
 const INTERACTIVE_SELECTION_IGNORE_SELECTOR =
 	'button, a, input, textarea, select, [contenteditable="true"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], .components-button';
+const BULK_DELETE_CONCURRENCY = 4;
 
 function findDataViewItemFromEvent( event, wrapper, layout, rows ) {
 	const target = event.target;
@@ -1199,13 +1201,14 @@ export default function CollectionDataViews( {
 			}
 
 			setRowActionError( null );
-			const results = await Promise.allSettled(
-				nextRows.map( ( row ) =>
+			const results = await allSettledWithConcurrency(
+				nextRows,
+				BULK_DELETE_CONCURRENCY,
+				( row ) =>
 					apiFetch( {
 						path: `/wp/v2/${ postType }/${ row.id }`,
 						method: 'DELETE',
 					} )
-				)
 			);
 
 			const deletedIds = [];

--- a/src/components/TableCalculationsFooter.js
+++ b/src/components/TableCalculationsFooter.js
@@ -96,6 +96,8 @@ export default function TableCalculationsFooter( {
 	fields,
 	data,
 	onChangeView,
+	hasSelectionColumn = false,
+	bulkActions = null,
 } ) {
 	const table = useDataViewsTable( wrapperRef );
 	const fieldsById = useMemo(
@@ -110,14 +112,20 @@ export default function TableCalculationsFooter( {
 			isCalculationAvailable( field, view?.calculations?.[ field.id ] )
 		);
 	} );
+	const hasBulkActions = Boolean( bulkActions );
 
-	if ( ! table || visibleFields.length === 0 || ! hasVisibleCalculation ) {
+	if ( ! table || ( ! hasVisibleCalculation && ! hasBulkActions ) ) {
 		return null;
 	}
 
 	return createPortal(
 		<tfoot className="cortext-table-calculations">
 			<tr>
+				{ hasSelectionColumn ? (
+					<td className="cortext-table-calculations__selection-spacer">
+						{ bulkActions }
+					</td>
+				) : null }
 				{ visibleFields.map( ( fieldId ) => {
 					const field = fieldsById.get( fieldId );
 					const style = view?.layout?.styles?.[ fieldId ] ?? {};

--- a/src/components/allSettledWithConcurrency.js
+++ b/src/components/allSettledWithConcurrency.js
@@ -1,0 +1,32 @@
+export default async function allSettledWithConcurrency(
+	items,
+	concurrency,
+	callback
+) {
+	const results = new Array( items.length );
+	const workerCount = Math.min( Math.max( concurrency, 1 ), items.length );
+	let nextIndex = 0;
+
+	await Promise.all(
+		Array.from( { length: workerCount }, async () => {
+			while ( nextIndex < items.length ) {
+				const index = nextIndex;
+				nextIndex += 1;
+
+				try {
+					results[ index ] = {
+						status: 'fulfilled',
+						value: await callback( items[ index ], index ),
+					};
+				} catch ( error ) {
+					results[ index ] = {
+						status: 'rejected',
+						reason: error,
+					};
+				}
+			}
+		} )
+	);
+
+	return results;
+}

--- a/src/components/dataViewSelection.js
+++ b/src/components/dataViewSelection.js
@@ -135,5 +135,8 @@ export function toggleVisibleSelection( previousSelection, visibleIds ) {
 
 export function removeDeletedSelection( previousSelection, deletedIds ) {
 	const deleted = new Set( deletedIds.map( normalizeRowId ) );
-	return previousSelection.filter( ( id ) => ! deleted.has( id ) );
+	return previousSelection
+		.map( normalizeRowId )
+		.filter( Boolean )
+		.filter( ( id ) => ! deleted.has( id ) );
 }

--- a/src/components/dataViewSelection.js
+++ b/src/components/dataViewSelection.js
@@ -1,0 +1,139 @@
+export function normalizeRowId( id ) {
+	if ( id === null || id === undefined ) {
+		return '';
+	}
+	return String( id );
+}
+
+export function rowIds( rows = [] ) {
+	return rows.map( ( row ) => normalizeRowId( row?.id ) ).filter( Boolean );
+}
+
+export function rowsInDataViewRenderOrder( rows = [], view = {}, fields = [] ) {
+	const groupFieldId = view?.groupByField;
+	if ( ! groupFieldId ) {
+		return rows;
+	}
+
+	const groupField = fields.find( ( field ) => field.id === groupFieldId );
+	if ( ! groupField?.getValue ) {
+		return rows;
+	}
+
+	const groups = new Map();
+	rows.forEach( ( row ) => {
+		const groupName = groupField.getValue( { item: row } );
+		if ( ! groups.has( groupName ) ) {
+			groups.set( groupName, [] );
+		}
+		groups.get( groupName ).push( row );
+	} );
+
+	return Array.from( groups.values() ).flat();
+}
+
+function uniqueIds( ids = [] ) {
+	const seen = new Set();
+	const next = [];
+	for ( const id of ids.map( normalizeRowId ).filter( Boolean ) ) {
+		if ( seen.has( id ) ) {
+			continue;
+		}
+		seen.add( id );
+		next.push( id );
+	}
+	return next;
+}
+
+export function mergeVisibleSelection(
+	previousSelection,
+	nextVisibleSelection,
+	visibleIds
+) {
+	const visible = new Set( visibleIds.map( normalizeRowId ) );
+	return uniqueIds( [
+		...previousSelection.filter( ( id ) => ! visible.has( id ) ),
+		...nextVisibleSelection,
+	] );
+}
+
+export function removeVisibleSelection( previousSelection, visibleIds ) {
+	const visible = new Set( visibleIds.map( normalizeRowId ) );
+	return previousSelection.filter( ( id ) => ! visible.has( id ) );
+}
+
+export function rangeSelection( visibleIds, anchorId, targetId ) {
+	const ids = visibleIds.map( normalizeRowId );
+	const target = normalizeRowId( targetId );
+	const targetIndex = ids.indexOf( target );
+	if ( targetIndex < 0 ) {
+		return [];
+	}
+
+	const anchor = normalizeRowId( anchorId );
+	const anchorIndex = ids.indexOf( anchor );
+	if ( anchorIndex < 0 ) {
+		return [ target ];
+	}
+
+	const start = Math.min( anchorIndex, targetIndex );
+	const end = Math.max( anchorIndex, targetIndex );
+	return ids.slice( start, end + 1 );
+}
+
+export function applyVisibleSelectionChange(
+	previousSelection,
+	nextVisibleSelection,
+	visibleIds,
+	interaction = {}
+) {
+	if ( interaction.type !== 'merge' ) {
+		return previousSelection;
+	}
+
+	const targetId = normalizeRowId( interaction.targetId );
+	const nextIds = uniqueIds( nextVisibleSelection );
+	if (
+		interaction.source === 'checkbox' &&
+		targetId &&
+		nextIds.length === 1 &&
+		nextIds[ 0 ] === targetId
+	) {
+		const visible = new Set( visibleIds.map( normalizeRowId ) );
+		const selected = new Set( previousSelection.map( normalizeRowId ) );
+		const hasOtherVisibleSelection = previousSelection.some( ( id ) => {
+			const normalizedId = normalizeRowId( id );
+			return visible.has( normalizedId ) && normalizedId !== targetId;
+		} );
+
+		if ( hasOtherVisibleSelection && ! selected.has( targetId ) ) {
+			return uniqueIds( [ ...previousSelection, targetId ] );
+		}
+	}
+
+	return mergeVisibleSelection(
+		previousSelection,
+		nextVisibleSelection,
+		visibleIds
+	);
+}
+
+export function toggleVisibleSelection( previousSelection, visibleIds ) {
+	const ids = visibleIds.map( normalizeRowId ).filter( Boolean );
+	if ( ids.length === 0 ) {
+		return previousSelection;
+	}
+
+	const selected = new Set( previousSelection );
+	const allVisibleSelected = ids.every( ( id ) => selected.has( id ) );
+	if ( allVisibleSelected ) {
+		return removeVisibleSelection( previousSelection, ids );
+	}
+
+	return mergeVisibleSelection( previousSelection, ids, ids );
+}
+
+export function removeDeletedSelection( previousSelection, deletedIds ) {
+	const deleted = new Set( deletedIds.map( normalizeRowId ) );
+	return previousSelection.filter( ( id ) => ! deleted.has( id ) );
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -1907,10 +1907,21 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 	padding-right: $grid-unit-05;
 }
 
+.dataviews-view-table th.dataviews-view-table__checkbox-column,
+.dataviews-view-table td.dataviews-view-table__checkbox-column,
+.dataviews-view-table td.cortext-table-calculations__selection-spacer {
+	width: 44px;
+	min-width: 44px;
+	max-width: 44px;
+}
+
 // Title carries the post name and tends to be longer than other
 // fields; give it more breathing room.
-.dataviews-view-table th:first-child,
-.dataviews-view-table td:first-child {
+.dataviews-view-table th.dataviews-view-table__checkbox-column + th,
+.dataviews-view-table td.dataviews-view-table__checkbox-column + td,
+.dataviews-view-table td.cortext-table-calculations__selection-spacer + td,
+.dataviews-view-table th:first-child:not(.dataviews-view-table__checkbox-column),
+.dataviews-view-table td:first-child:not(.dataviews-view-table__checkbox-column) {
 	width: 280px;
 }
 
@@ -4005,6 +4016,10 @@ body.cortext-row-detail-sidebar-resizing {
 		overflow: auto;
 	}
 
+	.dataviews__view-actions:has(.dataviews-filters__visibility-toggle[aria-expanded="false"]) + .dataviews-filters__container {
+		display: none;
+	}
+
 	// DataViews paints row height via td `padding-block` per density, but
 	// our shell's hover/edit background lives on the shell, so the gray
 	// floated inside the row instead of filling it. Zero the td's
@@ -4050,7 +4065,24 @@ body.cortext-row-detail-sidebar-resizing {
 				border-bottom: 0;
 				background: $white;
 				color: $gray-700;
-				vertical-align: top;
+				vertical-align: middle;
+			}
+
+			td.cortext-table-calculations__selection-spacer {
+				overflow: visible;
+			}
+
+			.cortext-table-calculations__bulk-actions {
+				position: relative;
+				z-index: 3;
+				width: max-content;
+				min-height: $grid-unit-40;
+				margin-right: 0;
+				padding-right: $grid-unit-20;
+			}
+
+			.dataviews-bulk-actions-footer__item-count {
+				white-space: nowrap;
 			}
 		}
 

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -32,6 +32,25 @@ async function expectTableScrolledToEnd( canvas ) {
 		.toBe( true );
 }
 
+const TABLE_DATA_HEADER_SELECTOR =
+	'thead > tr > th:not(.dataviews-view-table__checkbox-column):not(.dataviews-view-table__actions-column)';
+const TABLE_DATA_CELL_SELECTOR =
+	'td:not(.dataviews-view-table__checkbox-column):not(.dataviews-view-table__actions-column)';
+const TABLE_FOOTER_DATA_CELL_SELECTOR =
+	'td:not(.cortext-table-calculations__selection-spacer)';
+
+function tableDataHeaders( table ) {
+	return table.locator( TABLE_DATA_HEADER_SELECTOR );
+}
+
+function tableDataCells( row ) {
+	return row.locator( TABLE_DATA_CELL_SELECTOR );
+}
+
+function tableFooterDataCells( footer ) {
+	return footer.locator( TABLE_FOOTER_DATA_CELL_SELECTOR );
+}
+
 async function createCollectionFixture( requestUtils ) {
 	const suffix = Date.now().toString( 36 ).slice( -4 );
 	const slug = `e2ebooks${ suffix }`;
@@ -653,7 +672,11 @@ test.describe( 'Collection view block', () => {
 			);
 
 			const canvas = page.frameLocator( '[name="editor-canvas"]' );
-			await expect( canvas.getByText( 'Notes' ) ).toBeVisible();
+			await expect(
+				canvas.locator( '.cortext-column-header-label', {
+					hasText: /^Notes$/,
+				} )
+			).toBeVisible();
 
 			await page.evaluate( async () => {
 				await window.wp.data.dispatch( 'core/editor' ).savePost();
@@ -1292,7 +1315,7 @@ test.describe( 'Collection view block', () => {
 			await detail
 				.getByRole( 'textbox', { name: 'Author', exact: true } )
 				.fill( 'Octavia Butler' );
-			await expect( firstRow.locator( 'td' ).nth( 1 ) ).toContainText(
+			await expect( tableDataCells( firstRow ).nth( 1 ) ).toContainText(
 				'Octavia Butler'
 			);
 			const yearProperty = detail.getByRole( 'textbox', {
@@ -1562,8 +1585,7 @@ test.describe( 'Collection view block', () => {
 			const firstRow = table.locator( 'tbody > tr' ).first();
 
 			// Select: chip with the option's color.
-			const statusChip = firstRow
-				.locator( 'td' )
+			const statusChip = tableDataCells( firstRow )
 				.nth( 4 )
 				.locator( '.cortext-chip', { hasText: 'Open' } );
 			await expect( statusChip ).toBeVisible();
@@ -2068,7 +2090,7 @@ test.describe( 'Collection view block', () => {
 			const canvas = page.frameLocator( '[name="editor-canvas"]' );
 			await expect( canvas.getByText( 'Pages' ) ).toBeVisible();
 			const footer = canvas.locator( 'tfoot.cortext-table-calculations' );
-			const footerCells = footer.locator( 'td' );
+			const footerCells = tableFooterDataCells( footer );
 			await expect( footer ).toHaveCount( 0 );
 			const openColumnDropdown = async ( scope, name ) => {
 				const button = scope
@@ -2286,7 +2308,9 @@ test.describe( 'Collection view block', () => {
 			await expect( canvas.getByText( 'Beta Book' ) ).toBeHidden();
 			await expect( canvas.getByText( 'Gamma Book' ) ).toBeHidden();
 			await expect(
-				canvas.locator( 'tfoot.cortext-table-calculations td' ).nth( 1 )
+				tableFooterDataCells(
+					canvas.locator( 'tfoot.cortext-table-calculations' )
+				).nth( 1 )
 			).toContainText( '30' );
 		} finally {
 			for ( const row of fixture.rows ?? [] ) {
@@ -2355,44 +2379,41 @@ test.describe( 'Collection view block', () => {
 			const canvas = page.frameLocator( '[name="editor-canvas"]' );
 			await expect( canvas.getByText( 'Author' ) ).toBeVisible();
 
-			// Author is the second column (title is index 0, Author is
-			// index 1); its resizer is at .nth(1) in DOM order. Native
-			// pointer events drive the drag, and pointer capture keeps it
-			// tracking even if the pointer leaves the editor canvas iframe.
-			const resizer = canvas
-				.locator( '.cortext-column-resizer' )
-				.nth( 1 );
-			const header = canvas
-				.locator( '.dataviews-view-table thead > tr > th' )
-				.nth( 1 );
-			await expect( resizer ).toBeAttached();
-			const startBox = await resizer.boundingBox();
-			const startWidth = await header.evaluate(
-				( el ) => el.getBoundingClientRect().width
-			);
+			const table = canvas.locator( '.dataviews-view-table' );
+			const header = tableDataHeaders( table ).nth( 1 );
 
+			// Author is the second data column (title is index 0, Author is
+			// index 1). Dispatch pointer events on the handle so the resize
+			// code receives same-frame coordinates.
+			const resizer = header.locator( '.cortext-column-resizer' );
+			await expect( resizer ).toBeAttached();
 			const dragDelta = 80;
-			await page.mouse.move(
-				startBox.x + startBox.width / 2,
-				startBox.y + startBox.height / 2
-			);
-			await page.mouse.down();
-			await page.mouse.move(
-				startBox.x + startBox.width / 2 + 10,
-				startBox.y + startBox.height / 2,
-				{ steps: 4 }
-			);
-			const firstMoveWidth = await header.evaluate(
-				( el ) => el.getBoundingClientRect().width
-			);
-			expect( firstMoveWidth - startWidth ).toBeGreaterThan( 0 );
-			expect( firstMoveWidth - startWidth ).toBeLessThan( dragDelta );
-			await page.mouse.move(
-				startBox.x + startBox.width / 2 + dragDelta,
-				startBox.y + startBox.height / 2,
-				{ steps: 8 }
-			);
-			await page.mouse.up();
+			const pointer = {
+				button: 0,
+				pointerId: 1,
+				pointerType: 'mouse',
+				isPrimary: true,
+			};
+			await resizer.dispatchEvent( 'pointerdown', {
+				...pointer,
+				buttons: 1,
+				clientX: 0,
+			} );
+			await resizer.dispatchEvent( 'pointermove', {
+				...pointer,
+				buttons: 1,
+				clientX: 10,
+			} );
+			await resizer.dispatchEvent( 'pointermove', {
+				...pointer,
+				buttons: 1,
+				clientX: dragDelta,
+			} );
+			await resizer.dispatchEvent( 'pointerup', {
+				...pointer,
+				buttons: 0,
+				clientX: dragDelta,
+			} );
 
 			await page.evaluate( async () => {
 				await window.wp.data.dispatch( 'core/editor' ).savePost();
@@ -2419,8 +2440,7 @@ test.describe( 'Collection view block', () => {
 			await page.reload();
 			await expect( canvas.getByText( 'Author' ) ).toBeVisible();
 
-			const renderedWidth = await canvas
-				.locator( '.dataviews-view-table thead > tr > th' )
+			const renderedWidth = await tableDataHeaders( table )
 				.nth( 1 )
 				.evaluate( ( el ) => el.style.width );
 			expect( renderedWidth ).toBe( `${ persistedWidth }px` );
@@ -2499,14 +2519,11 @@ test.describe( 'Collection view block', () => {
 			const canvas = page.frameLocator( '[name="editor-canvas"]' );
 			await expect( canvas.getByText( 'Author' ) ).toBeVisible();
 
-			const header = canvas
-				.locator( '.dataviews-view-table thead > tr > th' )
-				.nth( 1 );
+			const table = canvas.locator( '.dataviews-view-table' );
+			const header = tableDataHeaders( table ).nth( 1 );
 			await expect( header ).toHaveAttribute( 'style', /width: 80px/ );
 
-			const resizer = canvas
-				.locator( '.cortext-column-resizer' )
-				.nth( 1 );
+			const resizer = header.locator( '.cortext-column-resizer' );
 			const box = await resizer.boundingBox();
 			await page.mouse.dblclick(
 				box.x + box.width / 2,
@@ -2521,11 +2538,9 @@ test.describe( 'Collection view block', () => {
 				)
 				.toBeGreaterThan( 80 );
 
-			const authorCell = canvas
-				.locator( '.dataviews-view-table tbody > tr' )
-				.first()
-				.locator( 'td' )
-				.nth( 1 );
+			const authorCell = tableDataCells(
+				table.locator( 'tbody > tr' ).first()
+			).nth( 1 );
 			const overflow = await authorCell.evaluate( ( cell ) => {
 				const wrapper = cell.querySelector(
 					'.dataviews-view-table__cell-content-wrapper'
@@ -2707,17 +2722,10 @@ test.describe( 'Collection view block', () => {
 
 		const assertContained = async ( canvas ) => {
 			const table = canvas.locator( '.dataviews-view-table' );
-			const tagsHeader = table.locator( 'thead > tr > th' ).nth( 1 );
-			const tagsCell = table
-				.locator( 'tbody > tr' )
-				.first()
-				.locator( 'td' )
-				.nth( 1 );
-			const dueCell = table
-				.locator( 'tbody > tr' )
-				.first()
-				.locator( 'td' )
-				.nth( 2 );
+			const firstRow = table.locator( 'tbody > tr' ).first();
+			const tagsHeader = tableDataHeaders( table ).nth( 1 );
+			const tagsCell = tableDataCells( firstRow ).nth( 1 );
+			const dueCell = tableDataCells( firstRow ).nth( 2 );
 
 			await expect( tagsCell.locator( '.cortext-chip' ) ).toHaveCount(
 				2
@@ -3032,20 +3040,16 @@ test.describe( 'Collection view block', () => {
 			// The entire header is the drag area. Pick a point on the
 			// Author header that's well clear of the right-edge resizer
 			// (~6px), then drag past the midpoint of the Notes header so
-			// Author lands after Notes. Author is index 1 (title is 0).
-			const authorTh = canvas
-				.locator( '.dataviews-view-table thead > tr > th' )
-				.nth( 1 );
+			// Author lands after Notes. Author is data index 1 (title is 0).
+			const table = canvas.locator( '.dataviews-view-table' );
+			const dataHeaders = tableDataHeaders( table );
+			const authorTh = dataHeaders.nth( 1 );
 			const authorBox = await authorTh.boundingBox();
-			const notesTh = canvas
-				.locator( '.dataviews-view-table thead > tr > th' )
-				.nth( 2 );
+			const notesTh = dataHeaders.nth( 2 );
 			const notesBox = await notesTh.boundingBox();
-			const notesCell = canvas
-				.locator( '.dataviews-view-table tbody > tr' )
-				.first()
-				.locator( 'td' )
-				.nth( 2 );
+			const notesCell = tableDataCells(
+				table.locator( 'tbody > tr' ).first()
+			).nth( 2 );
 			const notesCellBox = await notesCell.boundingBox();
 
 			const startX = authorBox.x + 20;

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -821,7 +821,7 @@ test.describe( 'Collection view block', () => {
 		}
 	} );
 
-	test( 'selects rows across pages and bulk deletes them', async ( {
+	test( 'selects rows across pages and trashes the selection', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -839,7 +839,7 @@ test.describe( 'Collection view block', () => {
 				method: 'POST',
 				path: '/wp/v2/crtxt_pages',
 				data: {
-					title: 'Bulk row delete page',
+					title: 'Bulk row trash page',
 					status: 'private',
 					content: createDataViewBlockMarkup( fixture.collection.id, {
 						fields: [ 'title', pagesKey ],
@@ -876,22 +876,22 @@ test.describe( 'Collection view block', () => {
 			await alphaRow
 				.locator( '.dataviews-selection-checkbox input' )
 				.check();
-			await expect( canvas.getByText( '1 Row selected' ) ).toBeVisible();
+			await expect( canvas.getByText( '1 row selected' ) ).toBeVisible();
 			await betaRow
 				.locator( '.dataviews-selection-checkbox input' )
 				.check();
-			await expect( canvas.getByText( '2 Rows selected' ) ).toBeVisible();
+			await expect( canvas.getByText( '2 rows selected' ) ).toBeVisible();
 			await canvas
 				.getByRole( 'button', { name: 'Clear selection' } )
 				.click();
-			await expect( canvas.getByText( '2 Rows selected' ) ).toBeHidden();
+			await expect( canvas.getByText( '2 rows selected' ) ).toBeHidden();
 
 			await alphaRow.dispatchEvent( 'click' );
-			await expect( canvas.getByText( '1 Row selected' ) ).toHaveCount(
+			await expect( canvas.getByText( '1 row selected' ) ).toHaveCount(
 				0
 			);
 			await betaRow.dispatchEvent( 'click', { shiftKey: true } );
-			await expect( canvas.getByText( '2 Rows selected' ) ).toBeVisible();
+			await expect( canvas.getByText( '2 rows selected' ) ).toBeVisible();
 
 			await canvas.getByRole( 'button', { name: 'Next page' } ).click();
 
@@ -899,21 +899,16 @@ test.describe( 'Collection view block', () => {
 				.locator( 'tbody > tr' )
 				.filter( { hasText: 'Gamma Book' } );
 			await expect( gammaRow ).toBeVisible();
-			await expect( canvas.getByText( '2 Rows selected' ) ).toBeVisible();
+			await expect( canvas.getByText( '2 rows selected' ) ).toBeVisible();
 			await gammaRow.dispatchEvent( 'click', {
 				[ process.platform === 'darwin' ? 'metaKey' : 'ctrlKey' ]: true,
 			} );
-			await expect( canvas.getByText( '3 Rows selected' ) ).toBeVisible();
+			await expect( canvas.getByText( '3 rows selected' ) ).toBeVisible();
 
 			await canvas
-				.getByRole( 'button', { name: 'Delete selected rows' } )
+				.getByRole( 'button', { name: 'Trash selected rows' } )
 				.click();
-			await expect(
-				page.getByText( 'Delete 3 rows? This cannot be undone.' )
-			).toBeVisible();
-			await page
-				.getByRole( 'button', { name: 'Delete', exact: true } )
-				.click();
+			await expect( canvas.getByText( '3 rows selected' ) ).toBeHidden();
 
 			await expect
 				.poll( async () => {
@@ -925,7 +920,6 @@ test.describe( 'Collection view block', () => {
 				} )
 				.toEqual( [] );
 
-			await expect( canvas.getByText( '3 Rows selected' ) ).toBeHidden();
 			await expect( canvas.getByText( 'Alpha Book' ) ).toBeHidden();
 			await expect( canvas.getByText( 'Beta Book' ) ).toBeHidden();
 			await expect( canvas.getByText( 'Gamma Book' ) ).toBeHidden();

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -197,6 +197,12 @@ function parseCollectionIdFromContent( content ) {
 	return match ? Number( match[ 1 ] ) : 0;
 }
 
+async function listCollectionRows( requestUtils, collectionId ) {
+	return requestUtils.rest( {
+		path: `/cortext/v1/rows?collection=${ collectionId }&per_page=100`,
+	} );
+}
+
 test.describe( 'Collection view block', () => {
 	test( 'renders a selected collection and persists block attributes', async ( {
 		admin,
@@ -807,6 +813,139 @@ test.describe( 'Collection view block', () => {
 				requestUtils,
 				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
 			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+
+	test( 'selects rows across pages and bulk deletes them', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCalculationFixture( requestUtils )
+			);
+			const pagesKey = `field-${ fixture.fields.pages.id }`;
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Bulk row delete page',
+					status: 'private',
+					content: createDataViewBlockMarkup( fixture.collection.id, {
+						fields: [ 'title', pagesKey ],
+						perPage: 2,
+						page: 1,
+					} ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			const table = canvas.locator( '.dataviews-view-table' );
+			const alphaRow = table
+				.locator( 'tbody > tr' )
+				.filter( { hasText: 'Alpha Book' } );
+			const betaRow = table
+				.locator( 'tbody > tr' )
+				.filter( { hasText: 'Beta Book' } );
+
+			await expect( alphaRow ).toBeVisible();
+			await alphaRow
+				.locator( '.dataviews-selection-checkbox input' )
+				.check();
+			await expect( canvas.getByText( '1 Row selected' ) ).toBeVisible();
+			await betaRow
+				.locator( '.dataviews-selection-checkbox input' )
+				.check();
+			await expect( canvas.getByText( '2 Rows selected' ) ).toBeVisible();
+			await canvas
+				.getByRole( 'button', { name: 'Clear selection' } )
+				.click();
+			await expect( canvas.getByText( '2 Rows selected' ) ).toBeHidden();
+
+			await alphaRow.dispatchEvent( 'click' );
+			await expect( canvas.getByText( '1 Row selected' ) ).toHaveCount(
+				0
+			);
+			await betaRow.dispatchEvent( 'click', { shiftKey: true } );
+			await expect( canvas.getByText( '2 Rows selected' ) ).toBeVisible();
+
+			await canvas.getByRole( 'button', { name: 'Next page' } ).click();
+
+			const gammaRow = table
+				.locator( 'tbody > tr' )
+				.filter( { hasText: 'Gamma Book' } );
+			await expect( gammaRow ).toBeVisible();
+			await expect( canvas.getByText( '2 Rows selected' ) ).toBeVisible();
+			await gammaRow.dispatchEvent( 'click', {
+				[ process.platform === 'darwin' ? 'metaKey' : 'ctrlKey' ]: true,
+			} );
+			await expect( canvas.getByText( '3 Rows selected' ) ).toBeVisible();
+
+			await canvas
+				.getByRole( 'button', { name: 'Delete selected rows' } )
+				.click();
+			await expect(
+				page.getByText( 'Delete 3 rows? This cannot be undone.' )
+			).toBeVisible();
+			await page
+				.getByRole( 'button', { name: 'Delete', exact: true } )
+				.click();
+
+			await expect
+				.poll( async () => {
+					const response = await listCollectionRows(
+						requestUtils,
+						fixture.collection.id
+					);
+					return response.rows.map( ( row ) => row.title.raw );
+				} )
+				.toEqual( [] );
+
+			await expect( canvas.getByText( '3 Rows selected' ) ).toBeHidden();
+			await expect( canvas.getByText( 'Alpha Book' ) ).toBeHidden();
+			await expect( canvas.getByText( 'Beta Book' ) ).toBeHidden();
+			await expect( canvas.getByText( 'Gamma Book' ) ).toBeHidden();
+		} finally {
+			for ( const row of fixture.rows ?? [] ) {
+				await deleteIfCreated(
+					requestUtils,
+					`/wp/v2/crtxt_${ fixture.slug }/${ row.id }`
+				);
+			}
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			for ( const field of Object.values( fixture.fields ?? {} ) ) {
+				await deleteIfCreated(
+					requestUtils,
+					`/wp/v2/crtxt_fields/${ field.id }`
+				);
+			}
 			await deleteIfCreated(
 				requestUtils,
 				fixture.collection &&

--- a/tests/js/components/allSettledWithConcurrency.test.js
+++ b/tests/js/components/allSettledWithConcurrency.test.js
@@ -1,0 +1,50 @@
+import allSettledWithConcurrency from '../../../src/components/allSettledWithConcurrency';
+
+describe( 'allSettledWithConcurrency', () => {
+	it( 'limits concurrent tasks and preserves result order', async () => {
+		let active = 0;
+		let maxActive = 0;
+
+		const results = await allSettledWithConcurrency(
+			[ 1, 2, 3, 4, 5 ],
+			2,
+			async ( value ) => {
+				active += 1;
+				maxActive = Math.max( maxActive, active );
+				await Promise.resolve();
+				active -= 1;
+				return value * 2;
+			}
+		);
+
+		expect( maxActive ).toBeLessThanOrEqual( 2 );
+		expect( results ).toEqual( [
+			{ status: 'fulfilled', value: 2 },
+			{ status: 'fulfilled', value: 4 },
+			{ status: 'fulfilled', value: 6 },
+			{ status: 'fulfilled', value: 8 },
+			{ status: 'fulfilled', value: 10 },
+		] );
+	} );
+
+	it( 'returns rejected results without stopping later tasks', async () => {
+		const error = new Error( 'Nope' );
+
+		const results = await allSettledWithConcurrency(
+			[ 'a', 'b', 'c' ],
+			2,
+			async ( value ) => {
+				if ( value === 'b' ) {
+					throw error;
+				}
+				return value.toUpperCase();
+			}
+		);
+
+		expect( results ).toEqual( [
+			{ status: 'fulfilled', value: 'A' },
+			{ status: 'rejected', reason: error },
+			{ status: 'fulfilled', value: 'C' },
+		] );
+	} );
+} );

--- a/tests/js/components/allSettledWithConcurrency.test.js
+++ b/tests/js/components/allSettledWithConcurrency.test.js
@@ -1,7 +1,7 @@
 import allSettledWithConcurrency from '../../../src/components/allSettledWithConcurrency';
 
 describe( 'allSettledWithConcurrency', () => {
-	it( 'limits concurrent tasks and preserves result order', async () => {
+	it( 'runs only the allowed number of tasks at once and keeps result order', async () => {
 		let active = 0;
 		let maxActive = 0;
 
@@ -27,7 +27,7 @@ describe( 'allSettledWithConcurrency', () => {
 		] );
 	} );
 
-	it( 'returns rejected results without stopping later tasks', async () => {
+	it( 'records failures and keeps running', async () => {
 		const error = new Error( 'Nope' );
 
 		const results = await allSettledWithConcurrency(

--- a/tests/js/components/dataViewSelection.test.js
+++ b/tests/js/components/dataViewSelection.test.js
@@ -1,0 +1,108 @@
+import {
+	applyVisibleSelectionChange,
+	mergeVisibleSelection,
+	rangeSelection,
+	removeDeletedSelection,
+	rowIds,
+	rowsInDataViewRenderOrder,
+	toggleVisibleSelection,
+} from '../../../src/components/dataViewSelection';
+
+describe( 'dataViewSelection', () => {
+	it( 'merges current-page selection changes without dropping hidden selections', () => {
+		expect(
+			mergeVisibleSelection( [ 'off-page', '1' ], [ '2' ], [ '1', '2' ] )
+		).toEqual( [ 'off-page', '2' ] );
+	} );
+
+	it( 'ignores selection changes without an explicit selection intent', () => {
+		expect(
+			applyVisibleSelectionChange(
+				[ 'off-page', '1' ],
+				[ '2' ],
+				[ '1', '2' ]
+			)
+		).toEqual( [ 'off-page', '1' ] );
+	} );
+
+	it( 'preserves hidden selections for modifier toggles', () => {
+		expect(
+			applyVisibleSelectionChange(
+				[ 'off-page', '1' ],
+				[ '1', '2' ],
+				[ '1', '2' ],
+				{ type: 'merge' }
+			)
+		).toEqual( [ 'off-page', '1', '2' ] );
+	} );
+
+	it( 'adds a checkbox target when the table row click reports a singleton first', () => {
+		expect(
+			applyVisibleSelectionChange( [ '1' ], [ '2' ], [ '1', '2' ], {
+				type: 'merge',
+				source: 'checkbox',
+				targetId: '2',
+			} )
+		).toEqual( [ '1', '2' ] );
+	} );
+
+	it( 'selects a visible range from the anchor to the target', () => {
+		expect( rangeSelection( [ '1', '2', '3', '4' ], '2', '4' ) ).toEqual( [
+			'2',
+			'3',
+			'4',
+		] );
+		expect( rangeSelection( [ '1', '2', '3', '4' ], '4', '2' ) ).toEqual( [
+			'2',
+			'3',
+			'4',
+		] );
+	} );
+
+	it( 'falls back to the target when a range anchor is unavailable', () => {
+		expect( rangeSelection( [ '1', '2', '3' ], '9', '2' ) ).toEqual( [
+			'2',
+		] );
+	} );
+
+	it( 'toggles all visible rows without dropping hidden selections', () => {
+		expect(
+			toggleVisibleSelection( [ 'off-page' ], [ '1', '2' ] )
+		).toEqual( [ 'off-page', '1', '2' ] );
+		expect(
+			toggleVisibleSelection( [ 'off-page', '1', '2' ], [ '1', '2' ] )
+		).toEqual( [ 'off-page' ] );
+	} );
+
+	it( 'removes deleted rows from selection', () => {
+		expect( removeDeletedSelection( [ '1', '2', '3' ], [ 2 ] ) ).toEqual( [
+			'1',
+			'3',
+		] );
+	} );
+
+	it( 'matches DataViews grouped render order', () => {
+		const rows = [
+			{ id: 1, status: 'A' },
+			{ id: 2, status: 'B' },
+			{ id: 3, status: 'A' },
+			{ id: 4, status: 'B' },
+		];
+		const fields = [
+			{
+				id: 'status',
+				getValue: ( { item } ) => item.status,
+			},
+		];
+
+		expect(
+			rowIds(
+				rowsInDataViewRenderOrder(
+					rows,
+					{ groupByField: 'status' },
+					fields
+				)
+			)
+		).toEqual( [ '1', '3', '2', '4' ] );
+	} );
+} );

--- a/tests/js/components/dataViewSelection.test.js
+++ b/tests/js/components/dataViewSelection.test.js
@@ -75,7 +75,7 @@ describe( 'dataViewSelection', () => {
 	} );
 
 	it( 'removes deleted rows from selection', () => {
-		expect( removeDeletedSelection( [ '1', '2', '3' ], [ 2 ] ) ).toEqual( [
+		expect( removeDeletedSelection( [ '1', 2, '3' ], [ 2 ] ) ).toEqual( [
 			'1',
 			'3',
 		] );

--- a/tests/js/components/dataViewSelection.test.js
+++ b/tests/js/components/dataViewSelection.test.js
@@ -9,13 +9,13 @@ import {
 } from '../../../src/components/dataViewSelection';
 
 describe( 'dataViewSelection', () => {
-	it( 'merges current-page selection changes without dropping hidden selections', () => {
+	it( 'keeps off-page selections when the visible page changes', () => {
 		expect(
 			mergeVisibleSelection( [ 'off-page', '1' ], [ '2' ], [ '1', '2' ] )
 		).toEqual( [ 'off-page', '2' ] );
 	} );
 
-	it( 'ignores selection changes without an explicit selection intent', () => {
+	it( 'ignores DataViews row clicks without a selection intent', () => {
 		expect(
 			applyVisibleSelectionChange(
 				[ 'off-page', '1' ],
@@ -25,7 +25,7 @@ describe( 'dataViewSelection', () => {
 		).toEqual( [ 'off-page', '1' ] );
 	} );
 
-	it( 'preserves hidden selections for modifier toggles', () => {
+	it( 'keeps off-page selections when modifier clicks change the visible page', () => {
 		expect(
 			applyVisibleSelectionChange(
 				[ 'off-page', '1' ],
@@ -36,7 +36,7 @@ describe( 'dataViewSelection', () => {
 		).toEqual( [ 'off-page', '1', '2' ] );
 	} );
 
-	it( 'adds a checkbox target when the table row click reports a singleton first', () => {
+	it( 'adds the checkbox target when DataViews reports the row click first', () => {
 		expect(
 			applyVisibleSelectionChange( [ '1' ], [ '2' ], [ '1', '2' ], {
 				type: 'merge',
@@ -46,7 +46,7 @@ describe( 'dataViewSelection', () => {
 		).toEqual( [ '1', '2' ] );
 	} );
 
-	it( 'selects a visible range from the anchor to the target', () => {
+	it( 'selects the visible range between anchor and target', () => {
 		expect( rangeSelection( [ '1', '2', '3', '4' ], '2', '4' ) ).toEqual( [
 			'2',
 			'3',
@@ -59,13 +59,13 @@ describe( 'dataViewSelection', () => {
 		] );
 	} );
 
-	it( 'falls back to the target when a range anchor is unavailable', () => {
+	it( 'selects the target when the range anchor is missing', () => {
 		expect( rangeSelection( [ '1', '2', '3' ], '9', '2' ) ).toEqual( [
 			'2',
 		] );
 	} );
 
-	it( 'toggles all visible rows without dropping hidden selections', () => {
+	it( 'toggles visible rows without losing off-page selections', () => {
 		expect(
 			toggleVisibleSelection( [ 'off-page' ], [ '1', '2' ] )
 		).toEqual( [ 'off-page', '1', '2' ] );
@@ -81,7 +81,7 @@ describe( 'dataViewSelection', () => {
 		] );
 	} );
 
-	it( 'matches DataViews grouped render order', () => {
+	it( 'orders rows the way grouped DataViews renders them', () => {
 		const rows = [
 			{ id: 1, status: 'A' },
 			{ id: 2, status: 'B' },


### PR DESCRIPTION
## What

Closes #182.

Adds row selection to collection DataViews, including checkbox selection, shift-click ranges, cmd/ctrl-click, and selection that survives pagination. Selected rows can be deleted using the same confirmation flow as a single-row delete. Plain row clicks do not select rows.

## How

- Keeping selected row IDs in Cortext so pagination does not clear them.
- Putting table bulk actions in the same footer row as calculations.
- Running bulk delete through the row delete endpoint with four requests at a time.

## Testing Instructions

1. Open a page with a collection DataView in table layout.
2. Select two rows with their checkboxes and confirm the count updates.
3. Clear the selection.
4. Click a row normally and confirm it is not selected.
5. Shift-click another row and confirm the range is selected.
6. Go to the next page, cmd/ctrl-click another row, and confirm the previous selection is still counted.
7. Delete the selected rows, confirm the dialog, and verify that the rows disappear and the selection clears.

## Screen recording

https://github.com/user-attachments/assets/de3d19be-2952-41db-a69e-e79439753029

