### PR TITLE
Fix autosave adding the wrong row to Recents

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -365,13 +365,15 @@ The user-facing placeholder is still Core's generic "Search commands and setting
 
 **Solution.** Reuse the relation picker in row detail and save relation changes through the row-field endpoint, not through generic post meta edits. Once DataViews has a real relation/reference field primitive (#37), there should be less custom wiring here.
 
-## 40. Autosave has to infer in-flight save completion `[upstream, soft]`
+## 40. Autosave has to infer save completion `[upstream, soft]`
 
 **What.** `savePost()` gives us a promise when Cortext starts the save. If a save is already running, though, Gutenberg only tells us about it through selectors like `isSavingPost()` and `didPostSaveRequestFail()`. There is no promise to await. `flushNow()` has to keep its own small list of waiters and release them when `isSaving` flips back to false.
 
-**Where.** `savePromiseRef`, `savingWaitersRef`, and `flushNow` in `src/hooks/useAutosave.js`.
+The same selector shape affects user-visible save side effects. `didPostSaveRequestSucceed()` and `didPostSaveRequestFail()` are level signals, not one-shot events. They can stay true after the save that set them, so mounting autosave on a different row or changing `recentTarget` can otherwise replay an old success into status and Recents. The hook tracks the previous `isSaving` value and only treats success as current when this hook observed the save finish.
 
-**Solution.** Gutenberg could expose the current save promise, or make `savePost()` return the in-flight promise when one already exists. Then Cortext could drop the waiter bookkeeping.
+**Where.** `savePromiseRef`, `savingWaitersRef`, `prevIsSavingRef`, `flushNow`, and the save-status effect in `src/hooks/useAutosave.js`.
+
+**Solution.** Gutenberg could expose the current save promise, make `savePost()` return the in-flight promise when one already exists, or expose per-save completion events/state keyed to a request. Then Cortext could drop the waiter bookkeeping and the local `isSaving` edge detection.
 
 ## 41. Favorite rows have their own sidebar-row shape `[internal, soft]`
 

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -209,7 +209,7 @@ export default function useAutosave( options = {} ) {
 	] );
 
 	useEffect( () => {
-		// The editor store keeps didSucceed/didFail as level signals, but
+		// tech-debt.md#40: the editor store keeps didSucceed/didFail as level signals, but
 		// the user-visible side effects below (status flip, Recents touch)
 		// are edges: they should fire once per save that *this hook ran*.
 		// Re-running the effect because recentTarget changed (the user opened

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -54,6 +54,7 @@ export default function useAutosave( options = {} ) {
 	const lastSaveAtRef = useRef( 0 );
 	const savePromiseRef = useRef( null );
 	const savingWaitersRef = useRef( [] );
+	const prevIsSavingRef = useRef( isSaving );
 
 	const stateRef = useRef( {
 		isDirty,
@@ -208,6 +209,14 @@ export default function useAutosave( options = {} ) {
 	] );
 
 	useEffect( () => {
+		// The editor store keeps didSucceed/didFail as level signals, but
+		// the user-visible side effects below (status flip, Recents touch)
+		// are edges: they should fire once per save that *this hook ran*.
+		// Re-running the effect because recentTarget changed (the user opened
+		// a different row) must not re-fire success against a stale flag.
+		const wasSaving = prevIsSavingRef.current;
+		prevIsSavingRef.current = isSaving;
+
 		if ( isSaving ) {
 			setStatus( 'saving' );
 		} else if ( didFail ) {
@@ -219,7 +228,7 @@ export default function useAutosave( options = {} ) {
 				id: AUTOSAVE_ERROR_NOTICE_ID,
 				type: 'snackbar',
 			} );
-		} else if ( didSucceed ) {
+		} else if ( didSucceed && wasSaving ) {
 			setStatus( 'saved' );
 			setLastSavedAt( Date.now() );
 			removeNotice( AUTOSAVE_ERROR_NOTICE_ID );

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -55,6 +55,7 @@ export default function useAutosave( options = {} ) {
 	const savePromiseRef = useRef( null );
 	const savingWaitersRef = useRef( [] );
 	const prevIsSavingRef = useRef( isSaving );
+	const savingTargetRef = useRef( null );
 
 	const stateRef = useRef( {
 		isDirty,
@@ -218,8 +219,25 @@ export default function useAutosave( options = {} ) {
 		prevIsSavingRef.current = isSaving;
 
 		if ( isSaving ) {
+			if ( ! wasSaving ) {
+				// Latch the target at the moment the save starts. If the
+				// user switches to a different row before this save resolves,
+				// recentTarget will have moved on by completion time and we
+				// would otherwise mark the new row as recent.
+				savingTargetRef.current =
+					recentKind && recentId
+						? {
+								kind: recentKind,
+								id: recentId,
+								...( recentCollectionId
+									? { collectionId: recentCollectionId }
+									: {} ),
+						  }
+						: null;
+			}
 			setStatus( 'saving' );
 		} else if ( didFail ) {
+			savingTargetRef.current = null;
 			setStatus( 'error' );
 			// The toolbar no longer carries a save status, so a failed
 			// autosave needs its own way of reaching the user. Snackbar
@@ -229,15 +247,13 @@ export default function useAutosave( options = {} ) {
 				type: 'snackbar',
 			} );
 		} else if ( didSucceed && wasSaving ) {
+			const latchedTarget = savingTargetRef.current;
+			savingTargetRef.current = null;
 			setStatus( 'saved' );
 			setLastSavedAt( Date.now() );
 			removeNotice( AUTOSAVE_ERROR_NOTICE_ID );
-			if ( recentKind && recentId ) {
-				const target = { kind: recentKind, id: recentId };
-				if ( recentCollectionId ) {
-					target.collectionId = recentCollectionId;
-				}
-				touchRecent( target );
+			if ( latchedTarget ) {
+				touchRecent( latchedTarget );
 			}
 		}
 	}, [

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -418,9 +418,18 @@ describe( 'useAutosave: status', () => {
 	} );
 
 	it( 'reports saved and captures lastSavedAt after a successful save', () => {
-		setStoreState( { didSucceed: true, currentPostId: 42 } );
+		setStoreState( { isSaving: true, currentPostId: 42 } );
 
-		const { result } = renderHook( () => useAutosave() );
+		const { result, rerender } = renderHook( () => useAutosave() );
+
+		act( () => {
+			setStoreState( {
+				isSaving: false,
+				didSucceed: true,
+				currentPostId: 42,
+			} );
+			rerender();
+		} );
 
 		expect( result.current.status ).toBe( 'saved' );
 		expect( typeof result.current.lastSavedAt ).toBe( 'number' );
@@ -428,13 +437,22 @@ describe( 'useAutosave: status', () => {
 	} );
 
 	it( 'touches the configured page recent after a successful save', () => {
-		setStoreState( { didSucceed: true, currentPostId: 42 } );
+		setStoreState( { isSaving: true, currentPostId: 42 } );
 
-		renderHook( () =>
+		const { rerender } = renderHook( () =>
 			useAutosave( {
 				recentTarget: { kind: 'page', id: 42 },
 			} )
 		);
+
+		act( () => {
+			setStoreState( {
+				isSaving: false,
+				didSucceed: true,
+				currentPostId: 42,
+			} );
+			rerender();
+		} );
 
 		expect( mockTouchRecent ).toHaveBeenCalledWith( {
 			kind: 'page',
@@ -443,7 +461,40 @@ describe( 'useAutosave: status', () => {
 	} );
 
 	it( 'touches the configured row recent after a successful save', () => {
-		setStoreState( { didSucceed: true, currentPostId: 42 } );
+		setStoreState( { isSaving: true, currentPostId: 42 } );
+
+		const { rerender } = renderHook( () =>
+			useAutosave( {
+				recentTarget: { kind: 'row', id: 42, collectionId: 9 },
+			} )
+		);
+
+		act( () => {
+			setStoreState( {
+				isSaving: false,
+				didSucceed: true,
+				currentPostId: 42,
+			} );
+			rerender();
+		} );
+
+		expect( mockTouchRecent ).toHaveBeenCalledWith( {
+			kind: 'row',
+			id: 42,
+			collectionId: 9,
+		} );
+	} );
+
+	it( 'does not touch recent when mounted with a stale didSucceed flag', () => {
+		// Simulates opening a different row while the editor store still
+		// reports the previous post's save as successful. Without a real
+		// isSaving transition observed by this hook, the success belongs to
+		// someone else and must not enter Recents.
+		setStoreState( {
+			isSaving: false,
+			didSucceed: true,
+			currentPostId: 42,
+		} );
 
 		renderHook( () =>
 			useAutosave( {
@@ -451,11 +502,29 @@ describe( 'useAutosave: status', () => {
 			} )
 		);
 
-		expect( mockTouchRecent ).toHaveBeenCalledWith( {
-			kind: 'row',
-			id: 42,
-			collectionId: 9,
+		expect( mockTouchRecent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not touch recent when recentTarget changes without an intervening save', () => {
+		setStoreState( {
+			isSaving: false,
+			didSucceed: true,
+			currentPostId: 42,
 		} );
+
+		const { rerender } = renderHook( ( props ) => useAutosave( props ), {
+			initialProps: {
+				recentTarget: { kind: 'row', id: 1, collectionId: 9 },
+			},
+		} );
+
+		act( () => {
+			rerender( {
+				recentTarget: { kind: 'row', id: 2, collectionId: 9 },
+			} );
+		} );
+
+		expect( mockTouchRecent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'reports error after a failed save', () => {
@@ -500,7 +569,11 @@ describe( 'useAutosave: status', () => {
 		const { rerender } = renderHook( () => useAutosave() );
 
 		act( () => {
-			setStoreState( { didFail: false, didSucceed: true } );
+			setStoreState( { isSaving: true, didFail: false } );
+			rerender();
+		} );
+		act( () => {
+			setStoreState( { isSaving: false, didSucceed: true } );
 			rerender();
 		} );
 

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -437,7 +437,7 @@ describe( 'useAutosave: status', () => {
 	} );
 
 	it( 'touches the configured page recent after a successful save', () => {
-		setStoreState( { isSaving: true, currentPostId: 42 } );
+		setStoreState( { isSaving: false, currentPostId: 42 } );
 
 		const { rerender } = renderHook( () =>
 			useAutosave( {
@@ -445,6 +445,10 @@ describe( 'useAutosave: status', () => {
 			} )
 		);
 
+		act( () => {
+			setStoreState( { isSaving: true, currentPostId: 42 } );
+			rerender();
+		} );
 		act( () => {
 			setStoreState( {
 				isSaving: false,
@@ -461,7 +465,7 @@ describe( 'useAutosave: status', () => {
 	} );
 
 	it( 'touches the configured row recent after a successful save', () => {
-		setStoreState( { isSaving: true, currentPostId: 42 } );
+		setStoreState( { isSaving: false, currentPostId: 42 } );
 
 		const { rerender } = renderHook( () =>
 			useAutosave( {
@@ -469,6 +473,10 @@ describe( 'useAutosave: status', () => {
 			} )
 		);
 
+		act( () => {
+			setStoreState( { isSaving: true, currentPostId: 42 } );
+			rerender();
+		} );
 		act( () => {
 			setStoreState( {
 				isSaving: false,
@@ -503,6 +511,44 @@ describe( 'useAutosave: status', () => {
 		);
 
 		expect( mockTouchRecent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'touches the recent target latched at save start, not the one swapped in mid-flight', () => {
+		// Edit row A → save starts → user opens row B before the save
+		// resolves. When the save lands, Recents must reflect A (which was
+		// actually saved), not B (which the parent has since swapped in).
+		const targetA = { kind: 'row', id: 1, collectionId: 9 };
+		const targetB = { kind: 'row', id: 2, collectionId: 9 };
+
+		setStoreState( { isSaving: false, currentPostId: 1 } );
+
+		const { rerender } = renderHook( ( props ) => useAutosave( props ), {
+			initialProps: { recentTarget: targetA },
+		} );
+
+		act( () => {
+			setStoreState( { isSaving: true, currentPostId: 1 } );
+			rerender( { recentTarget: targetA } );
+		} );
+
+		// Parent swaps in row B while the save for A is still in flight.
+		act( () => {
+			setStoreState( { isSaving: true, currentPostId: 1 } );
+			rerender( { recentTarget: targetB } );
+		} );
+
+		// Save for A resolves.
+		act( () => {
+			setStoreState( {
+				isSaving: false,
+				didSucceed: true,
+				currentPostId: 1,
+			} );
+			rerender( { recentTarget: targetB } );
+		} );
+
+		expect( mockTouchRecent ).toHaveBeenCalledTimes( 1 );
+		expect( mockTouchRecent ).toHaveBeenCalledWith( targetA );
 	} );
 
 	it( 'does not touch recent when recentTarget changes without an intervening save', () => {


### PR DESCRIPTION
## What

Fixes a bug where opening a row right after another row autosaved could add the newly opened row to Recents, even if you did not edit it.

## Why

The editor can still say "save succeeded" after the save is already over. Cortext now ignores that old success unless it saw the save happen for the current row.

## Testing Instructions

1. Edit a row and wait for autosave.
2. Open a different row without editing it.
3. Confirm the second row is not added to Recents.
4. Edit the second row and wait for autosave.
5. Confirm the second row is added to Recents.