### PR TITLE
Desktop app: Add bundled PHP runtime support for the desktop app

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -4,3 +4,6 @@ out
 snapshot.zip
 .snapshot-work
 .snapshot-cache
+.runtime-bench
+.runtime-cache
+runtime/bin

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -5,12 +5,18 @@ on PHP and SQLite, so you do not need to set up a server to try it.
 
 ## Requirements
 
-- macOS with PHP 8.1+ on `PATH`. If you use Homebrew, `brew install php`
-  is enough; Homebrew's PHP includes `pdo_sqlite`.
 - Node 24.x (matches the repo's `engines` field).
+- PHP 8.1+ with `pdo_sqlite`, either at `apps/desktop/runtime/bin/php`,
+  via `CORTEXT_PHP_BIN`, or on `PATH`. If you use Homebrew,
+  `brew install php` is enough; Homebrew's PHP includes `pdo_sqlite`.
 
-Bundling PHP is still future work. For now, the desktop app runs the
-`php` it finds on `PATH`.
+The source checkout does not commit a PHP binary. When a bundled PHP is
+present locally, both `npm run snapshot` and the desktop runtime prefer it
+over `PATH`.
+
+For this PR, either use a local PHP install or build the local runtime with
+`npm --prefix apps/desktop run runtime:php`. The signed app should ship that
+runtime. This spike stops short of wiring it into packaging.
 
 ## Run it
 
@@ -22,10 +28,10 @@ npm --prefix apps/desktop install
 npm --prefix apps/desktop run snapshot
 ```
 
-Most of the setup happens in `snapshot`. It downloads WordPress and
-wp-cli into `apps/desktop/.snapshot-cache/` (cached between builds),
-installs and activates the plugin, runs `wp cortext seed`, then zips the
-WordPress install into `apps/desktop/snapshot.zip` (~30 MB).
+Most of the setup happens in `snapshot`: it downloads WordPress and wp-cli
+into `apps/desktop/.snapshot-cache/`, installs and activates the plugin,
+runs `wp cortext seed`, then writes `apps/desktop/snapshot.zip` (~30 MB).
+The downloads are cached between builds.
 
 Re-run after changing plugin code, or when you want the seed back to a
 clean state.
@@ -40,6 +46,19 @@ The first launch unzips the snapshot into
 `~/Library/Application Support/cortext-desktop/site/` and boots PHP
 without reinstalling WordPress.
 
+To test the bundled-PHP path, build the static PHP CLI before running
+`snapshot` or `start`:
+
+```sh
+npm --prefix apps/desktop run runtime:php
+npm --prefix apps/desktop run snapshot
+npm --prefix apps/desktop start
+```
+
+That command downloads `static-php-cli` into `apps/desktop/.runtime-cache/`
+and writes `apps/desktop/runtime/bin/php`. It can take a few minutes on a
+fresh machine. The binary is ignored by git.
+
 ## What it does
 
 Electron spawns `php -S 127.0.0.1:9402` against the unzipped site and
@@ -47,15 +66,57 @@ uses `router.php` for the rewrite behavior WordPress normally gets from
 nginx or Apache. Once PHP reports that it is accepting connections, the
 window loads `http://127.0.0.1:9402/wp-admin/admin.php?page=cortext`.
 
-DevTools open by default; set `CORTEXT_DEVTOOLS=0` to turn them off.
+DevTools open by default. Set `CORTEXT_DEVTOOLS=0` to turn them off.
 Closing the window kills the PHP process.
+
+For runtime spikes, set `CORTEXT_RUNTIME` before launch:
+
+```sh
+CORTEXT_RUNTIME=php npm --prefix apps/desktop start
+CORTEXT_RUNTIME=franken npm --prefix apps/desktop start
+CORTEXT_RUNTIME=php-fpm npm --prefix apps/desktop start
+```
+
+`php` is the default. It uses `apps/desktop/runtime/bin/php` first, then
+falls back to `php` on `PATH`. Set `CORTEXT_PHP_BIN` to force a specific
+binary. Set `CORTEXT_PHP_CLI_SERVER_WORKERS=4` to run PHP's built-in server
+with worker children for request-heavy pages.
+
+`franken` expects FrankenPHP at `apps/desktop/runtime/bin/frankenphp`, on
+`PATH`, or at `CORTEXT_FRANKENPHP_BIN`. Install the local binary with:
+
+```sh
+npm --prefix apps/desktop run runtime:franken
+CORTEXT_RUNTIME=franken npm --prefix apps/desktop start
+```
+
+`php-fpm` expects `php-fpm` plus Caddy at
+`apps/desktop/runtime/bin/caddy`, on `PATH`, or at `CORTEXT_CADDY_BIN`.
+Install the local Caddy binary with `npm --prefix apps/desktop run
+runtime:caddy`. `php-fpm` itself still needs to come from `PATH` or
+`CORTEXT_PHP_FPM_BIN`.
 
 ## Performance
 
-Cold launch means extracting the zip and starting PHP, usually 3-5
-seconds. Warm launches are comfortably under a second. REST endpoints
-usually respond in 30-60 ms, roughly the same as Cortext running in
-`wp-env` or another local WordPress install on the same machine.
+Cold launch extracts the zip and starts PHP, usually in 3-5 seconds. Warm
+launches are under a second on the test machine. REST endpoints usually
+respond in 30-60 ms, roughly the same as Cortext running in `wp-env` or
+another local WordPress install on the same machine.
+
+To collect repeatable desktop HTTP timings:
+
+```sh
+npm --prefix apps/desktop run snapshot
+npm --prefix apps/desktop run bench:runtime -- --runtime=php --iterations=50 --warmup=10
+```
+
+The benchmark extracts the snapshot into `apps/desktop/.runtime-bench/`,
+starts the selected runtime on port 9402, measures representative admin
+and REST endpoints, and writes `artifacts/desktop-runtime-<runtime-or-label>.json`.
+Pass `--label=<name>` when comparing multiple binaries behind the same
+runtime, such as `--label=php-system` and `--label=php-bundled`.
+The desktop snapshot adds a `Server-Timing: cortext_wp` header, so the JSON
+has both total HTTP latency and WordPress request time.
 
 ## Tests
 
@@ -73,14 +134,18 @@ snapshot exists.
 
 ## Runtime files
 
-`runtime/` contains the native PHP files copied into the snapshot:
+`runtime/` contains the PHP-side files copied into the snapshot:
 
 - `router.php`: gives PHP's built-in server the `.htaccess` behavior
   WordPress expects. Existing files are served from disk; everything else
   goes through `index.php`.
+- `worker.php`: experimental FrankenPHP worker entrypoint used only when
+  `CORTEXT_RUNTIME=franken`.
 - `mu-plugins/cortext-autologin.php`: bypasses `auth_redirect()` and
   maps the current request to the local admin before `pluggable.php`
   loads. Desktop-only; do not ship this on a public site.
+- `mu-plugins/cortext-timing.php`: emits the local `Server-Timing` value
+  used by the desktop runtime benchmark.
 
 The `sqlite-database-integration` plugin and its `db.php` drop-in are
 downloaded during `npm run snapshot`, not vendored in git.

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -1,0 +1,419 @@
+const { spawn, spawnSync } = require( 'child_process' );
+const fs = require( 'fs' );
+const http = require( 'http' );
+const os = require( 'os' );
+const path = require( 'path' );
+
+const DEFAULT_PORT = 9402;
+const DEFAULT_READY_PATH = '/wp-includes/images/blank.gif';
+
+function normalizeRuntime( runtime ) {
+	const value = ( runtime || 'php' ).toLowerCase();
+	if ( [ 'php', 'php-cli', 'cli', 'php-s' ].includes( value ) ) {
+		return 'php';
+	}
+	if ( [ 'franken', 'frankenphp' ].includes( value ) ) {
+		return 'franken';
+	}
+	if ( [ 'php-fpm', 'fpm' ].includes( value ) ) {
+		return 'php-fpm';
+	}
+	throw new Error(
+		`Unsupported CORTEXT_RUNTIME="${ runtime }". Expected php, franken, or php-fpm.`
+	);
+}
+
+function commandExists( command ) {
+	if ( command.includes( path.sep ) ) {
+		return fs.existsSync( command );
+	}
+	const result = spawnSync( 'which', [ command ], {
+		stdio: [ 'ignore', 'pipe', 'ignore' ],
+		encoding: 'utf8',
+	} );
+	return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function resolveExecutable( envName, bundledPath, commandName, installHint ) {
+	const configured = process.env[ envName ];
+	if ( configured ) {
+		if ( fs.existsSync( configured ) || commandExists( configured ) ) {
+			return configured;
+		}
+		throw new Error( `${ envName } points to a missing executable: ${ configured }` );
+	}
+	if ( bundledPath && fs.existsSync( bundledPath ) ) {
+		return bundledPath;
+	}
+	const fromPath = commandExists( commandName );
+	if ( fromPath ) {
+		return fromPath;
+	}
+	throw new Error(
+		`Missing ${ commandName }. ${ installHint } Set ${ envName } to an executable path to override.`
+	);
+}
+
+function pipeProcessOutput( child ) {
+	if ( process.env.CORTEXT_RUNTIME_QUIET === '1' ) {
+		child.stdout.resume();
+		child.stderr.resume();
+		return;
+	}
+	child.stdout.on( 'data', ( chunk ) => {
+		process.stdout.write( chunk );
+	} );
+	child.stderr.on( 'data', ( chunk ) => {
+		process.stderr.write( chunk );
+	} );
+}
+
+function addProcess( handle, name, command, args, options = {} ) {
+	const child = spawn( command, args, {
+		stdio: [ 'ignore', 'pipe', 'pipe' ],
+		...options,
+	} );
+	handle.processes.push( {
+		name,
+		child,
+		killProcessGroup: options.detached === true,
+	} );
+	pipeProcessOutput( child );
+
+	child.on( 'exit', ( code, signal ) => {
+		console.log(
+			`[cortext-desktop] ${ name } exited (code=${ code }, signal=${ signal })`
+		);
+		if ( ! handle.stopping && typeof handle.onUnexpectedExit === 'function' ) {
+			handle.onUnexpectedExit( name, code, signal );
+		}
+	} );
+
+	return child;
+}
+
+function waitForHttpReady( handle, port, timeoutMs = 30000 ) {
+	return new Promise( ( resolve, reject ) => {
+		let settled = false;
+		let lastFailure = null;
+		let probeTimer = null;
+		const timeout = setTimeout( () => {
+			fail(
+				new Error(
+					`Runtime startup timed out (${ timeoutMs / 1000 }s). Last failure: ${
+						lastFailure ? String( lastFailure ) : 'no HTTP response'
+					}`
+				)
+			);
+		}, timeoutMs );
+
+		const cleanupFns = [];
+		const cleanup = () => {
+			clearTimeout( timeout );
+			if ( probeTimer ) {
+				clearTimeout( probeTimer );
+			}
+			for ( const fn of cleanupFns ) {
+				fn();
+			}
+		};
+		const fail = ( err ) => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			cleanup();
+			reject( err );
+		};
+		const pass = () => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			cleanup();
+			resolve();
+		};
+
+		for ( const { name, child } of handle.processes ) {
+			const onError = ( err ) => fail( err );
+			const onExit = ( code, signal ) => {
+				fail(
+					new Error(
+						`${ name } exited before the HTTP server became ready (code=${ code }, signal=${ signal })`
+					)
+				);
+			};
+			child.once( 'error', onError );
+			child.once( 'exit', onExit );
+			cleanupFns.push( () => {
+				child.off( 'error', onError );
+				child.off( 'exit', onExit );
+			} );
+		}
+
+		const probe = () => {
+			const req = http.get(
+				{
+					host: '127.0.0.1',
+					port,
+					path: DEFAULT_READY_PATH,
+					timeout: 1000,
+				},
+				( res ) => {
+					res.resume();
+					if ( res.statusCode && res.statusCode < 500 ) {
+						pass();
+						return;
+					}
+					lastFailure = `HTTP ${ res.statusCode }`;
+					probeTimer = setTimeout( probe, 250 );
+				}
+			);
+			req.on( 'timeout', () => {
+				req.destroy( new Error( 'HTTP probe timed out' ) );
+			} );
+			req.on( 'error', ( err ) => {
+				lastFailure = err.message;
+				if ( ! settled ) {
+					probeTimer = setTimeout( probe, 250 );
+				}
+			} );
+		};
+
+		probe();
+	} );
+}
+
+function startPhpCli( handle, wordpressDir, port, appDir ) {
+	const phpBin = resolveExecutable(
+		'CORTEXT_PHP_BIN',
+		path.join( appDir, 'runtime/bin/php' ),
+		'php',
+		'Install PHP 8.1+ or bundle apps/desktop/runtime/bin/php.'
+	);
+	const routerPath = path.join( wordpressDir, 'router.php' );
+	if ( ! fs.existsSync( routerPath ) ) {
+		throw new Error(
+			`router.php not found at ${ routerPath }. The snapshot is missing runtime files.`
+		);
+	}
+	console.log(
+		`[cortext-desktop] starting php -S (127.0.0.1:${ port }) against ${ wordpressDir }`
+	);
+	const workers =
+		process.env.CORTEXT_PHP_CLI_SERVER_WORKERS ||
+		process.env.PHP_CLI_SERVER_WORKERS;
+	const phpEnv = { ...process.env };
+	if ( workers ) {
+		phpEnv.PHP_CLI_SERVER_WORKERS = workers;
+	}
+	addProcess(
+		handle,
+		'php',
+		phpBin,
+		[ '-S', `127.0.0.1:${ port }`, '-t', wordpressDir, routerPath ],
+		{
+			cwd: wordpressDir,
+			env: phpEnv,
+			detached: Number.parseInt( workers || '1', 10 ) > 1,
+		}
+	);
+}
+
+function startFrankenPhp( handle, wordpressDir, port, appDir ) {
+	const frankenBin = resolveExecutable(
+		'CORTEXT_FRANKENPHP_BIN',
+		path.join( appDir, 'runtime/bin/frankenphp' ),
+		'frankenphp',
+		'Download the FrankenPHP macOS binary into apps/desktop/runtime/bin/frankenphp.'
+	);
+	const configPath = path.join( appDir, 'runtime/Caddyfile.frankenphp' );
+	if ( ! fs.existsSync( configPath ) ) {
+		throw new Error( `FrankenPHP Caddyfile not found at ${ configPath }.` );
+	}
+	if ( ! fs.existsSync( path.join( wordpressDir, 'worker.php' ) ) ) {
+		throw new Error(
+			`worker.php not found in ${ wordpressDir }. Rebuild the desktop snapshot.`
+		);
+	}
+	console.log(
+		`[cortext-desktop] starting FrankenPHP (127.0.0.1:${ port }) against ${ wordpressDir }`
+	);
+	addProcess(
+		handle,
+		'frankenphp',
+		frankenBin,
+		[ 'run', '--config', configPath, '--adapter', 'caddyfile' ],
+		{
+			cwd: wordpressDir,
+			env: {
+				...process.env,
+				CORTEXT_PORT: String( port ),
+				CORTEXT_WORDPRESS_ROOT: wordpressDir,
+				CORTEXT_CADDY_STORAGE: path.join( handle.stateDir, 'caddy' ),
+				CORTEXT_FRANKEN_WORKERS:
+					process.env.CORTEXT_FRANKEN_WORKERS || '1',
+			},
+		}
+	);
+}
+
+function writePhpFpmConfig( runtimeStateDir, wordpressDir ) {
+	fs.mkdirSync( runtimeStateDir, { recursive: true } );
+	const socketDir = fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-fpm-' ) );
+	const socketPath = path.join( socketDir, 'fpm.sock' );
+	const configPath = path.join( runtimeStateDir, 'php-fpm.conf' );
+	const children = process.env.CORTEXT_PHP_FPM_CHILDREN || '2';
+
+	fs.rmSync( socketPath, { force: true } );
+	fs.writeFileSync(
+		configPath,
+		[
+			'[global]',
+			'daemonize = no',
+			`error_log = ${ path.join( runtimeStateDir, 'php-fpm.log' ) }`,
+			`pid = ${ path.join( runtimeStateDir, 'php-fpm.pid' ) }`,
+			'',
+			'[www]',
+			`listen = ${ socketPath }`,
+			'listen.mode = 0600',
+			'pm = static',
+			`pm.max_children = ${ children }`,
+			'clear_env = no',
+			'catch_workers_output = yes',
+			`chdir = ${ wordpressDir }`,
+			`php_admin_value[doc_root] = ${ wordpressDir }`,
+			`php_admin_value[error_log] = ${ path.join(
+				runtimeStateDir,
+				'php-errors.log'
+			) }`,
+			'php_admin_flag[log_errors] = on',
+			'php_value[opcache.enable] = 1',
+			'php_value[opcache.validate_timestamps] = 0',
+			'',
+		].join( '\n' )
+	);
+
+	return { configPath, socketDir, socketPath };
+}
+
+function startPhpFpmCaddy( handle, wordpressDir, port, appDir, runtimeStateDir ) {
+	const phpFpmBin = resolveExecutable(
+		'CORTEXT_PHP_FPM_BIN',
+		path.join( appDir, 'runtime/bin/php-fpm' ),
+		'php-fpm',
+		'Install php-fpm or bundle apps/desktop/runtime/bin/php-fpm.'
+	);
+	const caddyBin = resolveExecutable(
+		'CORTEXT_CADDY_BIN',
+		path.join( appDir, 'runtime/bin/caddy' ),
+		'caddy',
+		'Download Caddy into apps/desktop/runtime/bin/caddy.'
+	);
+	const configPath = path.join( appDir, 'runtime/Caddyfile.php-fpm' );
+	if ( ! fs.existsSync( configPath ) ) {
+		throw new Error( `PHP-FPM Caddyfile not found at ${ configPath }.` );
+	}
+
+	const fpm = writePhpFpmConfig( runtimeStateDir, wordpressDir );
+	handle.cleanupPaths.push( fpm.socketDir );
+	console.log(
+		`[cortext-desktop] starting php-fpm + Caddy (127.0.0.1:${ port }) against ${ wordpressDir }`
+	);
+	addProcess(
+		handle,
+		'php-fpm',
+		phpFpmBin,
+		[ '-F', '-O', '-y', fpm.configPath ],
+		{ cwd: wordpressDir, env: process.env }
+	);
+	addProcess(
+		handle,
+		'caddy',
+		caddyBin,
+		[ 'run', '--config', configPath, '--adapter', 'caddyfile' ],
+		{
+			cwd: wordpressDir,
+			env: {
+				...process.env,
+				CORTEXT_PORT: String( port ),
+				CORTEXT_WORDPRESS_ROOT: wordpressDir,
+				CORTEXT_PHP_FPM_SOCKET: fpm.socketPath,
+				CORTEXT_CADDY_STORAGE: path.join( handle.stateDir, 'caddy' ),
+			},
+		}
+	);
+}
+
+function startRuntime( {
+	appDir,
+	wordpressDir,
+	port = DEFAULT_PORT,
+	runtime = process.env.CORTEXT_RUNTIME,
+	runtimeStateDir,
+	onUnexpectedExit,
+} ) {
+	const normalized = normalizeRuntime( runtime );
+	const handle = {
+		runtime: normalized,
+		processes: [],
+		cleanupPaths: [],
+		stopping: false,
+		onUnexpectedExit,
+	};
+	const stateDir =
+		runtimeStateDir ||
+		fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-desktop-runtime-' ) );
+	handle.stateDir = stateDir;
+
+	if ( normalized === 'php' ) {
+		startPhpCli( handle, wordpressDir, port, appDir );
+	} else if ( normalized === 'franken' ) {
+		startFrankenPhp( handle, wordpressDir, port, appDir );
+	} else if ( normalized === 'php-fpm' ) {
+		startPhpFpmCaddy( handle, wordpressDir, port, appDir, stateDir );
+	}
+
+	handle.ready = waitForHttpReady( handle, port );
+	return handle;
+}
+
+function stopRuntime( handle ) {
+	if ( ! handle ) {
+		return;
+	}
+	handle.stopping = true;
+	for ( const { child, killProcessGroup } of [ ...handle.processes ].reverse() ) {
+		if ( child && child.exitCode === null && child.signalCode === null ) {
+			try {
+				if ( killProcessGroup && child.pid ) {
+					process.kill( -child.pid, 'SIGTERM' );
+				} else {
+					child.kill( 'SIGTERM' );
+				}
+			} catch {}
+			const timer = setTimeout( () => {
+				if ( child.exitCode === null && child.signalCode === null ) {
+					try {
+						if ( killProcessGroup && child.pid ) {
+							process.kill( -child.pid, 'SIGKILL' );
+						} else {
+							child.kill( 'SIGKILL' );
+						}
+					} catch {}
+				}
+			}, 5000 );
+			timer.unref?.();
+		}
+	}
+	for ( const cleanupPath of handle.cleanupPaths || [] ) {
+		fs.rmSync( cleanupPath, { recursive: true, force: true } );
+	}
+}
+
+module.exports = {
+	DEFAULT_PORT,
+	normalizeRuntime,
+	startRuntime,
+	stopRuntime,
+};

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -1,13 +1,16 @@
 const { app, BrowserWindow } = require( 'electron' );
-const { spawn, spawnSync } = require( 'child_process' );
+const { spawnSync } = require( 'child_process' );
 const path = require( 'path' );
 const fs = require( 'fs' );
+const {
+	DEFAULT_PORT: PORT,
+	startRuntime,
+	stopRuntime,
+} = require( './lib/runtime' );
 
-const PORT = 9402;
 const SNAPSHOT_ZIP = path.resolve( __dirname, 'snapshot.zip' );
 
-let phpProcess = null;
-let phpReady = null;
+let runtimeHandle = null;
 let quitting = false;
 
 function getSiteRoot() {
@@ -40,70 +43,6 @@ function ensureSiteFromSnapshot() {
 	return wordpressDir;
 }
 
-function startPhp( wordpressDir ) {
-	const routerPath = path.join( wordpressDir, 'router.php' );
-	if ( ! fs.existsSync( routerPath ) ) {
-		throw new Error(
-			`router.php not found at ${ routerPath }. The snapshot is missing runtime files.`
-		);
-	}
-	console.log(
-		`[cortext-desktop] starting PHP server (127.0.0.1:${ PORT }) against ${ wordpressDir }`
-	);
-	phpProcess = spawn(
-		'php',
-		[
-			'-S',
-			`127.0.0.1:${ PORT }`,
-			'-t',
-			wordpressDir,
-			routerPath,
-		],
-		{
-			stdio: [ 'ignore', 'pipe', 'pipe' ],
-		}
-	);
-
-	// PHP writes its "Development Server ... started" line to stderr after
-	// binding the port. Wait for that before loading the admin screen.
-	phpReady = new Promise( ( resolve, reject ) => {
-		const timer = setTimeout( () => {
-			reject( new Error( 'PHP server startup timed out (30s)' ) );
-		}, 30000 );
-		phpProcess.stdout.on( 'data', ( chunk ) => {
-			process.stdout.write( chunk );
-		} );
-		phpProcess.stderr.on( 'data', ( chunk ) => {
-			const text = chunk.toString();
-			process.stderr.write( text );
-			if (
-				text.includes( 'Development Server' ) &&
-				text.includes( 'started' )
-			) {
-				clearTimeout( timer );
-				resolve();
-			}
-		} );
-		phpProcess.once( 'exit', () => {
-			clearTimeout( timer );
-			reject( new Error( 'PHP server exited before reporting ready' ) );
-		} );
-	} );
-
-	phpProcess.on( 'exit', ( code ) => {
-		console.log( `[cortext-desktop] php exited (code=${ code })` );
-		if ( ! quitting ) {
-			app.quit();
-		}
-	} );
-}
-
-function stopPhp() {
-	if ( phpProcess && ! phpProcess.killed ) {
-		phpProcess.kill( 'SIGTERM' );
-	}
-}
-
 async function createWindow() {
 	const win = new BrowserWindow( {
 		width: 1280,
@@ -118,7 +57,7 @@ async function createWindow() {
 	await win.loadFile( path.resolve( __dirname, 'loading.html' ) );
 
 	try {
-		await phpReady;
+		await runtimeHandle.ready;
 		await win.loadURL(
 			`http://127.0.0.1:${ PORT }/wp-admin/admin.php?page=cortext`
 		);
@@ -134,7 +73,16 @@ async function createWindow() {
 app.whenReady().then( () => {
 	try {
 		const wordpressDir = ensureSiteFromSnapshot();
-		startPhp( wordpressDir );
+		runtimeHandle = startRuntime( {
+			appDir: __dirname,
+			wordpressDir,
+			runtimeStateDir: path.join( app.getPath( 'temp' ), 'cortext-desktop-runtime' ),
+			onUnexpectedExit: () => {
+				if ( ! quitting ) {
+					app.quit();
+				}
+			},
+		} );
 		createWindow();
 	} catch ( err ) {
 		console.error( '[cortext-desktop]', err );
@@ -144,7 +92,7 @@ app.whenReady().then( () => {
 
 app.on( 'window-all-closed', () => {
 	quitting = true;
-	stopPhp();
+	stopRuntime( runtimeHandle );
 	if ( process.platform !== 'darwin' ) {
 		app.quit();
 	}
@@ -152,5 +100,5 @@ app.on( 'window-all-closed', () => {
 
 app.on( 'before-quit', () => {
 	quitting = true;
-	stopPhp();
+	stopRuntime( runtimeHandle );
 } );

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,11 @@
 	"scripts": {
 		"start": "electron .",
 		"snapshot": "node scripts/build-snapshot.mjs",
+		"runtime:php": "node scripts/install-runtime.mjs php",
+		"runtime:franken": "node scripts/install-runtime.mjs franken",
+		"runtime:caddy": "node scripts/install-runtime.mjs caddy",
+		"bench:runtime": "node scripts/bench-runtime.mjs",
+		"test": "npm run test:e2e",
 		"test:e2e": "playwright test"
 	},
 	"devDependencies": {

--- a/apps/desktop/runtime/Caddyfile.frankenphp
+++ b/apps/desktop/runtime/Caddyfile.frankenphp
@@ -1,0 +1,15 @@
+{
+	admin off
+	auto_https off
+	persist_config off
+	storage file_system {$CORTEXT_CADDY_STORAGE}
+}
+
+http://127.0.0.1:{$CORTEXT_PORT} {
+	root * "{$CORTEXT_WORDPRESS_ROOT}"
+	encode zstd gzip
+	php_server {
+		root "{$CORTEXT_WORDPRESS_ROOT}"
+		worker worker.php {$CORTEXT_FRANKEN_WORKERS}
+	}
+}

--- a/apps/desktop/runtime/Caddyfile.php-fpm
+++ b/apps/desktop/runtime/Caddyfile.php-fpm
@@ -1,0 +1,13 @@
+{
+	admin off
+	auto_https off
+	persist_config off
+	storage file_system {$CORTEXT_CADDY_STORAGE}
+}
+
+http://127.0.0.1:{$CORTEXT_PORT} {
+	root * "{$CORTEXT_WORDPRESS_ROOT}"
+	encode zstd gzip
+	php_fastcgi unix/{$CORTEXT_PHP_FPM_SOCKET}
+	file_server
+}

--- a/apps/desktop/runtime/mu-plugins/cortext-autologin.php
+++ b/apps/desktop/runtime/mu-plugins/cortext-autologin.php
@@ -26,6 +26,9 @@ add_filter(
 		if ( $user_id ) {
 			return $user_id;
 		}
+		if ( function_exists( 'wp_installing' ) && wp_installing() ) {
+			return $user_id;
+		}
 		$admin = get_user_by( 'login', 'admin' );
 		return $admin ? $admin->ID : $user_id;
 	},

--- a/apps/desktop/runtime/mu-plugins/cortext-timing.php
+++ b/apps/desktop/runtime/mu-plugins/cortext-timing.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Cortext desktop timing
+ * Description: Adds Server-Timing to desktop runtime responses for local spike measurements.
+ *
+ * @package Cortext
+ */
+
+$cortext_desktop_emit_timing = function () {
+	static $sent = false;
+
+	if ( $sent || headers_sent() ) {
+		return;
+	}
+
+	$started = $GLOBALS['cortext_desktop_request_start'] ?? ( $_SERVER['REQUEST_TIME_FLOAT'] ?? null );
+	if ( ! is_numeric( $started ) ) {
+		return;
+	}
+
+	$sent     = true;
+	$duration = max( 0, ( microtime( true ) - (float) $started ) * 1000 );
+	header( 'Server-Timing: cortext_wp;dur=' . round( $duration, 3 ) );
+};
+
+if ( function_exists( 'header_register_callback' ) ) {
+	header_register_callback( $cortext_desktop_emit_timing );
+}
+
+add_action( 'shutdown', $cortext_desktop_emit_timing, PHP_INT_MAX );

--- a/apps/desktop/runtime/worker.php
+++ b/apps/desktop/runtime/worker.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Experimental FrankenPHP worker for the desktop runtime spike.
+ *
+ * WordPress is not designed as a long-running worker. This file keeps core,
+ * plugins, and autoloaders in memory, then re-enters the requested PHP script
+ * for each request. It deliberately lives behind CORTEXT_RUNTIME=franken.
+ */
+
+if ( ! function_exists( 'frankenphp_handle_request' ) ) {
+	require __DIR__ . '/index.php';
+	return;
+}
+
+define( 'CORTEXT_FRANKENPHP_WORKER', true );
+
+function cortext_desktop_worker_reset_request_state() {
+	$GLOBALS['cortext_desktop_request_start'] = microtime( true );
+
+	unset( $GLOBALS['wp_did_header'] );
+
+	foreach ( array( 'wp_query', 'wp_the_query', 'wp', 'post', 'id', 'authordata' ) as $name ) {
+		unset( $GLOBALS[ $name ] );
+	}
+
+	if ( class_exists( 'WP' ) ) {
+		$GLOBALS['wp'] = new WP();
+	}
+	if ( class_exists( 'WP_Query' ) ) {
+		$GLOBALS['wp_the_query'] = new WP_Query();
+		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+	}
+	if ( function_exists( 'wp_set_current_user' ) ) {
+		wp_set_current_user( 0 );
+	}
+	if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+		wp_cache_flush_runtime();
+	}
+}
+
+function cortext_desktop_worker_script_for_request() {
+	$path = parse_url( $_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH );
+	$path = is_string( $path ) && $path !== '' ? $path : '/';
+
+	if ( $path !== '/' ) {
+		$requested = realpath( __DIR__ . '/' . ltrim( $path, '/' ) );
+		$root      = realpath( __DIR__ );
+		if (
+			$requested &&
+			$root &&
+			str_starts_with( $requested, $root ) &&
+			is_file( $requested ) &&
+			str_ends_with( $requested, '.php' )
+		) {
+			return $requested;
+		}
+	}
+
+	return __DIR__ . '/index.php';
+}
+
+$handler = static function () {
+	cortext_desktop_worker_reset_request_state();
+	require cortext_desktop_worker_script_for_request();
+};
+
+$max_requests = (int) ( $_SERVER['MAX_REQUESTS'] ?? 500 );
+for ( $handled = 0; $max_requests < 1 || $handled < $max_requests; ++$handled ) {
+	$keep_running = frankenphp_handle_request( $handler );
+	gc_collect_cycles();
+	if ( ! $keep_running ) {
+		break;
+	}
+}

--- a/apps/desktop/scripts/bench-runtime.mjs
+++ b/apps/desktop/scripts/bench-runtime.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import {
+	existsSync,
+	mkdirSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import http from 'node:http';
+import { dirname, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire( import.meta.url );
+const {
+	DEFAULT_PORT,
+	normalizeRuntime,
+	startRuntime,
+	stopRuntime,
+} = require( '../lib/runtime' );
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+const DESKTOP_DIR = resolve( __dirname, '..' );
+const SNAPSHOT_ZIP = resolve( DESKTOP_DIR, 'snapshot.zip' );
+
+const ENDPOINTS = [
+	{
+		name: 'admin_shell',
+		path: '/wp-admin/admin.php?page=cortext',
+	},
+	{
+		name: 'workspace_home',
+		path: '/wp-json/cortext/v1/workspace-home/',
+	},
+	{
+		name: 'pages_list',
+		path: '/wp-json/wp/v2/crtxt_pages/?context=edit&per_page=10',
+	},
+	{
+		name: 'collections_list',
+		path: '/wp-json/wp/v2/crtxt_collections/?context=edit&per_page=10',
+	},
+];
+
+function readOptions() {
+	const options = {
+		runtime: process.env.CORTEXT_RUNTIME || 'php',
+		iterations: 50,
+		warmup: 10,
+		label: process.env.CORTEXT_RUNTIME_LABEL || null,
+	};
+
+	for ( const arg of process.argv.slice( 2 ) ) {
+		const [ key, value ] = arg.replace( /^--/, '' ).split( '=' );
+		if ( key === 'runtime' && value ) {
+			options.runtime = value;
+		} else if ( key === 'iterations' && value ) {
+			options.iterations = Number.parseInt( value, 10 );
+		} else if ( key === 'warmup' && value ) {
+			options.warmup = Number.parseInt( value, 10 );
+		} else if ( key === 'label' && value ) {
+			options.label = value;
+		}
+	}
+
+	if ( ! Number.isInteger( options.iterations ) || options.iterations < 1 ) {
+		throw new Error( '--iterations must be a positive integer.' );
+	}
+	if ( ! Number.isInteger( options.warmup ) || options.warmup < 0 ) {
+		throw new Error( '--warmup must be zero or a positive integer.' );
+	}
+
+	options.runtime = normalizeRuntime( options.runtime );
+	if ( options.label && ! /^[a-z0-9._-]+$/i.test( options.label ) ) {
+		throw new Error( '--label may only contain letters, numbers, dots, underscores, and dashes.' );
+	}
+	return options;
+}
+
+function unzipSnapshot( workDir ) {
+	const siteRoot = resolve( workDir, 'site' );
+	const wordpressDir = resolve( siteRoot, 'wordpress' );
+	rmSync( workDir, { recursive: true, force: true } );
+	mkdirSync( siteRoot, { recursive: true } );
+
+	const result = spawnSync(
+		'unzip',
+		[ '-q', '-o', SNAPSHOT_ZIP, '-d', siteRoot ],
+		{ stdio: [ 'ignore', 'ignore', 'ignore' ] }
+	);
+	if (
+		result.status !== 0 &&
+		! existsSync( resolve( wordpressDir, 'index.php' ) )
+	) {
+		throw new Error( `Snapshot extraction failed from ${ SNAPSHOT_ZIP }.` );
+	}
+	return wordpressDir;
+}
+
+function parseServerTiming( header ) {
+	if ( ! header ) {
+		return null;
+	}
+	const value = Array.isArray( header ) ? header.join( ',' ) : String( header );
+	const match = value.match( /(?:^|,\s*)cortext_wp;dur=([0-9.]+)/ );
+	return match ? Number.parseFloat( match[1] ) : null;
+}
+
+function redirectedPath( location ) {
+	const url = new URL( location, `http://127.0.0.1:${ DEFAULT_PORT }` );
+	return `${ url.pathname }${ url.search }`;
+}
+
+function requestPath( endpoint, redirects = 0, startedAt = performance.now() ) {
+	return new Promise( ( resolveRequest, rejectRequest ) => {
+		const req = http.get(
+			{
+				host: '127.0.0.1',
+				port: DEFAULT_PORT,
+				path: endpoint.path,
+				timeout: 30000,
+			},
+			( res ) => {
+				res.resume();
+				res.on( 'end', () => {
+					const duration = performance.now() - startedAt;
+					const location = res.headers.location;
+					if (
+						res.statusCode &&
+						[ 301, 302, 303, 307, 308 ].includes( res.statusCode ) &&
+						location &&
+						redirects < 5
+					) {
+						requestPath(
+							{
+								...endpoint,
+								path: redirectedPath( location ),
+							},
+							redirects + 1,
+							startedAt
+						).then( resolveRequest, rejectRequest );
+						return;
+					}
+					if ( ! res.statusCode || res.statusCode >= 500 ) {
+						rejectRequest(
+							new Error(
+								`${ endpoint.name } returned HTTP ${ res.statusCode }`
+							)
+						);
+						return;
+					}
+					resolveRequest( {
+						totalMs: duration,
+						serverMs: parseServerTiming(
+							res.headers['server-timing']
+						),
+						status: res.statusCode,
+					} );
+				} );
+			}
+		);
+		req.on( 'timeout', () => {
+			req.destroy( new Error( `${ endpoint.name } timed out` ) );
+		} );
+		req.on( 'error', rejectRequest );
+	} );
+}
+
+function percentile( values, p ) {
+	if ( values.length === 0 ) {
+		return null;
+	}
+	const sorted = [ ...values ].sort( ( a, b ) => a - b );
+	const index = Math.min(
+		sorted.length - 1,
+		Math.max( 0, Math.ceil( ( p / 100 ) * sorted.length ) - 1 )
+	);
+	return Math.round( sorted[ index ] * 1000 ) / 1000;
+}
+
+function summarize( samples ) {
+	const total = samples.map( ( sample ) => sample.totalMs );
+	const server = samples
+		.map( ( sample ) => sample.serverMs )
+		.filter( ( value ) => typeof value === 'number' && ! Number.isNaN( value ) );
+	return {
+		status: samples[ samples.length - 1 ]?.status ?? null,
+		requests: samples.length,
+		total_p50_ms: percentile( total, 50 ),
+		total_p95_ms: percentile( total, 95 ),
+		server_p50_ms: percentile( server, 50 ),
+		server_p95_ms: percentile( server, 95 ),
+	};
+}
+
+async function runEndpoint( endpoint, warmup, iterations ) {
+	for ( let index = 0; index < warmup; index++ ) {
+		await requestPath( endpoint );
+	}
+
+	const samples = [];
+	for ( let index = 0; index < iterations; index++ ) {
+		samples.push( await requestPath( endpoint ) );
+	}
+
+	return summarize( samples );
+}
+
+async function stopAndWait( handle ) {
+	stopRuntime( handle );
+	await Promise.all(
+		handle.processes.map(
+			( { child } ) =>
+				new Promise( ( resolveStop ) => {
+					if ( child.exitCode !== null || child.signalCode !== null ) {
+						resolveStop();
+						return;
+					}
+					child.once( 'exit', resolveStop );
+				} )
+		)
+	);
+}
+
+function commandVersion( command, args ) {
+	const result = spawnSync( command, args, {
+		encoding: 'utf8',
+		stdio: [ 'ignore', 'pipe', 'pipe' ],
+	} );
+	if ( result.status !== 0 ) {
+		return null;
+	}
+	return ( result.stdout || result.stderr ).split( '\n' )[0].trim();
+}
+
+function phpRuntimeBin() {
+	if ( process.env.CORTEXT_PHP_BIN ) {
+		return process.env.CORTEXT_PHP_BIN;
+	}
+	const bundled = resolve( DESKTOP_DIR, 'runtime/bin/php' );
+	return existsSync( bundled ) ? bundled : 'php';
+}
+
+function runtimeBin( envName, bundledPath, command ) {
+	if ( process.env[ envName ] ) {
+		return process.env[ envName ];
+	}
+	return existsSync( bundledPath ) ? bundledPath : command;
+}
+
+function environmentInfo( runtime ) {
+	const environment = {
+		node: process.version,
+	};
+
+	if ( runtime === 'php' ) {
+		const phpBin = phpRuntimeBin();
+		environment.php = commandVersion( phpBin, [ '-v' ] );
+		environment.php_bin = phpBin;
+		return environment;
+	}
+
+	if ( runtime === 'franken' ) {
+		const frankenBin = runtimeBin(
+			'CORTEXT_FRANKENPHP_BIN',
+			resolve( DESKTOP_DIR, 'runtime/bin/frankenphp' ),
+			'frankenphp'
+		);
+		environment.frankenphp = commandVersion( frankenBin, [ 'version' ] );
+		environment.frankenphp_bin = frankenBin;
+		return environment;
+	}
+
+	if ( runtime === 'php-fpm' ) {
+		const phpFpmBin = runtimeBin(
+			'CORTEXT_PHP_FPM_BIN',
+			resolve( DESKTOP_DIR, 'runtime/bin/php-fpm' ),
+			'php-fpm'
+		);
+		const caddyBin = runtimeBin(
+			'CORTEXT_CADDY_BIN',
+			resolve( DESKTOP_DIR, 'runtime/bin/caddy' ),
+			'caddy'
+		);
+		environment.php_fpm = commandVersion( phpFpmBin, [ '-v' ] );
+		environment.php_fpm_bin = phpFpmBin;
+		environment.caddy = commandVersion( caddyBin, [ 'version' ] );
+		environment.caddy_bin = caddyBin;
+	}
+
+	return environment;
+}
+
+async function main() {
+	const options = readOptions();
+	if ( ! existsSync( SNAPSHOT_ZIP ) ) {
+		throw new Error(
+			`Missing ${ SNAPSHOT_ZIP }. Run 'npm --prefix apps/desktop run snapshot' first.`
+		);
+	}
+
+	const workDir = resolve( DESKTOP_DIR, '.runtime-bench', options.runtime );
+	const wordpressDir = unzipSnapshot( workDir );
+	process.env.CORTEXT_RUNTIME_QUIET = process.env.CORTEXT_RUNTIME_QUIET || '1';
+	let unexpectedExit = null;
+	const handle = startRuntime( {
+		appDir: DESKTOP_DIR,
+		wordpressDir,
+		runtime: options.runtime,
+		runtimeStateDir: resolve( workDir, 'state' ),
+		onUnexpectedExit: ( name, code, signal ) => {
+			unexpectedExit = new Error(
+				`${ name } exited unexpectedly (code=${ code }, signal=${ signal })`
+			);
+		},
+	} );
+
+	try {
+		await handle.ready;
+		if ( unexpectedExit ) {
+			throw unexpectedExit;
+		}
+		const scenarios = {};
+		for ( const endpoint of ENDPOINTS ) {
+			scenarios[ endpoint.name ] = await runEndpoint(
+				endpoint,
+				options.warmup,
+				options.iterations
+			);
+		}
+
+		const result = {
+			version: 1,
+			runtime: options.runtime,
+			iterations: options.iterations,
+			warmup: options.warmup,
+			port: DEFAULT_PORT,
+			generated_at: new Date().toISOString(),
+			environment: environmentInfo( options.runtime ),
+			scenarios,
+		};
+
+		const outDir = resolve( process.cwd(), 'artifacts' );
+		mkdirSync( outDir, { recursive: true } );
+		const outFile = resolve(
+			outDir,
+			`desktop-runtime-${ options.label || options.runtime }.json`
+		);
+		writeFileSync( outFile, JSON.stringify( result, null, 2 ) + '\n' );
+
+		console.table(
+			Object.entries( scenarios ).map( ( [ name, metrics ] ) => ( {
+				name,
+				...metrics,
+			} ) )
+		);
+		console.log( `[bench-runtime] Wrote ${ outFile }` );
+	} finally {
+		await stopAndWait( handle );
+	}
+}
+
+main().catch( ( err ) => {
+	console.error( `[bench-runtime] ${ err.message }` );
+	process.exitCode = 1;
+} );

--- a/apps/desktop/scripts/build-snapshot.mjs
+++ b/apps/desktop/scripts/build-snapshot.mjs
@@ -47,6 +47,43 @@ function run( cmd, opts = {} ) {
 	execSync( cmd, { stdio: 'inherit', ...opts } );
 }
 
+function shellQuote( value ) {
+	return `'${ String( value ).replace( /'/g, "'\\''" ) }'`;
+}
+
+function commandExists( command ) {
+	if ( command.includes( '/' ) ) {
+		return existsSync( command ) ? command : null;
+	}
+	const result = spawnSync( 'which', [ command ], {
+		stdio: [ 'ignore', 'pipe', 'ignore' ],
+		encoding: 'utf8',
+	} );
+	return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function resolvePhpBin() {
+	const configured = process.env.CORTEXT_PHP_BIN;
+	if ( configured ) {
+		const resolved = commandExists( configured );
+		if ( resolved ) {
+			return resolved;
+		}
+		throw new Error( `CORTEXT_PHP_BIN points to a missing executable: ${ configured }` );
+	}
+	const bundled = resolve( RUNTIME_DIR, 'bin/php' );
+	if ( existsSync( bundled ) ) {
+		return bundled;
+	}
+	const fromPath = commandExists( 'php' );
+	if ( fromPath ) {
+		return fromPath;
+	}
+	throw new Error(
+		'Missing php. Install PHP 8.1+, set CORTEXT_PHP_BIN, or bundle apps/desktop/runtime/bin/php.'
+	);
+}
+
 // macOS `unzip` can exit 1 for warnings, including archives with stored
 // absolute paths. Callers verify the files they need after extraction.
 function unzipQuiet( zipPath, dest ) {
@@ -139,6 +176,10 @@ function buildWpConfig() {
 	lines.push(
 		"if ( ! defined( 'CORTEXT_DESKTOP' ) ) { define( 'CORTEXT_DESKTOP', true ); }"
 	);
+	lines.push(
+		"if ( ! defined( 'DISABLE_WP_CRON' ) ) { define( 'DISABLE_WP_CRON', true ); }"
+	);
+	lines.push( "$GLOBALS['cortext_desktop_request_start'] = microtime( true );" );
 	lines.push( "if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', __DIR__ . '/' ); }" );
 	lines.push( "require_once ABSPATH . 'wp-settings.php';" );
 	return lines.join( '\n' ) + '\n';
@@ -190,10 +231,14 @@ cpSync(
 console.log( '[snapshot] Installing Cortext plugin' );
 cpSync( STAGED_PLUGIN, resolve( pluginsDir, 'cortext' ), { recursive: true } );
 
-console.log( '[snapshot] Adding runtime files (router + mu-plugins)' );
+console.log( '[snapshot] Adding runtime files (router + worker + mu-plugins)' );
 cpSync(
 	resolve( RUNTIME_DIR, 'router.php' ),
 	resolve( SITE_DIR, 'router.php' )
+);
+cpSync(
+	resolve( RUNTIME_DIR, 'worker.php' ),
+	resolve( SITE_DIR, 'worker.php' )
 );
 const muPluginsDest = resolve( SITE_DIR, 'wp-content/mu-plugins' );
 mkdirSync( muPluginsDest, { recursive: true } );
@@ -207,9 +252,14 @@ writeFileSync( resolve( SITE_DIR, 'wp-config.php' ), buildWpConfig() );
 console.log( `[snapshot] Fetching wp-cli` );
 const wpCliPhar = resolve( CACHE_DIR, 'wp-cli.phar' );
 await ensureCachedDownload( WP_CLI_PHAR_URL, wpCliPhar );
+const PHP_BIN = resolvePhpBin();
 
 function wpCli( args ) {
-	run( `php "${ wpCliPhar }" --path="${ SITE_DIR }" ${ args }` );
+	run(
+		`${ shellQuote( PHP_BIN ) } ${ shellQuote( wpCliPhar ) } --path=${ shellQuote(
+			SITE_DIR
+		) } ${ args }`
+	);
 }
 
 console.log( '[snapshot] Installing WordPress' );

--- a/apps/desktop/scripts/install-runtime.mjs
+++ b/apps/desktop/scripts/install-runtime.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	rmSync,
+} from 'node:fs';
+import https from 'node:https';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+const DESKTOP_DIR = resolve( __dirname, '..' );
+const BIN_DIR = resolve( DESKTOP_DIR, 'runtime/bin' );
+const CACHE_DIR = resolve( DESKTOP_DIR, '.runtime-cache' );
+
+const PHP_VERSION = process.env.CORTEXT_STATIC_PHP_VERSION || '8.5';
+const SPC_VERSION = process.env.CORTEXT_SPC_VERSION || '2.8.5';
+const FRANKENPHP_VERSION =
+	process.env.CORTEXT_FRANKENPHP_VERSION || 'v1.12.2';
+const CADDY_VERSION = process.env.CORTEXT_CADDY_VERSION || '2.11.3';
+
+const PHP_EXTENSIONS = [
+	'opcache',
+	'pdo',
+	'pdo_sqlite',
+	'sqlite3',
+	'mbstring',
+	'curl',
+	'openssl',
+	'zip',
+	'zlib',
+	'gd',
+	'xml',
+	'dom',
+	'simplexml',
+	'xmlreader',
+	'xmlwriter',
+	'phar',
+	'session',
+	'tokenizer',
+	'fileinfo',
+	'filter',
+	'ctype',
+	'iconv',
+	'bcmath',
+	'bz2',
+	'calendar',
+	'exif',
+];
+
+function readOptions() {
+	const options = {
+		runtime: process.argv[ 2 ],
+		force: process.argv.includes( '--force' ),
+		rebuild: process.argv.includes( '--rebuild' ),
+	};
+
+	if (
+		! options.runtime ||
+		[ '-h', '--help', 'help' ].includes( options.runtime )
+	) {
+		console.log(
+			[
+				'Usage: node scripts/install-runtime.mjs <php|franken|caddy> [--force] [--rebuild]',
+				'',
+				'Examples:',
+				'  npm --prefix apps/desktop run runtime:php',
+				'  npm --prefix apps/desktop run runtime:franken',
+				'  npm --prefix apps/desktop run runtime:caddy',
+			].join( '\n' )
+		);
+		process.exit( options.runtime ? 0 : 1 );
+	}
+
+	return options;
+}
+
+function platformKey() {
+	if ( process.platform !== 'darwin' ) {
+		throw new Error(
+			`Only macOS runtime artifacts are supported by this spike script. Current platform: ${ process.platform }.`
+		);
+	}
+	if ( process.arch === 'arm64' ) {
+		return 'macos-aarch64';
+	}
+	if ( process.arch === 'x64' ) {
+		return 'macos-x86_64';
+	}
+	throw new Error( `Unsupported macOS architecture: ${ process.arch }.` );
+}
+
+function frankenPlatformName() {
+	return platformKey() === 'macos-aarch64' ? 'mac-arm64' : 'mac-x86_64';
+}
+
+function caddyPlatformName() {
+	return platformKey() === 'macos-aarch64' ? 'mac_arm64' : 'mac_amd64';
+}
+
+function run( command, args, options = {} ) {
+	const result = spawnSync( command, args, {
+		stdio: 'inherit',
+		...options,
+	} );
+	if ( result.status !== 0 ) {
+		throw new Error(
+			`${ command } ${ args.join( ' ' ) } failed with exit code ${ result.status }`
+		);
+	}
+}
+
+function output( command, args ) {
+	const result = spawnSync( command, args, {
+		encoding: 'utf8',
+		stdio: [ 'ignore', 'pipe', 'pipe' ],
+	} );
+	if ( result.status !== 0 ) {
+		throw new Error(
+			`${ command } ${ args.join( ' ' ) } failed: ${ result.stderr || result.stdout }`
+		);
+	}
+	return ( result.stdout || result.stderr ).trim();
+}
+
+function download( url, dest, redirects = 0 ) {
+	if ( redirects > 5 ) {
+		return Promise.reject( new Error( `Too many redirects for ${ url }` ) );
+	}
+	mkdirSync( dirname( dest ), { recursive: true } );
+	return new Promise( ( resolveDownload, rejectDownload ) => {
+		const request = https.get( url, ( response ) => {
+			if (
+				response.statusCode &&
+				[ 301, 302, 303, 307, 308 ].includes( response.statusCode ) &&
+				response.headers.location
+			) {
+				response.resume();
+				download(
+					new URL( response.headers.location, url ).toString(),
+					dest,
+					redirects + 1
+				).then( resolveDownload, rejectDownload );
+				return;
+			}
+
+			if ( ! response.statusCode || response.statusCode >= 400 ) {
+				response.resume();
+				rejectDownload(
+					new Error( `Download failed (${ response.statusCode }) for ${ url }` )
+				);
+				return;
+			}
+
+			const file = createWriteStream( dest );
+			response.pipe( file );
+			file.on( 'finish', () => file.close( resolveDownload ) );
+			file.on( 'error', rejectDownload );
+		} );
+		request.on( 'error', rejectDownload );
+	} );
+}
+
+async function ensureDownload( url, dest ) {
+	if ( existsSync( dest ) ) {
+		console.log( `[runtime] Using cached ${ dest }` );
+		return dest;
+	}
+	console.log( `[runtime] Downloading ${ url }` );
+	await download( url, dest );
+	return dest;
+}
+
+function installExecutable( src, dest, force ) {
+	if ( existsSync( dest ) && ! force ) {
+		console.log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
+		return false;
+	}
+	mkdirSync( dirname( dest ), { recursive: true } );
+	copyFileSync( src, dest );
+	chmodSync( dest, 0o755 );
+	console.log( `[runtime] Installed ${ dest }` );
+	return true;
+}
+
+async function installFranken( options ) {
+	const dest = resolve( BIN_DIR, 'frankenphp' );
+	if ( existsSync( dest ) && ! options.force ) {
+		console.log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
+		console.log( output( dest, [ 'version' ] ).split( '\n' )[0] );
+		return;
+	}
+
+	const asset = `frankenphp-${ frankenPlatformName() }`;
+	const url = `https://github.com/php/frankenphp/releases/download/${ FRANKENPHP_VERSION }/${ asset }`;
+	const cachePath = resolve( CACHE_DIR, asset );
+
+	await ensureDownload( url, cachePath );
+	installExecutable( cachePath, dest, options.force );
+	console.log( output( dest, [ 'version' ] ).split( '\n' )[0] );
+}
+
+async function installCaddy( options ) {
+	const dest = resolve( BIN_DIR, 'caddy' );
+	if ( existsSync( dest ) && ! options.force ) {
+		console.log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
+		console.log( output( dest, [ 'version' ] ).split( '\n' )[0] );
+		return;
+	}
+
+	const asset = `caddy_${ CADDY_VERSION }_${ caddyPlatformName() }.tar.gz`;
+	const url = `https://github.com/caddyserver/caddy/releases/download/v${ CADDY_VERSION }/${ asset }`;
+	const archive = resolve( CACHE_DIR, asset );
+	const extractDir = resolve( CACHE_DIR, `caddy-${ CADDY_VERSION }-${ caddyPlatformName() }` );
+	const extracted = resolve( extractDir, 'caddy' );
+
+	await ensureDownload( url, archive );
+	if ( ! existsSync( extracted ) || options.force ) {
+		rmSync( extractDir, { recursive: true, force: true } );
+		mkdirSync( extractDir, { recursive: true } );
+		run( 'tar', [ '-xzf', archive, '-C', extractDir ] );
+	}
+	installExecutable( extracted, dest, options.force );
+	console.log( output( dest, [ 'version' ] ).split( '\n' )[0] );
+}
+
+function verifyPhp( phpBin ) {
+	const modules = output( phpBin, [ '-m' ] )
+		.split( '\n' )
+		.map( ( module ) => module.trim().toLowerCase() );
+	for ( const required of [
+		'pdo',
+		'pdo_sqlite',
+		'sqlite3',
+		'mbstring',
+		'curl',
+		'openssl',
+		'zip',
+		'gd',
+		'xml',
+		'dom',
+		'simplexml',
+		'xmlreader',
+		'xmlwriter',
+		'phar',
+		'session',
+		'tokenizer',
+		'fileinfo',
+		'filter',
+		'ctype',
+		'iconv',
+		'zend opcache',
+	] ) {
+		if ( ! modules.includes( required ) ) {
+			throw new Error( `Bundled PHP is missing required module: ${ required }` );
+		}
+	}
+	console.log( output( phpBin, [ '-v' ] ).split( '\n' )[0] );
+}
+
+async function installPhp( options ) {
+	const dest = resolve( BIN_DIR, 'php' );
+	if ( existsSync( dest ) && ! options.force ) {
+		console.log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
+		verifyPhp( dest );
+		return;
+	}
+
+	const spcAsset = `spc-${ platformKey() }.tar.gz`;
+	const spcUrl = `https://github.com/crazywhalecc/static-php-cli/releases/download/${ SPC_VERSION }/${ spcAsset }`;
+	const spcArchive = resolve( CACHE_DIR, spcAsset );
+	const spcDir = resolve( CACHE_DIR, `spc-build-${ SPC_VERSION }` );
+	const spcBin = resolve( spcDir, 'spc' );
+	const builtPhp = resolve( spcDir, 'buildroot/bin/php' );
+
+	await ensureDownload( spcUrl, spcArchive );
+	if ( ! existsSync( spcBin ) ) {
+		mkdirSync( spcDir, { recursive: true } );
+		run( 'tar', [ '-xzf', spcArchive, '-C', spcDir ] );
+		chmodSync( spcBin, 0o755 );
+	}
+
+	if ( ! existsSync( builtPhp ) || options.rebuild ) {
+		const extensionList = PHP_EXTENSIONS.join( ',' );
+		run(
+			spcBin,
+			[
+				'download',
+				`--for-extensions=${ extensionList }`,
+				`--with-php=${ PHP_VERSION }`,
+				'--prefer-pre-built',
+				'--retry=2',
+			],
+			{ cwd: spcDir }
+		);
+		run( spcBin, [ 'switch-php-version', PHP_VERSION ], { cwd: spcDir } );
+		run(
+			spcBin,
+			[
+				'build',
+				extensionList,
+				'--build-cli',
+				'--disable-opcache-jit',
+				'-I',
+				'opcache.enable_cli=1',
+				'-I',
+				'opcache.validate_timestamps=0',
+			],
+			{ cwd: spcDir }
+		);
+	}
+
+	installExecutable( builtPhp, dest, true );
+	verifyPhp( dest );
+}
+
+async function main() {
+	const options = readOptions();
+	if ( options.runtime === 'php' ) {
+		await installPhp( options );
+	} else if ( options.runtime === 'franken' ) {
+		await installFranken( options );
+	} else if ( options.runtime === 'caddy' ) {
+		await installCaddy( options );
+	} else {
+		throw new Error(
+			`Unknown runtime "${ options.runtime }". Expected php, franken, or caddy.`
+		);
+	}
+}
+
+main().catch( ( err ) => {
+	console.error( `[runtime] ${ err.message }` );
+	process.exitCode = 1;
+} );

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2,15 +2,7 @@
 
 Running log of significant design decisions. Newest first. Each entry captures *why* so future readers can evaluate whether the constraints still hold.
 
-## 2026-05-15 — Desktop app runs on native PHP, not Playground
-
-**Decision.** The Electron desktop app now starts the bundled site with `php -S` (PHP's built-in server) and a `wp-content/db.php` SQLite drop-in. It no longer starts `wp-playground-cli`. The build pipeline also downloads and installs WordPress directly (`wp core install`, plugin activation, seed data), so WordPress Playground is gone from both snapshot creation and runtime.
-
-**Why.** On the same machine and workspace, Playground REST endpoints took ~600-1000 ms per request. Native PHP took ~30-60 ms. Shell paint dropped from ~1 s to ~80 ms. With the seed dataset open in DataViews, that is the difference between "this needs work" and "this is fine".
-
-**Trade-off.** The desktop app now needs a working `php` binary on the host's PATH, and snapshot builds need `wp-cli` to run through that PHP. Bundled PHP per architecture is still future work.
-
-**Revisit when.** We bundle PHP, or another runtime gives us the same packaging story without giving up native-PHP performance.
+Desktop-specific runtime and packaging decisions live in `docs/desktop-decisions.md`.
 
 ## 2026-04-23 — Page URLs are id-based, slug is cosmetic
 

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -1,0 +1,54 @@
+# Desktop decisions
+
+Running log for desktop-specific runtime and packaging decisions. Keep the detailed benchmark numbers in PR comments or artifacts unless they become stable product guidance.
+
+## 2026-05-18 — Desktop startup avoids WordPress work in readiness checks
+
+**Decision.** The desktop runtime checks readiness with a static WordPress asset, not `wp-admin`. The generated desktop `wp-config.php` also sets `DISABLE_WP_CRON` to `true`.
+
+**Why.** Readiness should only prove that the local server is accepting requests. Loading `wp-admin` does real WordPress work before the window navigates. In a fresh single-worker `php -S` snapshot, that path can trigger WP-Cron. Cron then makes an HTTP loopback request to the same local server and waits behind the current request until PHP times out. That was enough to send the Electron smoke test to `error.html`, even though the app loaded manually once the timeout cleared.
+
+**Trade-off.** Desktop snapshots no longer run WP-Cron automatically. That is fine for the local single-user app: scheduled publishing, background update checks, and cron-style jobs are not part of the v1 desktop flow. Startup is more predictable without self-HTTP work.
+
+**Revisit when.** Cortext desktop needs scheduled jobs, sync, import/export queues, or any feature that depends on WordPress cron semantics. If that happens, use an explicit job runner or a separate controlled process. Do not hang it off startup readiness.
+
+## 2026-05-18 — Merge the desktop runtime baseline before deeper PHP tuning
+
+**Decision.** Merge the runtime baseline first: bundled-PHP discovery, `php -S` workers, runtime flags, and the benchmark harness. Leave detailed benchmark results in the PR discussion and deeper PHP tuning for follow-up PRs.
+
+**Why.** This branch already changes process lifecycle and packaging assumptions. It is enough to review on its own. The Library workflow bottleneck is request concurrency, and static PHP with `PHP_CLI_SERVER_WORKERS=4` gets the useful win without making FrankenPHP or PHP-FPM the default. The remaining ideas need separate proof: file cache changes cold/warm start behavior, APCu has coherency risk across workers, preload changes boot behavior, and JIT requires a new PHP build because the current static binary was compiled without OPcache JIT.
+
+**Follow-up order.** After merge, measure each idea against the merged baseline:
+
+- OPcache `file_cache` first, because it is runtime-configurable and does not need a PHP rebuild.
+- Request/query profiling for the Library workflow before adding object cache, so we know whether APCu is fixing real repeated reads or just adding cache coherency risk across CLI server workers.
+- Preload or targeted `opcache_compile_file()` only after the hot PHP files are known from profiling.
+- A JIT-enabled PHP rebuild last. If tested, verify `opcache_get_status()['jit']['buffer_used'] > 0` after warmup and measure memory at 4 and 8 workers.
+
+**Not in this branch.** Do not make FrankenPHP the default, do not switch v1 desktop back to Playground/WASM, and do not bundle PHP-FPM/Caddy unless a follow-up benchmark shows a real Library workflow win that justifies the packaging cost.
+
+**Trade-off.** This branch is not the final performance ceiling. Follow-up work should measure each optimization independently and keep only changes that move the real Library workflow. Single-endpoint p50 wins are not enough.
+
+**Revisit when.** The runtime baseline is merged, the PHP bundle build is automated for supported architectures, or the Library workflow is still too slow after worker concurrency is enabled.
+
+## 2026-05-15 — Desktop keeps `php -S`, but PHP bundling needs a tuned build
+
+**Decision.** Keep `php -S` as the default desktop runtime. The app and snapshot builder now prefer `apps/desktop/runtime/bin/php` when present, so a signed app can run without PHP installed on the user's machine. The current packaging candidate is a custom static PHP 8.5 CLI bundle with OPcache and `CORTEXT_PHP_CLI_SERVER_WORKERS=4`. FrankenPHP worker mode and PHP-FPM + Caddy stay as spike paths behind `CORTEXT_RUNTIME`.
+
+**Why.** The local benchmark runs did not give us a reason to leave `php -S`. Endpoint timings were close across system PHP, bundled static PHP, and PHP-FPM + Caddy. FrankenPHP did not win the endpoint benchmark either, though it helped show the real issue: Library hydrates several DataViews, and row detail opens trigger more requests. One-worker `php -S` serializes too much of that burst. `PHP_CLI_SERVER_WORKERS=4` gives the static PHP CLI bundle the needed concurrency without Caddy or a long-running WordPress worker. The detailed numbers live in the PR discussion rather than committed docs.
+
+Reviewers can exercise the bundled paths without committing binaries by running `npm --prefix apps/desktop run runtime:php` or `npm --prefix apps/desktop run runtime:franken`; both commands write ignored files under `apps/desktop/runtime/bin/`.
+
+**Trade-off.** Desktop still needs a reproducible PHP artifact before signed/notarized distribution. The packaging PR should build the custom PHP CLI for arm64 and x64, verify checksums, copy the selected binary into the Electron bundle, and run the smoke test on a machine without PHP on `PATH`.
+
+**Revisit when.** The custom PHP bundle regresses on another architecture, a WordPress-safe worker adapter exists, FrankenPHP publishes a smaller/checksummed macOS bundle, or a static PHP-FPM bundle proves substantially faster with production-equivalent PHP binaries.
+
+## 2026-05-15 — Desktop app runs on native PHP, not Playground
+
+**Decision.** The Electron desktop app starts the bundled site with `php -S` and a `wp-content/db.php` SQLite drop-in. It no longer starts `wp-playground-cli`. The build pipeline downloads and installs WordPress directly with wp-cli, then activates the plugin and seeds demo data.
+
+**Why.** On the same machine and workspace, Playground REST endpoints took ~600-1000 ms per request. Native PHP took ~30-60 ms. Shell paint dropped from ~1 s to ~80 ms. With the seed dataset open in DataViews, that is the difference between "this needs work" and "this is fine".
+
+**Trade-off.** The desktop app needs PHP at runtime. In development that can be `apps/desktop/runtime/bin/php`, `CORTEXT_PHP_BIN`, or `php` on `PATH`. The signed app should bundle PHP per architecture.
+
+**Revisit when.** We bundle PHP for distribution, or another runtime gives us the same packaging story without giving up native-PHP performance.


### PR DESCRIPTION
## What

Part of #196 

Adds the runtime plumbing the desktop app needs to run with a local PHP binary bundled in the app.

`php -S` stays the default runtime. The app now prefers `apps/desktop/runtime/bin/php`, supports `PHP_CLI_SERVER_WORKERS`, and keeps FrankenPHP / PHP-FPM available behind runtime flags for comparison.

The PR also adds helper scripts to build or download the ignored local runtime binaries, rather than copying them by hand.

## Why

The desktop app should not depend on users having PHP installed. This does not ship the final signed PHP artifact yet, but it makes the app behave the way packaging will need: use bundled PHP first, then fall back to a developer-provided or system PHP.

## How

- Resolves PHP from `CORTEXT_PHP_BIN`, then `apps/desktop/runtime/bin/php`, then `PATH`.
- Adds `npm --prefix apps/desktop run runtime:php` to build a local static PHP binary at `apps/desktop/runtime/bin/php`.
- Moves runtime process handling into `apps/desktop/lib/runtime.js`.
- Cleans up the full PHP process group when `PHP_CLI_SERVER_WORKERS` starts child workers.
- Adds local runtime install scripts for FrankenPHP and Caddy.
- Uses a static asset for readiness checks and disables WP-Cron in the desktop snapshot to avoid startup loopback deadlocks.

## Testing Instructions

1. Run `npm install`.
2. Run `npm --prefix apps/desktop install`.
3. Run `npm --prefix apps/desktop run runtime:php`.
4. Confirm `apps/desktop/runtime/bin/php -v` works.
5. Run `npm --prefix apps/desktop run snapshot`.
6. Start the app with `CORTEXT_PHP_CLI_SERVER_WORKERS=4 npm --prefix apps/desktop start`.
7. Confirm the Cortext shell loads, then close the app and confirm port `9402` is free.
8. Run `npm --prefix apps/desktop run runtime:franken`.
9. Start with `CORTEXT_RUNTIME=franken npm --prefix apps/desktop start` and confirm the shell loads.