### PR TITLE
Fix row links opening the parent collection

### DIFF
--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -275,8 +275,8 @@ final class Documents {
 			'kind'   => $kind,
 			'id'     => (int) $post->ID,
 			'title'  => $this->post_title( $post ),
-			'path'   => $collection instanceof WP_Post
-				? $this->collection_path( $collection )
+			'path'   => self::KIND_ROW === $kind
+				? $this->row_path( $post )
 				: $this->page_path( $post ),
 			'parent' => (int) $post->post_parent,
 		);
@@ -385,6 +385,11 @@ final class Documents {
 		$slug = trim( $post->post_name );
 		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
 		return "page/{$tail}";
+	}
+
+	private function row_path( WP_Post $post ): string {
+		$slug = trim( $post->post_name );
+		return '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
 	}
 
 	private function collection_path( WP_Post $collection ): string {

--- a/tests/e2e/specs/recents.spec.js
+++ b/tests/e2e/specs/recents.spec.js
@@ -223,7 +223,7 @@ test.describe( 'Sidebar recents', () => {
 		}
 	} );
 
-	test( 'records row edits and row recents open the parent collection', async ( {
+	test( 'records row edits and row recents open the row', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -287,12 +287,10 @@ test.describe( 'Sidebar recents', () => {
 
 			await expect
 				.poll( () => appPath( page ) )
-				.toContain(
-					`/collection/${ fixture.slug }-${ fixture.collection.id }`
-				);
+				.toContain( `/${ fixture.entry.slug }-${ fixture.entry.id }` );
 			await expect(
 				page.locator(
-					'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+					'.cortext-workspace__pane[data-active="true"] .cortext-row-detail__frame'
 				)
 			).toBeVisible( { timeout: 15_000 } );
 		} finally {

--- a/tests/e2e/specs/recents.spec.js
+++ b/tests/e2e/specs/recents.spec.js
@@ -290,7 +290,7 @@ test.describe( 'Sidebar recents', () => {
 				.toContain( `/${ fixture.entry.slug }-${ fixture.entry.id }` );
 			await expect(
 				page.locator(
-					'.cortext-workspace__pane[data-active="true"] .cortext-row-detail__frame'
+					'.cortext-workspace__pane[data-active="true"] .cortext-row-detail--canvas-properties'
 				)
 			).toBeVisible( { timeout: 15_000 } );
 		} finally {

--- a/tests/php/test-documents.php
+++ b/tests/php/test-documents.php
@@ -96,11 +96,29 @@ final class Test_Documents extends BaseTestCase {
 		$this->assertSame( Documents::KIND_ROW, $document['kind'] );
 		$this->assertSame( $row_id, $document['id'] );
 		$this->assertSame( 'Ship the thing', $document['title'] );
-		$this->assertSame( "collection/projects-{$collection_id}", $document['path'] );
+		$this->assertSame( "ship-the-thing-{$row_id}", $document['path'] );
 		$this->assertSame( $collection_id, $document['collection']['id'] );
 		$this->assertSame( 'Projects', $document['collection']['title'] );
 		$this->assertSame( "collection/projects-{$collection_id}", $document['collection']['path'] );
 		$this->assertArrayNotHasKey( 'icon', $document );
+	}
+
+	public function test_find_row_without_slug_falls_back_to_bare_id(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$this->create_collection( 'projects', 'Projects' );
+		$row_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'crtxt_projects',
+				'post_status' => 'private',
+				'post_title'  => '',
+				'post_name'   => '',
+			)
+		);
+
+		$document = $this->documents->find( $row_id );
+
+		$this->assertNotNull( $document );
+		$this->assertSame( (string) $row_id, $document['path'] );
 	}
 
 	public function test_find_returns_null_for_non_document_post_type(): void {

--- a/tests/php/test-rest-recents-controller.php
+++ b/tests/php/test-rest-recents-controller.php
@@ -90,7 +90,7 @@ final class Test_Rest_Recents_Controller extends BaseTestCase {
 		$this->assertSame( 'row', $recents[0]['kind'] );
 		$this->assertSame( $row_id, $recents[0]['id'] );
 		$this->assertSame( 'Ada Lovelace', $recents[0]['title'] );
-		$this->assertSame( "collection/people-{$collection}", $recents[0]['path'] );
+		$this->assertSame( "ada-lovelace-{$row_id}", $recents[0]['path'] );
 		$this->assertSame( $collection, $recents[0]['collection']['id'] );
 		$this->assertSame( 'People', $recents[0]['collection']['title'] );
 		$this->assertSame( 'collection', $recents[1]['kind'] );


### PR DESCRIPTION
## What
Prep for #149, #150.

Row documents now point to their own row URL, so selecting a row from recents opens that row directly rather than dropping the user at the parent collection.

## Why

A recent row item should take you back to the row you edited. Before this change, it opened the parent collection, which made the `recents` entry less useful.

## How

- Uses the row slug and ID for row document paths.
- Falls back to the row ID when the row has no slug.

## Testing Instructions

1. Edit a row in a collection.
2. Open recents from the sidebar.
3. Click the recent item for that row.
4. Confirm the row detail view opens at the row URL.

## Screen recording

https://github.com/user-attachments/assets/4b39b856-a6a5-4268-ad17-d8d00afc339f

