### PR TITLE
Performance: Lazy-load Cortext editor surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 		"@wordpress/prettier-config": "^4.46.0",
 		"@wordpress/scripts": "^32.0.0",
 		"react": "18.3.1",
-		"react-dom": "18.3.1"
+		"react-dom": "18.3.1",
+		"webpack-bundle-analyzer": "^5.3.0"
 	},
 	"dependencies": {
 		"@dnd-kit/core": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      webpack-bundle-analyzer:
+        specifier: ^5.3.0
+        version: 5.3.0
 
 packages:
 
@@ -944,6 +947,10 @@ packages:
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
+
+  '@discoveryjs/json-ext@0.6.3':
+    resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
+    engines: {node: '>=14.17.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -4096,6 +4103,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -4678,6 +4689,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -5371,6 +5386,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
   html-react-parser@5.2.11:
     resolution: {integrity: sha512-WnSQVn/D1UTj64nSz5y8MriL+MrbsZH80Ytr1oqKqs8DGZnphWY1R1pl3t7TY3rpqTSu+FHA21P80lrsmrdNBA==}
@@ -7667,6 +7685,10 @@ packages:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -8347,6 +8369,11 @@ packages:
   webpack-bundle-analyzer@4.10.2:
     resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
     engines: {node: '>= 10.13.0'}
+    hasBin: true
+
+  webpack-bundle-analyzer@5.3.0:
+    resolution: {integrity: sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg==}
+    engines: {node: '>= 20.9.0'}
     hasBin: true
 
   webpack-cli@5.1.4:
@@ -9707,6 +9734,8 @@ snapshots:
   '@date-fns/utc@2.1.1': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
+
+  '@discoveryjs/json-ext@0.6.3': {}
 
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
@@ -12030,17 +12059,17 @@ snapshots:
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2))(webpack@5.106.2)':
     dependencies:
       webpack: 5.106.2(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@4.15.2)(webpack@5.106.2)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2))(webpack@5.106.2)':
     dependencies:
       webpack: 5.106.2(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@4.15.2)(webpack@5.106.2)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2))(webpack-dev-server@4.15.2)(webpack@5.106.2)':
     dependencies:
       webpack: 5.106.2(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@4.15.2)(webpack@5.106.2)
     optionalDependencies:
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.106.2)
 
@@ -13551,7 +13580,7 @@ snapshots:
       url-loader: 4.1.1(webpack@5.106.2)
       webpack: 5.106.2(webpack-cli@5.1.4)
       webpack-bundle-analyzer: 4.10.2
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@4.15.2)(webpack@5.106.2)
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.106.2)
     optionalDependencies:
       '@wordpress/env': 11.4.0(@types/node@20.19.39)
@@ -14735,6 +14764,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@7.2.0: {}
@@ -15352,6 +15383,8 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -16169,6 +16202,8 @@ snapshots:
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
+
+  html-escaper@3.0.3: {}
 
   html-react-parser@5.2.11(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -18739,6 +18774,12 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -19541,7 +19582,23 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2):
+  webpack-bundle-analyzer@5.3.0:
+    dependencies:
+      '@discoveryjs/json-ext': 0.6.3
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      commander: 14.0.3
+      escape-string-regexp: 5.0.0
+      html-escaper: 3.0.3
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 3.0.2
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  webpack-cli@5.1.4(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@4.15.2)(webpack@5.106.2):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2))(webpack@5.106.2)
@@ -19558,7 +19615,7 @@ snapshots:
       webpack: 5.106.2(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-bundle-analyzer: 4.10.2
+      webpack-bundle-analyzer: 5.3.0
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.106.2)
 
   webpack-dev-middleware@5.3.4(webpack@5.106.2):
@@ -19604,7 +19661,7 @@ snapshots:
       ws: 8.20.0
     optionalDependencies:
       webpack: 5.106.2(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@4.15.2)(webpack@5.106.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19646,7 +19703,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.106.2)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@4.15.2)(webpack@5.106.2)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -12,6 +12,15 @@ import { store as noticesStore } from '@wordpress/notices';
 import { chevronDown, chevronUp, cog, seen, unseen } from '@wordpress/icons';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 
+// Editor-surface stylesheets. Imported via a sibling SCSS file (not
+// src/index.scss) so mini-css-extract emits them into the editor chunk's
+// CSS bundle, off the initial CSS path.
+import './Canvas.scss';
+
+// Registers core + Cortext blocks before any editor renders. Shared with
+// RowEditor so opening a row peek first (without a document open) still
+// gets the blocks registered.
+import './initEditor';
 import useAutosave from '../hooks/useAutosave';
 import { withViewTransition } from '../hooks/viewTransition';
 import { POST_TYPE } from './page-queries';

--- a/src/components/Canvas.scss
+++ b/src/components/Canvas.scss
@@ -1,0 +1,7 @@
+// Editor-surface stylesheets, imported from Canvas.js so mini-css-extract
+// emits them into the editor lazy chunk instead of index.css. Routed
+// through SCSS @use rather than a JS CSS import because the packages'
+// exports field does not expose ./build-style/style.css.
+
+@use "../../node_modules/@wordpress/interface/build-style/style.css";
+@use "../../node_modules/@wordpress/editor/build-style/style.css" as editor;

--- a/src/components/CanvasSkeleton.js
+++ b/src/components/CanvasSkeleton.js
@@ -1,0 +1,16 @@
+// Suspense fallback while the editor chunk loads on the first document
+// open. Mimics the editor's vertical rhythm (centered title strip + a few
+// content lines) so the swap to the real editor doesn't reflow the pane.
+export default function CanvasSkeleton() {
+	return (
+		<div className="cortext-canvas-skeleton" aria-hidden="true">
+			<div className="cortext-canvas-skeleton__title" />
+			<div className="cortext-canvas-skeleton__body">
+				<div className="cortext-canvas-skeleton__line" />
+				<div className="cortext-canvas-skeleton__line cortext-canvas-skeleton__line--short" />
+				<div className="cortext-canvas-skeleton__line" />
+				<div className="cortext-canvas-skeleton__line cortext-canvas-skeleton__line--medium" />
+			</div>
+		</div>
+	);
+}

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -1,8 +1,15 @@
 import { useEntityRecord } from '@wordpress/core-data';
 import { Icon, page as pageGlyph } from '@wordpress/icons';
-import { useMemo } from '@wordpress/element';
+import { lazy, Suspense, useMemo } from '@wordpress/element';
 
-import PageIconWp from './PageIconWp';
+// PageIconWp does `import * as icons from '@wordpress/icons'` so it can look
+// glyphs up by name at runtime. That defeats tree-shaking and would pull the
+// entire icon set (~238 KiB) into the initial bundle. Lazy-load it: most
+// page icons are emoji/image, and pages that do use a wp glyph only trigger
+// the chunk download on first render.
+const PageIconWp = lazy( () =>
+	import( /* webpackChunkName: "page-icon-wp" */ './PageIconWp' )
+);
 
 // Three shapes are persisted in the cortext_document_icon meta:
 //   { type: 'emoji', value: '📘' }
@@ -162,7 +169,11 @@ export default function PageIcon( { icon, size = 16, alt, className } ) {
 				role={ alt ? 'img' : undefined }
 				aria-label={ alt }
 			>
-				<PageIconWp name={ parsed.name } size={ size } />
+				<Suspense
+					fallback={ <Icon icon={ pageGlyph } size={ size } /> }
+				>
+					<PageIconWp name={ parsed.name } size={ size } />
+				</Suspense>
 			</span>
 		);
 	}

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -1,12 +1,11 @@
 import { Button, Modal, Notice, Spinner } from '@wordpress/components';
 import { useEntityRecord } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { EditorProvider, store as editorStore } from '@wordpress/editor';
 import {
+	lazy,
+	Suspense,
 	useCallback,
 	useEffect,
 	useMemo,
-	useRef,
 	useState,
 } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -21,10 +20,18 @@ import {
 	unseen,
 } from '@wordpress/icons';
 
-import useAutosave from '../hooks/useAutosave';
-import EditorBody from './EditorBody';
-import RowProperties from './RowProperties';
-import { getRowDetailMode } from './rowDetailUtils';
+// The editor surface (EditorProvider + EditorBody + autosave + block
+// registration) lives in the `editor` chunk, shared with Canvas, so it
+// stays off the initial admin entry. The peek's chrome (toolbar, modal,
+// navigation) renders synchronously; only the inner pane stack suspends.
+// First open per session pays the chunk-fetch cost; subsequent opens are
+// instant. src/index.js warms the chunk on idle after first paint, so
+// most opens skip the fallback. See the longer note in EntityRoute.js for
+// why this does not also drop the WP editor script handles.
+const RowEditor = lazy( () =>
+	import( /* webpackChunkName: "editor" */ './RowEditor' )
+);
+import { getRowDetailMode, titleFromDetail } from './rowDetailUtils';
 
 export const ROW_DETAIL_MODE_ICONS = {
 	side: drawerRight,
@@ -78,121 +85,6 @@ function settleDetailPanes( panes ) {
 	return panes.filter( ( pane ) => pane.state !== 'covered' );
 }
 
-function DetailReadySignal( { detailKey, onReady } ) {
-	useEffect( () => {
-		onReady( detailKey );
-	}, [ detailKey, onReady ] );
-
-	return null;
-}
-
-const ROW_DETAIL_EDITOR_CSS = `
-	body {
-		background: #fff;
-	}
-
-	.editor-styles-wrapper {
-		box-sizing: border-box;
-		min-height: 100%;
-		padding: 24px 32px 48px;
-	}
-
-	.editor-styles-wrapper .wp-block-post-content {
-		margin-block-start: 0;
-	}
-
-	.editor-styles-wrapper > .block-editor-block-list__layout,
-	.editor-styles-wrapper .block-editor-block-list__layout.is-root-container {
-		min-height: 180px;
-	}
-
-	.editor-styles-wrapper .block-list-appender {
-		margin-top: 12px;
-	}
-`;
-
-const ROW_DETAIL_EXTRA_STYLES = [ { css: ROW_DETAIL_EDITOR_CSS } ];
-
-function RowTitleBridge( { isActive, fallback, onTitle } ) {
-	const editedTitle = useSelect(
-		( select ) => select( editorStore ).getEditedPostAttribute( 'title' ),
-		[]
-	);
-	useEffect( () => {
-		if ( ! isActive || ! onTitle ) {
-			return;
-		}
-		const next =
-			typeof editedTitle === 'string' && editedTitle !== ''
-				? editedTitle
-				: fallback;
-		onTitle( next );
-	}, [ editedTitle, fallback, isActive, onTitle ] );
-	return null;
-}
-
-function titleFromRow( row ) {
-	const title = row?.title;
-	if ( typeof title === 'string' ) {
-		return title;
-	}
-	return title?.raw ?? title?.rendered ?? '';
-}
-
-function titleFromDetail( detail ) {
-	if ( ! detail ) {
-		return '';
-	}
-	return titleFromRow( detail.record ) || titleFromRow( detail.row );
-}
-
-function RowAutosaveBridge( {
-	isActive = true,
-	onApi,
-	onSaved,
-	recentTarget,
-} ) {
-	const { status, lastSavedAt, flushNow, isDirty, isSaving } = useAutosave( {
-		debounceMs: 0,
-		minSaveIntervalMs: 0,
-		recentTarget,
-	} );
-	const { resetPost } = useDispatch( editorStore );
-	const discard = useCallback( () => resetPost(), [ resetPost ] );
-	const lastNotifiedSaveRef = useRef( null );
-	const autosaveStateRef = useRef( { isDirty, isSaving } );
-	autosaveStateRef.current = { isDirty, isSaving };
-	const hasPendingEdits = useCallback(
-		() =>
-			autosaveStateRef.current.isDirty ||
-			autosaveStateRef.current.isSaving,
-		[]
-	);
-
-	useEffect( () => {
-		if ( ! isActive ) {
-			return undefined;
-		}
-		onApi?.( { flushNow, discard, hasPendingEdits } );
-		return () => onApi?.( null );
-	}, [ discard, flushNow, hasPendingEdits, isActive, onApi ] );
-
-	useEffect( () => {
-		if (
-			! isActive ||
-			status !== 'saved' ||
-			! lastSavedAt ||
-			lastNotifiedSaveRef.current === lastSavedAt
-		) {
-			return;
-		}
-		lastNotifiedSaveRef.current = lastSavedAt;
-		onSaved?.();
-	}, [ isActive, lastSavedAt, onSaved, status ] );
-
-	return null;
-}
-
 export function ModeControl( { mode, onChangeMode } ) {
 	const modes = Object.keys( ROW_DETAIL_MODE_LABELS ).filter(
 		( nextMode ) => nextMode !== mode
@@ -213,60 +105,6 @@ export function ModeControl( { mode, onChangeMode } ) {
 					} }
 				/>
 			) ) }
-		</>
-	);
-}
-
-function DetailPaneContent( {
-	collectionId,
-	fields,
-	isActive,
-	isHidden,
-	isTitleActive,
-	onApi,
-	onRestored,
-	onSaved,
-	onTitle,
-	postType,
-	propertiesVisible,
-	row,
-	rowId,
-} ) {
-	const fallbackTitle = useMemo( () => titleFromRow( row ), [ row ] );
-	return (
-		<>
-			<RowAutosaveBridge
-				isActive={ isActive }
-				onApi={ onApi }
-				onSaved={ onSaved }
-				recentTarget={
-					rowId && collectionId
-						? { kind: 'row', id: rowId, collectionId }
-						: null
-				}
-			/>
-			<RowTitleBridge
-				isActive={ isTitleActive }
-				fallback={ fallbackTitle }
-				onTitle={ onTitle }
-			/>
-			{ /* tech-debt.md#41: this is shell-mounted until row
-			     properties are a locked document block. */ }
-			<RowProperties
-				fields={ fields }
-				row={ row }
-				visible={ propertiesVisible }
-			/>
-			<EditorBody
-				postId={ row?.id }
-				postType={ postType }
-				extraStyles={ ROW_DETAIL_EXTRA_STYLES }
-				onRestored={ onRestored }
-			/>
-			<div
-				aria-hidden={ isHidden ? true : undefined }
-				{ ...( isHidden ? { inert: '' } : {} ) }
-			/>
 		</>
 	);
 }
@@ -634,77 +472,78 @@ export default function RowDetailView( {
 				title={ displayTitle }
 			>
 				<div className="cortext-row-detail__pane-stack">
-					{ detailPanes.map( ( pane ) => {
-						const isCurrentPane =
-							pane.key === activeDetailKey &&
-							( pane.state === 'active' ||
-								pane.state === 'entering' );
-						const isHiddenPane =
-							pane.state === 'preparing' ||
-							pane.state === 'covered';
-						const isApiActive = isCurrentPane && ! isHiddenPane;
-						const isTitleActive =
-							! isHiddenPane &&
-							( pane.state === 'active' ||
-								pane.state === 'entering' );
-						const paneRow = {
-							...( pane.detail.row ?? {} ),
-							...pane.detail.record,
-							title:
-								pane.detail.record.title ??
-								pane.detail.row?.title,
-							meta:
-								pane.detail.record.meta ??
-								pane.detail.row?.meta,
-							cortext_hydrated_meta:
-								pane.detail.record.cortext_hydrated_meta ??
-								pane.detail.row?.cortext_hydrated_meta,
-						};
+					<Suspense
+						fallback={
+							<div className="cortext-row-detail__pane cortext-row-detail__pane--loading">
+								<Spinner />
+							</div>
+						}
+					>
+						{ detailPanes.map( ( pane ) => {
+							const isCurrentPane =
+								pane.key === activeDetailKey &&
+								( pane.state === 'active' ||
+									pane.state === 'entering' );
+							const isHiddenPane =
+								pane.state === 'preparing' ||
+								pane.state === 'covered';
+							const isApiActive = isCurrentPane && ! isHiddenPane;
+							const isTitleActive =
+								! isHiddenPane &&
+								( pane.state === 'active' ||
+									pane.state === 'entering' );
+							const paneRow = {
+								...( pane.detail.row ?? {} ),
+								...pane.detail.record,
+								title:
+									pane.detail.record.title ??
+									pane.detail.row?.title,
+								meta:
+									pane.detail.record.meta ??
+									pane.detail.row?.meta,
+								cortext_hydrated_meta:
+									pane.detail.record.cortext_hydrated_meta ??
+									pane.detail.row?.cortext_hydrated_meta,
+							};
 
-						return (
-							<div
-								key={ pane.key }
-								className="cortext-row-detail__pane"
-								data-state={ pane.state }
-								data-interactive={
-									isApiActive ? 'true' : 'false'
-								}
-								aria-hidden={ isHiddenPane ? true : undefined }
-								{ ...( isHiddenPane ? { inert: '' } : {} ) }
-								onAnimationEnd={ onPaneAnimationEnd }
-							>
-								<EditorProvider
-									post={ pane.detail.record }
-									settings={
-										window.cortextEditorSettings ?? {}
+							return (
+								<div
+									key={ pane.key }
+									className="cortext-row-detail__pane"
+									data-state={ pane.state }
+									data-interactive={
+										isApiActive ? 'true' : 'false'
 									}
-									useSubRegistry
+									aria-hidden={
+										isHiddenPane ? true : undefined
+									}
+									{ ...( isHiddenPane ? { inert: '' } : {} ) }
+									onAnimationEnd={ onPaneAnimationEnd }
 								>
-									<DetailReadySignal
+									<RowEditor
+										collectionId={ collectionId }
 										detailKey={ pane.key }
-										onReady={ onPaneReady }
-									/>
-									<DetailPaneContent
 										fields={ propertyFields }
 										isActive={ isApiActive }
 										isHidden={ isHiddenPane }
 										isTitleActive={ isTitleActive }
 										onApi={ onApi }
+										onPaneReady={ onPaneReady }
 										onRestored={ onRestored }
 										onSaved={ onSaved }
 										onTitle={ setDisplayTitle }
+										post={ pane.detail.record }
 										postType={ pane.detail.postType }
 										propertiesVisible={
 											arePropertiesVisible
 										}
-										collectionId={ collectionId }
 										row={ paneRow }
 										rowId={ pane.detail.rowId }
 									/>
-								</EditorProvider>
-							</div>
-						);
-					} ) }
+								</div>
+							);
+						} ) }
+					</Suspense>
 				</div>
 			</DetailShell>
 		);

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -1,0 +1,221 @@
+// Editor-coupled subtree of the row detail surface. Loaded as part of the
+// `editor` lazy chunk (shared with Canvas) so the Cortext wrappers around
+// EditorProvider/EditorBody, the autosave bridge, and the row property
+// panel stay off the initial admin bundle. The row peek's chrome
+// (toolbar, modal frame, navigation buttons) lives in RowDetailView and
+// renders synchronously; only this inner stack suspends on first row open.
+import { useDispatch, useSelect } from '@wordpress/data';
+import { EditorProvider, store as editorStore } from '@wordpress/editor';
+import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
+
+import useAutosave from '../hooks/useAutosave';
+// Registers core + Cortext blocks before any editor renders. Living here
+// (rather than at a static import in RowDetailView) keeps the Cortext
+// block sources and the registerCoreBlocks call site off the initial
+// bundle. The module is idempotent, so Canvas's copy of this import is
+// a no-op when RowEditor mounts second, or vice versa.
+import './initEditor';
+import EditorBody from './EditorBody';
+import RowProperties from './RowProperties';
+import { titleFromRow } from './rowDetailUtils';
+
+const ROW_DETAIL_EDITOR_CSS = `
+	body {
+		background: #fff;
+	}
+
+	.editor-styles-wrapper {
+		box-sizing: border-box;
+		min-height: 100%;
+		padding: 24px 32px 48px;
+	}
+
+	.editor-styles-wrapper .wp-block-post-content {
+		margin-block-start: 0;
+	}
+
+	.editor-styles-wrapper > .block-editor-block-list__layout,
+	.editor-styles-wrapper .block-editor-block-list__layout.is-root-container {
+		min-height: 180px;
+	}
+
+	.editor-styles-wrapper .block-list-appender {
+		margin-top: 12px;
+	}
+`;
+
+const ROW_DETAIL_EXTRA_STYLES = [ { css: ROW_DETAIL_EDITOR_CSS } ];
+
+function DetailReadySignal( { detailKey, onReady } ) {
+	useEffect( () => {
+		onReady( detailKey );
+	}, [ detailKey, onReady ] );
+
+	return null;
+}
+
+function RowTitleBridge( { isActive, fallback, onTitle } ) {
+	const editedTitle = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'title' ),
+		[]
+	);
+	useEffect( () => {
+		if ( ! isActive || ! onTitle ) {
+			return;
+		}
+		const next =
+			typeof editedTitle === 'string' && editedTitle !== ''
+				? editedTitle
+				: fallback;
+		onTitle( next );
+	}, [ editedTitle, fallback, isActive, onTitle ] );
+	return null;
+}
+
+function RowAutosaveBridge( {
+	isActive = true,
+	onApi,
+	onSaved,
+	recentTarget,
+} ) {
+	const { status, lastSavedAt, flushNow, isDirty, isSaving } = useAutosave( {
+		debounceMs: 0,
+		minSaveIntervalMs: 0,
+		recentTarget,
+	} );
+	const { resetPost } = useDispatch( editorStore );
+	const discard = useCallback( () => resetPost(), [ resetPost ] );
+	const lastNotifiedSaveRef = useRef( null );
+	const autosaveStateRef = useRef( { isDirty, isSaving } );
+	autosaveStateRef.current = { isDirty, isSaving };
+	const hasPendingEdits = useCallback(
+		() =>
+			autosaveStateRef.current.isDirty ||
+			autosaveStateRef.current.isSaving,
+		[]
+	);
+
+	useEffect( () => {
+		if ( ! isActive ) {
+			return undefined;
+		}
+		onApi?.( { flushNow, discard, hasPendingEdits } );
+		return () => onApi?.( null );
+	}, [ discard, flushNow, hasPendingEdits, isActive, onApi ] );
+
+	useEffect( () => {
+		if (
+			! isActive ||
+			status !== 'saved' ||
+			! lastSavedAt ||
+			lastNotifiedSaveRef.current === lastSavedAt
+		) {
+			return;
+		}
+		lastNotifiedSaveRef.current = lastSavedAt;
+		onSaved?.();
+	}, [ isActive, lastSavedAt, onSaved, status ] );
+
+	return null;
+}
+
+function DetailPaneContent( {
+	collectionId,
+	fields,
+	isActive,
+	isHidden,
+	isTitleActive,
+	onApi,
+	onRestored,
+	onSaved,
+	onTitle,
+	postType,
+	propertiesVisible,
+	row,
+	rowId,
+} ) {
+	const fallbackTitle = useMemo( () => titleFromRow( row ), [ row ] );
+	return (
+		<>
+			<RowAutosaveBridge
+				isActive={ isActive }
+				onApi={ onApi }
+				onSaved={ onSaved }
+				recentTarget={
+					rowId && collectionId
+						? { kind: 'row', id: rowId, collectionId }
+						: null
+				}
+			/>
+			<RowTitleBridge
+				isActive={ isTitleActive }
+				fallback={ fallbackTitle }
+				onTitle={ onTitle }
+			/>
+			{ /* tech-debt.md#41: this is shell-mounted until row
+			     properties are a locked document block. */ }
+			<RowProperties
+				fields={ fields }
+				row={ row }
+				visible={ propertiesVisible }
+			/>
+			<EditorBody
+				postId={ row?.id }
+				postType={ postType }
+				extraStyles={ ROW_DETAIL_EXTRA_STYLES }
+				onRestored={ onRestored }
+			/>
+			<div
+				aria-hidden={ isHidden ? true : undefined }
+				{ ...( isHidden ? { inert: '' } : {} ) }
+			/>
+		</>
+	);
+}
+
+export default function RowEditor( {
+	collectionId,
+	detailKey,
+	fields,
+	isActive,
+	isHidden,
+	isTitleActive,
+	onApi,
+	onPaneReady,
+	onRestored,
+	onSaved,
+	onTitle,
+	post,
+	postType,
+	propertiesVisible,
+	row,
+	rowId,
+} ) {
+	return (
+		<EditorProvider
+			post={ post }
+			settings={ window.cortextEditorSettings ?? {} }
+			useSubRegistry
+		>
+			<DetailReadySignal
+				detailKey={ detailKey }
+				onReady={ onPaneReady }
+			/>
+			<DetailPaneContent
+				collectionId={ collectionId }
+				fields={ fields }
+				isActive={ isActive }
+				isHidden={ isHidden }
+				isTitleActive={ isTitleActive }
+				onApi={ onApi }
+				onRestored={ onRestored }
+				onSaved={ onSaved }
+				onTitle={ onTitle }
+				postType={ postType }
+				propertiesVisible={ propertiesVisible }
+				row={ row }
+				rowId={ rowId }
+			/>
+		</EditorProvider>
+	);
+}

--- a/src/components/initEditor.js
+++ b/src/components/initEditor.js
@@ -1,0 +1,14 @@
+// Registers the core and Cortext blocks for every editor surface in the
+// shell. Canvas (full document editor) and RowEditor (row peek, modal,
+// and full-page row editor) both mount EditorProvider, so each one
+// imports this module to make sure registration runs before any editor
+// renders blocks. The guard makes the side effect idempotent: whichever
+// surface loads first wins, the second is a no-op.
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+import '../blocks';
+
+if ( ! window.__cortextBlocksRegistered ) {
+	registerCoreBlocks();
+	window.__cortextBlocksRegistered = true;
+}

--- a/src/components/rowDetailUtils.js
+++ b/src/components/rowDetailUtils.js
@@ -1,3 +1,18 @@
+export function titleFromRow( row ) {
+	const title = row?.title;
+	if ( typeof title === 'string' ) {
+		return title;
+	}
+	return title?.raw ?? title?.rendered ?? '';
+}
+
+export function titleFromDetail( detail ) {
+	if ( ! detail ) {
+		return '';
+	}
+	return titleFromRow( detail.record ) || titleFromRow( detail.row );
+}
+
 export const ROW_DETAIL_MODES = [ 'side', 'modal', 'full' ];
 export const DEFAULT_ROW_DETAIL_MODE = 'side';
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,4 +7,24 @@ const root = document.getElementById( 'cortext-root' );
 if ( root ) {
 	window.cortextRouter = router;
 	createRoot( root ).render( <RouterProvider router={ router } /> );
+
+	// Warm the editor chunk in the background once the shell has painted.
+	// Both Canvas and RowEditor resolve to the same `editor` chunk, so one
+	// dynamic import primes both. Without it, the first document open or
+	// row click on a fresh session pays the fetch cost and briefly shows
+	// the Suspense fallback; with it, most navigations find the chunk
+	// already in memory. requestIdleCallback yields to anything the user
+	// initiates; the setTimeout fallback covers browsers without it.
+	const warmEditor = () =>
+		import(
+			/* webpackChunkName: "editor" */
+			'./components/Canvas'
+		).catch( () => {
+			// Network hiccup; the first real navigation will retry.
+		} );
+	if ( typeof window.requestIdleCallback === 'function' ) {
+		window.requestIdleCallback( warmEditor, { timeout: 4000 } );
+	} else {
+		window.setTimeout( warmEditor, 200 );
+	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,14 +14,11 @@ if ( root ) {
 	// row click on a fresh session pays the fetch cost and briefly shows
 	// the Suspense fallback; with it, most navigations find the chunk
 	// already in memory. requestIdleCallback yields to anything the user
-	// initiates; the setTimeout fallback covers browsers without it.
+	// initiates; the setTimeout fallback covers browsers without it. A
+	// rejected import here only fails the idle job, and the real lazy
+	// import on first navigation will retry on its own.
 	const warmEditor = () =>
-		import(
-			/* webpackChunkName: "editor" */
-			'./components/Canvas'
-		).catch( () => {
-			// Network hiccup; the first real navigation will retry.
-		} );
+		import( /* webpackChunkName: "editor" */ './components/Canvas' );
 	if ( typeof window.requestIdleCallback === 'function' ) {
 		window.requestIdleCallback( warmEditor, { timeout: 4000 } );
 	} else {

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,7 @@
 import { createRoot } from '@wordpress/element';
-import { registerCoreBlocks } from '@wordpress/block-library';
 
 import { router, RouterProvider } from './router';
-import './blocks';
 import './index.scss';
-
-registerCoreBlocks();
 
 const root = document.getElementById( 'cortext-root' );
 if ( root ) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -2,10 +2,10 @@
 @use "@wordpress/base-styles/variables" as *;
 @use "./styles/tokens";
 
-// @wordpress/interface is a BUNDLED_PACKAGE (inlined into our JS) and WP
-// doesn't register a `wp-interface` style handle, so bundle its stylesheet.
-@use "../node_modules/@wordpress/interface/build-style/style.css";
-@use "../node_modules/@wordpress/editor/build-style/style.css" as editor;
+// @wordpress/interface and @wordpress/editor styles are only needed inside
+// the editor surface. They're imported from Canvas.js so mini-css-extract
+// emits them into the editor chunk's CSS file and skip the initial CSS
+// bundle on home and collection views.
 
 // tech-debt.md#38: wp-admin does not expose this handle on our screen, so
 // bundle the palette styles here.
@@ -1418,6 +1418,74 @@ body:has([data-type="cortext/document-icon"]:hover) .cortext-canvas__identity-ac
 body:has([data-type="cortext/document-icon"]:focus-within) .cortext-canvas__identity-action,
 body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-action {
 	opacity: 1;
+}
+
+// Suspense fallback while the editor chunk loads on first document open.
+// Matches the editor's content-size and vertical rhythm so the swap to the
+// real Canvas doesn't reflow. Animation is intentionally subtle: a slow
+// pulse keeps it from competing with whatever lands next.
+.cortext-canvas-skeleton {
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
+	min-height: 0;
+	padding-block: $grid-unit-40 $grid-unit-30;
+
+	&__title {
+		height: $grid-unit-50;
+		max-width: var(--wp--style--global--content-size, 840px);
+		width: 100%;
+		margin: 0 auto $grid-unit-30;
+		padding-inline: $grid-unit-20;
+		border-radius: var(--cortext-shell-radius);
+		background: var(--cortext-state-hover);
+		animation: cortext-canvas-skeleton-pulse 1.6s ease-in-out infinite;
+	}
+
+	&__body {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-20;
+		max-width: var(--wp--style--global--content-size, 840px);
+		width: 100%;
+		margin: 0 auto;
+		padding-inline: $grid-unit-20;
+	}
+
+	&__line {
+		height: $grid-unit-20;
+		border-radius: var(--cortext-shell-radius);
+		background: var(--cortext-state-hover);
+		animation: cortext-canvas-skeleton-pulse 1.6s ease-in-out infinite;
+
+		&--short {
+			width: 60%;
+		}
+
+		&--medium {
+			width: 80%;
+		}
+	}
+}
+
+@keyframes cortext-canvas-skeleton-pulse {
+
+	0%,
+	100% {
+		opacity: 1;
+	}
+
+	50% {
+		opacity: 0.55;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.cortext-canvas-skeleton__title,
+	.cortext-canvas-skeleton__line {
+		animation: none;
+	}
 }
 
 .cortext-data-view-picker__empty {

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -16,9 +16,8 @@ import {
 
 // Lazy-loading Canvas keeps its Cortext subtree (publish toggle, page
 // inspector, autosave hook, snackbars, etc.) and the editor + interface
-// stylesheets off the initial JS/CSS bundles. Together with the parallel
-// split in RowDetailView, this trimmed ~160 KiB JS and ~130 KiB CSS from
-// the initial entry on first measurement.
+// stylesheets off the initial JS/CSS bundles. The parallel split in
+// RowDetailView does the same for the row peek surface.
 //
 // This split does not change which WP core editor handles WP enqueues:
 // wp-editor, wp-block-editor, wp-block-library, and wp-blocks still ship

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -463,11 +463,7 @@ export default function EntityRoute( { history } ) {
 					postId={ editorPostId }
 					postType={ editorPostType }
 					fields={ isRow ? rowFields : undefined }
-					row={
-						isRow
-							? documentResolution.entity ?? undefined
-							: undefined
-					}
+					row={ isRow ? documentResolution.entity : undefined }
 					onDisplayedPost={ handleDocumentDisplayed }
 					isActive={ isDocumentActive }
 					onRestored={ onRestoreDocument }

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -4,6 +4,8 @@ import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
+	lazy,
+	Suspense,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -12,7 +14,22 @@ import {
 	useState,
 } from '@wordpress/element';
 
-import Canvas from '../components/Canvas';
+// Lazy-loading Canvas keeps its Cortext subtree (publish toggle, page
+// inspector, autosave hook, snackbars, etc.) and the editor + interface
+// stylesheets off the initial JS/CSS bundles. Together with the parallel
+// split in RowDetailView, this trimmed ~160 KiB JS and ~130 KiB CSS from
+// the initial entry on first measurement.
+//
+// This split does not change which WP core editor handles WP enqueues:
+// wp-editor, wp-block-editor, wp-block-library, and wp-blocks still ship
+// on every admin route because the DEP plugin only emits one asset
+// manifest per entry and folds in externals reached through lazy chunks
+// too. Those scripts are cached by WP and most sessions open an editor
+// at some point, so we accept the cost.
+const Canvas = lazy( () =>
+	import( /* webpackChunkName: "editor" */ '../components/Canvas' )
+);
+import CanvasSkeleton from '../components/CanvasSkeleton';
 import CollectionDataViews from '../components/CollectionDataViews';
 import { CollectionFieldsProvider } from '../components/CollectionFieldsContext';
 import { RowMutationContext } from '../components/EditableCell';
@@ -442,18 +459,22 @@ export default function EntityRoute( { history } ) {
 			: null;
 	const editorCanvas =
 		editorPostId !== null && editorPostType ? (
-			<Canvas
-				postId={ editorPostId }
-				postType={ editorPostType }
-				fields={ isRow ? rowFields : undefined }
-				row={
-					isRow ? documentResolution.entity ?? undefined : undefined
-				}
-				onDisplayedPost={ handleDocumentDisplayed }
-				isActive={ isDocumentActive }
-				onRestored={ onRestoreDocument }
-				recentTarget={ editorRecentTarget }
-			/>
+			<Suspense fallback={ <CanvasSkeleton /> }>
+				<Canvas
+					postId={ editorPostId }
+					postType={ editorPostType }
+					fields={ isRow ? rowFields : undefined }
+					row={
+						isRow
+							? documentResolution.entity ?? undefined
+							: undefined
+					}
+					onDisplayedPost={ handleDocumentDisplayed }
+					isActive={ isDocumentActive }
+					onRestored={ onRestoreDocument }
+					recentTarget={ editorRecentTarget }
+				/>
+			</Suspense>
 		) : null;
 
 	return (

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -22,10 +22,10 @@ import {
 //
 // This split does not change which WP core editor handles WP enqueues:
 // wp-editor, wp-block-editor, wp-block-library, and wp-blocks still ship
-// on every admin route because the DEP plugin only emits one asset
-// manifest per entry and folds in externals reached through lazy chunks
-// too. Those scripts are cached by WP and most sessions open an editor
-// at some point, so we accept the cost.
+// on every admin route because @wordpress/dependency-extraction-webpack-plugin
+// only emits one asset manifest per entry and folds in externals reached
+// through lazy chunks too. Those scripts are cached by WP and most sessions
+// open an editor at some point, so we accept the cost.
 const Canvas = lazy( () =>
 	import( /* webpackChunkName: "editor" */ '../components/Canvas' )
 );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require( 'path' );
 const webpack = require( 'webpack' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 
 // `@wordpress/route` is not yet registered as a WP core script handle, so
 // wp-scripts' default externalization would emit a missing `wp-route`
@@ -91,5 +92,22 @@ module.exports = {
 			/@wordpress[\\/]route[\\/]build-module[\\/]lock-unlock\.mjs$/,
 			routeLockUnlockShim
 		),
+		...( process.env.ANALYZE
+			? [
+					new BundleAnalyzerPlugin( {
+						analyzerMode: 'static',
+						openAnalyzer: false,
+						reportFilename: path.resolve(
+							__dirname,
+							'build/bundle-report.html'
+						),
+						generateStatsFile: true,
+						statsFilename: path.resolve(
+							__dirname,
+							'build/bundle-stats.json'
+						),
+					} ),
+			  ]
+			: [] ),
 	],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,28 @@ module.exports = {
 		chunkIds: 'named',
 		moduleIds: 'named',
 	},
+	// Scope wp-scripts' default 244 KiB asset-size warning to the initial
+	// entry. Intentional lazy chunks (emoji-mart data, icon library, the
+	// editor split, the icons vendor chunk pulled by PageIconWp) are gated
+	// behind user actions, so flagging them is noise that drowns out the
+	// warning when index.js actually regresses. Source maps are dev-only
+	// and never served to end users. RTL stylesheets are alternates for
+	// LTR ones (browsers load one per request, never both), so counting
+	// them toward the entrypoint sum double-bills the user's payload.
+	performance: {
+		hints: 'warning',
+		assetFilter: ( assetFilename ) => {
+			if ( assetFilename.endsWith( '.map' ) ) {
+				return false;
+			}
+			if ( assetFilename.endsWith( '-rtl.css' ) ) {
+				return false;
+			}
+			return ! /^(emoji-mart-data|emoji-mart-react|icon-library-picker|page-icon-wp|editor|vendors-.*icons)/.test(
+				assetFilename
+			);
+		},
+	},
 	plugins: [
 		...defaultConfig.plugins.map( ( plugin ) => {
 			if ( plugin instanceof DependencyExtractionWebpackPlugin ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require( 'path' );
 const webpack = require( 'webpack' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 
 // `@wordpress/route` is not yet registered as a WP core script handle, so
@@ -84,6 +85,19 @@ module.exports = {
 							return false;
 						}
 					},
+				} );
+			}
+			// Lazy CSS chunks (e.g. editor.css) need the same `?ver=...`
+			// cache buster the JS chunks get from output.chunkFilename
+			// above. Without this, webpack's runtime loads them as plain
+			// `editor.css`, so after a deploy the browser can pair fresh
+			// editor.js with a stale cached editor.css. wp-scripts' default
+			// MiniCssExtractPlugin instance only sets `filename`, so
+			// rebuild it with both options preserved.
+			if ( plugin instanceof MiniCssExtractPlugin ) {
+				return new MiniCssExtractPlugin( {
+					...plugin.options,
+					chunkFilename: '[name].css?ver=[contenthash]',
 				} );
 			}
 			return plugin;


### PR DESCRIPTION
## What

Keep the editor stack out of Cortext’s first admin load. Home and collection views render the shell first; the document canvas and row editor are fetched only when a document or row is opened. After the first paint, Cortext also warms the editor chunk during idle time, so later editor opens are usually ready by the time the user gets there.

| Asset | main | main gzip | PR | PR gzip | Δ | Δ gzip |
|---|---:|---:|---:|---:|---:|---:|
| `index.js` | 794 KiB | 223 KiB | 632 KiB | 180 KiB | -162 KiB (-20%) | -43 KiB (-19%) |
| `index.css` | 277 KiB | 38 KiB | 144 KiB | 20 KiB | -133 KiB (-48%) | -19 KiB (-49%) |
| **Entrypoint** | **1071 KiB** | **261 KiB** | **776 KiB** | **200 KiB** | **-295 KiB (-28%)** | **-61 KiB (-23%)** |

## Why

The editor is expensive, and we were paying for it even on routes that never mount it. Deferring that work makes the shell lighter without changing the editing flow once the editor is needed.

## How

- Moves the canvas and row detail editor into a shared lazy `editor` chunk.
- Shares block registration through `initEditor`, used by both editor surfaces. This also fixes a case where opening a row peek before opening any document could leave blocks unregistered.
- Lazy-loads `PageIconWp`, since it imports the full `@wordpress/icons` set. Pages with emoji or image icons no longer pay that cost upfront.
- Adds cache-busting filenames for lazy CSS chunks so async editor styles do not go stale after deploys.
- Narrows the 244 KiB asset-size warning to assets that affect initial paint, skipping lazy chunks, source maps, and RTL alternates.
- Keeps bundle analysis opt-in with `ANALYZE=1`.

One caveat: `build/index.asset.php` still lists `wp-editor`, `wp-block-editor`, `wp-block-library`, and `wp-blocks`. The dependency extraction plugin aggregates externals per entry, not per chunk, so WordPress still enqueues those handles on every admin route. Those scripts are cached by WordPress, and most sessions eventually open an editor, so this PR accepts that part of the cost.

Another caveat: the first row open can be slower if it happens before the idle preload finishes. A follow-up will add intent-based prefetching for the row detail editor.
## Testing Instructions

1. Open the admin shell in a fresh session and go to the home or a collection without opening a document. With “Disable cache” enabled in DevTools Network, confirm `editor.js?ver=...` and `editor.css?ver=...` are not in the initial waterfall. They may appear shortly after the idle preload.
2. Open a document and confirm the canvas skeleton resolves into the editor.
3. Open a collection row before opening any document. The row peek should mount with blocks rendered and no console errors about unregistered block types.
4. Edit a row title or body in the peek and confirm autosave still works.
5. Hard-refresh and reopen a document. Editor styles should load correctly.