### PR TITLE
Add document search to the command palette

### DIFF
--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -171,10 +171,18 @@ final class Documents {
 			add_filter( 'posts_search', $search_filter, 10, 2 );
 		}
 
+		$orderby_filter = $this->build_search_orderby_filter( $search, $post_types );
+		if ( null !== $orderby_filter ) {
+			add_filter( 'posts_search_orderby', $orderby_filter, 10, 2 );
+		}
+
 		$query = new WP_Query( $query_args );
 
 		if ( null !== $search_filter ) {
 			remove_filter( 'posts_search', $search_filter, 10 );
+		}
+		if ( null !== $orderby_filter ) {
+			remove_filter( 'posts_search_orderby', $orderby_filter, 10 );
 		}
 
 		$editable_ids = array_values(
@@ -573,5 +581,69 @@ final class Documents {
 		}
 
 		return ' AND ( ' . implode( ' AND ', $term_clauses ) . ' )';
+	}
+
+	/**
+	 * Returns a `posts_search_orderby` filter that ranks documents by where
+	 * the query lives in them. WP's default `search_orderby_title` for
+	 * single-term queries only distinguishes "title contains" vs "title
+	 * does not contain", so a recently edited document whose title happens
+	 * to include the term as a substring ties with one whose title starts
+	 * with it. For a palette the user expects the prefix match first.
+	 *
+	 * Tiers (ASC):
+	 *   1. title starts with the query
+	 *   2. title contains the query
+	 *   3. excerpt contains the query
+	 *   4. content contains the query
+	 *   5. everything else (rows that matched only by meta, etc.)
+	 *
+	 * Returns null for an empty search or when the WP_Query is not the one
+	 * `list()` is currently running.
+	 *
+	 * @param string   $search     Trimmed search string.
+	 * @param string[] $post_types Post types used by the WP_Query.
+	 */
+	private function build_search_orderby_filter( string $search, array $post_types ): ?callable {
+		if ( '' === $search ) {
+			return null;
+		}
+
+		$post_type_signature = $post_types;
+		sort( $post_type_signature );
+
+		return function (
+			string $search_orderby,
+			WP_Query $wp_query
+		) use (
+			$search,
+			$post_type_signature
+		): string {
+			$query_post_types = (array) $wp_query->get( 'post_type' );
+			sort( $query_post_types );
+			if ( $query_post_types !== $post_type_signature ) {
+				return $search_orderby;
+			}
+
+			global $wpdb;
+			$like_prefix   = $wpdb->esc_like( $search ) . '%';
+			$like_anywhere = '%' . $wpdb->esc_like( $search ) . '%';
+
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			return $wpdb->prepare(
+				"(CASE
+					WHEN {$wpdb->posts}.post_title LIKE %s THEN 1
+					WHEN {$wpdb->posts}.post_title LIKE %s THEN 2
+					WHEN {$wpdb->posts}.post_excerpt LIKE %s THEN 3
+					WHEN {$wpdb->posts}.post_content LIKE %s THEN 4
+					ELSE 5
+				END)",
+				$like_prefix,
+				$like_anywhere,
+				$like_anywhere,
+				$like_anywhere
+			);
+			// phpcs:enable
+		};
 	}
 }

--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -148,13 +148,21 @@ final class Documents {
 			'post_status'         => $statuses,
 			'fields'              => 'ids',
 			'posts_per_page'      => -1,
-			'orderby'             => 'modified',
-			'order'               => 'DESC',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
 		);
 
-		if ( '' !== $search ) {
+		if ( '' === $search ) {
+			// No search: most recently modified first.
+			$query_args['orderby'] = 'modified';
+			$query_args['order']   = 'DESC';
+		} else {
+			// With a search term, let `WP_Query` apply its
+			// `search_orderby_title` scoring so title hits bubble up before
+			// body/meta-only matches. The palette caps results to a small
+			// page, so ordering by modified date alone would arbitrarily
+			// hide the most relevant document when the recently-edited
+			// long tail happens to match.
 			$query_args['s'] = $search;
 		}
 

--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -17,11 +17,13 @@ declare( strict_types=1 );
 
 namespace Cortext;
 
+use Cortext\Fields\FieldTypeRegistry;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Page;
 use Cortext\PostType\PageTrashCascade;
+use Cortext\Rest\RowsFilterQuery;
 use WP_Post;
 use WP_Query;
 
@@ -44,6 +46,12 @@ final class Documents {
 	 * @var array<string,?WP_Post>
 	 */
 	private array $collection_cache = array();
+
+	private RowsFilterQuery $rows_filter_query;
+
+	public function __construct( ?RowsFilterQuery $rows_filter_query = null ) {
+		$this->rows_filter_query = $rows_filter_query ?? new RowsFilterQuery();
+	}
 
 	/**
 	 * Returns every registered post type that opts into the `cortext-document`
@@ -150,7 +158,17 @@ final class Documents {
 			$query_args['s'] = $search;
 		}
 
-		$query        = new WP_Query( $query_args );
+		$search_filter = $this->build_search_filter( $search, $post_types );
+		if ( null !== $search_filter ) {
+			add_filter( 'posts_search', $search_filter, 10, 2 );
+		}
+
+		$query = new WP_Query( $query_args );
+
+		if ( null !== $search_filter ) {
+			remove_filter( 'posts_search', $search_filter, 10 );
+		}
+
 		$editable_ids = array_values(
 			array_filter(
 				array_map( 'intval', $query->posts ),
@@ -428,5 +446,124 @@ final class Documents {
 		$rendered = trim( (string) $rendered );
 
 		return wp_trim_words( $rendered, 30, '…' );
+	}
+
+	/**
+	 * Returns a `posts_search` filter that lets row documents match text-like
+	 * field meta (text, email, url), not only title/content/excerpt. This
+	 * replaces WP's search clause, so split-term matching behaves the same way
+	 * it does in `/rows`.
+	 *
+	 * Returns null for an empty search, a page-only query, or row CPTs without
+	 * any text-like fields.
+	 *
+	 * @param string   $search     Trimmed search string.
+	 * @param string[] $post_types Post types used by the WP_Query.
+	 */
+	private function build_search_filter( string $search, array $post_types ): ?callable {
+		if ( '' === $search ) {
+			return null;
+		}
+
+		$row_text_keys_by_cpt = array();
+		foreach ( $post_types as $post_type ) {
+			if ( Page::POST_TYPE === $post_type ) {
+				continue;
+			}
+			$collection = $this->find_collection_by_row_post_type( $post_type );
+			if ( ! $collection instanceof WP_Post ) {
+				continue;
+			}
+
+			$schema = $this->rows_filter_query->field_schema_for( (int) $collection->ID );
+			$keys   = array();
+			foreach ( $schema as $field ) {
+				if ( empty( $field['system'] ) && FieldTypeRegistry::is_text_like( (string) $field['type'] ) ) {
+					$keys[] = (string) $field['key'];
+				}
+			}
+			if ( count( $keys ) > 0 ) {
+				$row_text_keys_by_cpt[ $post_type ] = $keys;
+			}
+		}
+
+		if ( count( $row_text_keys_by_cpt ) === 0 ) {
+			return null;
+		}
+
+		$post_type_signature = $post_types;
+		sort( $post_type_signature );
+
+		return function (
+			string $search_sql,
+			WP_Query $wp_query
+		) use (
+			$search,
+			$post_type_signature,
+			$row_text_keys_by_cpt
+		): string {
+			$query_post_types = (array) $wp_query->get( 'post_type' );
+			sort( $query_post_types );
+			if ( $query_post_types !== $post_type_signature ) {
+				return $search_sql;
+			}
+
+			return $this->build_documents_search_sql( $search, $row_text_keys_by_cpt );
+		};
+	}
+
+	/**
+	 * Builds the SQL used by the documents endpoint instead of WP_Query's
+	 * default search clause. Each search term must match somewhere. Pages use
+	 * title/content/excerpt; rows can also use their collection's text-like
+	 * field meta values.
+	 *
+	 * @param string                 $search               Search string.
+	 * @param array<string,string[]> $row_text_keys_by_cpt Row CPT to its text-like meta keys.
+	 */
+	private function build_documents_search_sql( string $search, array $row_text_keys_by_cpt ): string {
+		global $wpdb;
+
+		$terms = preg_split( '/\s+/', trim( $search ) );
+		$terms = is_array( $terms )
+			? array_values(
+				array_filter(
+					$terms,
+					static fn( $term ) => '' !== $term
+				)
+			)
+			: array();
+
+		if ( count( $terms ) === 0 ) {
+			return '';
+		}
+
+		$term_clauses = array();
+		foreach ( $terms as $term ) {
+			$like = '%' . $wpdb->esc_like( (string) $term ) . '%';
+
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$branches = array(
+				'( ' . $wpdb->prepare(
+					"{$wpdb->posts}.post_title LIKE %s OR {$wpdb->posts}.post_content LIKE %s OR {$wpdb->posts}.post_excerpt LIKE %s",
+					$like,
+					$like,
+					$like
+				) . ' )',
+			);
+
+			foreach ( $row_text_keys_by_cpt as $cpt => $keys ) {
+				$meta_sql = $this->rows_filter_query->meta_search_sql( $keys, $like );
+				if ( '' === $meta_sql ) {
+					continue;
+				}
+				$branches[] = '( ' . $wpdb->prepare( "{$wpdb->posts}.post_type = %s", $cpt ) . " AND {$meta_sql} )";
+			}
+			// phpcs:enable
+
+			$term_clauses[] = '( ' . implode( ' OR ', $branches ) . ' )';
+		}
+
+		return ' AND ( ' . implode( ' AND ', $term_clauses ) . ' )';
 	}
 }

--- a/includes/Rest/RowsFilterQuery.php
+++ b/includes/Rest/RowsFilterQuery.php
@@ -595,13 +595,27 @@ final class RowsFilterQuery {
 		);
 
 		if ( count( $text_keys ) > 0 ) {
-			$parts[] = $this->meta_key_in_like_sql( $text_keys, $like );
+			$parts[] = $this->meta_search_sql( $text_keys, $like );
 		}
 
 		return '( ' . implode( ' OR ', $parts ) . ' )';
 	}
 
-	private function meta_key_in_like_sql( array $keys, string $like ): string {
+	/**
+	 * Builds an `EXISTS` subquery for matching one of the given meta keys on
+	 * the current post. Returns an empty string when there are no keys.
+	 *
+	 * The caller should pass a LIKE pattern that is already wrapped in `%` and
+	 * escaped with `esc_like()`.
+	 *
+	 * @param string[] $keys Meta keys to scan, e.g. row text-like field keys.
+	 * @param string   $like Prepared LIKE pattern, e.g. `%foo%`.
+	 */
+	public function meta_search_sql( array $keys, string $like ): string {
+		if ( count( $keys ) === 0 ) {
+			return '';
+		}
+
 		global $wpdb;
 
 		$placeholders = implode( ', ', array_fill( 0, count( $keys ), '%s' ) );

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -327,6 +327,17 @@ function CommandPaletteContents( {
 		}
 	}, [ search ] );
 
+	// Reset the anchor whenever the palette closes so a value left over from
+	// the previous session (e.g. when a result callback called `close()`
+	// directly without going through `closeAndReset`) does not pin the
+	// highlight onto a recent that happens to share the title of a fresh
+	// search result.
+	useEffect( () => {
+		if ( ! isPaletteOpen ) {
+			setSelectedValue( undefined );
+		}
+	}, [ isPaletteOpen ] );
+
 	const handleDocumentsResolved = useCallback( ( firstValue ) => {
 		if ( ! firstValue ) {
 			return;

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -204,11 +204,20 @@ function DocumentCommandRegistration( { canvasRef, document, search } ) {
 	return null;
 }
 
+function firstDocumentValue( documents ) {
+	const first = documents[ 0 ];
+	if ( ! first ) {
+		return undefined;
+	}
+	return `document-cortext/document/${ first.kind }-${ first.id }`;
+}
+
 function DocumentResultsRegistration( {
 	canvasRef,
 	search,
 	onPendingChange,
 	onDescriptionsChange,
+	onDocumentsResolved,
 } ) {
 	const { documents, hasResolved, error } = useDocuments( {
 		search,
@@ -232,7 +241,8 @@ function DocumentResultsRegistration( {
 			return;
 		}
 		setLastResolvedSearch( search );
-	}, [ hasFreshDocuments, search ] );
+		onDocumentsResolved( firstDocumentValue( documents ) );
+	}, [ hasFreshDocuments, search, documents, onDocumentsResolved ] );
 
 	useEffect( () => {
 		if ( ! hasFreshDocuments ) {
@@ -282,6 +292,13 @@ function CommandPaletteContents( {
 	const [ documentDescriptions, setDocumentDescriptions ] = useState(
 		() => new Map()
 	);
+	// Controlled cmdk selection. When the first batch of documents arrives,
+	// anchor the selection on the first result so it doesn't sit on whatever
+	// recent/static command was selected before. After that cmdk owns the
+	// value: arrow-key moves, item unmounts (search refinement that drops
+	// the prior selection) and clicks all flow back here. Clearing the
+	// input resets the anchor so the next session starts fresh.
+	const [ selectedValue, setSelectedValue ] = useState();
 	const isPaletteOpen = useSelect(
 		( select ) => select( commandsStore ).isOpen(),
 		[]
@@ -291,6 +308,19 @@ function CommandPaletteContents( {
 	const shouldFetchDocuments = isPaletteOpen && Boolean( debouncedSearch );
 	const isDocumentSearchPending =
 		Boolean( search ) && ( isDebouncing || isFetchingDocuments );
+
+	useEffect( () => {
+		if ( ! search ) {
+			setSelectedValue( undefined );
+		}
+	}, [ search ] );
+
+	const handleDocumentsResolved = useCallback( ( firstValue ) => {
+		if ( ! firstValue ) {
+			return;
+		}
+		setSelectedValue( ( current ) => current ?? firstValue );
+	}, [] );
 
 	return (
 		<CommandDescriptionContext.Provider value={ documentDescriptions }>
@@ -313,12 +343,15 @@ function CommandPaletteContents( {
 					search={ debouncedSearch }
 					onPendingChange={ setIsFetchingDocuments }
 					onDescriptionsChange={ setDocumentDescriptions }
+					onDocumentsResolved={ handleDocumentsResolved }
 				/>
 			) }
 			<CortextCommandMenu
 				search={ search }
 				setSearch={ setSearch }
 				isDocumentSearchPending={ isDocumentSearchPending }
+				selectedValue={ selectedValue }
+				onSelectedValueChange={ setSelectedValue }
 			/>
 		</CommandDescriptionContext.Provider>
 	);

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -327,13 +327,14 @@ function CommandPaletteContents( {
 		}
 	}, [ search ] );
 
-	// Reset the anchor whenever the palette closes so a value left over from
-	// the previous session (e.g. when a result callback called `close()`
-	// directly without going through `closeAndReset`) does not pin the
-	// highlight onto a recent that happens to share the title of a fresh
-	// search result.
+	// Reset the input and the controlled selection whenever the palette
+	// closes, regardless of how it closed. Picking a result calls
+	// `close()` directly without going through `closeAndReset`, so without
+	// this the next open would land with a stale search string and a
+	// selection pinned to an item that may no longer be relevant.
 	useEffect( () => {
 		if ( ! isPaletteOpen ) {
+			setSearch( '' );
 			setSelectedValue( undefined );
 		}
 	}, [ isPaletteOpen ] );

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -180,7 +180,7 @@ function documentDescription( doc ) {
 	return rowCollectionHint( doc );
 }
 
-function DocumentCommandRegistration( { canvasRef, document, search } ) {
+function DocumentCommandRegistration( { canvasRef, document } ) {
 	const navigate = useNavigate();
 	const goToDocument = useCallback(
 		( { close } ) => {
@@ -201,9 +201,7 @@ function DocumentCommandRegistration( { canvasRef, document, search } ) {
 		label: document.title?.trim?.() || __( '(untitled)', 'cortext' ),
 		context: DEFAULT_COMMAND_CONTEXT,
 		icon: documentCommandIcon( document ),
-		// Give cmdk the active search term so server-side body/meta matches stay
-		// visible even when the title does not include the query.
-		keywords: [ search, document.kind ],
+		keywords: [ document.kind ],
 		disabled: ! document.path,
 		callback: goToDocument,
 	} );
@@ -231,11 +229,11 @@ function DocumentResultsRegistration( {
 	} );
 	const hasFreshDocuments = hasResolved && ! error;
 	// `useDocuments` keeps the previous documents while a refresh is in
-	// flight or after a failure. Tag the rendered commands with the search
-	// that actually produced them so cmdk filters them out naturally when
-	// the new query no longer matches, instead of unmounting and re-mounting
-	// (which would flicker every time the user refined their input).
-	const [ lastResolvedSearch, setLastResolvedSearch ] = useState( '' );
+	// flight (intentional, to avoid flicker during refinement) and also on
+	// a failed fetch (which we explicitly hide below). Track whether we
+	// have ever resolved successfully so we don't render anything before
+	// the first response arrives.
+	const [ hasEverResolved, setHasEverResolved ] = useState( false );
 
 	useEffect( () => {
 		onPendingChange( ! hasResolved );
@@ -252,9 +250,9 @@ function DocumentResultsRegistration( {
 		if ( ! hasFreshDocuments ) {
 			return;
 		}
-		setLastResolvedSearch( search );
+		setHasEverResolved( true );
 		onDocumentsResolved( firstDocumentValue( documents ) );
-	}, [ hasFreshDocuments, search, documents, onDocumentsResolved ] );
+	}, [ hasFreshDocuments, documents, onDocumentsResolved ] );
 
 	useEffect( () => {
 		if ( ! hasFreshDocuments ) {
@@ -278,7 +276,10 @@ function DocumentResultsRegistration( {
 		return () => onDescriptionsChange( new Map() );
 	}, [ onDescriptionsChange ] );
 
-	if ( ! lastResolvedSearch ) {
+	// Hide everything until the first successful response, and drop the
+	// stale list whenever a fetch fails so the user does not navigate to a
+	// document that no longer matches their query.
+	if ( ! hasEverResolved || error ) {
 		return null;
 	}
 
@@ -287,7 +288,6 @@ function DocumentResultsRegistration( {
 			key={ `${ doc.kind }:${ doc.id }` }
 			canvasRef={ canvasRef }
 			document={ doc }
-			search={ lastResolvedSearch }
 		/>
 	) );
 }

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -9,14 +9,18 @@ import {
 	RegistryProvider,
 	useDispatch,
 	useRegistry,
+	useSelect,
 } from '@wordpress/data';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import { home as homeIcon, listItem, table } from '@wordpress/icons';
-import { useCallback, useEffect, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 
-import CortextCommandMenu from './CortextCommandMenu';
+import CortextCommandMenu, {
+	CommandDescriptionContext,
+} from './CortextCommandMenu';
 import PageIcon from './PageIcon';
+import useDocuments from '../hooks/useDocuments';
 import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHomePath } from '../hooks/useWorkspaceHomePath';
 
@@ -53,27 +57,47 @@ function focusCanvasAfterPaletteCloses( canvasRef ) {
 	}, 0 );
 }
 
-function recentCommandIcon( recent ) {
-	if ( recent?.kind === 'collection' ) {
+function documentCommandIcon( doc ) {
+	if ( doc?.kind === 'collection' ) {
 		return table;
 	}
-	if ( recent?.kind === 'row' ) {
+	if ( doc?.kind === 'row' ) {
 		return listItem;
 	}
-	return <PageIcon icon={ recent?.icon ?? '' } size={ 16 } />;
+	return <PageIcon icon={ doc?.icon ?? '' } size={ 16 } />;
 }
 
-function recentTitle( recent ) {
-	const title = recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
-	if ( recent?.kind === 'row' && recent?.collection?.title ) {
+function documentTitle( doc ) {
+	const title = doc?.title?.trim?.() || __( '(untitled)', 'cortext' );
+	if ( doc?.kind === 'row' && doc?.collection?.title ) {
 		return sprintf(
 			/* translators: 1: row title, 2: collection title */
 			__( '%1$s in %2$s', 'cortext' ),
 			title,
-			recent.collection.title
+			doc.collection.title
 		);
 	}
 	return title;
+}
+
+function rowCollectionHint( doc ) {
+	if ( doc?.kind !== 'row' || ! doc?.collection?.title ) {
+		return '';
+	}
+	return sprintf(
+		/* translators: %s: parent collection title */
+		__( 'in %s', 'cortext' ),
+		doc.collection.title
+	);
+}
+
+function useDebouncedValue( value, delay ) {
+	const [ debounced, setDebounced ] = useState( value );
+	useEffect( () => {
+		const id = setTimeout( () => setDebounced( value ), delay );
+		return () => clearTimeout( id );
+	}, [ value, delay ] );
+	return debounced;
 }
 
 function HomeCommandRegistration( {
@@ -128,19 +152,107 @@ function RecentCommandRegistration( { canvasRef, recent } ) {
 
 	useCommand( {
 		name: `cortext/recent/${ recent.kind }-${ recent.id }`,
-		label: recentTitle( recent ),
+		label: documentTitle( recent ),
 		searchLabel: sprintf(
 			/* translators: %s: recent item title */
 			__( 'Open recent: %s', 'cortext' ),
-			recentTitle( recent )
+			documentTitle( recent )
 		),
 		context: DEFAULT_COMMAND_CONTEXT,
-		icon: recentCommandIcon( recent ),
+		icon: documentCommandIcon( recent ),
 		keywords: [ __( 'recent', 'cortext' ), recent.kind ],
 		disabled: ! recent.path,
 		callback: goToRecent,
 	} );
 	return null;
+}
+
+function documentDescription( doc ) {
+	if ( doc.kind === 'page' ) {
+		return doc.excerpt ?? '';
+	}
+	return rowCollectionHint( doc );
+}
+
+function DocumentCommandRegistration( { canvasRef, document, search } ) {
+	const navigate = useNavigate();
+	const goToDocument = useCallback(
+		( { close } ) => {
+			if ( document?.path ) {
+				navigate( {
+					to: '/$',
+					params: { _splat: document.path },
+				} );
+			}
+			close();
+			focusCanvasAfterPaletteCloses( canvasRef );
+		},
+		[ canvasRef, navigate, document?.path ]
+	);
+
+	useCommand( {
+		name: `cortext/document/${ document.kind }-${ document.id }`,
+		label: document.title?.trim?.() || __( '(untitled)', 'cortext' ),
+		context: DEFAULT_COMMAND_CONTEXT,
+		icon: documentCommandIcon( document ),
+		// Give cmdk the active search term so server-side body/meta matches stay
+		// visible even when the title does not include the query.
+		keywords: [ search, document.kind ],
+		disabled: ! document.path,
+		callback: goToDocument,
+	} );
+	return null;
+}
+
+function DocumentResultsRegistration( {
+	canvasRef,
+	search,
+	onPendingChange,
+	onDescriptionsChange,
+} ) {
+	const { documents, hasResolved } = useDocuments( {
+		search,
+		perPage: 10,
+	} );
+
+	useEffect( () => {
+		onPendingChange( ! hasResolved );
+		return () => onPendingChange( false );
+	}, [ hasResolved, onPendingChange ] );
+
+	useEffect( () => {
+		if ( ! hasResolved ) {
+			return undefined;
+		}
+		const map = new Map();
+		for ( const doc of documents ) {
+			const description = documentDescription( doc );
+			if ( description ) {
+				map.set(
+					`cortext/document/${ doc.kind }-${ doc.id }`,
+					description
+				);
+			}
+		}
+		onDescriptionsChange( map );
+		return () => onDescriptionsChange( new Map() );
+	}, [ documents, hasResolved, onDescriptionsChange ] );
+
+	// Skip stale results while a new search is loading. `useDocuments` keeps the
+	// last documents until the next response; registering them under the new
+	// query would let users open the wrong item.
+	if ( ! hasResolved ) {
+		return null;
+	}
+
+	return documents.map( ( doc ) => (
+		<DocumentCommandRegistration
+			key={ `${ doc.kind }:${ doc.id }` }
+			canvasRef={ canvasRef }
+			document={ doc }
+			search={ search }
+		/>
+	) );
 }
 
 function CommandPaletteContents( {
@@ -149,9 +261,24 @@ function CommandPaletteContents( {
 	isResolvingHomePath,
 } ) {
 	const { recents } = useRecents();
+	const [ search, setSearch ] = useState( '' );
+	const debouncedSearch = useDebouncedValue( search, 150 );
+	const [ isFetchingDocuments, setIsFetchingDocuments ] = useState( false );
+	const [ documentDescriptions, setDocumentDescriptions ] = useState(
+		() => new Map()
+	);
+	const isPaletteOpen = useSelect(
+		( select ) => select( commandsStore ).isOpen(),
+		[]
+	);
+
+	const isDebouncing = search !== debouncedSearch;
+	const shouldFetchDocuments = isPaletteOpen && Boolean( debouncedSearch );
+	const isDocumentSearchPending =
+		Boolean( search ) && ( isDebouncing || isFetchingDocuments );
 
 	return (
-		<>
+		<CommandDescriptionContext.Provider value={ documentDescriptions }>
 			<CommandPaletteOpenBridge />
 			<HomeCommandRegistration
 				canvasRef={ canvasRef }
@@ -165,8 +292,20 @@ function CommandPaletteContents( {
 					recent={ recent }
 				/>
 			) ) }
-			<CortextCommandMenu />
-		</>
+			{ shouldFetchDocuments && (
+				<DocumentResultsRegistration
+					canvasRef={ canvasRef }
+					search={ debouncedSearch }
+					onPendingChange={ setIsFetchingDocuments }
+					onDescriptionsChange={ setDocumentDescriptions }
+				/>
+			) }
+			<CortextCommandMenu
+				search={ search }
+				setSearch={ setSearch }
+				isDocumentSearchPending={ isDocumentSearchPending }
+			/>
+		</CommandDescriptionContext.Provider>
 	);
 }
 

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -14,7 +14,13 @@ import {
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
 import { home as homeIcon, listItem, table } from '@wordpress/icons';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useState,
+} from '@wordpress/element';
 
 import CortextCommandMenu, {
 	CommandDescriptionContext,
@@ -236,7 +242,13 @@ function DocumentResultsRegistration( {
 		return () => onPendingChange( false );
 	}, [ hasResolved, onPendingChange ] );
 
-	useEffect( () => {
+	// `useLayoutEffect` so the parent's controlled `selectedValue` gets
+	// pointed at the new first document in the same commit as the freshly
+	// mounted DocumentCommandRegistration children. With a plain
+	// `useEffect`, the user would see a frame where the new documents
+	// rendered without a visible highlight (cmdk's old pick is filtered
+	// out by the new query) before React flushed the selection update.
+	useLayoutEffect( () => {
 		if ( ! hasFreshDocuments ) {
 			return;
 		}

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -210,10 +210,17 @@ function DocumentResultsRegistration( {
 	onPendingChange,
 	onDescriptionsChange,
 } ) {
-	const { documents, hasResolved } = useDocuments( {
+	const { documents, hasResolved, error } = useDocuments( {
 		search,
 		perPage: 10,
 	} );
+	const hasFreshDocuments = hasResolved && ! error;
+	// `useDocuments` keeps the previous documents while a refresh is in
+	// flight or after a failure. Tag the rendered commands with the search
+	// that actually produced them so cmdk filters them out naturally when
+	// the new query no longer matches, instead of unmounting and re-mounting
+	// (which would flicker every time the user refined their input).
+	const [ lastResolvedSearch, setLastResolvedSearch ] = useState( '' );
 
 	useEffect( () => {
 		onPendingChange( ! hasResolved );
@@ -221,7 +228,14 @@ function DocumentResultsRegistration( {
 	}, [ hasResolved, onPendingChange ] );
 
 	useEffect( () => {
-		if ( ! hasResolved ) {
+		if ( ! hasFreshDocuments ) {
+			return;
+		}
+		setLastResolvedSearch( search );
+	}, [ hasFreshDocuments, search ] );
+
+	useEffect( () => {
+		if ( ! hasFreshDocuments ) {
 			return undefined;
 		}
 		const map = new Map();
@@ -235,13 +249,14 @@ function DocumentResultsRegistration( {
 			}
 		}
 		onDescriptionsChange( map );
-		return () => onDescriptionsChange( new Map() );
-	}, [ documents, hasResolved, onDescriptionsChange ] );
+		return undefined;
+	}, [ documents, hasFreshDocuments, onDescriptionsChange ] );
 
-	// Skip stale results while a new search is loading. `useDocuments` keeps the
-	// last documents until the next response; registering them under the new
-	// query would let users open the wrong item.
-	if ( ! hasResolved ) {
+	useEffect( () => {
+		return () => onDescriptionsChange( new Map() );
+	}, [ onDescriptionsChange ] );
+
+	if ( ! lastResolvedSearch ) {
 		return null;
 	}
 
@@ -250,7 +265,7 @@ function DocumentResultsRegistration( {
 			key={ `${ doc.kind }:${ doc.id }` }
 			canvasRef={ canvasRef }
 			document={ doc }
-			search={ search }
+			search={ lastResolvedSearch }
 		/>
 	) );
 }

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -208,12 +208,10 @@ function DocumentCommandRegistration( { canvasRef, document } ) {
 	return null;
 }
 
-function firstDocumentValue( documents ) {
-	const first = documents[ 0 ];
-	if ( ! first ) {
-		return undefined;
-	}
-	return `document-cortext/document/${ first.kind }-${ first.id }`;
+function documentCommandValues( documents ) {
+	return documents.map(
+		( doc ) => `document-cortext/document/${ doc.kind }-${ doc.id }`
+	);
 }
 
 function DocumentResultsRegistration( {
@@ -251,7 +249,7 @@ function DocumentResultsRegistration( {
 			return;
 		}
 		setHasEverResolved( true );
-		onDocumentsResolved( firstDocumentValue( documents ) );
+		onDocumentsResolved( documentCommandValues( documents ) );
 	}, [ hasFreshDocuments, documents, onDocumentsResolved ] );
 
 	useEffect( () => {
@@ -339,11 +337,20 @@ function CommandPaletteContents( {
 		}
 	}, [ isPaletteOpen ] );
 
-	const handleDocumentsResolved = useCallback( ( firstValue ) => {
-		if ( ! firstValue ) {
+	const handleDocumentsResolved = useCallback( ( values ) => {
+		if ( values.length === 0 ) {
 			return;
 		}
-		setSelectedValue( ( current ) => current ?? firstValue );
+		setSelectedValue( ( current ) => {
+			// If the user's current selection survived into the new
+			// result set, keep it. Otherwise jump to the first new doc so
+			// the highlight does not blink off while cmdk's internal
+			// recovery is still scheduled.
+			if ( current && values.includes( current ) ) {
+				return current;
+			}
+			return values[ 0 ];
+		} );
 	}, [] );
 
 	return (

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -226,14 +226,10 @@ function PaletteGroups( { search } ) {
 					/>
 				</Command.Group>
 			) }
-			{ commands.length > 0 && (
+			{ ! search && commands.length > 0 && (
 				<Command.Group
 					className="cortext-command-palette__group"
-					heading={
-						search
-							? __( 'Commands', 'cortext' )
-							: __( 'Suggestions', 'cortext' )
-					}
+					heading={ __( 'Suggestions', 'cortext' ) }
 				>
 					<CommandList commands={ commands } search={ search } />
 				</Command.Group>

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -213,7 +213,7 @@ function PaletteGroups( { search } ) {
 					/>
 				</Command.Group>
 			) }
-			{ recentCommands.length > 0 && (
+			{ ! search && recentCommands.length > 0 && (
 				<Command.Group
 					className="cortext-command-palette__group cortext-command-palette__group--recent"
 					heading={ __( 'Recent', 'cortext' ) }

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -3,10 +3,11 @@ import { Command, useCommandState } from 'cmdk';
 import { Modal, TextHighlight } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
+	createContext,
+	useContext,
 	useEffect,
 	useMemo,
 	useRef,
-	useState,
 	isValidElement,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -17,11 +18,17 @@ import {
 } from '@wordpress/keyboard-shortcuts';
 import { store as commandsStore } from '@wordpress/commands';
 
+// `@wordpress/commands` drops unknown command fields. Keep descriptions in a
+// separate map keyed by `command.name`.
+const EMPTY_DESCRIPTIONS = new Map();
+export const CommandDescriptionContext = createContext( EMPTY_DESCRIPTIONS );
+
 // tech-debt.md#38: @wordpress/commands has no custom group API. Keep the
 // upstream store/hooks, but render the menu locally so workspace recents
 // can live in their own section.
 const ITEM_ID_PREFIX = 'command-palette-item-';
 const RECENT_COMMAND_PREFIX = 'cortext/recent/';
+const DOCUMENT_COMMAND_PREFIX = 'cortext/document/';
 const commandMenuLabel = __( 'Search or run a command', 'cortext' );
 const inputPlaceholder = __(
 	'Search pages, collections, and actions',
@@ -40,17 +47,23 @@ function isRecentCommand( command ) {
 	return command?.name?.startsWith( RECENT_COMMAND_PREFIX );
 }
 
+function isDocumentCommand( command ) {
+	return command?.name?.startsWith( DOCUMENT_COMMAND_PREFIX );
+}
+
 export function splitPaletteCommands( commands ) {
 	return commands.reduce(
 		( groups, command ) => {
-			if ( isRecentCommand( command ) ) {
+			if ( isDocumentCommand( command ) ) {
+				groups.documentCommands.push( command );
+			} else if ( isRecentCommand( command ) ) {
 				groups.recentCommands.push( command );
 			} else {
 				groups.commands.push( command );
 			}
 			return groups;
 		},
-		{ recentCommands: [], commands: [] }
+		{ documentCommands: [], recentCommands: [], commands: [] }
 	);
 }
 
@@ -82,6 +95,8 @@ function CommandItem( {
 	valuePrefix = '',
 } ) {
 	const { close } = useDispatch( commandsStore );
+	const descriptions = useContext( CommandDescriptionContext );
+	const description = descriptions.get( command.name );
 	const label = command.searchLabel ?? command.label;
 	const value = valuePrefix ? `${ valuePrefix }${ command.name }` : label;
 	const itemId = `${ ITEM_ID_PREFIX }${ value.toLowerCase() }`;
@@ -107,12 +122,22 @@ function CommandItem( {
 					.join( ' ' ) }
 			>
 				<CommandIcon icon={ command.icon } />
-				<span className="commands-command-menu__item-label">
-					<TextHighlight
-						text={ command.label }
-						highlight={ search }
-					/>
-				</span>
+				<div className="commands-command-menu__item-main">
+					<span className="commands-command-menu__item-label">
+						<TextHighlight
+							text={ command.label }
+							highlight={ search }
+						/>
+					</span>
+					{ description && (
+						<span className="commands-command-menu__item-description">
+							<TextHighlight
+								text={ description }
+								highlight={ search }
+							/>
+						</span>
+					) }
+				</div>
 				{ showCategory && CATEGORY_LABELS[ command.category ] && (
 					<span className="commands-command-menu__item-category">
 						{ CATEGORY_LABELS[ command.category ] }
@@ -169,12 +194,25 @@ function PaletteGroups( { search } ) {
 		() => [ ...staticCommands, ...contextualCommands ],
 		[ staticCommands, contextualCommands ]
 	);
-	const { recentCommands, commands } = splitPaletteCommands(
+	const { documentCommands, recentCommands, commands } = splitPaletteCommands(
 		search ? allCommands : contextualCommands
 	);
 
 	return (
 		<>
+			{ search && documentCommands.length > 0 && (
+				<Command.Group
+					className="cortext-command-palette__group cortext-command-palette__group--documents"
+					heading={ __( 'Search results', 'cortext' ) }
+				>
+					<CommandList
+						commands={ documentCommands }
+						search={ search }
+						showCategory={ false }
+						valuePrefix="document-"
+					/>
+				</Command.Group>
+			) }
 			{ recentCommands.length > 0 && (
 				<Command.Group
 					className="cortext-command-palette__group cortext-command-palette__group--recent"
@@ -193,7 +231,7 @@ function PaletteGroups( { search } ) {
 					className="cortext-command-palette__group"
 					heading={
 						search
-							? __( 'Results', 'cortext' )
+							? __( 'Commands', 'cortext' )
 							: __( 'Suggestions', 'cortext' )
 					}
 				>
@@ -204,10 +242,13 @@ function PaletteGroups( { search } ) {
 	);
 }
 
-export default function CortextCommandMenu() {
+export default function CortextCommandMenu( {
+	search = '',
+	setSearch = () => {},
+	isDocumentSearchPending = false,
+} = {} ) {
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
 	const { open, close } = useDispatch( commandsStore );
-	const [ search, setSearch ] = useState( '' );
 	const paletteIsOpen = useSelect(
 		( select ) => select( commandsStore ).isOpen(),
 		[]
@@ -273,7 +314,7 @@ export default function CortextCommandMenu() {
 						/>
 					</div>
 					<Command.List label={ __( 'Command suggestions' ) }>
-						{ search && (
+						{ search && ! isDocumentSearchPending && (
 							<Command.Empty>
 								{ __( 'No results found.' ) }
 							</Command.Empty>

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -1,4 +1,4 @@
-import { Command, useCommandState } from 'cmdk';
+import { Command, defaultFilter, useCommandState } from 'cmdk';
 
 import { Modal, TextHighlight } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -242,10 +242,24 @@ function PaletteGroups( { search } ) {
 	);
 }
 
+// cmdk re-scores and re-sorts every item on each keystroke. For server-side
+// search results (the documents group) that means the highlighted item can
+// hop around the list as the user types. Pin all document commands to a
+// constant score so cmdk keeps the server's order and stops shuffling them.
+// Non-document items still go through cmdk's default filter.
+function palettePinnedFilter( value, search, keywords ) {
+	if ( value.startsWith( 'document-' ) ) {
+		return 1;
+	}
+	return defaultFilter( value, search, keywords );
+}
+
 export default function CortextCommandMenu( {
 	search = '',
 	setSearch = () => {},
 	isDocumentSearchPending = false,
+	selectedValue,
+	onSelectedValueChange = () => {},
 } = {} ) {
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
 	const { open, close } = useDispatch( commandsStore );
@@ -302,7 +316,13 @@ export default function CortextCommandMenu( {
 			contentLabel={ __( 'Command palette' ) }
 		>
 			<div className="commands-command-menu__container">
-				<Command label={ commandMenuLabel } loop>
+				<Command
+					label={ commandMenuLabel }
+					loop
+					filter={ palettePinnedFilter }
+					value={ selectedValue }
+					onValueChange={ onSelectedValueChange }
+				>
 					<div className="commands-command-menu__header">
 						<Icon
 							className="commands-command-menu__header-search-icon"

--- a/src/index.scss
+++ b/src/index.scss
@@ -25,6 +25,22 @@
 		width: 100%;
 	}
 
+	.commands-command-menu__item-main {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.commands-command-menu__item-description {
+		color: var(--cortext-text-muted, #757575);
+		font-size: 12px;
+		line-height: 1.3;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
 	.cortext-command-palette__group + .cortext-command-palette__group [cmdk-group-heading] {
 		border-top: var(--cortext-shell-border-width, 1px) solid var(--cortext-chrome-border, #e0e0e0);
 	}

--- a/tests/e2e/specs/palette-search.spec.js
+++ b/tests/e2e/specs/palette-search.spec.js
@@ -1,0 +1,147 @@
+/**
+ * E2E coverage for searching pages and collection rows from the
+ * command palette.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Cleanup is best effort.
+	}
+}
+
+async function appPath( page ) {
+	return page.evaluate(
+		() => new URL( window.location.href ).searchParams.get( 'p' ) || '/'
+	);
+}
+
+async function openPalette( page ) {
+	// Wait for the shell to mount before dispatching the bridge event.
+	await expect( page.locator( '.cortext-root' ) ).toBeVisible( {
+		timeout: 15000,
+	} );
+	// The keyboard shortcut uses this same bridge but is flaky in headless
+	// Chromium, so dispatch the event directly.
+	await page.evaluate( () => {
+		window.dispatchEvent( new Event( 'cortext:open-command-palette' ) );
+	} );
+	await expect(
+		page.getByPlaceholder( 'Search pages, collections, and actions' )
+	).toBeVisible( { timeout: 5000 } );
+}
+
+test.describe( 'Command palette search', () => {
+	test( 'finds a page by unique body text and navigates to it', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const token = `palettetoken${ suffix }`;
+		const pageTitle = `Palette search page ${ suffix }`;
+		let seededPage;
+
+		try {
+			seededPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: pageTitle,
+					status: 'private',
+					content: `<!-- wp:paragraph --><p>${ token } body text.</p><!-- /wp:paragraph -->`,
+				},
+			} );
+
+			await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+
+			await openPalette( page );
+			await page
+				.getByPlaceholder( 'Search pages, collections, and actions' )
+				.fill( token );
+
+			const result = page.getByRole( 'option', { name: pageTitle } );
+			await expect( result ).toBeVisible( { timeout: 5000 } );
+
+			await result.click();
+
+			await expect
+				.poll( () => appPath( page ) )
+				.toContain( `${ seededPage.id }` );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				seededPage && `/wp/v2/crtxt_pages/${ seededPage.id }`
+			);
+		}
+	} );
+
+	test( 'finds a row by title and navigates to the row itself', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const slug = `palette${ suffix }`;
+		const rowToken = `palrow${ suffix }`;
+		const collectionTitle = `Palette rows ${ suffix }`;
+		const fixture = {};
+
+		try {
+			fixture.collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_collections',
+				data: {
+					title: collectionTitle,
+					status: 'private',
+					meta: { slug },
+				},
+			} );
+
+			fixture.entry = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_${ slug }`,
+				data: {
+					title: rowToken,
+					status: 'private',
+				},
+			} );
+
+			await admin.visitAdminPage( 'admin.php', 'page=cortext' );
+
+			await openPalette( page );
+			await page
+				.getByPlaceholder( 'Search pages, collections, and actions' )
+				.fill( rowToken );
+
+			const result = page.getByRole( 'option', { name: rowToken } );
+			await expect( result ).toBeVisible( { timeout: 5000 } );
+
+			await result.click();
+
+			await expect
+				.poll( () => appPath( page ) )
+				.toContain( `${ fixture.entry.id }` );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry && `/wp/v2/crtxt_${ slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+} );

--- a/tests/e2e/specs/perf-ui.spec.js
+++ b/tests/e2e/specs/perf-ui.spec.js
@@ -14,6 +14,8 @@
  *     ascending", wait for sorted rows.
  *   - page_edit_ready: crtxt_page in Gutenberg until the editor is mounted.
  *   - command_palette_open: shell event to command palette mount.
+ *   - palette_search_ready: command palette search from typing to the first
+ *     document result from /cortext/v1/documents.
  *   - column_actions_open: column header trigger to visible menu.
  *   - column_rename_inline: open the column menu, choose "Rename", type a new
  *     name, press Enter, then wait for the save to finish.
@@ -318,6 +320,46 @@ test.describe( 'Cortext UI performance', () => {
 		await waitForCommandPaletteReady( page );
 
 		scenarios.command_palette_open = tag(
+			'surface',
+			await probe.snapshot( startedAt )
+		);
+	} );
+
+	test( 'palette_search_ready', async ( { admin, page } ) => {
+		const probe = await setupProbe( page );
+
+		await admin.visitAdminPage( 'admin.php', collection.adminQuery );
+		await waitForCollectionReady( page );
+
+		await page.evaluate( () => {
+			window.dispatchEvent( new Event( 'cortext:open-command-palette' ) );
+		} );
+		await waitForCommandPaletteReady( page );
+
+		const input = page.getByPlaceholder(
+			'Search pages, collections, and actions'
+		);
+
+		await probe.reset();
+		const responsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( '/cortext/v1/documents' ) &&
+				response.url().includes( 'search=' ),
+			{ timeout: READY_TIMEOUT_MS }
+		);
+		const startedAt = Date.now();
+
+		// "Perf" matches every seeded row in `perfmain`; the palette only shows
+		// 10 results, so the first visible option is enough.
+		await input.fill( 'Perf' );
+		await responsePromise;
+		await page
+			.getByRole( 'option' )
+			.first()
+			.waitFor( { state: 'visible', timeout: READY_TIMEOUT_MS } );
+		await waitForPaint( page );
+
+		scenarios.palette_search_ready = tag(
 			'surface',
 			await probe.snapshot( startedAt )
 		);

--- a/tests/js/components/CommandPalette.test.js
+++ b/tests/js/components/CommandPalette.test.js
@@ -258,11 +258,11 @@ describe( 'CommandPalette document search', () => {
 
 		expect( pageCommand ).toMatchObject( {
 			label: 'Roadmap',
-			keywords: [ 'quarterly', 'page' ],
+			keywords: [ 'page' ],
 		} );
 		expect( rowCommand ).toMatchObject( {
 			label: 'Ship the thing',
-			keywords: [ 'quarterly', 'row' ],
+			keywords: [ 'row' ],
 		} );
 		expect( mockMenu.descriptions.get( 'cortext/document/page-42' ) ).toBe(
 			'Quarterly themes for next half.'
@@ -326,7 +326,7 @@ describe( 'CommandPalette document search', () => {
 		expect( mockMenu.isDocumentSearchPending ).toBe( false );
 	} );
 
-	it( 'keeps stale documents under the prior keyword while a new query loads', () => {
+	it( 'keeps stale documents visible while the next query is in flight', () => {
 		mockIsPaletteOpen = true;
 		const staleDocs = [
 			{
@@ -355,21 +355,18 @@ describe( 'CommandPalette document search', () => {
 			jest.advanceTimersByTime( 150 );
 		} );
 
-		// Sanity check: the resolved doc is registered for the first search.
+		// Sanity check: the resolved doc is registered.
 		expect(
 			mockUseCommand.mock.calls
 				.map( ( [ c ] ) => c )
-				.some(
-					( c ) =>
-						c.name === 'cortext/document/page-1' &&
-						c.keywords?.includes( 'first' )
-				)
+				.some( ( c ) => c.name === 'cortext/document/page-1' )
 		).toBe( true );
 
 		mockUseCommand.mockClear();
 
 		// New query is in flight: useDocuments keeps the previous documents
-		// but flips hasResolved to false.
+		// but flips hasResolved to false. The stale doc stays registered so
+		// the user does not see a flicker between keystrokes.
 		mockUseDocuments.mockReturnValue( {
 			documents: staleDocs,
 			total: 1,
@@ -386,25 +383,11 @@ describe( 'CommandPalette document search', () => {
 			jest.advanceTimersByTime( 150 );
 		} );
 
-		const calls = mockUseCommand.mock.calls.map( ( [ c ] ) => c );
-
-		// The stale doc stays registered so the user does not see a flicker
-		// between keystrokes, but the keyword is the search that produced it
-		// — never the new query — so cmdk can filter it out on replacement.
 		expect(
-			calls.some(
-				( c ) =>
-					c.name === 'cortext/document/page-1' &&
-					c.keywords?.includes( 'first' )
-			)
+			mockUseCommand.mock.calls
+				.map( ( [ c ] ) => c )
+				.some( ( c ) => c.name === 'cortext/document/page-1' )
 		).toBe( true );
-		expect(
-			calls.some(
-				( c ) =>
-					c.name === 'cortext/document/page-1' &&
-					c.keywords?.includes( 'second' )
-			)
-		).toBe( false );
 
 		// Descriptions stay populated so the second line does not flicker.
 		expect(
@@ -475,7 +458,7 @@ describe( 'CommandPalette document search', () => {
 		expect( mockMenu.selectedValue ).toBeUndefined();
 	} );
 
-	it( 'keeps stale documents under the prior keyword when the new query fails', () => {
+	it( 'drops stale documents when the next query fails', () => {
 		mockIsPaletteOpen = true;
 		const staleDocs = [
 			{
@@ -507,7 +490,9 @@ describe( 'CommandPalette document search', () => {
 		mockUseCommand.mockClear();
 
 		// Failed fetch: useDocuments resolves with hasResolved=true,
-		// keeps the previous documents, and exposes the error.
+		// keeps the previous documents, and exposes the error. The
+		// palette must hide the stale list so the user does not navigate
+		// to a document that no longer matches their query.
 		mockUseDocuments.mockReturnValue( {
 			documents: staleDocs,
 			total: 1,
@@ -524,20 +509,10 @@ describe( 'CommandPalette document search', () => {
 			jest.advanceTimersByTime( 150 );
 		} );
 
-		const calls = mockUseCommand.mock.calls.map( ( [ c ] ) => c );
 		expect(
-			calls.some(
-				( c ) =>
-					c.name === 'cortext/document/page-1' &&
-					c.keywords?.includes( 'first' )
-			)
-		).toBe( true );
-		expect(
-			calls.some(
-				( c ) =>
-					c.name === 'cortext/document/page-1' &&
-					c.keywords?.includes( 'second' )
-			)
+			mockUseCommand.mock.calls
+				.map( ( [ c ] ) => c )
+				.some( ( c ) => c.name === 'cortext/document/page-1' )
 		).toBe( false );
 	} );
 } );

--- a/tests/js/components/CommandPalette.test.js
+++ b/tests/js/components/CommandPalette.test.js
@@ -59,6 +59,8 @@ const mockMenu = {
 	setSearch: () => {},
 	isDocumentSearchPending: false,
 	descriptions: new Map(),
+	selectedValue: undefined,
+	onSelectedValueChange: () => {},
 };
 
 jest.mock( '../../../src/components/CortextCommandMenu', () => {
@@ -69,6 +71,8 @@ jest.mock( '../../../src/components/CortextCommandMenu', () => {
 		mockMenu.setSearch = props.setSearch;
 		mockMenu.isDocumentSearchPending = props.isDocumentSearchPending;
 		mockMenu.descriptions = useContext( CommandDescriptionContext );
+		mockMenu.selectedValue = props.selectedValue;
+		mockMenu.onSelectedValueChange = props.onSelectedValueChange;
 		return null;
 	};
 	return {
@@ -406,6 +410,69 @@ describe( 'CommandPalette document search', () => {
 		expect(
 			mockMenu.descriptions.get( 'cortext/document/page-1' )
 		).toBeTruthy();
+	} );
+
+	it( 'anchors the selection to the first document on first arrival, leaves later fetches alone, and clears on empty input', () => {
+		mockIsPaletteOpen = true;
+		mockUseDocuments.mockReturnValue( {
+			documents: [
+				{ kind: 'page', id: 42, title: 'Alice', path: 'alice-42' },
+				{ kind: 'row', id: 77, title: 'Bob', path: 'bob-77' },
+			],
+			total: 2,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		act( () => {
+			mockMenu.setSearch( 'ali' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		expect( mockMenu.selectedValue ).toBe(
+			'document-cortext/document/page-42'
+		);
+
+		// User (or cmdk) moves the selection. The next refinement must not
+		// jump back to the new first doc; cmdk owns the value from here.
+		act( () => {
+			mockMenu.onSelectedValueChange(
+				'document-cortext/document/row-77'
+			);
+		} );
+		mockUseDocuments.mockReturnValue( {
+			documents: [
+				{ kind: 'row', id: 99, title: 'Alicia', path: 'alicia-99' },
+				{ kind: 'page', id: 42, title: 'Alice', path: 'alice-42' },
+				{ kind: 'row', id: 77, title: 'Bob', path: 'bob-77' },
+			],
+			total: 3,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+		act( () => {
+			mockMenu.setSearch( 'alic' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+		expect( mockMenu.selectedValue ).toBe(
+			'document-cortext/document/row-77'
+		);
+
+		// Clearing the input drops the anchor so cmdk picks fresh next time.
+		act( () => {
+			mockMenu.setSearch( '' );
+		} );
+		expect( mockMenu.selectedValue ).toBeUndefined();
 	} );
 
 	it( 'keeps stale documents under the prior keyword when the new query fails', () => {

--- a/tests/js/components/CommandPalette.test.js
+++ b/tests/js/components/CommandPalette.test.js
@@ -458,6 +458,43 @@ describe( 'CommandPalette document search', () => {
 		expect( mockMenu.selectedValue ).toBeUndefined();
 	} );
 
+	it( 'clears the input and the controlled selection when the palette closes', () => {
+		mockIsPaletteOpen = true;
+		mockUseDocuments.mockReturnValue( {
+			documents: [ { kind: 'page', id: 1, title: 'Foo', path: 'foo-1' } ],
+			total: 1,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+
+		const { rerender } = render(
+			<CommandPalette canvasRef={ { current: null } } />
+		);
+
+		act( () => {
+			mockMenu.setSearch( 'foo' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+		expect( mockMenu.search ).toBe( 'foo' );
+		expect( mockMenu.selectedValue ).toBe(
+			'document-cortext/document/page-1'
+		);
+
+		// Simulate the palette closing after the user picked a result.
+		// `close()` from the command callback bypasses `closeAndReset`, so
+		// without the new cleanup the next open would start with the old
+		// search prepopulated.
+		mockIsPaletteOpen = false;
+		rerender( <CommandPalette canvasRef={ { current: null } } /> );
+
+		expect( mockMenu.search ).toBe( '' );
+		expect( mockMenu.selectedValue ).toBeUndefined();
+	} );
+
 	it( 'drops stale documents when the next query fails', () => {
 		mockIsPaletteOpen = true;
 		const staleDocs = [

--- a/tests/js/components/CommandPalette.test.js
+++ b/tests/js/components/CommandPalette.test.js
@@ -458,6 +458,65 @@ describe( 'CommandPalette document search', () => {
 		expect( mockMenu.selectedValue ).toBeUndefined();
 	} );
 
+	it( 'moves the selection to the new first document when the previous pick is no longer in the results', () => {
+		mockIsPaletteOpen = true;
+		mockUseDocuments.mockReturnValue( {
+			documents: [
+				{ kind: 'page', id: 42, title: 'Alice', path: 'alice-42' },
+				{ kind: 'row', id: 77, title: 'Bob', path: 'bob-77' },
+			],
+			total: 2,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		act( () => {
+			mockMenu.setSearch( 'ali' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		// User arrows to the second doc.
+		act( () => {
+			mockMenu.onSelectedValueChange(
+				'document-cortext/document/row-77'
+			);
+		} );
+		expect( mockMenu.selectedValue ).toBe(
+			'document-cortext/document/row-77'
+		);
+
+		// Refinement returns a set that no longer contains row-77. The
+		// selection has to jump to the new first doc so cmdk does not show
+		// a frame with nothing highlighted.
+		mockUseDocuments.mockReturnValue( {
+			documents: [
+				{ kind: 'row', id: 99, title: 'Alicia', path: 'alicia-99' },
+				{ kind: 'page', id: 42, title: 'Alice', path: 'alice-42' },
+			],
+			total: 2,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+		act( () => {
+			mockMenu.setSearch( 'alic' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		expect( mockMenu.selectedValue ).toBe(
+			'document-cortext/document/row-99'
+		);
+	} );
+
 	it( 'clears the input and the controlled selection when the palette closes', () => {
 		mockIsPaletteOpen = true;
 		mockUseDocuments.mockReturnValue( {

--- a/tests/js/components/CommandPalette.test.js
+++ b/tests/js/components/CommandPalette.test.js
@@ -322,7 +322,7 @@ describe( 'CommandPalette document search', () => {
 		expect( mockMenu.isDocumentSearchPending ).toBe( false );
 	} );
 
-	it( 'does not register stale documents while a new query is loading', () => {
+	it( 'keeps stale documents under the prior keyword while a new query loads', () => {
 		mockIsPaletteOpen = true;
 		const staleDocs = [
 			{
@@ -382,19 +382,95 @@ describe( 'CommandPalette document search', () => {
 			jest.advanceTimersByTime( 150 );
 		} );
 
-		// The stale doc must NOT be re-registered with the new keyword.
+		const calls = mockUseCommand.mock.calls.map( ( [ c ] ) => c );
+
+		// The stale doc stays registered so the user does not see a flicker
+		// between keystrokes, but the keyword is the search that produced it
+		// — never the new query — so cmdk can filter it out on replacement.
 		expect(
-			mockUseCommand.mock.calls
-				.map( ( [ c ] ) => c )
-				.some(
-					( c ) =>
-						c.name === 'cortext/document/page-1' &&
-						c.keywords?.includes( 'second' )
-				)
+			calls.some(
+				( c ) =>
+					c.name === 'cortext/document/page-1' &&
+					c.keywords?.includes( 'first' )
+			)
+		).toBe( true );
+		expect(
+			calls.some(
+				( c ) =>
+					c.name === 'cortext/document/page-1' &&
+					c.keywords?.includes( 'second' )
+			)
 		).toBe( false );
 
-		// Description for the stale result is cleared too, so the next item
-		// rendered under the new query does not inherit an old hint.
-		expect( mockMenu.descriptions.size ).toBe( 0 );
+		// Descriptions stay populated so the second line does not flicker.
+		expect(
+			mockMenu.descriptions.get( 'cortext/document/page-1' )
+		).toBeTruthy();
+	} );
+
+	it( 'keeps stale documents under the prior keyword when the new query fails', () => {
+		mockIsPaletteOpen = true;
+		const staleDocs = [
+			{
+				kind: 'page',
+				id: 1,
+				title: 'Stale',
+				path: 'stale-1',
+				excerpt: 'old content',
+			},
+		];
+		mockUseDocuments.mockReturnValue( {
+			documents: staleDocs,
+			total: 1,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		act( () => {
+			mockMenu.setSearch( 'first' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		mockUseCommand.mockClear();
+
+		// Failed fetch: useDocuments resolves with hasResolved=true,
+		// keeps the previous documents, and exposes the error.
+		mockUseDocuments.mockReturnValue( {
+			documents: staleDocs,
+			total: 1,
+			isLoading: false,
+			hasResolved: true,
+			error: new Error( 'network' ),
+			refresh: jest.fn(),
+		} );
+
+		act( () => {
+			mockMenu.setSearch( 'second' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		const calls = mockUseCommand.mock.calls.map( ( [ c ] ) => c );
+		expect(
+			calls.some(
+				( c ) =>
+					c.name === 'cortext/document/page-1' &&
+					c.keywords?.includes( 'first' )
+			)
+		).toBe( true );
+		expect(
+			calls.some(
+				( c ) =>
+					c.name === 'cortext/document/page-1' &&
+					c.keywords?.includes( 'second' )
+			)
+		).toBe( false );
 	} );
 } );

--- a/tests/js/components/CommandPalette.test.js
+++ b/tests/js/components/CommandPalette.test.js
@@ -1,11 +1,13 @@
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 const mockUseCommand = jest.fn();
 const mockCreateRegistry = jest.fn( () => ( { register: jest.fn() } ) );
 const mockOpen = jest.fn();
 const mockNavigate = jest.fn();
 const mockParentRegistry = { parent: true };
+const mockUseDocuments = jest.fn();
 let mockRecents = [];
+let mockIsPaletteOpen = false;
 
 jest.mock( '@wordpress/commands', () => ( {
 	store: { name: 'core/commands' },
@@ -20,12 +22,17 @@ jest.mock( '@wordpress/preferences', () => ( {
 	store: { name: 'core/preferences' },
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	createRegistry: ( ...args ) => mockCreateRegistry( ...args ),
-	RegistryProvider: ( { children } ) => children,
-	useDispatch: () => ( { open: mockOpen } ),
-	useRegistry: () => mockParentRegistry,
-} ) );
+jest.mock( '@wordpress/data', () => {
+	const fakeIsOpenSelector = () => mockIsPaletteOpen;
+	return {
+		createRegistry: ( ...args ) => mockCreateRegistry( ...args ),
+		RegistryProvider: ( { children } ) => children,
+		useDispatch: () => ( { open: mockOpen } ),
+		useRegistry: () => mockParentRegistry,
+		useSelect: ( mapSelect ) =>
+			mapSelect( () => ( { isOpen: fakeIsOpenSelector } ) ),
+	};
+} );
 
 jest.mock( '@tanstack/react-router', () => ( {
 	useNavigate: () => mockNavigate,
@@ -42,7 +49,34 @@ jest.mock( '../../../src/hooks/useRecents', () => ( {
 	useRecents: () => ( { recents: mockRecents } ),
 } ) );
 
-jest.mock( '../../../src/components/CortextCommandMenu', () => () => null );
+jest.mock( '../../../src/hooks/useDocuments', () => ( {
+	__esModule: true,
+	default: ( args ) => mockUseDocuments( args ),
+} ) );
+
+const mockMenu = {
+	search: '',
+	setSearch: () => {},
+	isDocumentSearchPending: false,
+	descriptions: new Map(),
+};
+
+jest.mock( '../../../src/components/CortextCommandMenu', () => {
+	const { createContext, useContext } = require( '@wordpress/element' );
+	const CommandDescriptionContext = createContext( new Map() );
+	const MockCortextCommandMenu = ( props ) => {
+		mockMenu.search = props.search;
+		mockMenu.setSearch = props.setSearch;
+		mockMenu.isDocumentSearchPending = props.isDocumentSearchPending;
+		mockMenu.descriptions = useContext( CommandDescriptionContext );
+		return null;
+	};
+	return {
+		__esModule: true,
+		default: MockCortextCommandMenu,
+		CommandDescriptionContext,
+	};
+} );
 
 jest.mock( '../../../src/components/PageIcon', () => () => null );
 
@@ -54,7 +88,18 @@ beforeEach( () => {
 	mockCreateRegistry.mockClear();
 	mockOpen.mockReset();
 	mockNavigate.mockReset();
+	mockUseDocuments.mockReset();
+	mockUseDocuments.mockReturnValue( {
+		documents: [],
+		total: 0,
+		isLoading: false,
+		hasResolved: true,
+		error: null,
+		refresh: jest.fn(),
+	} );
 	mockRecents = [];
+	mockIsPaletteOpen = false;
+	mockMenu.descriptions = new Map();
 } );
 
 afterEach( () => {
@@ -135,5 +180,221 @@ describe( 'CommandPalette recents', () => {
 		expect( close ).toHaveBeenCalled();
 		jest.runOnlyPendingTimers();
 		expect( focus ).toHaveBeenCalledWith( { preventScroll: true } );
+	} );
+} );
+
+describe( 'CommandPalette document search', () => {
+	it( 'does not fetch documents while the palette is closed', () => {
+		mockIsPaletteOpen = false;
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		expect( mockUseDocuments ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not fetch documents when the palette is open but the input is empty', () => {
+		mockIsPaletteOpen = true;
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		expect( mockUseDocuments ).not.toHaveBeenCalled();
+	} );
+
+	it( 'registers document results and opens the selected path', () => {
+		const close = jest.fn();
+		mockIsPaletteOpen = true;
+		mockUseDocuments.mockReturnValue( {
+			documents: [
+				{
+					kind: 'page',
+					id: 42,
+					title: 'Roadmap',
+					path: 'roadmap-42',
+					excerpt: 'Quarterly themes for next half.',
+				},
+				{
+					kind: 'row',
+					id: 77,
+					title: 'Ship the thing',
+					path: 'ship-the-thing-77',
+					collection: {
+						id: 9,
+						title: 'Projects',
+						path: 'collection/projects-9',
+					},
+				},
+			],
+			total: 2,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		act( () => {
+			mockMenu.setSearch( 'quarterly' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		expect( mockUseDocuments ).toHaveBeenCalledWith(
+			expect.objectContaining( { search: 'quarterly', perPage: 10 } )
+		);
+
+		const commands = mockUseCommand.mock.calls.map(
+			( [ command ] ) => command
+		);
+		const pageCommand = commands.find(
+			( c ) => c.name === 'cortext/document/page-42'
+		);
+		const rowCommand = commands.find(
+			( c ) => c.name === 'cortext/document/row-77'
+		);
+
+		expect( pageCommand ).toMatchObject( {
+			label: 'Roadmap',
+			keywords: [ 'quarterly', 'page' ],
+		} );
+		expect( rowCommand ).toMatchObject( {
+			label: 'Ship the thing',
+			keywords: [ 'quarterly', 'row' ],
+		} );
+		expect( mockMenu.descriptions.get( 'cortext/document/page-42' ) ).toBe(
+			'Quarterly themes for next half.'
+		);
+		expect( mockMenu.descriptions.get( 'cortext/document/row-77' ) ).toBe(
+			'in Projects'
+		);
+
+		pageCommand.callback( { close } );
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'roadmap-42' },
+		} );
+		expect( close ).toHaveBeenCalled();
+	} );
+
+	it( 'keeps the menu pending while document search resolves', () => {
+		mockIsPaletteOpen = true;
+		mockUseDocuments.mockReturnValue( {
+			documents: [],
+			total: 0,
+			isLoading: true,
+			hasResolved: false,
+			error: null,
+			refresh: jest.fn(),
+		} );
+
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		act( () => {
+			mockMenu.setSearch( 'pending' );
+		} );
+
+		// The menu should stay pending during the debounce so it does not flash
+		// "No results".
+		expect( mockMenu.isDocumentSearchPending ).toBe( true );
+
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		expect( mockMenu.isDocumentSearchPending ).toBe( true );
+
+		// Resolve the fetch. A new search makes the parent re-render, which lets
+		// DocumentResultsRegistration read the mocked hook value again.
+		mockUseDocuments.mockReturnValue( {
+			documents: [],
+			total: 0,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+		act( () => {
+			mockMenu.setSearch( 'resolved' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		expect( mockMenu.isDocumentSearchPending ).toBe( false );
+	} );
+
+	it( 'does not register stale documents while a new query is loading', () => {
+		mockIsPaletteOpen = true;
+		const staleDocs = [
+			{
+				kind: 'page',
+				id: 1,
+				title: 'Stale',
+				path: 'stale-1',
+				excerpt: 'old content',
+			},
+		];
+		mockUseDocuments.mockReturnValue( {
+			documents: staleDocs,
+			total: 1,
+			isLoading: false,
+			hasResolved: true,
+			error: null,
+			refresh: jest.fn(),
+		} );
+
+		render( <CommandPalette canvasRef={ { current: null } } /> );
+
+		act( () => {
+			mockMenu.setSearch( 'first' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		// Sanity check: the resolved doc is registered for the first search.
+		expect(
+			mockUseCommand.mock.calls
+				.map( ( [ c ] ) => c )
+				.some(
+					( c ) =>
+						c.name === 'cortext/document/page-1' &&
+						c.keywords?.includes( 'first' )
+				)
+		).toBe( true );
+
+		mockUseCommand.mockClear();
+
+		// New query is in flight: useDocuments keeps the previous documents
+		// but flips hasResolved to false.
+		mockUseDocuments.mockReturnValue( {
+			documents: staleDocs,
+			total: 1,
+			isLoading: true,
+			hasResolved: false,
+			error: null,
+			refresh: jest.fn(),
+		} );
+
+		act( () => {
+			mockMenu.setSearch( 'second' );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 150 );
+		} );
+
+		// The stale doc must NOT be re-registered with the new keyword.
+		expect(
+			mockUseCommand.mock.calls
+				.map( ( [ c ] ) => c )
+				.some(
+					( c ) =>
+						c.name === 'cortext/document/page-1' &&
+						c.keywords?.includes( 'second' )
+				)
+		).toBe( false );
+
+		// Description for the stale result is cleared too, so the next item
+		// rendered under the new query does not inherit an old hint.
+		expect( mockMenu.descriptions.size ).toBe( 0 );
 	} );
 } );

--- a/tests/js/components/CortextCommandMenu.test.js
+++ b/tests/js/components/CortextCommandMenu.test.js
@@ -177,6 +177,38 @@ describe( 'CortextCommandMenu', () => {
 		).not.toBeInTheDocument();
 	} );
 
+	it( 'hides the commands group while the search input is non-empty', async () => {
+		global.ResizeObserver = ResizeObserverMock;
+		window.Element.prototype.scrollIntoView = jest.fn();
+		const registry = createCommandPaletteRegistry();
+		registry.dispatch( commandsStore ).registerCommand( {
+			name: 'cortext/home',
+			label: 'Go to home',
+			context: 'root',
+			callback: jest.fn(),
+		} );
+		registry.dispatch( commandsStore ).open();
+
+		const { rerender } = render(
+			<RegistryProvider value={ registry }>
+				<CortextCommandMenu search="" setSearch={ () => {} } />
+			</RegistryProvider>
+		);
+
+		// With no search, static commands render under "Suggestions".
+		expect( await screen.findByText( 'Go to home' ) ).toBeInTheDocument();
+
+		// Once the user starts typing, the commands group disappears so it
+		// cannot steal the selection from live document results.
+		rerender(
+			<RegistryProvider value={ registry }>
+				<CortextCommandMenu search="home" setSearch={ () => {} } />
+			</RegistryProvider>
+		);
+
+		expect( screen.queryByText( 'Go to home' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'hides the recent group while the search input is non-empty', async () => {
 		global.ResizeObserver = ResizeObserverMock;
 		window.Element.prototype.scrollIntoView = jest.fn();

--- a/tests/js/components/CortextCommandMenu.test.js
+++ b/tests/js/components/CortextCommandMenu.test.js
@@ -176,4 +176,42 @@ describe( 'CortextCommandMenu', () => {
 			screen.queryByText( 'Also unrelated' )
 		).not.toBeInTheDocument();
 	} );
+
+	it( 'hides the recent group while the search input is non-empty', async () => {
+		global.ResizeObserver = ResizeObserverMock;
+		window.Element.prototype.scrollIntoView = jest.fn();
+		const registry = createCommandPaletteRegistry();
+		registry.dispatch( commandsStore ).registerCommand( {
+			name: 'cortext/recent/page-7',
+			label: 'Welcome to Cortext',
+			searchLabel: 'Open recent: Welcome to Cortext',
+			context: 'root',
+			keywords: [ 'recent', 'page' ],
+			callback: jest.fn(),
+		} );
+		registry.dispatch( commandsStore ).open();
+
+		const { rerender } = render(
+			<RegistryProvider value={ registry }>
+				<CortextCommandMenu search="" setSearch={ () => {} } />
+			</RegistryProvider>
+		);
+
+		// With no search, the recent group renders.
+		expect(
+			await screen.findByText( 'Welcome to Cortext' )
+		).toBeInTheDocument();
+
+		// As soon as the user types, the recent group is hidden so it
+		// cannot steal the selection from the live search results.
+		rerender(
+			<RegistryProvider value={ registry }>
+				<CortextCommandMenu search="welcome" setSearch={ () => {} } />
+			</RegistryProvider>
+		);
+
+		expect(
+			screen.queryByText( 'Welcome to Cortext' )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/tests/js/components/CortextCommandMenu.test.js
+++ b/tests/js/components/CortextCommandMenu.test.js
@@ -141,4 +141,39 @@ describe( 'CortextCommandMenu', () => {
 			await screen.findByText( 'Plan for next quarter.' )
 		).toBeInTheDocument();
 	} );
+
+	it( 'keeps document commands visible even when the search does not match their label', async () => {
+		global.ResizeObserver = ResizeObserverMock;
+		window.Element.prototype.scrollIntoView = jest.fn();
+		const registry = createCommandPaletteRegistry();
+		// Register a doc whose label does not contain the search term and a
+		// non-doc that also does not match. Only the doc must survive cmdk's
+		// filter: the custom palette filter pins it to score 1.
+		registry.dispatch( commandsStore ).registerCommand( {
+			name: 'cortext/document/page-1',
+			label: 'Unrelated title',
+			context: 'root',
+			callback: jest.fn(),
+		} );
+		registry.dispatch( commandsStore ).registerCommand( {
+			name: 'cortext/other',
+			label: 'Also unrelated',
+			context: 'root',
+			callback: jest.fn(),
+		} );
+		registry.dispatch( commandsStore ).open();
+
+		render(
+			<RegistryProvider value={ registry }>
+				<CortextCommandMenu search="zzzz" setSearch={ () => {} } />
+			</RegistryProvider>
+		);
+
+		expect(
+			await screen.findByText( 'Unrelated title' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Also unrelated' )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/tests/js/components/CortextCommandMenu.test.js
+++ b/tests/js/components/CortextCommandMenu.test.js
@@ -6,6 +6,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { table } from '@wordpress/icons';
 
 import {
+	CommandDescriptionContext,
 	CommandIcon,
 	default as CortextCommandMenu,
 	splitPaletteCommands,
@@ -26,16 +27,33 @@ function createCommandPaletteRegistry() {
 }
 
 describe( 'splitPaletteCommands', () => {
-	it( 'separates Cortext recents from the rest of the palette commands', () => {
+	it( 'puts document results before recents and commands', () => {
 		const home = { name: 'cortext/home', label: 'Go to home' };
-		const page = { name: 'cortext/recent/page-7', label: 'Notes' };
-		const row = {
+		const recentPage = { name: 'cortext/recent/page-7', label: 'Notes' };
+		const recentRow = {
 			name: 'cortext/recent/row-12',
 			label: 'Ada Lovelace in People',
 		};
+		const docPage = {
+			name: 'cortext/document/page-42',
+			label: 'Roadmap',
+		};
+		const docRow = {
+			name: 'cortext/document/row-77',
+			label: 'Ship plan',
+		};
 
-		expect( splitPaletteCommands( [ home, page, row ] ) ).toEqual( {
-			recentCommands: [ page, row ],
+		expect(
+			splitPaletteCommands( [
+				home,
+				recentPage,
+				recentRow,
+				docPage,
+				docRow,
+			] )
+		).toEqual( {
+			documentCommands: [ docPage, docRow ],
+			recentCommands: [ recentPage, recentRow ],
 			commands: [ home ],
 		} );
 	} );
@@ -54,7 +72,7 @@ describe( 'CommandIcon', () => {
 describe( 'CortextCommandMenu', () => {
 	it( 'opens from the primary+k keyboard shortcut', async () => {
 		global.ResizeObserver = ResizeObserverMock;
-		Element.prototype.scrollIntoView = jest.fn();
+		window.Element.prototype.scrollIntoView = jest.fn();
 		const registry = createCommandPaletteRegistry();
 		registry.dispatch( commandsStore ).registerCommand( {
 			name: 'cortext/test',
@@ -89,5 +107,38 @@ describe( 'CortextCommandMenu', () => {
 			)
 		).toBeInTheDocument();
 		expect( screen.getByText( 'Test command' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the description from CommandDescriptionContext for matching commands', async () => {
+		global.ResizeObserver = ResizeObserverMock;
+		window.Element.prototype.scrollIntoView = jest.fn();
+		const registry = createCommandPaletteRegistry();
+		registry.dispatch( commandsStore ).registerCommand( {
+			name: 'cortext/document/page-99',
+			label: 'Quarterly review',
+			context: 'root',
+			keywords: [ 'roadmap' ],
+			callback: jest.fn(),
+		} );
+		registry.dispatch( commandsStore ).open();
+
+		const descriptions = new Map( [
+			[ 'cortext/document/page-99', 'Plan for next quarter.' ],
+		] );
+
+		render(
+			<RegistryProvider value={ registry }>
+				<CommandDescriptionContext.Provider value={ descriptions }>
+					<CortextCommandMenu
+						search="roadmap"
+						setSearch={ () => {} }
+					/>
+				</CommandDescriptionContext.Provider>
+			</RegistryProvider>
+		);
+
+		expect(
+			await screen.findByText( 'Plan for next quarter.' )
+		).toBeInTheDocument();
 	} );
 } );

--- a/tests/js/hooks/useDocuments.test.js
+++ b/tests/js/hooks/useDocuments.test.js
@@ -26,7 +26,9 @@ it( 'fetches documents without filters', async () => {
 
 	await waitFor( () => expect( result.current.hasResolved ).toBe( true ) );
 
-	expect( apiFetch ).toHaveBeenCalledWith( { path: '/cortext/v1/documents' } );
+	expect( apiFetch ).toHaveBeenCalledWith( {
+		path: '/cortext/v1/documents',
+	} );
 	expect( result.current.documents ).toEqual( [ document ] );
 	expect( result.current.total ).toBe( 1 );
 	expect( result.current.error ).toBeNull();
@@ -70,11 +72,18 @@ it( 'refetches when the search term changes', async () => {
 } );
 
 it( 'keeps the last result visible while a refresh is in flight', async () => {
-	const document = { kind: 'page', id: 1, title: 'Cached', path: 'page/cached-1' };
+	const document = {
+		kind: 'page',
+		id: 1,
+		title: 'Cached',
+		path: 'page/cached-1',
+	};
 	apiFetch.mockResolvedValueOnce( { documents: [ document ], total: 1 } );
 
 	const { result } = renderHook( () => useDocuments() );
-	await waitFor( () => expect( result.current.documents ).toEqual( [ document ] ) );
+	await waitFor( () =>
+		expect( result.current.documents ).toEqual( [ document ] )
+	);
 
 	let resolveRefresh;
 	apiFetch.mockReturnValueOnce(
@@ -99,11 +108,18 @@ it( 'keeps the last result visible while a refresh is in flight', async () => {
 } );
 
 it( 'reports errors without dropping the previous result', async () => {
-	const document = { kind: 'page', id: 1, title: 'Cached', path: 'page/cached-1' };
+	const document = {
+		kind: 'page',
+		id: 1,
+		title: 'Cached',
+		path: 'page/cached-1',
+	};
 	apiFetch.mockResolvedValueOnce( { documents: [ document ], total: 1 } );
 
 	const { result } = renderHook( () => useDocuments() );
-	await waitFor( () => expect( result.current.documents ).toEqual( [ document ] ) );
+	await waitFor( () =>
+		expect( result.current.documents ).toEqual( [ document ] )
+	);
 
 	const error = new Error( 'nope' );
 	apiFetch.mockRejectedValueOnce( error );

--- a/tests/php/InMemoryPostsQuery.php
+++ b/tests/php/InMemoryPostsQuery.php
@@ -136,6 +136,27 @@ trait InMemoryPostsQuery {
 					return 'ASC' === $direction ? -$cmp : $cmp;
 				}
 			);
+		} elseif ( $wants_search && '' === $orderby ) {
+			// Mirror WP_Query's `search_orderby_title`: when a search
+			// query is set and the caller does not pin `orderby`, items
+			// whose title contains the query rank above title-less hits.
+			// Modified-date DESC is the tiebreaker.
+			$needle     = strtolower( trim( (string) $vars['s'] ) );
+			$candidates = array_values( $candidates );
+			usort(
+				$candidates,
+				function ( WP_Post $a, WP_Post $b ) use ( $needle ): int {
+					$score_a = $this->title_relevance_score( $a, $needle );
+					$score_b = $this->title_relevance_score( $b, $needle );
+					if ( $score_a !== $score_b ) {
+						return $score_b - $score_a;
+					}
+					return strcmp(
+						(string) $b->post_modified_gmt,
+						(string) $a->post_modified_gmt
+					);
+				}
+			);
 		}
 
 		$candidates = array_values( $candidates );
@@ -170,6 +191,35 @@ trait InMemoryPostsQuery {
 			$out[] = new WP_Post( $row );
 		}
 		return $out;
+	}
+
+	/**
+	 * Scores how well a post title matches a search query, used to sort
+	 * search results in the absence of an explicit `orderby`. A full-needle
+	 * hit ranks above per-term hits; both rank above 0.
+	 */
+	private function title_relevance_score( WP_Post $post, string $needle ): int {
+		if ( '' === $needle ) {
+			return 0;
+		}
+		$title = strtolower( (string) $post->post_title );
+		if ( false !== strpos( $title, $needle ) ) {
+			return 100;
+		}
+		$terms = preg_split( '/\s+/', $needle );
+		if ( ! is_array( $terms ) ) {
+			return 0;
+		}
+		$score = 0;
+		foreach ( $terms as $term ) {
+			if ( '' === $term ) {
+				continue;
+			}
+			if ( false !== strpos( $title, $term ) ) {
+				$score += 10;
+			}
+		}
+		return $score;
 	}
 
 	/**

--- a/tests/php/InMemoryPostsQuery.php
+++ b/tests/php/InMemoryPostsQuery.php
@@ -20,6 +20,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Fields\FieldTypeRegistry;
+use Cortext\PostType\CollectionEntries;
 use WorDBless\Posts as WorDBlessPosts;
 use WP_Post;
 use WP_Query;
@@ -100,12 +102,24 @@ trait InMemoryPostsQuery {
 		}
 
 		if ( $wants_search ) {
-			$needle     = strtolower( (string) $vars['s'] );
+			$terms      = preg_split( '/\s+/', strtolower( trim( (string) $vars['s'] ) ) );
+			$terms      = is_array( $terms )
+				? array_values(
+					array_filter(
+						$terms,
+						static fn( string $term ): bool => '' !== $term
+					)
+				)
+				: array();
 			$candidates = array_filter(
 				$candidates,
-				static function ( WP_Post $post ) use ( $needle ): bool {
-					$haystack = strtolower( $post->post_title . ' ' . $post->post_excerpt . ' ' . $post->post_content );
-					return false !== strpos( $haystack, $needle );
+				function ( WP_Post $post ) use ( $terms ): bool {
+					foreach ( $terms as $term ) {
+						if ( ! $this->post_matches_search( $post, $term ) ) {
+							return false;
+						}
+					}
+					return true;
 				}
 			);
 		}
@@ -156,5 +170,74 @@ trait InMemoryPostsQuery {
 			$out[] = new WP_Post( $row );
 		}
 		return $out;
+	}
+
+	/**
+	 * Keep test search close to `Documents::list()`: pages use
+	 * title/content/excerpt, and rows can also match text-like field meta
+	 * (text, email, url).
+	 *
+	 * @param WP_Post $post   Post to inspect.
+	 * @param string  $needle Lowercase search term.
+	 */
+	private function post_matches_search( WP_Post $post, string $needle ): bool {
+		$haystack = strtolower( $post->post_title . ' ' . $post->post_excerpt . ' ' . $post->post_content );
+		if ( false !== strpos( $haystack, $needle ) ) {
+			return true;
+		}
+
+		if ( ! str_starts_with( $post->post_type, CollectionEntries::CPT_PREFIX ) ) {
+			return false;
+		}
+
+		foreach ( $this->text_like_field_keys_for_row_post_type( $post->post_type ) as $meta_key ) {
+			$value = strtolower( (string) get_post_meta( (int) $post->ID, $meta_key, true ) );
+			if ( false !== strpos( $value, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Finds the text-like (`text`, `email`, `url`) field meta keys for a row
+	 * CPT from its parent collection's `fields` meta.
+	 *
+	 * @param string $post_type Row post type.
+	 * @return string[]
+	 */
+	private function text_like_field_keys_for_row_post_type( string $post_type ): array {
+		$slug = substr( $post_type, strlen( CollectionEntries::CPT_PREFIX ) );
+		if ( '' === $slug ) {
+			return array();
+		}
+
+		$collection_id = 0;
+		foreach ( $this->all_in_memory_posts() as $candidate ) {
+			if ( 'crtxt_collection' !== $candidate->post_type ) {
+				continue;
+			}
+			if ( (string) get_post_meta( (int) $candidate->ID, 'slug', true ) === $slug ) {
+				$collection_id = (int) $candidate->ID;
+				break;
+			}
+		}
+		if ( 0 === $collection_id ) {
+			return array();
+		}
+
+		$keys = array();
+		foreach ( get_post_meta( $collection_id, 'fields', false ) as $raw_field_id ) {
+			$field_id = (int) $raw_field_id;
+			if ( $field_id < 1 ) {
+				continue;
+			}
+			$type = (string) get_post_meta( $field_id, 'type', true );
+			if ( FieldTypeRegistry::is_text_like( $type ) ) {
+				$keys[] = "field-{$field_id}";
+			}
+		}
+		return $keys;
 	}
 }

--- a/tests/php/InMemoryPostsQuery.php
+++ b/tests/php/InMemoryPostsQuery.php
@@ -137,19 +137,19 @@ trait InMemoryPostsQuery {
 				}
 			);
 		} elseif ( $wants_search && '' === $orderby ) {
-			// Mirror WP_Query's `search_orderby_title`: when a search
-			// query is set and the caller does not pin `orderby`, items
-			// whose title contains the query rank above title-less hits.
-			// Modified-date DESC is the tiebreaker.
+			// Mirror the `posts_search_orderby` filter `Documents::list()`
+			// installs: title prefix wins over title contains, which wins
+			// over excerpt and content matches. Modified-date DESC is the
+			// tiebreaker.
 			$needle     = strtolower( trim( (string) $vars['s'] ) );
 			$candidates = array_values( $candidates );
 			usort(
 				$candidates,
 				function ( WP_Post $a, WP_Post $b ) use ( $needle ): int {
-					$score_a = $this->title_relevance_score( $a, $needle );
-					$score_b = $this->title_relevance_score( $b, $needle );
-					if ( $score_a !== $score_b ) {
-						return $score_b - $score_a;
+					$tier_a = $this->search_relevance_tier( $a, $needle );
+					$tier_b = $this->search_relevance_tier( $b, $needle );
+					if ( $tier_a !== $tier_b ) {
+						return $tier_a - $tier_b;
 					}
 					return strcmp(
 						(string) $b->post_modified_gmt,
@@ -194,32 +194,30 @@ trait InMemoryPostsQuery {
 	}
 
 	/**
-	 * Scores how well a post title matches a search query, used to sort
-	 * search results in the absence of an explicit `orderby`. A full-needle
-	 * hit ranks above per-term hits; both rank above 0.
+	 * Returns the tier (1-best, 5-worst) for a post against a search
+	 * needle. Matches the CASE expression `Documents::list()` registers via
+	 * the `posts_search_orderby` filter.
 	 */
-	private function title_relevance_score( WP_Post $post, string $needle ): int {
+	private function search_relevance_tier( WP_Post $post, string $needle ): int {
 		if ( '' === $needle ) {
-			return 0;
+			return 5;
 		}
 		$title = strtolower( (string) $post->post_title );
-		if ( false !== strpos( $title, $needle ) ) {
-			return 100;
+		if ( '' !== $title && str_starts_with( $title, $needle ) ) {
+			return 1;
 		}
-		$terms = preg_split( '/\s+/', $needle );
-		if ( ! is_array( $terms ) ) {
-			return 0;
+		if ( '' !== $title && false !== strpos( $title, $needle ) ) {
+			return 2;
 		}
-		$score = 0;
-		foreach ( $terms as $term ) {
-			if ( '' === $term ) {
-				continue;
-			}
-			if ( false !== strpos( $title, $term ) ) {
-				$score += 10;
-			}
+		$excerpt = strtolower( (string) $post->post_excerpt );
+		if ( '' !== $excerpt && false !== strpos( $excerpt, $needle ) ) {
+			return 3;
 		}
-		return $score;
+		$content = strtolower( (string) $post->post_content );
+		if ( '' !== $content && false !== strpos( $content, $needle ) ) {
+			return 4;
+		}
+		return 5;
 	}
 
 	/**

--- a/tests/php/test-documents.php
+++ b/tests/php/test-documents.php
@@ -375,6 +375,125 @@ final class Test_Documents extends BaseTestCase {
 		$this->assertNotContains( $trashed_id, $ids );
 	}
 
+	public function test_list_search_matches_row_by_text_field(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'projects', 'Projects' );
+		$status_field  = $this->create_collection_field( $collection_id, 'Status', 'text' );
+
+		$matching_id  = $this->create_row( 'crtxt_projects', 'First row' );
+		$unrelated_id = $this->create_row( 'crtxt_projects', 'Second row' );
+		update_post_meta( $matching_id, "field-{$status_field}", 'shipping today' );
+		update_post_meta( $unrelated_id, "field-{$status_field}", 'parked' );
+
+		$result = $this->documents->list( array( 'search' => 'shipping' ) );
+
+		$ids = array_map( static fn ( array $doc ): int => $doc['id'], $result['documents'] );
+		$this->assertContains( $matching_id, $ids );
+		$this->assertNotContains( $unrelated_id, $ids );
+	}
+
+	public function test_list_search_matches_row_by_email_and_url_fields(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'contacts', 'Contacts' );
+		$email_field   = $this->create_collection_field( $collection_id, 'Email', 'email' );
+		$url_field     = $this->create_collection_field( $collection_id, 'Site', 'url' );
+
+		$email_match_id = $this->create_row( 'crtxt_contacts', 'Alice' );
+		$url_match_id   = $this->create_row( 'crtxt_contacts', 'Bob' );
+		$unrelated_id   = $this->create_row( 'crtxt_contacts', 'Carol' );
+		update_post_meta( $email_match_id, "field-{$email_field}", 'alice@example.org' );
+		update_post_meta( $url_match_id, "field-{$url_field}", 'https://acme.test/blog' );
+
+		$by_email = $this->documents->list( array( 'search' => 'example.org' ) );
+		$by_url   = $this->documents->list( array( 'search' => 'acme.test' ) );
+
+		$email_ids = array_map( static fn ( array $doc ): int => $doc['id'], $by_email['documents'] );
+		$url_ids   = array_map( static fn ( array $doc ): int => $doc['id'], $by_url['documents'] );
+
+		$this->assertContains( $email_match_id, $email_ids );
+		$this->assertNotContains( $unrelated_id, $email_ids );
+		$this->assertContains( $url_match_id, $url_ids );
+		$this->assertNotContains( $unrelated_id, $url_ids );
+	}
+
+	public function test_list_search_ignores_non_text_field_values(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'projects', 'Projects' );
+		$count_field   = $this->create_collection_field( $collection_id, 'Count', 'number' );
+		$pick_field    = $this->create_collection_field( $collection_id, 'Pick', 'select' );
+
+		$number_row_id = $this->create_row( 'crtxt_projects', 'Numbers' );
+		$select_row_id = $this->create_row( 'crtxt_projects', 'Selects' );
+		update_post_meta( $number_row_id, "field-{$count_field}", '12345' );
+		update_post_meta( $select_row_id, "field-{$pick_field}", 'shipping' );
+
+		$result = $this->documents->list( array( 'search' => '12345' ) );
+		$ids    = array_map( static fn ( array $doc ): int => $doc['id'], $result['documents'] );
+		$this->assertNotContains( $number_row_id, $ids );
+
+		$result = $this->documents->list( array( 'search' => 'shipping' ) );
+		$ids    = array_map( static fn ( array $doc ): int => $doc['id'], $result['documents'] );
+		$this->assertNotContains( $select_row_id, $ids );
+	}
+
+	public function test_list_search_returns_pages_and_rows_in_one_pass(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'projects', 'Projects' );
+		$status_field  = $this->create_collection_field( $collection_id, 'Status', 'text' );
+
+		$page_id = $this->create_page(
+			array(
+				'post_title'   => 'Notes',
+				'post_content' => 'Discussing the alpha launch this week.',
+			)
+		);
+		$row_id  = $this->create_row( 'crtxt_projects', 'Mobile rollout' );
+		update_post_meta( $row_id, "field-{$status_field}", 'alpha pilot' );
+
+		$result = $this->documents->list( array( 'search' => 'alpha' ) );
+
+		$ids = array_map( static fn ( array $doc ): int => $doc['id'], $result['documents'] );
+		$this->assertContains( $page_id, $ids );
+		$this->assertContains( $row_id, $ids );
+	}
+
+	public function test_list_search_requires_all_terms_to_match_somewhere(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'projects', 'Projects' );
+		$status_field  = $this->create_collection_field( $collection_id, 'Status', 'text' );
+
+		$row_one = $this->create_row( 'crtxt_projects', 'Apollo' );
+		update_post_meta( $row_one, "field-{$status_field}", 'pilot' );
+
+		$row_two = $this->create_row( 'crtxt_projects', 'Apollo' );
+		update_post_meta( $row_two, "field-{$status_field}", 'frozen' );
+
+		$result = $this->documents->list( array( 'search' => 'apollo pilot' ) );
+		$ids    = array_map( static fn ( array $doc ): int => $doc['id'], $result['documents'] );
+
+		$this->assertContains( $row_one, $ids );
+		$this->assertNotContains( $row_two, $ids );
+	}
+
+	public function test_list_trash_still_finds_row_by_title(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$this->create_collection( 'projects', 'Projects' );
+		$kept_row_id    = $this->create_row( 'crtxt_projects', 'Keeper' );
+		$trashed_row_id = $this->create_row( 'crtxt_projects', 'Spaceship' );
+		wp_trash_post( $trashed_row_id );
+
+		$result = $this->documents->list(
+			array(
+				'status' => Documents::STATUS_TRASH,
+				'search' => 'spaceship',
+			)
+		);
+
+		$ids = array_map( static fn ( array $doc ): int => $doc['id'], $result['documents'] );
+		$this->assertContains( $trashed_row_id, $ids );
+		$this->assertNotContains( $kept_row_id, $ids );
+	}
+
 	public function test_format_document_returns_null_for_non_document_post_type(): void {
 		$post_id = (int) wp_insert_post(
 			array(
@@ -442,6 +561,21 @@ final class Test_Documents extends BaseTestCase {
 		$this->assertGreaterThan( 0, $id );
 
 		return (int) $id;
+	}
+
+	private function create_collection_field( int $collection_id, string $title, string $type ): int {
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => array( 'type' => $type ),
+			)
+		);
+		$this->assertGreaterThan( 0, $field_id );
+		add_post_meta( $collection_id, 'fields', (string) $field_id );
+
+		return $field_id;
 	}
 
 	private function unregister_dynamic_collection_post_types(): void {

--- a/tests/php/test-documents.php
+++ b/tests/php/test-documents.php
@@ -475,6 +475,45 @@ final class Test_Documents extends BaseTestCase {
 		);
 	}
 
+	public function test_list_search_ranks_title_prefix_above_title_substring(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		// Page whose title CONTAINS the term but does not start with it,
+		// and that has been modified more recently.
+		$substring_match = $this->create_page(
+			array(
+				'post_title'        => 'Meeting notes',
+				'post_modified'     => '2025-06-01 00:00:00',
+				'post_modified_gmt' => '2025-06-01 00:00:00',
+			)
+		);
+		// Page whose title STARTS with the term, older.
+		$prefix_match = $this->create_page(
+			array(
+				'post_title'        => 'Terry Pratchett',
+				'post_modified'     => '2025-01-01 00:00:00',
+				'post_modified_gmt' => '2025-01-01 00:00:00',
+			)
+		);
+
+		$result = $this->documents->list( array( 'search' => 'te' ) );
+		$ids    = array_map(
+			static fn ( array $doc ): int => $doc['id'],
+			$result['documents']
+		);
+
+		$prefix_pos    = array_search( $prefix_match, $ids, true );
+		$substring_pos = array_search( $substring_match, $ids, true );
+
+		$this->assertNotFalse( $prefix_pos );
+		$this->assertNotFalse( $substring_pos );
+		$this->assertLessThan(
+			$substring_pos,
+			$prefix_pos,
+			'Title prefix match should rank above title substring match regardless of modified date.'
+		);
+	}
+
 	public function test_list_search_returns_pages_and_rows_in_one_pass(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
 		$collection_id = $this->create_collection( 'projects', 'Projects' );

--- a/tests/php/test-documents.php
+++ b/tests/php/test-documents.php
@@ -436,6 +436,45 @@ final class Test_Documents extends BaseTestCase {
 		$this->assertNotContains( $select_row_id, $ids );
 	}
 
+	public function test_list_search_ranks_title_matches_above_body_matches(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		// Older page with the term in its title.
+		$title_match = $this->create_page(
+			array(
+				'post_title'        => 'Quarterly report',
+				'post_modified'     => '2025-01-01 00:00:00',
+				'post_modified_gmt' => '2025-01-01 00:00:00',
+			)
+		);
+		// Newer page whose title misses the term but body matches.
+		$body_match = $this->create_page(
+			array(
+				'post_title'        => 'Notes',
+				'post_content'      => 'Quarterly review notes for the team.',
+				'post_modified'     => '2025-06-01 00:00:00',
+				'post_modified_gmt' => '2025-06-01 00:00:00',
+			)
+		);
+
+		$result = $this->documents->list( array( 'search' => 'quarterly' ) );
+		$ids    = array_map(
+			static fn ( array $doc ): int => $doc['id'],
+			$result['documents']
+		);
+
+		$title_pos = array_search( $title_match, $ids, true );
+		$body_pos  = array_search( $body_match, $ids, true );
+
+		$this->assertNotFalse( $title_pos );
+		$this->assertNotFalse( $body_pos );
+		$this->assertLessThan(
+			$body_pos,
+			$title_pos,
+			'Title match should rank above body-only match even when the body-match document is newer.'
+		);
+	}
+
 	public function test_list_search_returns_pages_and_rows_in_one_pass(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
 		$collection_id = $this->create_collection( 'projects', 'Projects' );


### PR DESCRIPTION
## What

Closes #149, closes #150.

Adds document search to the Cortext command palette. Users can search pages and collection rows, get a bit of context for each result, and open the one they choose.

A title match ranks above a weaker body or field match, and recents/commands (as there is only one command so far) stay out of the way while someone is searching.

## Why

The command palette worked well for commands and recent items, but it was not useful enough for finding workspace content.

## How

- Searches pages and rows through `/cortext/v1/documents` while the palette is open.
- Includes text, email, and URL field values when matching collection rows.
- Ranks title prefix and title substring matches above body or field-only matches.
- Hides recents and command suggestions during search so they do not steal the active selection.

## Testing Instructions

1. Create or use a page with unique text in its body.
2. Create or use a collection row with unique text in its title or in a text, email, or URL field.
3. Open the command palette and search for the page body text.
4. Confirm the page appears under Search results with an excerpt and opens when selected.
5. Search for the row text and confirm the row appears with its collection hint and opens directly.
6. Type `te`. A page or row whose title starts with `Te` should rank above documents that only contain `te` in the body, even if the body match was modified more recently.

## Screen recording


https://github.com/user-attachments/assets/112bc308-649b-491d-94bc-8eb8073df226



