### PR TITLE
Desktop app: Explore `php -S` tuning

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -16,7 +16,7 @@ over `PATH`.
 
 For this PR, either use a local PHP install or build the local runtime with
 `npm --prefix apps/desktop run runtime:php`. The signed app should ship that
-runtime. This spike stops short of wiring it into packaging.
+runtime. This exploration stops short of wiring it into packaging.
 
 ## Run it
 
@@ -69,7 +69,7 @@ window loads `http://127.0.0.1:9402/wp-admin/admin.php?page=cortext`.
 DevTools open by default. Set `CORTEXT_DEVTOOLS=0` to turn them off.
 Closing the window kills the PHP process.
 
-For runtime spikes, set `CORTEXT_RUNTIME` before launch:
+For runtime experiments, set `CORTEXT_RUNTIME` before launch:
 
 ```sh
 CORTEXT_RUNTIME=php npm --prefix apps/desktop start

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -6,6 +6,8 @@ const path = require( 'path' );
 
 const DEFAULT_PORT = 9402;
 const DEFAULT_READY_PATH = '/wp-includes/images/blank.gif';
+const EXPLORATION_OBJECT_CACHE_MARKER =
+	'Cortext Desktop APCu object-cache exploration drop-in';
 
 function normalizeRuntime( runtime ) {
 	const value = ( runtime || 'php' ).toLowerCase();
@@ -66,6 +68,115 @@ function pipeProcessOutput( child ) {
 	child.stderr.on( 'data', ( chunk ) => {
 		process.stderr.write( chunk );
 	} );
+}
+
+function isEnabled( value ) {
+	return [ '1', 'true', 'yes', 'on' ].includes(
+		String( value || '' ).toLowerCase()
+	);
+}
+
+function addPhpIni( args, key, value ) {
+	args.push( '-d', `${ key }=${ value }` );
+}
+
+function ensureDir( dir ) {
+	fs.mkdirSync( dir, { recursive: true } );
+	return dir;
+}
+
+function configureObjectCacheDropIn( wordpressDir, appDir ) {
+	const dropInPath = path.join( wordpressDir, 'wp-content/object-cache.php' );
+	const sourcePath = path.join( appDir, 'runtime/object-cache-apcu.php' );
+
+	if ( process.env.CORTEXT_DESKTOP_OBJECT_CACHE === 'apcu' ) {
+		if ( ! fs.existsSync( sourcePath ) ) {
+			throw new Error( `APCu object-cache drop-in not found at ${ sourcePath }.` );
+		}
+		fs.copyFileSync( sourcePath, dropInPath );
+		return;
+	}
+
+	if ( ! fs.existsSync( dropInPath ) ) {
+		return;
+	}
+
+	const existing = fs.readFileSync( dropInPath, 'utf8' );
+	if ( existing.includes( EXPLORATION_OBJECT_CACHE_MARKER ) ) {
+		fs.rmSync( dropInPath, { force: true } );
+	}
+}
+
+function configurePreloadFiles( wordpressDir, appDir ) {
+	const files = [
+		[ 'preload.php', 'cortext-preload.php' ],
+		[ 'preload-manifest.php', 'cortext-preload-manifest.php' ],
+	];
+
+	for ( const [ sourceName, destName ] of files ) {
+		const source = path.join( appDir, 'runtime', sourceName );
+		if ( ! fs.existsSync( source ) ) {
+			throw new Error( `Preload file not found at ${ source }.` );
+		}
+		fs.copyFileSync( source, path.join( wordpressDir, destName ) );
+	}
+
+	return path.join( wordpressDir, 'cortext-preload.php' );
+}
+
+function phpCliIniArgs( wordpressDir, appDir, runtimeStateDir ) {
+	const args = [];
+	const needsOpcache =
+		isEnabled( process.env.CORTEXT_PHP_OPCACHE_FILE_CACHE ) ||
+		isEnabled( process.env.CORTEXT_PHP_PRELOAD ) ||
+		isEnabled( process.env.CORTEXT_PHP_JIT );
+
+	if ( needsOpcache ) {
+		addPhpIni( args, 'opcache.enable_cli', '1' );
+		addPhpIni( args, 'opcache.enable', '1' );
+		addPhpIni( args, 'opcache.validate_timestamps', '0' );
+	}
+
+	if ( isEnabled( process.env.CORTEXT_PHP_OPCACHE_FILE_CACHE ) ) {
+		const fileCacheDir = ensureDir(
+			path.join( runtimeStateDir, 'opcache-file-cache' )
+		);
+		addPhpIni( args, 'opcache.file_cache', fileCacheDir );
+		addPhpIni( args, 'opcache.file_cache_only', '0' );
+	}
+
+	if ( isEnabled( process.env.CORTEXT_PHP_PRELOAD ) ) {
+		const preloadPath = configurePreloadFiles( wordpressDir, appDir );
+		const markerPath = path.join(
+			ensureDir( runtimeStateDir ),
+			'preload-engagement.json'
+		);
+		process.env.CORTEXT_DESKTOP_PRELOAD_MARKER = markerPath;
+		addPhpIni( args, 'opcache.preload', preloadPath );
+	} else {
+		delete process.env.CORTEXT_DESKTOP_PRELOAD_MARKER;
+	}
+
+	if ( isEnabled( process.env.CORTEXT_PHP_JIT ) ) {
+		addPhpIni(
+			args,
+			'opcache.jit_buffer_size',
+			process.env.CORTEXT_PHP_JIT_BUFFER_SIZE || '64M'
+		);
+		addPhpIni(
+			args,
+			'opcache.jit',
+			process.env.CORTEXT_PHP_JIT_MODE || 'tracing'
+		);
+		addPhpIni( args, 'pcre.jit', '1' );
+	}
+
+	if ( process.env.CORTEXT_DESKTOP_OBJECT_CACHE === 'apcu' ) {
+		addPhpIni( args, 'apc.enabled', '1' );
+		addPhpIni( args, 'apc.enable_cli', '1' );
+	}
+
+	return args;
 }
 
 function addProcess( handle, name, command, args, options = {} ) {
@@ -184,7 +295,7 @@ function waitForHttpReady( handle, port, timeoutMs = 30000 ) {
 	} );
 }
 
-function startPhpCli( handle, wordpressDir, port, appDir ) {
+function startPhpCli( handle, wordpressDir, port, appDir, runtimeStateDir ) {
 	const phpBin = resolveExecutable(
 		'CORTEXT_PHP_BIN',
 		path.join( appDir, 'runtime/bin/php' ),
@@ -203,6 +314,14 @@ function startPhpCli( handle, wordpressDir, port, appDir ) {
 	const workers =
 		process.env.CORTEXT_PHP_CLI_SERVER_WORKERS ||
 		process.env.PHP_CLI_SERVER_WORKERS;
+	const phpArgs = [
+		...phpCliIniArgs( wordpressDir, appDir, runtimeStateDir ),
+		'-S',
+		`127.0.0.1:${ port }`,
+		'-t',
+		wordpressDir,
+		routerPath,
+	];
 	const phpEnv = { ...process.env };
 	if ( workers ) {
 		phpEnv.PHP_CLI_SERVER_WORKERS = workers;
@@ -211,7 +330,7 @@ function startPhpCli( handle, wordpressDir, port, appDir ) {
 		handle,
 		'php',
 		phpBin,
-		[ '-S', `127.0.0.1:${ port }`, '-t', wordpressDir, routerPath ],
+		phpArgs,
 		{
 			cwd: wordpressDir,
 			env: phpEnv,
@@ -366,8 +485,10 @@ function startRuntime( {
 		fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-desktop-runtime-' ) );
 	handle.stateDir = stateDir;
 
+	configureObjectCacheDropIn( wordpressDir, appDir );
+
 	if ( normalized === 'php' ) {
-		startPhpCli( handle, wordpressDir, port, appDir );
+		startPhpCli( handle, wordpressDir, port, appDir, stateDir );
 	} else if ( normalized === 'franken' ) {
 		startFrankenPhp( handle, wordpressDir, port, appDir );
 	} else if ( normalized === 'php-fpm' ) {

--- a/apps/desktop/runtime/mu-plugins/cortext-runtime-probe.php
+++ b/apps/desktop/runtime/mu-plugins/cortext-runtime-probe.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Plugin Name: Cortext desktop runtime probe
+ * Description: Reports local php -S runtime tuning state.
+ *
+ * @package Cortext
+ */
+
+if ( getenv( 'CORTEXT_DESKTOP_RUNTIME_PROBE' ) !== '1' ) {
+	return;
+}
+
+function cortext_desktop_probe_ini_bool( string $name ): bool {
+	return in_array( strtolower( (string) ini_get( $name ) ), array( '1', 'on', 'true', 'yes' ), true );
+}
+
+function cortext_desktop_probe_count_files( string $dir ): int {
+	if ( $dir === '' || ! is_dir( $dir ) ) {
+		return 0;
+	}
+
+	$count = 0;
+	$files = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $dir, FilesystemIterator::SKIP_DOTS )
+	);
+
+	foreach ( $files as $file ) {
+		if ( $file->isFile() ) {
+			++$count;
+		}
+	}
+
+	return $count;
+}
+
+function cortext_desktop_probe_opcache(): array {
+	$file_cache = (string) ini_get( 'opcache.file_cache' );
+	$status     = function_exists( 'opcache_get_status' )
+		? @opcache_get_status( false )
+		: false;
+	$marker     = getenv( 'CORTEXT_DESKTOP_PRELOAD_MARKER' ) ?: '';
+	$preload    = null;
+
+	if ( $marker && is_readable( $marker ) ) {
+		$preload = json_decode( (string) file_get_contents( $marker ), true );
+	}
+
+	return array(
+		'extension_loaded'         => extension_loaded( 'Zend OPcache' ),
+		'enable'                   => cortext_desktop_probe_ini_bool( 'opcache.enable' ),
+		'enable_cli'               => cortext_desktop_probe_ini_bool( 'opcache.enable_cli' ),
+		'validate_timestamps'      => cortext_desktop_probe_ini_bool( 'opcache.validate_timestamps' ),
+		'file_cache'               => $file_cache,
+		'file_cache_files'         => cortext_desktop_probe_count_files( $file_cache ),
+		'preload'                  => (string) ini_get( 'opcache.preload' ),
+		'preload_marker'           => $preload,
+		'jit'                      => (string) ini_get( 'opcache.jit' ),
+		'jit_buffer_size'          => (string) ini_get( 'opcache.jit_buffer_size' ),
+		'status_available'         => is_array( $status ),
+		'opcache_enabled'          => is_array( $status ) ? (bool) ( $status['opcache_enabled'] ?? false ) : false,
+		'cached_scripts'           => is_array( $status ) ? (int) ( $status['opcache_statistics']['num_cached_scripts'] ?? 0 ) : 0,
+		'jit_enabled'              => is_array( $status ) ? (bool) ( $status['jit']['enabled'] ?? false ) : false,
+		'jit_on'                   => is_array( $status ) ? (bool) ( $status['jit']['on'] ?? false ) : false,
+		'jit_buffer_used'          => is_array( $status ) ? (int) ( $status['jit']['buffer_used'] ?? 0 ) : 0,
+	);
+}
+
+function cortext_desktop_probe_apcu(): array {
+	$key             = 'cortext_desktop_runtime_probe_' . md5( ABSPATH );
+	$previous_found  = false;
+	$previous_value  = false;
+	$current_value   = uniqid( 'probe_', true );
+	$store_succeeded = false;
+
+	if ( function_exists( 'apcu_fetch' ) ) {
+		$previous_value = apcu_fetch( $key, $previous_found );
+	}
+	if ( function_exists( 'apcu_store' ) ) {
+		$store_succeeded = apcu_store( $key, $current_value, 300 );
+	}
+
+	return array(
+		'extension_loaded'      => extension_loaded( 'apcu' ),
+		'apc_enabled'           => cortext_desktop_probe_ini_bool( 'apc.enabled' ),
+		'apc_enable_cli'        => cortext_desktop_probe_ini_bool( 'apc.enable_cli' ),
+		'functions_available'   => function_exists( 'apcu_fetch' ) && function_exists( 'apcu_store' ),
+		'store_succeeded'       => (bool) $store_succeeded,
+		'previous_value_found'  => (bool) $previous_found,
+		'previous_value_sample' => $previous_found ? (string) $previous_value : null,
+	);
+}
+
+function cortext_desktop_probe_object_cache(): array {
+	global $wp_object_cache;
+
+	$found          = false;
+	$key            = 'runtime_probe';
+	$group          = 'cortext_desktop_probe';
+	$previous_value = wp_cache_get( $key, $group, false, $found );
+	$current_value  = uniqid( 'wp_cache_', true );
+	$set_succeeded  = wp_cache_set( $key, $current_value, $group, 300 );
+	$stats          = method_exists( $wp_object_cache, 'cortext_stats' )
+		? $wp_object_cache->cortext_stats()
+		: null;
+
+	return array(
+		'using_external_object_cache' => wp_using_ext_object_cache(),
+		'class'                       => is_object( $wp_object_cache ) ? get_class( $wp_object_cache ) : null,
+		'set_succeeded'               => (bool) $set_succeeded,
+		'previous_value_found'        => (bool) $found,
+		'previous_value_sample'       => $found ? (string) $previous_value : null,
+		'stats'                       => $stats,
+	);
+}
+
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'cortext-desktop/v1',
+			'/runtime-probe',
+			array(
+				'methods'             => 'GET',
+				'permission_callback' => '__return_true',
+				'callback'            => function () {
+					return rest_ensure_response(
+						array(
+							'php'          => array(
+								'version'  => PHP_VERSION,
+								'sapi'     => PHP_SAPI,
+								'binary'   => PHP_BINARY,
+								'pid'      => getmypid(),
+								'pcre_jit' => cortext_desktop_probe_ini_bool( 'pcre.jit' ),
+							),
+							'opcache'      => cortext_desktop_probe_opcache(),
+							'apcu'         => cortext_desktop_probe_apcu(),
+							'object_cache' => cortext_desktop_probe_object_cache(),
+						)
+					);
+				},
+			)
+		);
+	}
+);

--- a/apps/desktop/runtime/mu-plugins/cortext-timing.php
+++ b/apps/desktop/runtime/mu-plugins/cortext-timing.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Cortext desktop timing
- * Description: Adds Server-Timing to desktop runtime responses for local spike measurements.
+ * Description: Adds Server-Timing to desktop runtime responses for local measurements.
  *
  * @package Cortext
  */

--- a/apps/desktop/runtime/object-cache-apcu.php
+++ b/apps/desktop/runtime/object-cache-apcu.php
@@ -1,0 +1,495 @@
+<?php
+/**
+ * Cortext Desktop APCu object-cache exploration drop-in.
+ *
+ * This file is copied into wp-content/object-cache.php only when the Desktop
+ * runtime starts with CORTEXT_DESKTOP_OBJECT_CACHE=apcu.
+ *
+ * @package Cortext
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function wp_cache_init() {
+	$GLOBALS['wp_object_cache'] = new Cortext_Desktop_APCu_Object_Cache();
+}
+
+function wp_cache_add( $key, $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->add( $key, $data, $group, (int) $expire );
+}
+
+function wp_cache_add_multiple( array $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->add_multiple( $data, $group, (int) $expire );
+}
+
+function wp_cache_replace( $key, $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->replace( $key, $data, $group, (int) $expire );
+}
+
+function wp_cache_set( $key, $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->set( $key, $data, $group, (int) $expire );
+}
+
+function wp_cache_set_multiple( array $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+	return $wp_object_cache->set_multiple( $data, $group, (int) $expire );
+}
+
+function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
+	global $wp_object_cache;
+	return $wp_object_cache->get( $key, $group, $force, $found );
+}
+
+function wp_cache_get_multiple( $keys, $group = '', $force = false ) {
+	global $wp_object_cache;
+	return $wp_object_cache->get_multiple( $keys, $group, $force );
+}
+
+function wp_cache_delete( $key, $group = '' ) {
+	global $wp_object_cache;
+	return $wp_object_cache->delete( $key, $group );
+}
+
+function wp_cache_delete_multiple( array $keys, $group = '' ) {
+	global $wp_object_cache;
+	return $wp_object_cache->delete_multiple( $keys, $group );
+}
+
+function wp_cache_incr( $key, $offset = 1, $group = '' ) {
+	global $wp_object_cache;
+	return $wp_object_cache->incr( $key, $offset, $group );
+}
+
+function wp_cache_decr( $key, $offset = 1, $group = '' ) {
+	global $wp_object_cache;
+	return $wp_object_cache->decr( $key, $offset, $group );
+}
+
+function wp_cache_flush() {
+	global $wp_object_cache;
+	return $wp_object_cache->flush();
+}
+
+function wp_cache_flush_runtime() {
+	global $wp_object_cache;
+	return $wp_object_cache->flush_runtime();
+}
+
+function wp_cache_flush_group( $group ) {
+	global $wp_object_cache;
+	return $wp_object_cache->flush_group( $group );
+}
+
+function wp_cache_supports( $feature ) {
+	global $wp_object_cache;
+	return is_object( $wp_object_cache ) && $wp_object_cache->supports( $feature );
+}
+
+function wp_cache_close() {
+	return true;
+}
+
+function wp_cache_add_global_groups( $groups ) {
+	global $wp_object_cache;
+	$wp_object_cache->add_global_groups( $groups );
+}
+
+function wp_cache_add_non_persistent_groups( $groups ) {
+	global $wp_object_cache;
+	$wp_object_cache->add_non_persistent_groups( $groups );
+}
+
+function wp_cache_switch_to_blog( $blog_id ) {
+	global $wp_object_cache;
+	$wp_object_cache->switch_to_blog( $blog_id );
+}
+
+function wp_cache_reset() {
+	global $wp_object_cache;
+	return $wp_object_cache->reset();
+}
+
+#[AllowDynamicProperties]
+class Cortext_Desktop_APCu_Object_Cache {
+	private array $cache = array();
+	private array $global_groups = array();
+	private array $non_persistent_groups = array();
+	private string $blog_prefix = '';
+	private string $key_salt = '';
+	private bool $multisite = false;
+	private bool $apcu_available = false;
+
+	public int $cache_hits = 0;
+	public int $cache_misses = 0;
+	private int $apcu_hits = 0;
+	private int $apcu_misses = 0;
+	private int $apcu_sets = 0;
+	private int $apcu_deletes = 0;
+
+	public function __construct() {
+		$this->multisite      = function_exists( 'is_multisite' ) && is_multisite();
+		$this->blog_prefix    = $this->multisite && function_exists( 'get_current_blog_id' )
+			? get_current_blog_id() . ':'
+			: '';
+		$this->key_salt       = 'cortext-desktop:' . md5( ABSPATH ) . ':';
+		$this->apcu_available = function_exists( 'apcu_fetch' )
+			&& function_exists( 'apcu_store' )
+			&& filter_var( ini_get( 'apc.enabled' ), FILTER_VALIDATE_BOOLEAN );
+	}
+
+	public function __get( $name ) {
+		return $this->$name;
+	}
+
+	public function __set( $name, $value ): void {
+		$this->$name = $value;
+	}
+
+	public function __isset( $name ): bool {
+		return isset( $this->$name );
+	}
+
+	public function __unset( $name ): void {
+		unset( $this->$name );
+	}
+
+	public function add( $key, $data, $group = 'default', $expire = 0 ): bool {
+		if ( function_exists( 'wp_suspend_cache_addition' ) && wp_suspend_cache_addition() ) {
+			return false;
+		}
+
+		$prepared = $this->prepare_key( $key, $group );
+		if ( ! $prepared ) {
+			return false;
+		}
+
+		list( $id, $group ) = $prepared;
+
+		if ( $this->exists_local( $id, $group ) ) {
+			return false;
+		}
+
+		if ( $this->is_persistent_group( $group ) && $this->apcu_available ) {
+			$stored = apcu_add( $this->apcu_key( $id, $group ), $this->clone_for_storage( $data ), max( 0, (int) $expire ) );
+			if ( ! $stored ) {
+				return false;
+			}
+			++$this->apcu_sets;
+		}
+
+		$this->cache[ $group ][ $id ] = $this->clone_for_storage( $data );
+		return true;
+	}
+
+	public function add_multiple( array $data, $group = '', $expire = 0 ): array {
+		$values = array();
+		foreach ( $data as $key => $value ) {
+			$values[ $key ] = $this->add( $key, $value, $group, $expire );
+		}
+		return $values;
+	}
+
+	public function replace( $key, $data, $group = 'default', $expire = 0 ): bool {
+		$found = false;
+		$this->get( $key, $group, true, $found );
+		if ( ! $found ) {
+			return false;
+		}
+		return $this->set( $key, $data, $group, $expire );
+	}
+
+	public function set( $key, $data, $group = 'default', $expire = 0 ): bool {
+		$prepared = $this->prepare_key( $key, $group );
+		if ( ! $prepared ) {
+			return false;
+		}
+
+		list( $id, $group ) = $prepared;
+		$value              = $this->clone_for_storage( $data );
+
+		if ( $this->is_persistent_group( $group ) && $this->apcu_available ) {
+			if ( apcu_store( $this->apcu_key( $id, $group ), $value, max( 0, (int) $expire ) ) ) {
+				++$this->apcu_sets;
+			}
+		}
+
+		$this->cache[ $group ][ $id ] = $value;
+		return true;
+	}
+
+	public function set_multiple( array $data, $group = '', $expire = 0 ): array {
+		$values = array();
+		foreach ( $data as $key => $value ) {
+			$values[ $key ] = $this->set( $key, $value, $group, $expire );
+		}
+		return $values;
+	}
+
+	public function get( $key, $group = 'default', $force = false, &$found = null ) {
+		$prepared = $this->prepare_key( $key, $group );
+		if ( ! $prepared ) {
+			$found = false;
+			return false;
+		}
+
+		list( $id, $group ) = $prepared;
+
+		$can_force_persistent = $force && $this->is_persistent_group( $group ) && $this->apcu_available;
+		if ( ! $can_force_persistent && $this->exists_local( $id, $group ) ) {
+			$found = true;
+			++$this->cache_hits;
+			return $this->clone_for_return( $this->cache[ $group ][ $id ] );
+		}
+
+		if ( $this->is_persistent_group( $group ) && $this->apcu_available ) {
+			$success = false;
+			$value   = apcu_fetch( $this->apcu_key( $id, $group ), $success );
+			if ( $success ) {
+				$found                       = true;
+				$this->cache[ $group ][ $id ] = $value;
+				++$this->cache_hits;
+				++$this->apcu_hits;
+				return $this->clone_for_return( $value );
+			}
+			++$this->apcu_misses;
+		}
+
+		$found = false;
+		++$this->cache_misses;
+		return false;
+	}
+
+	public function get_multiple( $keys, $group = 'default', $force = false ): array {
+		$values = array();
+		foreach ( $keys as $key ) {
+			$values[ $key ] = $this->get( $key, $group, $force );
+		}
+		return $values;
+	}
+
+	public function delete( $key, $group = 'default' ): bool {
+		$prepared = $this->prepare_key( $key, $group );
+		if ( ! $prepared ) {
+			return false;
+		}
+
+		list( $id, $group ) = $prepared;
+		$deleted            = false;
+
+		if ( $this->exists_local( $id, $group ) ) {
+			unset( $this->cache[ $group ][ $id ] );
+			$deleted = true;
+		}
+
+		if ( $this->is_persistent_group( $group ) && $this->apcu_available ) {
+			$deleted = apcu_delete( $this->apcu_key( $id, $group ) ) || $deleted;
+			++$this->apcu_deletes;
+		}
+
+		return $deleted;
+	}
+
+	public function delete_multiple( array $keys, $group = '' ): array {
+		$values = array();
+		foreach ( $keys as $key ) {
+			$values[ $key ] = $this->delete( $key, $group );
+		}
+		return $values;
+	}
+
+	public function incr( $key, $offset = 1, $group = 'default' ) {
+		return $this->change_counter( $key, (int) $offset, $group );
+	}
+
+	public function decr( $key, $offset = 1, $group = 'default' ) {
+		return $this->change_counter( $key, -1 * (int) $offset, $group );
+	}
+
+	public function flush(): bool {
+		$this->cache = array();
+		if ( $this->apcu_available ) {
+			return apcu_clear_cache();
+		}
+		return true;
+	}
+
+	public function flush_runtime(): bool {
+		$this->cache = array();
+		return true;
+	}
+
+	public function flush_group( $group ): bool {
+		$group = $this->normalize_group( $group );
+		unset( $this->cache[ $group ] );
+
+		if ( ! $this->apcu_available || ! class_exists( 'APCUIterator' ) ) {
+			return true;
+		}
+
+		foreach ( new APCUIterator( '/^' . preg_quote( $this->key_salt . $group . ':', '/' ) . '/' ) as $item ) {
+			if ( isset( $item['key'] ) ) {
+				apcu_delete( $item['key'] );
+			}
+		}
+
+		return true;
+	}
+
+	public function supports( $feature ): bool {
+		return in_array(
+			$feature,
+			array( 'add_multiple', 'set_multiple', 'get_multiple', 'delete_multiple', 'flush_runtime', 'flush_group' ),
+			true
+		);
+	}
+
+	public function add_global_groups( $groups ): void {
+		foreach ( (array) $groups as $group ) {
+			$this->global_groups[ (string) $group ] = true;
+		}
+	}
+
+	public function add_non_persistent_groups( $groups ): void {
+		foreach ( (array) $groups as $group ) {
+			$this->non_persistent_groups[ (string) $group ] = true;
+		}
+	}
+
+	public function switch_to_blog( $blog_id ): void {
+		$this->blog_prefix = $this->multisite ? (int) $blog_id . ':' : '';
+	}
+
+	public function reset(): bool {
+		foreach ( array_keys( $this->cache ) as $group ) {
+			if ( ! isset( $this->global_groups[ $group ] ) ) {
+				unset( $this->cache[ $group ] );
+			}
+		}
+		return true;
+	}
+
+	public function cortext_stats(): array {
+		return array(
+			'apcu_available'        => $this->apcu_available,
+			'cache_hits'            => $this->cache_hits,
+			'cache_misses'          => $this->cache_misses,
+			'apcu_hits'             => $this->apcu_hits,
+			'apcu_misses'           => $this->apcu_misses,
+			'apcu_sets'             => $this->apcu_sets,
+			'apcu_deletes'          => $this->apcu_deletes,
+			'groups_in_runtime'     => count( $this->cache ),
+			'non_persistent_groups' => array_keys( $this->non_persistent_groups ),
+		);
+	}
+
+	private function prepare_key( $key, $group ): array|false {
+		if ( ! is_int( $key ) && ( ! is_string( $key ) || trim( $key ) === '' ) ) {
+			return false;
+		}
+
+		$group = $this->normalize_group( $group );
+		$id    = (string) $key;
+
+		if ( $this->multisite && ! isset( $this->global_groups[ $group ] ) ) {
+			$id = $this->blog_prefix . $id;
+		}
+
+		return array( $id, $group );
+	}
+
+	private function normalize_group( $group ): string {
+		$group = (string) $group;
+		return $group === '' ? 'default' : $group;
+	}
+
+	private function is_persistent_group( string $group ): bool {
+		return ! isset( $this->non_persistent_groups[ $group ] );
+	}
+
+	private function exists_local( string $id, string $group ): bool {
+		return isset( $this->cache[ $group ] )
+			&& ( isset( $this->cache[ $group ][ $id ] ) || array_key_exists( $id, $this->cache[ $group ] ) );
+	}
+
+	private function change_counter( $key, int $offset, $group = 'default' ) {
+		$prepared = $this->prepare_key( $key, $group );
+		if ( ! $prepared ) {
+			return false;
+		}
+
+		list( $id, $group ) = $prepared;
+
+		if ( $this->is_persistent_group( $group ) && $this->apcu_available && function_exists( 'apcu_cas' ) ) {
+			return $this->change_persistent_counter( $id, $group, $offset );
+		}
+
+		return $this->change_local_counter( $id, $group, $offset );
+	}
+
+	private function change_local_counter( string $id, string $group, int $offset ) {
+		if ( ! $this->exists_local( $id, $group ) ) {
+			return false;
+		}
+
+		$value                       = $this->cache[ $group ][ $id ];
+		$value                       = is_numeric( $value ) ? (int) $value : 0;
+		$value                       = max( 0, $value + $offset );
+		$this->cache[ $group ][ $id ] = $value;
+		return $value;
+	}
+
+	private function change_persistent_counter( string $id, string $group, int $offset ) {
+		$apcu_key = $this->apcu_key( $id, $group );
+
+		for ( $attempt = 0; $attempt < 50; ++$attempt ) {
+			$found = false;
+			$value = apcu_fetch( $apcu_key, $found );
+			if ( ! $found ) {
+				unset( $this->cache[ $group ][ $id ] );
+				return false;
+			}
+
+			$current = is_numeric( $value ) ? (int) $value : 0;
+			$next    = max( 0, $current + $offset );
+
+			if ( ! is_int( $value ) ) {
+				if ( ! apcu_store( $apcu_key, $next ) ) {
+					return false;
+				}
+				$this->cache[ $group ][ $id ] = $next;
+				++$this->cache_hits;
+				++$this->apcu_hits;
+				++$this->apcu_sets;
+				return $next;
+			}
+
+			if ( apcu_cas( $apcu_key, $current, $next ) ) {
+				$this->cache[ $group ][ $id ] = $next;
+				++$this->cache_hits;
+				++$this->apcu_hits;
+				++$this->apcu_sets;
+				return $next;
+			}
+		}
+
+		return false;
+	}
+
+	private function apcu_key( string $id, string $group ): string {
+		return $this->key_salt . $group . ':' . md5( $id );
+	}
+
+	private function clone_for_storage( $value ) {
+		return is_object( $value ) ? clone $value : $value;
+	}
+
+	private function clone_for_return( $value ) {
+		return is_object( $value ) ? clone $value : $value;
+	}
+}

--- a/apps/desktop/runtime/preload-manifest.php
+++ b/apps/desktop/runtime/preload-manifest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * PHP files to compile during the Desktop OPcache preload exploration.
+ *
+ * Avoid bootstrap files such as wp-config.php, wp-load.php, and
+ * wp-settings.php. This list should compile definitions without running
+ * WordPress startup side effects.
+ *
+ * @package Cortext
+ */
+
+return array(
+	'wp-content/plugins/cortext/includes/Plugin.php',
+	'wp-content/plugins/cortext/includes/Documents.php',
+	'wp-content/plugins/cortext/includes/Relations.php',
+	'wp-content/plugins/cortext/includes/Block/DataView.php',
+	'wp-content/plugins/cortext/includes/Rest/CollectionsController.php',
+	'wp-content/plugins/cortext/includes/Rest/DocumentsController.php',
+	'wp-content/plugins/cortext/includes/Rest/FieldsController.php',
+	'wp-content/plugins/cortext/includes/Rest/RowsController.php',
+	'wp-content/plugins/cortext/includes/Rest/RowsFilterQuery.php',
+	'wp-content/plugins/cortext/includes/Rest/RowsMetaQuery.php',
+	'wp-content/plugins/cortext/includes/Rest/RowsQueryScope.php',
+	'wp-content/plugins/cortext/includes/Rest/WorkspaceHomeController.php',
+	'wp-content/plugins/cortext/includes/PostType/Collection.php',
+	'wp-content/plugins/cortext/includes/PostType/CollectionEntries.php',
+	'wp-content/plugins/cortext/includes/PostType/DocumentIdentity.php',
+	'wp-content/plugins/cortext/includes/PostType/Field.php',
+	'wp-content/plugins/cortext/includes/PostType/Page.php',
+);

--- a/apps/desktop/runtime/preload.php
+++ b/apps/desktop/runtime/preload.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * OPcache preload entrypoint for the Desktop runtime exploration.
+ *
+ * @package Cortext
+ */
+
+$manifest_path = __DIR__ . '/cortext-preload-manifest.php';
+$compiled      = array();
+$failed        = array();
+
+if ( is_readable( $manifest_path ) && function_exists( 'opcache_compile_file' ) ) {
+	$manifest = require $manifest_path;
+
+	foreach ( $manifest as $relative_path ) {
+		$file = __DIR__ . '/' . ltrim( $relative_path, '/' );
+
+		if ( ! is_readable( $file ) ) {
+			$failed[] = $relative_path;
+			continue;
+		}
+
+		if ( @opcache_compile_file( $file ) ) {
+			$compiled[] = $relative_path;
+		} else {
+			$failed[] = $relative_path;
+		}
+	}
+}
+
+$marker_path = getenv( 'CORTEXT_DESKTOP_PRELOAD_MARKER' ) ?: '';
+if ( $marker_path ) {
+	@file_put_contents(
+		$marker_path,
+		json_encode(
+			array(
+				'manifest'       => basename( $manifest_path ),
+				'compiled_count' => count( $compiled ),
+				'failed_count'   => count( $failed ),
+				'failed'         => $failed,
+				'generated_at'   => gmdate( 'c' ),
+			),
+			JSON_PRETTY_PRINT
+		) . "\n"
+	);
+}

--- a/apps/desktop/runtime/worker.php
+++ b/apps/desktop/runtime/worker.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Experimental FrankenPHP worker for the desktop runtime spike.
+ * Experimental FrankenPHP worker for the desktop runtime exploration.
  *
  * WordPress is not designed as a long-running worker. This file keeps core,
  * plugins, and autoloaders in memory, then re-enters the requested PHP script

--- a/apps/desktop/scripts/build-snapshot.mjs
+++ b/apps/desktop/scripts/build-snapshot.mjs
@@ -231,7 +231,9 @@ cpSync(
 console.log( '[snapshot] Installing Cortext plugin' );
 cpSync( STAGED_PLUGIN, resolve( pluginsDir, 'cortext' ), { recursive: true } );
 
-console.log( '[snapshot] Adding runtime files (router + worker + mu-plugins)' );
+console.log(
+	'[snapshot] Adding runtime files (router + worker + preload + mu-plugins)'
+);
 cpSync(
 	resolve( RUNTIME_DIR, 'router.php' ),
 	resolve( SITE_DIR, 'router.php' )
@@ -239,6 +241,14 @@ cpSync(
 cpSync(
 	resolve( RUNTIME_DIR, 'worker.php' ),
 	resolve( SITE_DIR, 'worker.php' )
+);
+cpSync(
+	resolve( RUNTIME_DIR, 'preload.php' ),
+	resolve( SITE_DIR, 'cortext-preload.php' )
+);
+cpSync(
+	resolve( RUNTIME_DIR, 'preload-manifest.php' ),
+	resolve( SITE_DIR, 'cortext-preload-manifest.php' )
 );
 const muPluginsDest = resolve( SITE_DIR, 'wp-content/mu-plugins' );
 mkdirSync( muPluginsDest, { recursive: true } );
@@ -262,6 +272,30 @@ function wpCli( args ) {
 	);
 }
 
+function snapshotSeedCommands() {
+	const override = process.env.CORTEXT_DESKTOP_SEED_COMMANDS;
+	if ( override?.trim() ) {
+		return override
+			.split( /\r?\n/ )
+			.map( ( command ) => command.trim() )
+			.filter( Boolean );
+	}
+
+	const seedArgs = process.env.CORTEXT_DESKTOP_SEED_ARGS?.trim();
+	const commands = [ `cortext seed${ seedArgs ? ` ${ seedArgs }` : '' }` ];
+	const extra = process.env.CORTEXT_DESKTOP_EXTRA_SEED_COMMANDS;
+	if ( extra?.trim() ) {
+		commands.push(
+			...extra
+				.split( /\r?\n/ )
+				.map( ( command ) => command.trim() )
+				.filter( Boolean )
+		);
+	}
+
+	return commands;
+}
+
 console.log( '[snapshot] Installing WordPress' );
 wpCli(
 	'core install ' +
@@ -277,7 +311,10 @@ console.log( '[snapshot] Activating Cortext' );
 wpCli( 'plugin activate cortext' );
 
 console.log( '[snapshot] Seeding sample content' );
-wpCli( 'cortext seed' );
+for ( const seedCommand of snapshotSeedCommands() ) {
+	console.log( `[snapshot] Running seed command: wp ${ seedCommand }` );
+	wpCli( seedCommand );
+}
 
 console.log( '[snapshot] Zipping site' );
 rmSync( OUTFILE, { force: true } );

--- a/apps/desktop/scripts/install-runtime.mjs
+++ b/apps/desktop/scripts/install-runtime.mjs
@@ -23,7 +23,21 @@ const FRANKENPHP_VERSION =
 	process.env.CORTEXT_FRANKENPHP_VERSION || 'v1.12.2';
 const CADDY_VERSION = process.env.CORTEXT_CADDY_VERSION || '2.11.3';
 
-const PHP_EXTENSIONS = [
+function isEnabled( value ) {
+	return [ '1', 'true', 'yes', 'on' ].includes(
+		String( value || '' ).toLowerCase()
+	);
+}
+
+const PHP_EXPERIMENTAL = isEnabled(
+	process.env.CORTEXT_STATIC_PHP_EXPERIMENTAL
+);
+const PHP_WITH_APCU =
+	PHP_EXPERIMENTAL || isEnabled( process.env.CORTEXT_STATIC_PHP_APCU );
+const PHP_WITH_JIT =
+	PHP_EXPERIMENTAL || isEnabled( process.env.CORTEXT_STATIC_PHP_JIT );
+
+const BASE_PHP_EXTENSIONS = [
 	'opcache',
 	'pdo',
 	'pdo_sqlite',
@@ -51,6 +65,14 @@ const PHP_EXTENSIONS = [
 	'calendar',
 	'exif',
 ];
+
+function phpExtensions() {
+	const extensions = [ ...BASE_PHP_EXTENSIONS ];
+	if ( PHP_WITH_APCU ) {
+		extensions.push( 'apcu' );
+	}
+	return extensions;
+}
 
 function readOptions() {
 	const options = {
@@ -82,7 +104,7 @@ function readOptions() {
 function platformKey() {
 	if ( process.platform !== 'darwin' ) {
 		throw new Error(
-			`Only macOS runtime artifacts are supported by this spike script. Current platform: ${ process.platform }.`
+			`Only macOS runtime artifacts are supported by this exploration script. Current platform: ${ process.platform }.`
 		);
 	}
 	if ( process.arch === 'arm64' ) {
@@ -232,7 +254,7 @@ function verifyPhp( phpBin ) {
 	const modules = output( phpBin, [ '-m' ] )
 		.split( '\n' )
 		.map( ( module ) => module.trim().toLowerCase() );
-	for ( const required of [
+	const requiredModules = [
 		'pdo',
 		'pdo_sqlite',
 		'sqlite3',
@@ -254,11 +276,35 @@ function verifyPhp( phpBin ) {
 		'ctype',
 		'iconv',
 		'zend opcache',
-	] ) {
+	];
+
+	if ( PHP_WITH_APCU ) {
+		requiredModules.push( 'apcu' );
+	}
+
+	for ( const required of requiredModules ) {
 		if ( ! modules.includes( required ) ) {
 			throw new Error( `Bundled PHP is missing required module: ${ required }` );
 		}
 	}
+
+	if ( PHP_WITH_JIT ) {
+		const jit = output( phpBin, [
+			'-d',
+			'opcache.enable_cli=1',
+			'-d',
+			'opcache.jit_buffer_size=16M',
+			'-d',
+			'opcache.jit=tracing',
+			'-r',
+			"echo json_encode(opcache_get_status(false)['jit'] ?? null);",
+		] );
+		const parsed = JSON.parse( jit || 'null' );
+		if ( ! parsed || parsed.enabled !== true ) {
+			throw new Error( 'Bundled PHP did not report enabled OPcache JIT.' );
+		}
+	}
+
 	console.log( output( phpBin, [ '-v' ] ).split( '\n' )[0] );
 }
 
@@ -285,7 +331,22 @@ async function installPhp( options ) {
 	}
 
 	if ( ! existsSync( builtPhp ) || options.rebuild ) {
-		const extensionList = PHP_EXTENSIONS.join( ',' );
+		const extensionList = phpExtensions().join( ',' );
+		const buildArgs = [ 'build', extensionList, '--build-cli' ];
+
+		if ( ! PHP_WITH_JIT ) {
+			buildArgs.push( '--disable-opcache-jit' );
+		}
+
+		buildArgs.push(
+			'-I',
+			'opcache.enable_cli=1',
+			'-I',
+			'opcache.validate_timestamps=0',
+			'-I',
+			'pcre.jit=1'
+		);
+
 		run(
 			spcBin,
 			[
@@ -298,20 +359,7 @@ async function installPhp( options ) {
 			{ cwd: spcDir }
 		);
 		run( spcBin, [ 'switch-php-version', PHP_VERSION ], { cwd: spcDir } );
-		run(
-			spcBin,
-			[
-				'build',
-				extensionList,
-				'--build-cli',
-				'--disable-opcache-jit',
-				'-I',
-				'opcache.enable_cli=1',
-				'-I',
-				'opcache.validate_timestamps=0',
-			],
-			{ cwd: spcDir }
-		);
+		run( spcBin, buildArgs, { cwd: spcDir } );
 	}
 
 	installExecutable( builtPhp, dest, true );

--- a/docs/explorations/desktop-php-s-optimization.md
+++ b/docs/explorations/desktop-php-s-optimization.md
@@ -1,0 +1,510 @@
+# Exploration: Desktop `php -S` optimization
+
+Issue: #205
+
+This exploration keeps the Desktop runtime on `php -S` and adds opt-in hooks
+for the runtime ideas from #205: APCu-backed object cache, OPcache file cache,
+preload, JIT, and PCRE JIT. None of these change the default runtime unless the
+matching environment flag is set.
+
+## Runtime flags
+
+Baseline command used for most runs:
+
+```sh
+CORTEXT_RUNTIME=php \
+CORTEXT_PHP_BIN=apps/desktop/runtime/bin/php \
+CORTEXT_PHP_CLI_SERVER_WORKERS=4 \
+npm --prefix apps/desktop start
+```
+
+Runtime flags used in this exploration:
+
+- `CORTEXT_PHP_OPCACHE_FILE_CACHE=1`: starts `php -S` with
+  `opcache.file_cache` under the runtime state directory.
+- `CORTEXT_PHP_PRELOAD=1`: starts `php -S` with
+  `opcache.preload=<site>/cortext-preload.php`.
+- `CORTEXT_PHP_JIT=1`: enables OPcache JIT for the process with
+  `opcache.jit=tracing` and `opcache.jit_buffer_size=64M` unless overridden
+  by `CORTEXT_PHP_JIT_MODE` or `CORTEXT_PHP_JIT_BUFFER_SIZE`.
+- `CORTEXT_DESKTOP_OBJECT_CACHE=apcu`: copies the APCu exploration
+  `object-cache.php` drop-in into the runtime site before PHP starts. When
+  unset, the runtime removes this drop-in if it previously copied it.
+- `CORTEXT_DESKTOP_RUNTIME_PROBE=1`: exposes
+  `/?rest_route=/cortext-desktop/v1/runtime-probe` for engagement checks.
+
+Build the local PHP bundle with APCu and JIT support:
+
+```sh
+CORTEXT_STATIC_PHP_EXPERIMENTAL=1 npm --prefix apps/desktop run runtime:php -- --force --rebuild
+```
+
+Narrower build flags:
+
+- `CORTEXT_STATIC_PHP_APCU=1`: include APCu.
+- `CORTEXT_STATIC_PHP_JIT=1`: keep OPcache JIT support instead of building
+  with `--disable-opcache-jit`.
+
+## Engagement checks
+
+Run with `CORTEXT_DESKTOP_RUNTIME_PROBE=1`, then fetch:
+
+```sh
+curl -s 'http://127.0.0.1:9402/?rest_route=/cortext-desktop/v1/runtime-probe'
+```
+
+The probe should show:
+
+- File cache: `opcache.file_cache` is non-empty and
+  `opcache.file_cache_files > 0` after warmup.
+- Preload: `opcache.preload` points at `cortext-preload.php`, and
+  `opcache.preload_marker.compiled_count > 0`.
+- APCu: `apcu.extension_loaded`, `apcu.apc_enabled`,
+  `apcu.apc_enable_cli`, and `apcu.store_succeeded` are true.
+- Object cache: `object_cache.using_external_object_cache` is true and
+  `object_cache.class` is `Cortext_Desktop_APCu_Object_Cache`.
+- JIT: `opcache.jit_enabled` is true and `opcache.jit_buffer_used > 0`
+  after warmup.
+- PCRE JIT: `php.pcre_jit` is true.
+
+For APCu/object-cache persistence, call the probe twice. The second response
+should report `apcu.previous_value_found=true` and
+`object_cache.previous_value_found=true`.
+
+## Benchmark matrix
+
+Restore the archived workflow benches into `.context/` before running:
+
+```sh
+cp /Users/priethor/conductor/archived-contexts/cortext/beirut/bench-desktop-library-workflow.cjs .context/
+cp /Users/priethor/conductor/archived-contexts/cortext/beirut/bench-desktop-e2e.cjs .context/
+```
+
+The current workspace has those copies at:
+
+- `.context/bench-desktop-library-workflow.cjs`
+- `.context/bench-desktop-e2e.cjs`
+
+Run useful variants with:
+
+```sh
+npm --prefix apps/desktop run bench:runtime -- --runtime=php --iterations=50 --warmup=10 --label=<variant>
+node .context/bench-desktop-library-workflow.cjs 5 <variant>
+node .context/bench-desktop-e2e.cjs 5 <variant>
+```
+
+Suggested variants:
+
+| Variant | Extra environment |
+| --- | --- |
+| `baseline-static-workers4` | `CORTEXT_PHP_CLI_SERVER_WORKERS=4` |
+| `file-cache-workers4` | baseline + `CORTEXT_PHP_OPCACHE_FILE_CACHE=1` |
+| `apcu-bundle-no-features-workers4` | rebuilt PHP only, no feature flags |
+| `object-cache-workers4` | rebuilt PHP + `CORTEXT_DESKTOP_OBJECT_CACHE=apcu` |
+| `preload-workers4` | baseline + `CORTEXT_PHP_PRELOAD=1` |
+| `jit-workers4` | rebuilt PHP + `CORTEXT_PHP_JIT=1` |
+| `composed-workers4` | only the variants that pass the decision thresholds |
+
+## Decision thresholds
+
+- Keep object cache if it gets the Library workflow under 1.5s p50, or close
+  enough to be worth keeping.
+- Keep `opcache.file_cache` if cold launch improves by more than 100ms.
+- Keep preload only if it still adds more than 5ms p50 after object cache and
+  file cache.
+- Keep JIT only if DataView endpoints improve by more than 5% and add less
+  than 300MB total RSS.
+- If the composed result still leaves the Library workflow above 1.5s p50,
+  reopen the worker-runtime investigation with this better baseline.
+
+## Results log
+
+Prior baseline from PR #203:
+
+| Runtime | Workers | Total to opened row p50 | p95 | Open Library p50 | Open row p50 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Bundled PHP, `php -S` | 2 | 3029.6 ms | 3583.5 ms | 1137.3 ms | 474.1 ms |
+| Bundled PHP, `php -S` | 4 | 2996.7 ms | 3182.6 ms | 1198.8 ms | 340.9 ms |
+| Bundled PHP, `php -S` | 8 | 2818.5 ms | 3435.0 ms | 1114.0 ms | 308.6 ms |
+| FrankenPHP worker | n/a | 2832.6 ms | 3253.7 ms | 1108.2 ms | 346.3 ms |
+
+Local bundled PHP matrix from 2026-05-18, using 4 PHP CLI server workers. Every
+row forces `apps/desktop/runtime/bin/php`; none of these numbers use the
+Homebrew/system PHP.
+
+Artifacts:
+
+- `.context/bench-results/*-http.json`
+- `.context/bench-results/*-library.json`
+- `.context/bench-results/*-e2e.json`
+- `.context/bench-results/engagement-*.json`
+- `.context/bench-results/rss-*.json`
+- `.context/bench-results/summary.json`
+
+| Variant | DataView HTTP avg p50 | Launch p50 | Open Library p50 | Open row p50 | Total to row p50 | Total to row p95 | RSS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Baseline static bundle | 54.6 ms | 1440.8 ms | 1213.5 ms | 323.0 ms | 2989.4 ms | 3454.5 ms | n/a |
+| `opcache.file_cache` | 57.2 ms | 1288.0 ms | 1215.1 ms | 761.7 ms | 3147.6 ms | 4387.4 ms | n/a |
+| `opcache.preload` | 57.6 ms | 1471.4 ms | failed | failed | failed | failed | n/a |
+| APCu/JIT-capable bundle, no flags | 52.1 ms | 1320.1 ms | 1302.0 ms | 375.3 ms | 3184.4 ms | 3355.8 ms | 181.5 MB |
+| APCu object cache | 16.5 ms | 2610.9 ms | 673.3 ms | 272.7 ms | 3551.1 ms | 3628.4 ms | 182.7 MB |
+| JIT | 36.5 ms | 1535.6 ms | 1182.0 ms | 205.1 ms | 2876.9 ms | 3620.7 ms | 227.5 MB |
+| File cache + object cache + JIT | 14.6 ms | 2426.0 ms | 682.8 ms | 265.7 ms | 3405.6 ms | 3440.5 ms | 135.9 MB |
+
+## Engagement log
+
+Engagement checks came from the runtime probe against the bundled PHP 8.5.6
+APCu/JIT-capable binary:
+
+- File cache: `opcache.file_cache` pointed at the runtime state directory and
+  `opcache.file_cache_files=490`.
+- Preload: `opcache.preload` pointed at `cortext-preload.php`, with
+  `preload_compiled_count=32` and `preload_failed_count=0`.
+- APCu object cache: `apcu.extension_loaded=true`, `apcu.apc_enable_cli=true`,
+  `apcu.store_succeeded=true`,
+  `object_cache.class=Cortext_Desktop_APCu_Object_Cache`, and the second probe
+  returned both APCu and object-cache previous values.
+- JIT: `opcache.jit=tracing`, `opcache.jit_enabled=true`,
+  `opcache.jit_on=true`, and `php.pcre_jit=true`.
+- RSS after a 30x endpoint warmup: APCu/JIT-capable no-flags bundle was
+  181.5 MB; JIT was 227.5 MB, for a +46.0 MB delta.
+
+## First Compact Run
+
+These were the first calls from the compact 5-iteration matrix. The larger seed
+and longer-session runs below are a better basis for the call because they split
+the one-time launch cost from repeated Library/DataView navigation.
+
+- Keep JIT as a candidate. DataView endpoint p50 improved by about 30% versus
+  the APCu/JIT-capable bundle without flags, and RSS stayed well under the
+  +300 MB limit. It also had the best `total_to_row` p50 in this run, though
+  launch-to-shell regressed versus the no-flags APCu/JIT-capable bundle.
+- Do not keep APCu object cache based on this run alone. It cut REST endpoint
+  latency and the Library page hydration time sharply, but launch-to-shell more
+  than erased that win and `total_to_row` stayed above baseline.
+- Do not keep preload from this pass. The engagement check passed, but the
+  Library workflow produced 0/5 usable samples because the Library sidebar item
+  never appeared.
+- Treat `opcache.file_cache` as inconclusive here. Launch p50 improved by
+  152.8 ms, which clears the cold-start threshold in this run, but HTTP and
+  Library workflow p50 regressed and p95 was noisy. It needs a repeat before
+  becoming a default.
+- Do not keep the composed result from this run. It produced the best endpoint
+  p50s but launch-to-shell regressed enough that the Library workflow remained
+  at 3405.6 ms p50.
+
+At this point the best measured `total_to_row` p50 was still 2876.9 ms with
+JIT, well above the 1.5s target. The later runs changed the recommendation.
+
+## Object Cache Break-Even
+
+The 5-iteration UI run was too noisy to make a call on object cache. I repeated
+it with 20 launch/workflow samples and 30 warm-session interactions, still on
+the bundled APCu/JIT-capable PHP binary.
+
+Artifacts:
+
+- `.context/bench-results/apcu-jit-bundle-no-flags-workers4-ui20-library.json`
+- `.context/bench-results/apcu-jit-bundle-no-flags-workers4-ui20-e2e.json`
+- `.context/bench-results/apcu-jit-bundle-no-flags-workers4-warm30.json`
+- `.context/bench-results/apcu-jit-bundle-no-flags-workers4-warm-nav30.json`
+- `.context/bench-results/object-cache-workers4-ui20-library.json`
+- `.context/bench-results/object-cache-workers4-ui20-e2e.json`
+- `.context/bench-results/object-cache-workers4-warm30.json`
+- `.context/bench-results/object-cache-workers4-warm-nav30.json`
+- `.context/bench-results/ui20-warm-object-cache-summary.json`
+
+| Variant | Launch p50 | Open Library p50 | Open row p50 | Total to row p50 | Warm row cycle p50 | Warm return-to-Library p50 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| APCu/JIT-capable bundle, no flags | 1442.3 ms | 1151.1 ms | 473.0 ms | 3091.1 ms | 259.4 ms | 840.7 ms |
+| APCu object cache | 2656.1 ms | 725.9 ms | 286.4 ms | 3706.9 ms | 256.8 ms | 706.0 ms |
+
+Object cache adds about 1213.8 ms to launch p50 in this run. It saves about
+425.2 ms on a fresh Library load and 134.7 ms on a warm return to Library after
+navigating away to the welcome page. Warm row open/close cycles are nearly
+flat: 259.4 ms p50 without object cache and 256.8 ms p50 with object cache.
+
+That makes the tradeoff depend on the session:
+
+- For the first launch-to-row workflow, object cache does not pay for itself:
+  total-to-row is 615.8 ms slower.
+- For repeated Library/DataView page loads, the launch tax breaks even after
+  roughly three fresh Library loads, or roughly ten warm return-to-Library
+  navigations after the app is already open.
+- For repeated row open/close on an already-loaded Library page, there is no
+  win to measure.
+
+This made object cache worth keeping in the investigation, but not enough to
+call it the default yet. The later full/perf seed runs are the stronger signal.
+
+## Deep Navigation Follow-Up
+
+Added `.context/bench-desktop-library-deep-navigation.cjs` to cover an open app
+session closer to normal use:
+
+- open 8 distinct Library rows by title instead of toggling the same row;
+- create one Library row between row navigation and page navigation;
+- navigate 13 distinct sidebar pages, including normal pages plus the Library
+  and Music Catalog DataView pages.
+
+Artifacts:
+
+- `.context/bench-results/apcu-jit-bundle-no-flags-workers4-deep-nav.json`
+- `.context/bench-results/object-cache-workers4-deep-nav.json`
+- `.context/bench-results/deep-nav-summary.json`
+
+| Variant | Launch | First Library | Distinct row p50 | Distinct row p95 | Create row | 13-page nav p50 | 13-page nav p95 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| APCu/JIT-capable bundle, no flags | 1451.7 ms | 1199.4 ms | 331.3 ms | 1002.6 ms | 423.8 ms | 139.8 ms | 1876.3 ms |
+| APCu object cache | 2779.0 ms | 938.5 ms | 355.3 ms | 381.5 ms | 699.5 ms | 537.3 ms | 3159.4 ms |
+
+This compact-seed navigation test still did not justify object cache as a
+default. The larger dataset runs below changed that read: the perf-sized
+Library row path benefits much more from APCu.
+
+## Seed Size and JIT Follow-Up
+
+Added two local helpers for the larger dataset matrix:
+
+- `.context/run-desktop-seed-matrix.sh`
+- `.context/summarize-desktop-seed-matrix.cjs`
+
+The runner restores a saved snapshot before each block and always uses the
+bundled PHP binary with four `php -S` workers. Saved snapshots:
+
+- `.context/snapshots/snapshot-full-seed.zip`
+- `.context/snapshots/snapshot-full-plus-perf-seed.zip`
+
+The full+perf snapshot starts from `wp cortext seed --full`, then adds
+`wp cortext perf-seed --reset --force`, which creates three benchmark
+collections with 1250 rows each.
+
+Artifacts:
+
+- `.context/bench-results/full-seed-*-workers4-*.json`
+- `.context/bench-results/full-perf-seed-*-workers4-*.json`
+- `.context/bench-results/seed-matrix-summary.json`
+
+| Dataset / variant | HTTP avg p50 | Launch p50 | Open Library p50 | Open row p50 | Total to row p50 | Warm return Library p50 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Compact, no flags | 53.5 ms | 1442.3 ms | 1151.1 ms | 473.0 ms | 3091.1 ms | 840.7 ms |
+| Compact, APCu object cache | 18.4 ms | 2656.1 ms | 725.9 ms | 286.4 ms | 3706.9 ms | 706.0 ms |
+| Full, no flags | n/a | 1424.5 ms | 1386.4 ms | 916.3 ms | 4238.8 ms | 1110.2 ms |
+| Full, APCu object cache | n/a | 2657.4 ms | 964.8 ms | 428.3 ms | 4216.6 ms | 1083.6 ms |
+| Full, JIT | 43.2 ms | 1600.7 ms | 1209.3 ms | 415.5 ms | 3359.8 ms | 869.4 ms |
+| Full, APCu object cache + JIT | 19.6 ms | 2868.6 ms | 1079.6 ms | 460.4 ms | 4429.2 ms | 1149.8 ms |
+| Full+perf, no flags | 75.9 ms | 1447.1 ms | 1438.9 ms | 1742.1 ms | 4680.9 ms | 933.1 ms |
+| Full+perf, APCu object cache | 21.7 ms | 2671.0 ms | 996.2 ms | 437.1 ms | 4295.1 ms | 1132.1 ms |
+| Full+perf, JIT | 53.9 ms | 1632.3 ms | 1260.1 ms | 574.0 ms | 3568.4 ms | 1111.7 ms |
+| Full+perf, APCu object cache + JIT | 20.0 ms | 2869.0 ms | 1098.6 ms | 450.4 ms | 4391.5 ms | 1117.4 ms |
+
+The larger datasets changed the read:
+
+- Database size does not move launch much without object cache:
+  compact/full/full+perf stayed around 1.4-1.45s p50.
+- Database size does change Library and row work. Full seed added about
+  1.15s to the launch-to-row workflow versus compact. Adding the perf dataset
+  pushed no-flags row open from 916.3 ms to 1742.1 ms p50.
+- Treat the APCu launch cost as acceptable for the Desktop app. It is paid once
+  per session, while Library/DataView navigation is repeated during normal use.
+- With launch excluded, APCu object cache has the best measured effect on the
+  Library workflow. On full seed, Library+row p50 is 1393.1 ms with APCu
+  versus 2302.7 ms with no flags and 1624.8 ms with JIT. On full+perf seed,
+  Library+row p50 is 1433.2 ms with APCu versus 3180.9 ms with no flags and
+  1834.1 ms with JIT.
+- APCu also gives the fastest endpoint p50s, cuts full+perf row open from
+  1742.1 ms to 437.1 ms, and is the only variant that avoided the Music
+  Catalog timeout without also enabling JIT.
+- APCu object cache + JIT did not compose well before adding
+  `opcache.file_cache`. It kept the best endpoint p50s, but was slightly worse
+  than APCu-only for the post-launch Library+row workflow on both full and
+  full+perf seeds.
+- Music Catalog is the warning sign in the perf-sized database. In deep
+  navigation, `full-perf-seed` no-flags and JIT-only timed out waiting for
+  `Abbey Road` after 120s. APCu object cache and APCu+JIT loaded Music Catalog
+  in about 4.4-4.5s. JIT-only on full seed also produced one extreme
+  Music Catalog sample at 98.3s. Treat the deep-session totals for these rows
+  as timeout diagnostics, not normal p50 session timing.
+
+### Full OPcache File Cache Matrix
+
+The file-cache follow-up used the same full and full+perf snapshots, still
+forcing `apps/desktop/runtime/bin/php` and four `php -S` workers. It tested
+`opcache.file_cache` by itself and with APCu object cache and JIT. The table
+also repeats the earlier JIT-only and APCu+JIT rows so the comparison is in one
+place.
+
+Artifacts:
+
+- `.context/bench-results/full-seed-file-cache-*-workers4-*.json`
+- `.context/bench-results/full-perf-seed-file-cache-*-workers4-*.json`
+- `.context/bench-results/seed-matrix-summary.json`
+
+Full seed:
+
+| Variant | HTTP avg p50 | Launch p50 | Library+row p50 | Total to row p50 | Warm return Library p50 | Deep nav total |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| No flags | n/a | 1424.5 ms | 2302.7 ms | 4238.8 ms | 1110.2 ms | 21591.0 ms |
+| APCu object cache | n/a | 2657.4 ms | 1393.1 ms | 4216.6 ms | 1083.6 ms | 20327.1 ms |
+| JIT | 43.2 ms | 1600.7 ms | 1624.8 ms | 3359.8 ms | 869.4 ms | 112042.7 ms |
+| APCu object cache + JIT | 19.6 ms | 2868.6 ms | 1540.1 ms | 4429.2 ms | 1149.8 ms | 21764.3 ms |
+| File cache | 59.0 ms | 1234.1 ms | 1946.7 ms | 3927.1 ms | 1130.5 ms | 137113.0 ms |
+| File cache + APCu object cache | 21.8 ms | 2445.6 ms | 1433.6 ms | 3903.3 ms | 1093.3 ms | 19046.7 ms |
+| File cache + JIT | 40.0 ms | 1231.4 ms | 1865.5 ms | 3334.9 ms | 1108.7 ms | 137736.0 ms |
+| File cache + APCu object cache + JIT | 19.7 ms | 2449.7 ms | 1436.8 ms | 3902.5 ms | 1095.3 ms | 21161.7 ms |
+
+Full+perf seed:
+
+| Variant | HTTP avg p50 | Launch p50 | Library+row p50 | Total to row p50 | Warm return Library p50 | Deep nav total |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| No flags | 75.9 ms | 1447.1 ms | 3180.9 ms | 4680.9 ms | 933.1 ms | 138073.1 ms |
+| APCu object cache | 21.7 ms | 2671.0 ms | 1433.2 ms | 4295.1 ms | 1132.1 ms | 20828.6 ms |
+| JIT | 53.9 ms | 1632.3 ms | 1834.1 ms | 3568.4 ms | 1111.7 ms | 134387.9 ms |
+| APCu object cache + JIT | 20.0 ms | 2869.0 ms | 1549.0 ms | 4391.5 ms | 1117.4 ms | 21088.0 ms |
+| File cache | 75.8 ms | 1170.7 ms | 2979.5 ms | 4342.5 ms | 883.1 ms | 23842.1 ms |
+| File cache + APCu object cache | 21.0 ms | 2400.4 ms | 1338.9 ms | 3733.9 ms | 847.7 ms | 19751.0 ms |
+| File cache + JIT | 51.4 ms | 1186.3 ms | 2909.4 ms | 4186.5 ms | 871.7 ms | 21743.9 ms |
+| File cache + APCu object cache + JIT | 18.9 ms | 2411.9 ms | 1286.8 ms | 3713.3 ms | 777.8 ms | 18135.6 ms |
+
+File-cache takeaways:
+
+- `opcache.file_cache` engagement passed: the runtime probe reported
+  a non-empty file-cache directory and `opcache.file_cache_files=490` after
+  warmup.
+- `opcache.file_cache` alone clears the cold-launch threshold. It improved
+  full launch by 190.4 ms and full+perf launch by 276.3 ms versus no flags.
+  It should not be kept alone for the Library workflow, though: post-launch
+  Library+row stayed at 1946.7 ms on full seed and 2979.5 ms on full+perf.
+- `opcache.file_cache + APCu object cache` is worth keeping in the candidate
+  stack. On full+perf it improved APCu-only Library+row from 1433.2 ms to
+  1338.9 ms and warm return-to-Library from 1132.1 ms to 847.7 ms, while also
+  lowering launch by 270.5 ms versus APCu-only.
+- `opcache.file_cache + JIT` is not useful without APCu for the Library
+  workflow. It keeps launch low, but full+perf Library+row stayed at
+  2909.4 ms.
+- `opcache.file_cache + APCu object cache + JIT` was the best full+perf
+  session result: 1286.8 ms Library+row p50, 777.8 ms warm return-to-Library
+  p50, and the lowest endpoint p50. On full seed it was roughly tied with
+  file-cache + APCu object cache, so JIT matters most on the larger perf-sized
+  dataset.
+
+### Bundle Size Impact
+
+Measured by rebuilding the bundled PHP binary four times with the same
+static-php-cli version and PHP 8.5.6, then saving each binary under
+`.context/php-bundle-size/`.
+
+| Build | Raw PHP binary | Raw delta | gzip size | gzip delta |
+| --- | ---: | ---: | ---: | ---: |
+| Baseline | 30.06 MB | 0.00 MB | 9.08 MB | 0.00 MB |
+| APCu | 30.10 MB | +0.04 MB | 9.10 MB | +0.02 MB |
+| JIT | 30.71 MB | +0.65 MB | 9.39 MB | +0.31 MB |
+| APCu + JIT | 30.77 MB | +0.71 MB | 9.41 MB | +0.33 MB |
+
+Other size notes:
+
+- `opcache.file_cache` adds no binary size. It creates runtime cache files in
+  the app state directory.
+- `object-cache-apcu.php` is 12 KB.
+- Preload support files are about 8 KB total.
+- The runtime probe mu-plugin is about 8 KB. I would keep it exploration-only
+  unless we decide we want a hidden diagnostic endpoint.
+
+### Before Making This Default
+
+Before making `opcache.file_cache + APCu object cache + JIT` the default:
+
+- Repeat the full+perf hard matrix at least once more from a clean machine state,
+  because file-cache UI wins are plausible but not as structurally obvious as
+  APCu's HTTP/DataView wins.
+- Capture RSS for the final composed variant after the HTTP warmup and after
+  the deep navigation test. The compact JIT delta was only +46.0 MB, but the
+  final call should use the same dataset as the winning UI result.
+- Keep the engagement checks in CI or in a manual smoke script: file cache has
+  files, APCu object cache persists between probe calls, JIT is enabled and
+  uses buffer, and PCRE JIT stays on.
+- Run the Desktop smoke test with the final composed flags, then manually
+  verify launch, autologin, restart, persisted rows/pages, and clearing the
+  runtime state directory.
+- Verify cache lifecycle across app update/snapshot replacement. File cache
+  must be safe to clear, and stale bytecode must not survive a runtime or app
+  code update.
+- If shipping a universal macOS bundle, repeat the final engagement and smoke
+  checks on both Apple Silicon and Intel binaries.
+
+### Preload Retest
+
+The first preload manifest mixed WordPress core files, the Cortext plugin
+entrypoint, and Cortext classes. Its engagement check passed, but the Desktop
+UI stayed blank. Local UI diagnostics showed the admin page loading with missing
+WordPress JS globals:
+
+- `wp is not defined`
+- `jQuery is not defined`
+- `Cannot read properties of undefined (reading 'hooks')`
+- `Cannot read properties of undefined (reading '__')`
+
+Removing `wp-content/plugins/cortext/cortext.php` was not enough. A safer
+Cortext-only manifest, with no `wp-includes/*` files and no plugin entrypoint,
+fixed the blank page and produced a clean preload engagement check:
+
+- `preload_compiled_count=17`
+- `preload_failed_count=0`
+- APCu object cache persisted across probe calls
+
+That still did not help performance. The full+perf matrix against the current
+best stack (`opcache.file_cache + APCu object cache + JIT`) regressed:
+
+| Variant | HTTP avg p50 | Launch p50 | Library+row p50 | Total to row p50 | Warm return Library p50 | Deep nav total |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| File cache + APCu object cache + JIT | 18.9 ms | 2411.9 ms | 1286.8 ms | 3713.3 ms | 777.8 ms | 18135.6 ms |
+| File cache + APCu object cache + JIT + preload | 19.9 ms | 2503.0 ms | 1513.3 ms | 3994.6 ms | 1124.0 ms | 23809.6 ms |
+
+The takeaway is narrow: manual preloading of WordPress core is unsafe in this
+setup, and a safe Cortext-only manifest does not improve the best stack. Do not
+keep preload for this iteration.
+
+Current recommendation:
+
+- Keep APCu object cache as the main Desktop-session optimization. With the
+  one-time launch cost treated as acceptable, APCu is the change that moves the
+  repeated Library/DataView workflow under or near 1.5s p50 on full and
+  full+perf seeds.
+- Keep `opcache.file_cache + APCu object cache` as the lower-risk composed
+  candidate. It improves full+perf Library+row to 1338.9 ms p50 and improves
+  warm return-to-Library to 847.7 ms p50.
+- Keep `opcache.file_cache + APCu object cache + JIT` as the fastest measured
+  composed candidate for the perf-sized database. Review the JIT surface before
+  making it the default. The measured RSS delta for JIT was only +46.0 MB in
+  the compact matrix, but the final candidate should get its own RSS pass.
+- Do not keep `opcache.file_cache` alone or `opcache.file_cache + JIT` for the
+  Library workflow. They improve launch and sometimes avoid the worst deep-nav
+  timeout, but they do not fix the repeated Library/DataView path.
+- Do not keep preload. The original core+plugin manifest made the Desktop UI
+  blank, and the safer Cortext-only manifest worked but regressed the winning
+  full+perf stack.
+
+## Verification
+
+Checks run while adding and testing the exploration hooks:
+
+- `node --check` passes for the edited Desktop runtime scripts and restored
+  `.context` benchmark scripts.
+- `php -l` passes for the runtime probe, APCu object-cache drop-in, and
+  preload files.
+- `git diff --check` passes.
+- `npm --prefix apps/desktop run snapshot` succeeds and copies preload/probe
+  runtime files into the Desktop snapshot.
+- `npm --prefix apps/desktop run test:e2e` passes.
+- `npm --prefix apps/desktop run runtime:php` builds the baseline bundled PHP
+  8.5.6 binary.
+- `CORTEXT_STATIC_PHP_EXPERIMENTAL=1 npm --prefix apps/desktop run runtime:php -- --force --rebuild`
+  builds the bundled PHP 8.5.6 binary with APCu and OPcache JIT support.
+- The full local matrix above ran with `apps/desktop/runtime/bin/php`; the
+  archived `.context` benchmark scripts were adjusted locally so their prime
+  phase also uses the selected bundled runtime instead of Homebrew PHP.
+- `.context/run-desktop-seed-matrix.sh full-jit` and
+  `.context/run-desktop-seed-matrix.sh perf-all` completed the full/full+perf
+  seed matrix with no system PHP rows.
+- `.context/run-desktop-seed-matrix.sh opcache-all` completed the full/full+perf
+  `opcache.file_cache` hard matrix with no system PHP rows.


### PR DESCRIPTION
## What

Part of #205.

This PR explores how far we can push the current Desktop `php -S` runtime before going back to the worker-runtime path. It keeps the default behavior unchanged, and adds opt-in flags for OPcache file cache, APCu object cache, JIT, preload, and a runtime probe. The benchmark notes and current recommendation live in `docs/explorations/desktop-php-s-optimization.md`.

The main comparison uses the bundled PHP binary only, with 4 `php -S` workers on the full+perf seed:

| Variant | HTTP avg p50 | Launch p50 | Library+row p50 | Total to row p50 | Warm return Library p50 | Deep nav total |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| No flags | 75.9 ms | 1447.1 ms | 3180.9 ms | 4680.9 ms | 933.1 ms | 138073.1 ms |
| File cache + APCu object cache + JIT | 18.9 ms | 2411.9 ms | 1286.8 ms | 3713.3 ms | 777.8 ms | 18135.6 ms |

The composed stack makes the first launch about 965 ms slower, from opening the app to seeing the Cortext shell. That cost is paid once per app session. The repeated Library work is much faster: after the app opens, opening the Library and then opening a row drops from 3180.9 ms to 1286.8 ms p50. Even including the slower launch, the full path from app start to an opened row improves from 4680.9 ms to 3713.3 ms p50. The longer navigation test also improves, because the baseline spent much of that run waiting on slow or timed-out Library/DataView loads. Preload stays out because it slowed this stack, which points to DB/query work rather than PHP file loading as the remaining bottleneck.

## Why

The bundled PHP runtime is still the simplest Desktop path to ship. The Library workflow was the weak spot, so this gives us a cleaner baseline before deciding whether worker-runtime work is worth reopening.

## How

- Keeps every runtime change behind an environment flag.
- Adds local PHP bundle builds with optional APCu and JIT.
- Installs and removes the APCu object-cache drop-in from the shared runtime startup path, so it does not leak between runtimes.
- Leaves preload available to measure, but records why it should not ship from this round.

## Testing Instructions

1. Launch the Desktop app with the default bundled PHP runtime and confirm it reaches the Cortext shell.
2. Start the app with APCu object cache enabled and confirm autologin still works.
3. Start it again without APCu object cache and confirm the app still loads.
4. Enable the runtime probe with the tuning flags and confirm file cache, APCu, JIT, and PCRE JIT report as active.
5. Rebuild a snapshot with a larger seed and compare Library row opening against the exploration doc.
