### PR TITLE
Perfformance: Lazy-load editor images

### DIFF
--- a/src/blocks/document-cover/edit.js
+++ b/src/blocks/document-cover/edit.js
@@ -172,6 +172,8 @@ export default function Edit( { context, clientId } ) {
 						className="cortext-document-cover-block__image"
 						src={ src }
 						alt={ media?.alt_text ?? '' }
+						loading="lazy"
+						decoding="async"
 					/>
 				) }
 				<div className="cortext-document-cover-block__controls">

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -93,6 +93,8 @@ function ImageIcon( { id, size, alt, className } ) {
 			alt={ alt ?? '' }
 			width={ size }
 			height={ size }
+			loading="lazy"
+			decoding="async"
 		/>
 	);
 }

--- a/src/components/PageInspectorSidebar.js
+++ b/src/components/PageInspectorSidebar.js
@@ -388,7 +388,12 @@ function PageFeaturedImageInspectorControls( { postId } ) {
 		featuredImagePreview = <Spinner />;
 	} else if ( src ) {
 		featuredImagePreview = (
-			<img src={ src } alt={ media?.alt_text ?? '' } />
+			<img
+				src={ src }
+				alt={ media?.alt_text ?? '' }
+				loading="lazy"
+				decoding="async"
+			/>
 		);
 	}
 


### PR DESCRIPTION
## What

Add `loading="lazy"` and `decoding="async"` to three `<img>` tags in the editor shell:

- The cover image in the `document-cover` block
- The image variant of `PageIcon` (sidebar and command palette)
- The featured-image preview in `PageInspectorSidebar`

## Why

None of these are on screen at first render, so the browser doesn't need to fetch or decode them eagerly. `decoding="async"` also lets the decode work happen off the main thread.

WordPress core sets the same attributes on the public frontend via `wp_get_attachment_image()`. This brings the editor's own `<img>` tags in line.

## Test plan

- Open a document with a cover and a featured image; reload with the Network tab open.
- Off-screen images should load only after scrolling them into view.
- No visible layout shift.