### PR TITLE
Make `format:check` actually check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ node_modules/
 vendor/
 build/
 dist/
+wordpress/
 
 # Lockfiles
 package-lock.json

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -42,7 +42,9 @@ function resolveExecutable( envName, bundledPath, commandName, installHint ) {
 		if ( fs.existsSync( configured ) || commandExists( configured ) ) {
 			return configured;
 		}
-		throw new Error( `${ envName } points to a missing executable: ${ configured }` );
+		throw new Error(
+			`${ envName } points to a missing executable: ${ configured }`
+		);
 	}
 	if ( bundledPath && fs.existsSync( bundledPath ) ) {
 		return bundledPath;
@@ -91,7 +93,9 @@ function configureObjectCacheDropIn( wordpressDir, appDir ) {
 
 	if ( process.env.CORTEXT_DESKTOP_OBJECT_CACHE === 'apcu' ) {
 		if ( ! fs.existsSync( sourcePath ) ) {
-			throw new Error( `APCu object-cache drop-in not found at ${ sourcePath }.` );
+			throw new Error(
+				`APCu object-cache drop-in not found at ${ sourcePath }.`
+			);
 		}
 		fs.copyFileSync( sourcePath, dropInPath );
 		return;
@@ -195,7 +199,10 @@ function addProcess( handle, name, command, args, options = {} ) {
 		console.log(
 			`[cortext-desktop] ${ name } exited (code=${ code }, signal=${ signal })`
 		);
-		if ( ! handle.stopping && typeof handle.onUnexpectedExit === 'function' ) {
+		if (
+			! handle.stopping &&
+			typeof handle.onUnexpectedExit === 'function'
+		) {
 			handle.onUnexpectedExit( name, code, signal );
 		}
 	} );
@@ -211,7 +218,9 @@ function waitForHttpReady( handle, port, timeoutMs = 30000 ) {
 		const timeout = setTimeout( () => {
 			fail(
 				new Error(
-					`Runtime startup timed out (${ timeoutMs / 1000 }s). Last failure: ${
+					`Runtime startup timed out (${
+						timeoutMs / 1000
+					}s). Last failure: ${
 						lastFailure ? String( lastFailure ) : 'no HTTP response'
 					}`
 				)
@@ -326,17 +335,11 @@ function startPhpCli( handle, wordpressDir, port, appDir, runtimeStateDir ) {
 	if ( workers ) {
 		phpEnv.PHP_CLI_SERVER_WORKERS = workers;
 	}
-	addProcess(
-		handle,
-		'php',
-		phpBin,
-		phpArgs,
-		{
-			cwd: wordpressDir,
-			env: phpEnv,
-			detached: Number.parseInt( workers || '1', 10 ) > 1,
-		}
-	);
+	addProcess( handle, 'php', phpBin, phpArgs, {
+		cwd: wordpressDir,
+		env: phpEnv,
+		detached: Number.parseInt( workers || '1', 10 ) > 1,
+	} );
 }
 
 function startFrankenPhp( handle, wordpressDir, port, appDir ) {
@@ -379,7 +382,9 @@ function startFrankenPhp( handle, wordpressDir, port, appDir ) {
 
 function writePhpFpmConfig( runtimeStateDir, wordpressDir ) {
 	fs.mkdirSync( runtimeStateDir, { recursive: true } );
-	const socketDir = fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-fpm-' ) );
+	const socketDir = fs.mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-fpm-' )
+	);
 	const socketPath = path.join( socketDir, 'fpm.sock' );
 	const configPath = path.join( runtimeStateDir, 'php-fpm.conf' );
 	const children = process.env.CORTEXT_PHP_FPM_CHILDREN || '2';
@@ -416,7 +421,13 @@ function writePhpFpmConfig( runtimeStateDir, wordpressDir ) {
 	return { configPath, socketDir, socketPath };
 }
 
-function startPhpFpmCaddy( handle, wordpressDir, port, appDir, runtimeStateDir ) {
+function startPhpFpmCaddy(
+	handle,
+	wordpressDir,
+	port,
+	appDir,
+	runtimeStateDir
+) {
 	const phpFpmBin = resolveExecutable(
 		'CORTEXT_PHP_FPM_BIN',
 		path.join( appDir, 'runtime/bin/php-fpm' ),
@@ -504,7 +515,9 @@ function stopRuntime( handle ) {
 		return;
 	}
 	handle.stopping = true;
-	for ( const { child, killProcessGroup } of [ ...handle.processes ].reverse() ) {
+	for ( const { child, killProcessGroup } of [
+		...handle.processes,
+	].reverse() ) {
 		if ( child && child.exitCode === null && child.signalCode === null ) {
 			try {
 				if ( killProcessGroup && child.pid ) {

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -32,13 +32,13 @@ function ensureSiteFromSnapshot() {
 	fs.mkdirSync( siteRoot, { recursive: true } );
 	// macOS `unzip` can exit 1 for warnings such as "stripped absolute path".
 	// Treat extraction as successful only if the WordPress files appear below.
-	spawnSync(
-		'unzip',
-		[ '-q', '-o', SNAPSHOT_ZIP, '-d', siteRoot ],
-		{ stdio: [ 'ignore', 'ignore', 'ignore' ] }
-	);
+	spawnSync( 'unzip', [ '-q', '-o', SNAPSHOT_ZIP, '-d', siteRoot ], {
+		stdio: [ 'ignore', 'ignore', 'ignore' ],
+	} );
 	if ( ! fs.existsSync( path.join( wordpressDir, 'index.php' ) ) ) {
-		throw new Error( `Snapshot extraction failed: ${ wordpressDir } is empty.` );
+		throw new Error(
+			`Snapshot extraction failed: ${ wordpressDir } is empty.`
+		);
 	}
 	return wordpressDir;
 }
@@ -76,7 +76,10 @@ app.whenReady().then( () => {
 		runtimeHandle = startRuntime( {
 			appDir: __dirname,
 			wordpressDir,
-			runtimeStateDir: path.join( app.getPath( 'temp' ), 'cortext-desktop-runtime' ),
+			runtimeStateDir: path.join(
+				app.getPath( 'temp' ),
+				'cortext-desktop-runtime'
+			),
 			onUnexpectedExit: () => {
 				if ( ! quitting ) {
 					app.quit();

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -23,16 +23,10 @@ const SNAPSHOT_PATH = path.join( APP_PATH, 'snapshot.zip' );
 function getUserDataPath() {
 	const home = os.homedir();
 	if ( process.platform === 'darwin' ) {
-		return path.join(
-			home,
-			'Library/Application Support/cortext-desktop'
-		);
+		return path.join( home, 'Library/Application Support/cortext-desktop' );
 	}
 	if ( process.platform === 'win32' ) {
-		return path.join(
-			process.env.APPDATA ?? home,
-			'cortext-desktop'
-		);
+		return path.join( process.env.APPDATA ?? home, 'cortext-desktop' );
 	}
 	return path.join(
 		process.env.XDG_CONFIG_HOME ?? path.join( home, '.config' ),

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"dev": "wp-scripts start",
 		"build": "wp-scripts build",
 		"format": "wp-scripts format",
-		"format:check": "wp-scripts format --check",
+		"format:check": "prettier --check '**/*.{js,jsx,json,ts,tsx,yml,yaml}' --config .prettierrc.js --ignore-path .prettierignore",
 		"lint:js": "wp-scripts lint-js src",
 		"lint:php": "composer run phpcs",
 		"lint:style": "wp-scripts lint-style 'src/**/*.{css,pcss,scss}'",
@@ -45,6 +45,7 @@
 		"@wordpress/env": "^11.4.0",
 		"@wordpress/prettier-config": "^4.46.0",
 		"@wordpress/scripts": "^32.0.0",
+		"prettier": "npm:wp-prettier@3.0.3",
 		"react": "18.3.1",
 		"react-dom": "18.3.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,10 +122,13 @@ importers:
         version: 11.4.0(@types/node@20.19.39)
       '@wordpress/prettier-config':
         specifier: ^4.46.0
-        version: 4.46.0(prettier@3.8.3)
+        version: 4.46.0(wp-prettier@3.0.3)
       '@wordpress/scripts':
         specifier: ^32.0.0
         version: 32.0.0(@playwright/test@1.59.1)(@types/eslint@9.6.1)(@types/node@20.19.39)(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(@wordpress/env@11.4.0(@types/node@20.19.39))(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.14.0(stylelint@16.26.1(typescript@6.0.3)))(type-fest@4.41.0)(typescript@6.0.3)
+      prettier:
+        specifier: npm:wp-prettier@3.0.3
+        version: wp-prettier@3.0.3
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -7094,11 +7097,6 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -13381,9 +13379,9 @@ snapshots:
     dependencies:
       prettier: wp-prettier@3.0.3
 
-  '@wordpress/prettier-config@4.46.0(prettier@3.8.3)':
+  '@wordpress/prettier-config@4.46.0(wp-prettier@3.0.3)':
     dependencies:
-      prettier: 3.8.3
+      prettier: wp-prettier@3.0.3
 
   '@wordpress/primitives@4.45.0(react@18.3.1)':
     dependencies:
@@ -18077,8 +18075,6 @@ snapshots:
   prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
-
-  prettier@3.8.3: {}
 
   pretty-format@27.5.1:
     dependencies:


### PR DESCRIPTION
## What

Follow-up to #206. `format:check` now actually checks. It runs Prettier in check mode, skips the generated `wordpress/` directory, and includes a small desktop reformat that came out once the check started running.

## Why

There were two bugs at once:

- Since #206, pnpm picks standard `prettier` for the project config, which quietly drops the WP-style `parenSpacing` rule (it only applies when the resolved `prettier` is the `wp-prettier` fork).
- `wp-scripts format --check` hardcodes `--write`, so the check was always writing.

Combined, whoever ran `format` or `format:check` was silently rewriting the codebase away from the style we have committed.

## How

- Alias `prettier` to `wp-prettier@3.0.3` so the WP config applies fully (this is what Gutenberg and wp-calypso do too).
- Call Prettier directly in check mode against the repo config and ignore file.