### PR TITLE
Fix prettier formatting in CollectionRow test

### DIFF
--- a/tests/js/components/CollectionRow.test.js
+++ b/tests/js/components/CollectionRow.test.js
@@ -50,9 +50,7 @@ describe( 'CollectionRow', () => {
 		const { container, props } = renderRow();
 		// dnd-kit gives the draggable wrapper button semantics, so there are
 		// two "Books" buttons here. Click the title button directly.
-		fireEvent.click(
-			container.querySelector( '.cortext-sidebar__title' )
-		);
+		fireEvent.click( container.querySelector( '.cortext-sidebar__title' ) );
 
 		expect( props.onSelect ).toHaveBeenCalledTimes( 1 );
 	} );


### PR DESCRIPTION
## What

Fixes `format:check` on main.

## Why

Main has been red since #211 landed, and #214 made `format:check` actually fail.

## How

Ran prettier on `tests/js/components/CollectionRow.test.js`. #211 split a `fireEvent.click( ... )` call across three lines; prettier puts it back on one.

## Testing Instructions

`pnpm run format:check` should exit 0, and CI's Lint job should go green.