### PR TITLE
Bugfix: Fix side peek reloading on navigation

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -17,7 +17,6 @@ import { withViewTransition } from '../hooks/viewTransition';
 import { POST_TYPE } from './page-queries';
 import EditorBody from './EditorBody';
 import PublishToggle from './PublishToggle';
-import { RowDetailSidebarSlot } from './RowDetailSidebarSlot';
 import RowProperties from './RowProperties';
 import { TopBarActionsFill } from './WorkspaceTopBar';
 import PageInspectorSidebar, {
@@ -188,15 +187,6 @@ function CanvasEditor( {
 	} );
 	const { resetPost } = useDispatch( editorStore );
 	const discard = useCallback( () => resetPost(), [ resetPost ] );
-	const isInspectorOpen = useSelect(
-		( select ) =>
-			isInspectorArea(
-				select( interfaceStore ).getActiveComplementaryArea(
-					INSPECTOR_SCOPE
-				)
-			),
-		[]
-	);
 	const isTrashed = post.status === 'trash';
 
 	useEffect( () => {
@@ -310,16 +300,7 @@ function CanvasEditor( {
 						/>
 					</>
 				}
-				sidebar={
-					isActive ? (
-						<RowDetailSidebarSlot
-							fallback={ <InspectorSidebarSlot /> }
-							isFallbackActive={ isInspectorOpen }
-						/>
-					) : (
-						<InspectorSidebarSlot />
-					)
-				}
+				sidebar={ <InspectorSidebarSlot /> }
 			/>
 			<PageInspectorSidebar postId={ post.id } postType={ postType } />
 		</>

--- a/src/components/RowDetailSidebarSlot.js
+++ b/src/components/RowDetailSidebarSlot.js
@@ -56,10 +56,7 @@ function initialWidth() {
 	return clampWidth( Number.isFinite( stored ) ? stored : DEFAULT_WIDTH );
 }
 
-export function RowDetailSidebarSlot( {
-	fallback = null,
-	isFallbackActive = false,
-} ) {
+export function RowDetailSidebarSlot() {
 	const fills = useSlotFills( RowDetailSidebar.name );
 	const hasRowDetail = Boolean( fills?.length );
 	const [ isRendered, setIsRendered ] = useState( hasRowDetail );
@@ -202,14 +199,13 @@ export function RowDetailSidebarSlot( {
 	);
 
 	if ( ! isRendered ) {
-		return fallback;
+		return null;
 	}
 
 	const maxWidth = getMaxWidth();
 	const isClosing = ! hasRowDetail;
-	const shouldReserveFallback = Boolean( fallback && isFallbackActive );
 
-	const shell = (
+	return (
 		<div
 			className={
 				'cortext-row-detail-sidebar-shell' +
@@ -253,21 +249,4 @@ export function RowDetailSidebarSlot( {
 			) : null }
 		</div>
 	);
-
-	if ( shouldReserveFallback ) {
-		return (
-			<div className="cortext-row-detail-sidebar-handoff cortext-row-detail-sidebar-handoff--reserve">
-				<div
-					className="cortext-row-detail-sidebar-handoff__fallback"
-					aria-hidden={ hasRowDetail ? true : undefined }
-					{ ...( hasRowDetail ? { inert: '' } : {} ) }
-				>
-					{ fallback }
-				</div>
-				{ shell }
-			</div>
-		);
-	}
-
-	return shell;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -106,7 +106,10 @@ body.cortext-fullscreen {
 
 .cortext-shell {
 	display: grid;
-	grid-template-columns: var(--cortext-sidebar-width) 1fr;
+	// The trailing `auto` track is reserved for the side peek panel
+	// (RowDetailSidebarSlot). It collapses to 0 when no peek is mounted and
+	// follows the panel's own width animation when it is.
+	grid-template-columns: var(--cortext-sidebar-width) minmax(0, 1fr) auto;
 	height: 100vh;
 	transition: grid-template-columns 160ms ease;
 }
@@ -120,7 +123,7 @@ body.cortext-fullscreen {
 // Collapsed: pin to rail width but keep the saved expanded width on the
 // root, so toggling back restores it.
 .cortext-root[data-sidebar-collapsed="true"] .cortext-shell {
-	grid-template-columns: var(--cortext-sidebar-width-rail) 1fr;
+	grid-template-columns: var(--cortext-sidebar-width-rail) minmax(0, 1fr) auto;
 }
 
 .cortext-sidebar {
@@ -3910,70 +3913,6 @@ tr:has(.cortext-title-cell--is-open)
 
 		&:focus-visible {
 			outline: none;
-		}
-	}
-}
-
-.cortext-collection-pane > .cortext-row-detail-sidebar-shell {
-	position: absolute;
-	inset-block: 0;
-	inset-inline-end: 0;
-	z-index: 8;
-}
-
-.cortext-row-detail-sidebar-handoff {
-	position: relative;
-	width: 100%;
-	height: 100%;
-	min-width: 0;
-	min-height: 0;
-	overflow: visible;
-
-	&__fallback {
-		width: 100%;
-		height: 100%;
-		min-height: 0;
-	}
-
-	&--reserve > .cortext-row-detail-sidebar-shell {
-		position: absolute;
-		inset-block: 0;
-		inset-inline-end: 0;
-		z-index: 2;
-	}
-}
-
-.cortext-canvas:has(.cortext-row-detail-sidebar-handoff--reserve) {
-
-	.interface-interface-skeleton__sidebar {
-		position: relative;
-		z-index: 8;
-		overflow: visible;
-	}
-}
-
-.cortext-canvas:has(.cortext-row-detail-sidebar-shell):not(
-:has(.cortext-row-detail-sidebar-handoff--reserve)
-) {
-
-	.interface-interface-skeleton__body {
-		position: relative;
-	}
-
-	.interface-interface-skeleton__sidebar {
-		position: absolute;
-		inset-block: 0;
-		inset-inline-end: 0;
-		z-index: 8;
-		width: auto;
-		min-width: 0;
-		max-width: none;
-		overflow: visible;
-		pointer-events: none;
-
-		.cortext-row-detail-sidebar-shell {
-			position: relative;
-			pointer-events: auto;
 		}
 	}
 }

--- a/src/router.js
+++ b/src/router.js
@@ -15,6 +15,7 @@ import CommandPalette from './components/CommandPalette';
 import AlphaNoticeModal from './components/AlphaNoticeModal';
 import { DocumentPeekProvider } from './components/DocumentPeekProvider';
 import DocumentPeekHost from './components/DocumentPeekHost';
+import { RowDetailSidebarSlot } from './components/RowDetailSidebarSlot';
 import useSidebarLayout from './hooks/useSidebarLayout';
 import useAlphaNotice from './hooks/useAlphaNotice';
 import { FavoritesProvider } from './hooks/useFavorites';
@@ -88,6 +89,7 @@ function RootLayout() {
 								>
 									<EntityRoute history={ router.history } />
 								</main>
+								<RowDetailSidebarSlot />
 							</div>
 							<CommandPalette canvasRef={ canvasRef } />
 							{ alphaNotice.isOpen && (

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -16,7 +16,6 @@ import Canvas from '../components/Canvas';
 import CollectionDataViews from '../components/CollectionDataViews';
 import { CollectionFieldsProvider } from '../components/CollectionFieldsContext';
 import { RowMutationContext } from '../components/EditableCell';
-import { RowDetailSidebarSlot } from '../components/RowDetailSidebarSlot';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
 import {
 	ACTIVE_PAGES_QUERY,
@@ -85,7 +84,6 @@ function CollectionPane( { collectionId, onReady } ) {
 						onReady={ onReady }
 					/>
 				</div>
-				<RowDetailSidebarSlot />
 			</div>
 		</CollectionFieldsProvider>
 	);


### PR DESCRIPTION
## What

Navigating between routes no longer reloads the side peek. It stays mounted as it always should have, and now shows alongside the editor's settings sidebar on document routes.

## Why

Scroll position, focus, and any local edits inside the peek were lost on every navigation.

## How

- Moving `RowDetailSidebarSlot` from per-route components into `RootLayout` so the SlotFill portal target stays stable.
- Adding a third `auto` column to the shell grid and dropping the peek/Inspector handoff in the editor sidebar.

## Testing Instructions

1. Open a row in a collection to open the side peek.
2. Click another collection in the sidebar. The peek should stay mounted with the same row, no reload.
3. Click a page in the Pages section. The peek should still be there. Open the editor's settings (cog icon); both should be visible side by side.
4. Close the peek with the X. It should slide out cleanly.

## Screen recording
Before:

https://github.com/user-attachments/assets/c88bcf22-0672-402d-8a2c-714aaa16363b

After:

https://github.com/user-attachments/assets/49ac6886-adc6-40a0-bd1d-69b586bf069e

