### PR TITLE
Pin side peek to keep it open across navigation

### DIFF
--- a/src/components/DocumentPeekHost.js
+++ b/src/components/DocumentPeekHost.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useParams } from '@tanstack/react-router';
 
 import RowDetailView from './RowDetailView';
 import { RowDetailSidebar } from './RowDetailSidebarSlot';
@@ -32,7 +33,7 @@ function withTitleField( fields ) {
 // root. Keeping this separate stops relation chips and collection cells from
 // importing RowDetailView and the editor stack.
 export default function DocumentPeekHost() {
-	const { peek } = useDocumentPeekState();
+	const { peek, isPinned } = useDocumentPeekState();
 	const { closeDocument, requestMode } = useDocumentPeekActions();
 	const {
 		modeSurfaceTransition,
@@ -41,7 +42,32 @@ export default function DocumentPeekHost() {
 		goToAdjacentDocument,
 		retryPendingTransition,
 		discardPendingTransition,
+		togglePin,
 	} = useDocumentPeekSurface();
+
+	// Side peeks close on route change unless pinned. Modal mode floats over
+	// the route, so it doesn't need the same gate.
+	const params = useParams( { strict: false } );
+	const splat = params?._splat ?? '';
+	const prevSplatRef = useRef( splat );
+	const peekStateRef = useRef( { peek, isPinned } );
+	peekStateRef.current = { peek, isPinned };
+	useEffect( () => {
+		const prev = prevSplatRef.current;
+		prevSplatRef.current = splat;
+		if ( prev === splat ) {
+			return;
+		}
+		const current = peekStateRef.current;
+		if ( ! current.peek || current.peek.mode !== 'side' ) {
+			return;
+		}
+		if ( current.isPinned ) {
+			return;
+		}
+		closeDocument();
+	}, [ splat, closeDocument ] );
+
 	const { fields: collectionFields } = useCollectionFields(
 		peek?.collectionId ?? null
 	);
@@ -77,6 +103,7 @@ export default function DocumentPeekHost() {
 				canGoPrevious={ canGoPrevious }
 				collectionId={ peek.collectionId }
 				fields={ peekFields }
+				isPinned={ isPinned }
 				mode={ renderedMode }
 				onApi={ setDetailApi }
 				onClose={ closeDocument }
@@ -87,6 +114,7 @@ export default function DocumentPeekHost() {
 				onRestored={ handleRestored }
 				onRetryPending={ retryPendingTransition }
 				onSaved={ handleSaved }
+				onTogglePin={ togglePin }
 				postType={ peek.postType }
 				row={ undefined }
 				rowId={ peek.docId }

--- a/src/components/DocumentPeekProvider.js
+++ b/src/components/DocumentPeekProvider.js
@@ -30,7 +30,7 @@ const NO_PEEK_ACTIONS = {
 	closeDocument: () => {},
 	requestMode: () => {},
 };
-const NO_PEEK_STATE = { peek: null };
+const NO_PEEK_STATE = { peek: null, isPinned: false };
 
 const PeekActionsContext = createContext( NO_PEEK_ACTIONS );
 const PeekStateContext = createContext( NO_PEEK_STATE );
@@ -78,6 +78,10 @@ export function DocumentPeekProvider( { children } ) {
 	const peekRef = useRef( peek );
 	peekRef.current = peek;
 
+	// In-memory pin. Resets when the peek closes or a different row opens.
+	// Survives side/modal flips so enlarging the peek doesn't drop it.
+	const [ isPinned, setIsPinned ] = useState( false );
+
 	// RowDetailView exposes flush/discard through onApi. Run it before close or
 	// row switches so unsaved edits do not vanish.
 	const detailApiRef = useRef( null );
@@ -119,9 +123,11 @@ export function DocumentPeekProvider( { children } ) {
 			if ( transition.type === 'close' ) {
 				clearModeSurfaceTransition();
 				setPeek( null );
+				setIsPinned( false );
 			} else if ( transition.type === 'peek' ) {
 				clearModeSurfaceTransition();
 				setPeek( transition.peek );
+				setIsPinned( false );
 			} else if ( transition.type === 'mode' ) {
 				setPeek( ( current ) =>
 					current ? { ...current, mode: transition.mode } : current
@@ -129,6 +135,7 @@ export function DocumentPeekProvider( { children } ) {
 			} else if ( transition.type === 'full' ) {
 				clearModeSurfaceTransition();
 				setPeek( null );
+				setIsPinned( false );
 				navigate( {
 					to: '/$',
 					params: { _splat: transition.uri },
@@ -321,11 +328,15 @@ export function DocumentPeekProvider( { children } ) {
 		}
 	}, [ pendingTransition, runTransition ] );
 
+	const togglePin = useCallback( () => {
+		setIsPinned( ( current ) => ! current );
+	}, [] );
+
 	const actions = useMemo(
 		() => ( { openDocument, closeDocument, requestMode } ),
 		[ openDocument, closeDocument, requestMode ]
 	);
-	const state = useMemo( () => ( { peek } ), [ peek ] );
+	const state = useMemo( () => ( { peek, isPinned } ), [ peek, isPinned ] );
 	const surface = useMemo(
 		() => ( {
 			modeSurfaceTransition,
@@ -334,6 +345,7 @@ export function DocumentPeekProvider( { children } ) {
 			goToAdjacentDocument,
 			retryPendingTransition,
 			discardPendingTransition,
+			togglePin,
 		} ),
 		[
 			modeSurfaceTransition,
@@ -342,6 +354,7 @@ export function DocumentPeekProvider( { children } ) {
 			goToAdjacentDocument,
 			retryPendingTransition,
 			discardPendingTransition,
+			togglePin,
 		]
 	);
 

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -16,6 +16,7 @@ import {
 	closeSmall,
 	drawerRight,
 	fullscreen,
+	pin,
 	seen,
 	square,
 	unseen,
@@ -25,6 +26,24 @@ import useAutosave from '../hooks/useAutosave';
 import EditorBody from './EditorBody';
 import RowProperties from './RowProperties';
 import { getRowDetailMode } from './rowDetailUtils';
+
+// Solid version of @wordpress/icons `pin` (which only ships outlined), so the
+// pressed state reads as filled.
+const pinFilled = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<path
+			fill="currentColor"
+			d="m21.5 9.1-6.6-6.6-4.2 5.6c-1.2-.1-2.4.1-3.6.7-.1 0-.1.1-.2.1-.5.3-.9.6-1.2.9l3.7 3.7-5.7 5.7v1.1h1.1l5.7-5.7 3.7 3.7c.4-.4.7-.8.9-1.2.1-.1.1-.2.2-.3.6-1.1.8-2.4.6-3.6l5.6-4.1z"
+		/>
+	</svg>
+);
 
 export const ROW_DETAIL_MODE_ICONS = {
 	side: drawerRight,
@@ -275,6 +294,7 @@ function DetailShell( {
 	arePropertiesVisible,
 	children,
 	fields,
+	isPinned,
 	mode,
 	onClose,
 	onDiscardPending,
@@ -282,6 +302,7 @@ function DetailShell( {
 	onNext,
 	onPrevious,
 	onRetryPending,
+	onTogglePin,
 	saveError,
 	canGoNext,
 	canGoPrevious,
@@ -344,6 +365,21 @@ function DetailShell( {
 							onChangeMode={ onModeChange }
 						/>
 					</div>
+					{ mode === 'side' && onTogglePin ? (
+						<div className="cortext-row-detail__toolbar-group">
+							<Button
+								className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--icon"
+								icon={ isPinned ? pinFilled : pin }
+								isPressed={ isPinned }
+								label={
+									isPinned
+										? __( 'Unpin', 'cortext' )
+										: __( 'Pin', 'cortext' )
+								}
+								onClick={ onTogglePin }
+							/>
+						</div>
+					) : null }
 					<div className="cortext-row-detail__toolbar-group cortext-row-detail__toolbar-group--end">
 						<Button
 							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--close"
@@ -406,6 +442,7 @@ export default function RowDetailView( {
 	canGoPrevious,
 	collectionId,
 	fields,
+	isPinned,
 	mode,
 	onApi,
 	onClose,
@@ -416,6 +453,7 @@ export default function RowDetailView( {
 	onRestored,
 	onRetryPending,
 	onSaved,
+	onTogglePin,
 	postType,
 	row,
 	rowId,
@@ -622,6 +660,7 @@ export default function RowDetailView( {
 				canGoNext={ canUseRowControls && canGoNext }
 				canGoPrevious={ canUseRowControls && canGoPrevious }
 				fields={ propertyFields }
+				isPinned={ isPinned }
 				mode={ normalizedMode }
 				onClose={ requestClose }
 				onDiscardPending={ onDiscardPending }
@@ -629,6 +668,7 @@ export default function RowDetailView( {
 				onNext={ onNext }
 				onPrevious={ onPrevious }
 				onRetryPending={ onRetryPending }
+				onTogglePin={ onTogglePin }
 				saveError={ canUseRowControls ? saveError : null }
 				setArePropertiesVisible={ setArePropertiesVisible }
 				title={ displayTitle }


### PR DESCRIPTION
## What

Follow-up to #218.

Adds a pin button to the side peek toolbar. Without a pin, navigating now closes the peek. Pinning keeps it open until you close it yourself.

## Why

The side peek used to always be sticky, which is probably not the default intended behaviour.. but an interesting one. Pinning lets you lock the side peek open while you click around the rest of the workspace.

## How

- Showing the pin button only in side mode, and resetting the pin when the peek closes, or a different row opens.
- Closing an unpinned side peek on route change; modal mode is unaffected.

## Testing Instructions

1. Open a row in a collection. Click another collection in the sidebar; the peek closes.
2. Open a row again. Click the pin button (icon fills). Click another collection; the peek stays with the same row.
3. Switch to the Center modal via the mode control. Pin button disappears. Switch back to Side peek; pin state is preserved.
4. Close with the X. Open a different row; pin starts unpinned.

## Screen recording

https://github.com/user-attachments/assets/dda4763e-3002-47df-9723-5765b14047af

