### PR TITLE
Collections: treat as first-class documents

### DIFF
--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -330,11 +330,19 @@ final class Documents {
 			}
 		}
 
+		// Inline collections have no workspace route of their own. Set their
+		// path to the owner page so command palette results and trash-row
+		// clicks land on the page that contains them instead of bouncing to
+		// Not Found through `EntityRoute`'s inline-collection guard.
+		$path = $owner_page instanceof WP_Post
+			? $this->page_path( $owner_page )
+			: $this->document_path( $post, $kind );
+
 		$document = array(
 			'kind'   => $kind,
 			'id'     => (int) $post->ID,
 			'title'  => $this->post_title( $post ),
-			'path'   => $this->document_path( $post, $kind ),
+			'path'   => $path,
 			'parent' => (int) $post->post_parent,
 		);
 

--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -20,6 +20,7 @@ namespace Cortext;
 use Cortext\Fields\FieldTypeRegistry;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\CollectionTrashCascade;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Page;
 use Cortext\PostType\PageTrashCascade;
@@ -29,8 +30,9 @@ use WP_Query;
 
 final class Documents {
 
-	public const KIND_PAGE = 'page';
-	public const KIND_ROW  = 'row';
+	public const KIND_PAGE       = 'page';
+	public const KIND_ROW        = 'row';
+	public const KIND_COLLECTION = 'collection';
 
 	public const STATUS_TRASH = 'trash';
 
@@ -268,11 +270,21 @@ final class Documents {
 			);
 		}
 
+		if ( self::KIND_COLLECTION === $kind ) {
+			return array_values(
+				array_filter(
+					$post_types,
+					static fn( string $post_type ): bool => Collection::POST_TYPE === $post_type
+				)
+			);
+		}
+
 		if ( self::KIND_ROW === $kind ) {
 			return array_values(
 				array_filter(
 					$post_types,
 					static fn( string $post_type ): bool => Page::POST_TYPE !== $post_type
+						&& Collection::POST_TYPE !== $post_type
 						&& str_starts_with( $post_type, CollectionEntries::CPT_PREFIX )
 				)
 			);
@@ -305,13 +317,24 @@ final class Documents {
 			return null;
 		}
 
+		// An inline collection's owner page is the breadcrumb users see in
+		// search and trash. Without it the collection feels like an unmoored
+		// row, since inline collections don't have a sidebar entry of their
+		// own.
+		$owner_page = null;
+		if ( self::KIND_COLLECTION === $kind && Collection::is_inline( (int) $post->ID ) ) {
+			$owner_id   = (int) get_post_meta( $post->ID, Collection::INLINE_OWNER_META_KEY, true );
+			$owner_post = $owner_id > 0 ? get_post( $owner_id ) : null;
+			if ( $owner_post instanceof WP_Post && Page::POST_TYPE === $owner_post->post_type ) {
+				$owner_page = $owner_post;
+			}
+		}
+
 		$document = array(
 			'kind'   => $kind,
 			'id'     => (int) $post->ID,
 			'title'  => $this->post_title( $post ),
-			'path'   => self::KIND_ROW === $kind
-				? $this->row_path( $post )
-				: $this->page_path( $post ),
+			'path'   => $this->document_path( $post, $kind ),
 			'parent' => (int) $post->post_parent,
 		);
 
@@ -320,7 +343,7 @@ final class Documents {
 		}
 
 		$icon = '';
-		if ( self::KIND_PAGE === $kind ) {
+		if ( self::KIND_PAGE === $kind || self::KIND_COLLECTION === $kind ) {
 			$icon = (string) get_post_meta( $post->ID, DocumentIdentity::META_KEY, true );
 			if ( '' !== $icon ) {
 				$document['icon'] = $icon;
@@ -335,15 +358,49 @@ final class Documents {
 			);
 		}
 
+		if ( $owner_page instanceof WP_Post ) {
+			$document['owner'] = array(
+				'id'    => (int) $owner_page->ID,
+				'title' => $this->post_title( $owner_page ),
+				'path'  => $this->page_path( $owner_page ),
+			);
+		}
+
 		if ( ! empty( $opts['include_trash_meta'] ) ) {
 			$document['modified_at'] = $this->format_gmt_date( $post->post_modified_gmt );
 			$document['meta']        = array(
 				'cortext_document_icon'    => $icon,
 				PageTrashCascade::META_KEY => (int) get_post_meta( $post->ID, PageTrashCascade::META_KEY, true ),
 			);
+			// Inline collections trashed alongside their owner page carry a
+			// separate marker. The sidebar uses it to nest them under the
+			// page's trash entry instead of listing them as siblings.
+			if ( self::KIND_COLLECTION === $kind ) {
+				$document['meta'][ CollectionTrashCascade::TRASHED_BY_OWNER_META_KEY ] = (int) get_post_meta(
+					$post->ID,
+					CollectionTrashCascade::TRASHED_BY_OWNER_META_KEY,
+					true
+				);
+			}
 		}
 
 		return $document;
+	}
+
+	/**
+	 * Routes a document to its URL path based on its kind.
+	 *
+	 * @param WP_Post $post Document post.
+	 * @param string  $kind Document kind constant.
+	 */
+	private function document_path( WP_Post $post, string $kind ): string {
+		if ( self::KIND_ROW === $kind ) {
+			return $this->row_path( $post );
+		}
+		if ( self::KIND_COLLECTION === $kind ) {
+			return $this->collection_path( $post );
+		}
+		return $this->page_path( $post );
 	}
 
 	private function format_gmt_date( string $mysql_gmt ): string {
@@ -360,12 +417,17 @@ final class Documents {
 	 */
 	public function kind_for_post_type( string $post_type ): ?string {
 		// Only post types that opt into the document trait count here. That
-		// keeps `crtxt_field` and `crtxt_collection` out of row handling.
+		// keeps `crtxt_field` out of document handling. `crtxt_collection`
+		// opts in too: collections are documents whose canvas is a DataView
+		// rather than block-editor content.
 		if ( ! post_type_supports( $post_type, 'cortext-document' ) ) {
 			return null;
 		}
 		if ( Page::POST_TYPE === $post_type ) {
 			return self::KIND_PAGE;
+		}
+		if ( Collection::POST_TYPE === $post_type ) {
+			return self::KIND_COLLECTION;
 		}
 		return self::KIND_ROW;
 	}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -24,6 +24,7 @@ use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
 use Cortext\PostType\Page;
 use Cortext\PostType\PageTrashCascade;
+use Cortext\PostType\RowTrashCascade;
 use Cortext\Rest\CollectionsController;
 use Cortext\Rest\DocumentLocatorController;
 use Cortext\Rest\DocumentsController;
@@ -52,6 +53,7 @@ final class Plugin {
 		( new PageTrashCascade() )->register();
 		( new Collection() )->register();
 		( new CollectionTrashCascade() )->register();
+		( new RowTrashCascade() )->register();
 		( new Field() )->register();
 		( new CollectionEntries() )->register();
 		( new RevisionThrottle() )->register();

--- a/includes/PostType/Collection.php
+++ b/includes/PostType/Collection.php
@@ -57,6 +57,11 @@ final class Collection {
 			)
 		);
 
+		// Collections share the document lifecycle: title, identity, trash,
+		// restore, permanent delete, command palette search. The DataView is
+		// their canvas; block-editor content support stays off for now.
+		DocumentIdentity::register_for_post_type( self::POST_TYPE );
+
 		$this->register_meta();
 	}
 

--- a/includes/PostType/CollectionTrashCascade.php
+++ b/includes/PostType/CollectionTrashCascade.php
@@ -1,11 +1,13 @@
 <?php
 /**
- * Keeps collections in step with the document that owns or contains them.
+ * Trashes a collection when the document that owns or contains it is trashed.
  *
- * Inline collections follow `_cortext_inline_owner_page`. Full-page
- * collections follow `post_parent`. When a document goes to Trash, the marker
- * meta records which document moved the collection so restore only brings back
+ * Inline collections follow `_cortext_inline_owner_page`; full-page
+ * collections nested under a document follow `post_parent`. The marker meta
+ * records which document moved the collection so restore only revives
  * collections from that same cascade.
+ *
+ * The collection → row direction lives in `RowTrashCascade`.
  *
  * @package Cortext
  */
@@ -19,9 +21,8 @@ use Cortext\Documents;
 final class CollectionTrashCascade {
 
 	/**
-	 * Stores the document id that moved a collection to Trash. Collections
-	 * that were already trashed stay unmarked, so restore does not revive
-	 * unrelated items.
+	 * Document id that moved a collection to Trash. Collections already in
+	 * Trash stay unmarked, so restore does not revive unrelated items.
 	 */
 	public const TRASHED_BY_OWNER_META_KEY = '_cortext_trashed_by_owner_page';
 
@@ -59,7 +60,7 @@ final class CollectionTrashCascade {
 	 * @param int $post_id ID of the post about to be trashed.
 	 */
 	public function cascade_trash( int $post_id ): void {
-		if ( ! $this->is_document( $post_id ) ) {
+		if ( ! $this->is_owning_document( $post_id ) ) {
 			return;
 		}
 
@@ -75,7 +76,7 @@ final class CollectionTrashCascade {
 	 * @param int $post_id ID of the post that was just restored.
 	 */
 	public function cascade_restore( int $post_id ): void {
-		if ( ! $this->is_document( $post_id ) ) {
+		if ( ! $this->is_owning_document( $post_id ) ) {
 			return;
 		}
 
@@ -86,14 +87,14 @@ final class CollectionTrashCascade {
 	}
 
 	/**
-	 * Permanently deletes collections owned by the document. This checks both
+	 * Permanently deletes collections owned by the document. Checks both
 	 * active and trashed collections because a document may be force-deleted
 	 * after it has already been moved to Trash.
 	 *
 	 * @param int $post_id ID of the post about to be permanently deleted.
 	 */
 	public function cascade_delete( int $post_id ): void {
-		if ( ! $this->is_document( $post_id ) ) {
+		if ( ! $this->is_owning_document( $post_id ) ) {
 			return;
 		}
 
@@ -102,9 +103,19 @@ final class CollectionTrashCascade {
 		}
 	}
 
-	private function is_document( int $post_id ): bool {
+	/**
+	 * Whether the post is a document that can own collections (page or row).
+	 * Collections themselves are documents too, but they own rows, not other
+	 * collections; the collection → row direction lives in `RowTrashCascade`.
+	 *
+	 * @param int $post_id Candidate post id.
+	 */
+	private function is_owning_document( int $post_id ): bool {
 		$post_type = get_post_type( $post_id );
 		if ( ! is_string( $post_type ) || '' === $post_type ) {
+			return false;
+		}
+		if ( Collection::POST_TYPE === $post_type ) {
 			return false;
 		}
 		return null !== $this->documents->kind_for_post_type( $post_type );

--- a/includes/PostType/RowTrashCascade.php
+++ b/includes/PostType/RowTrashCascade.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Trashes a collection's rows when the collection itself is trashed.
+ *
+ * Rows live in a dynamic CPT (`crtxt_<slug>`) owned by their collection.
+ * Trashing a collection trashes every row; restoring brings them back;
+ * force-deleting wipes them. The marker meta records which collection moved
+ * a row to Trash so restore only revives rows from that same cascade.
+ *
+ * The doc → collection direction lives in `CollectionTrashCascade`.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\PostType;
+
+use WP_Post;
+
+final class RowTrashCascade {
+
+	/**
+	 * Collection id that moved a row to Trash. Rows already in Trash stay
+	 * unmarked, so restore does not revive unrelated items.
+	 */
+	public const TRASHED_BY_OWNER_META_KEY = '_cortext_trashed_by_owner_collection';
+
+	private CollectionEntries $entries;
+
+	public function __construct( ?CollectionEntries $entries = null ) {
+		$this->entries = $entries ?? new CollectionEntries();
+	}
+
+	public function register(): void {
+		add_action( 'init', array( $this, 'register_meta' ) );
+		add_action( 'wp_trash_post', array( $this, 'cascade_trash' ), 10, 1 );
+		add_action( 'untrashed_post', array( $this, 'cascade_restore' ), 10, 1 );
+		add_action( 'before_delete_post', array( $this, 'cascade_delete' ), 10, 1 );
+	}
+
+	public function register_meta(): void {
+		// The marker is registered on every entry CPT known at init.
+		// CPTs registered later (a new collection in the same request)
+		// read the marker by raw key in cascade_restore; missing the
+		// registration here only affects REST exposure.
+		foreach ( CollectionEntries::get_entry_post_types() as $post_type ) {
+			register_post_meta(
+				$post_type,
+				self::TRASHED_BY_OWNER_META_KEY,
+				array(
+					'type'          => 'integer',
+					'single'        => true,
+					'show_in_rest'  => false,
+					'auth_callback' => static function () {
+						return false;
+					},
+				)
+			);
+		}
+	}
+
+	/**
+	 * Trashes rows owned by the collection and marks them for restore.
+	 *
+	 * @param int $post_id Post about to be trashed.
+	 */
+	public function cascade_trash( int $post_id ): void {
+		$collection = $this->collection_for( $post_id );
+		if ( null === $collection ) {
+			return;
+		}
+
+		foreach ( $this->active_row_ids( $collection ) as $row_id ) {
+			update_post_meta( $row_id, self::TRASHED_BY_OWNER_META_KEY, $post_id );
+			wp_trash_post( $row_id );
+		}
+	}
+
+	/**
+	 * Restores rows this collection moved to Trash and clears the marker.
+	 *
+	 * @param int $post_id Post that was just restored.
+	 */
+	public function cascade_restore( int $post_id ): void {
+		$collection = $this->collection_for( $post_id );
+		if ( null === $collection ) {
+			return;
+		}
+
+		foreach ( $this->trashed_rows_tagged_with( $collection, $post_id ) as $row_id ) {
+			wp_untrash_post( $row_id );
+			delete_post_meta( $row_id, self::TRASHED_BY_OWNER_META_KEY );
+		}
+	}
+
+	/**
+	 * Permanently deletes rows owned by the collection. Walks both active
+	 * and trashed rows: a collection may be force-deleted from Trash, so
+	 * its rows may already be marked `trash`.
+	 *
+	 * @param int $post_id Post about to be permanently deleted.
+	 */
+	public function cascade_delete( int $post_id ): void {
+		$collection = $this->collection_for( $post_id );
+		if ( null === $collection ) {
+			return;
+		}
+
+		foreach ( $this->all_row_ids( $collection ) as $row_id ) {
+			wp_delete_post( $row_id, true );
+		}
+	}
+
+	/**
+	 * Returns the collection post when the id is a collection that has a
+	 * dynamic row CPT we can query, or null otherwise. The row CPT for a
+	 * trashed collection is not registered during `init`
+	 * (`CollectionEntries::register_all` queries active statuses only), so
+	 * the cascade registers it on demand before the row lookup runs.
+	 *
+	 * @param int $post_id Post id under inspection.
+	 */
+	private function collection_for( int $post_id ): ?WP_Post {
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post || Collection::POST_TYPE !== $post->post_type ) {
+			return null;
+		}
+
+		$this->entries->register_for_collection( $post );
+
+		return $post;
+	}
+
+	/**
+	 * Returns ids of rows that can be sent to Trash by the cascade.
+	 *
+	 * @param WP_Post $collection Collection post the rows belong to.
+	 *
+	 * @return int[]
+	 */
+	private function active_row_ids( WP_Post $collection ): array {
+		$post_type = $this->row_post_type( $collection );
+		if ( null === $post_type ) {
+			return array();
+		}
+
+		$ids = get_posts(
+			array(
+				'post_type'      => $post_type,
+				'post_status'    => array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft' ),
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Returns ids of every row tied to the collection, including trashed ones.
+	 *
+	 * @param WP_Post $collection Collection post the rows belong to.
+	 *
+	 * @return int[]
+	 */
+	private function all_row_ids( WP_Post $collection ): array {
+		$post_type = $this->row_post_type( $collection );
+		if ( null === $post_type ) {
+			return array();
+		}
+
+		$ids = get_posts(
+			array(
+				'post_type'      => $post_type,
+				'post_status'    => array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft', 'trash' ),
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Returns ids of rows tagged as cascaded-by-this-collection.
+	 *
+	 * @param WP_Post $collection    Collection post the rows belong to.
+	 * @param int     $collection_id Same collection id, used to match the marker.
+	 *
+	 * @return int[]
+	 */
+	private function trashed_rows_tagged_with( WP_Post $collection, int $collection_id ): array {
+		$post_type = $this->row_post_type( $collection );
+		if ( null === $post_type ) {
+			return array();
+		}
+
+		$ids = get_posts(
+			array(
+				'post_type'      => $post_type,
+				'post_status'    => 'trash',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_key'       => self::TRASHED_BY_OWNER_META_KEY,   // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => (string) $collection_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	private function row_post_type( WP_Post $collection ): ?string {
+		$slug = get_post_meta( $collection->ID, 'slug', true );
+		if ( ! is_string( $slug ) || '' === $slug ) {
+			return null;
+		}
+		$post_type = CollectionEntries::CPT_PREFIX . $slug;
+		return post_type_exists( $post_type ) ? $post_type : null;
+	}
+}

--- a/includes/PostType/RowTrashCascade.php
+++ b/includes/PostType/RowTrashCascade.php
@@ -33,31 +33,9 @@ final class RowTrashCascade {
 	}
 
 	public function register(): void {
-		add_action( 'init', array( $this, 'register_meta' ) );
 		add_action( 'wp_trash_post', array( $this, 'cascade_trash' ), 10, 1 );
 		add_action( 'untrashed_post', array( $this, 'cascade_restore' ), 10, 1 );
 		add_action( 'before_delete_post', array( $this, 'cascade_delete' ), 10, 1 );
-	}
-
-	public function register_meta(): void {
-		// The marker is registered on every entry CPT known at init.
-		// CPTs registered later (a new collection in the same request)
-		// read the marker by raw key in cascade_restore; missing the
-		// registration here only affects REST exposure.
-		foreach ( CollectionEntries::get_entry_post_types() as $post_type ) {
-			register_post_meta(
-				$post_type,
-				self::TRASHED_BY_OWNER_META_KEY,
-				array(
-					'type'          => 'integer',
-					'single'        => true,
-					'show_in_rest'  => false,
-					'auth_callback' => static function () {
-						return false;
-					},
-				)
-			);
-		}
 	}
 
 	/**

--- a/includes/Rest/CollectionsController.php
+++ b/includes/Rest/CollectionsController.php
@@ -286,7 +286,14 @@ final class CollectionsController {
 			);
 		}
 
-		if ( null === $this->documents->kind_for_post_type( $parent->post_type ) ) {
+		// Collections are documents now, so `kind_for_post_type` alone would
+		// let a request nest a collection under another collection. Reject
+		// that explicitly: collections live under pages or rows, not under
+		// other collections.
+		if (
+			null === $this->documents->kind_for_post_type( $parent->post_type ) ||
+			Collection::POST_TYPE === $parent->post_type
+		) {
 			return new WP_Error(
 				'cortext_collection_parent_invalid_type',
 				__( 'Collections can only be placed under pages or rows.', 'cortext' ),

--- a/includes/Rest/DocumentsController.php
+++ b/includes/Rest/DocumentsController.php
@@ -60,7 +60,7 @@ final class DocumentsController {
 						'kind'     => array(
 							'type'    => 'string',
 							'default' => '',
-							'enum'    => array( '', Documents::KIND_PAGE, Documents::KIND_ROW ),
+							'enum'    => array( '', Documents::KIND_PAGE, Documents::KIND_ROW, Documents::KIND_COLLECTION ),
 						),
 						'status'   => array(
 							'type'    => 'string',

--- a/includes/Rest/DocumentsController.php
+++ b/includes/Rest/DocumentsController.php
@@ -224,29 +224,40 @@ final class DocumentsController {
 			);
 		}
 
-		// Record the subtree, then delete leaves-first so WP's
-		// hierarchical-delete reparenting has nothing to do for any non-leaf.
-		$descendants = $this->cascade->descendants_for_root( $id );
-
+		// Hook deleted_post so the response includes every id that
+		// disappeared during this request: explicit page descendants, the
+		// document itself, and posts removed by other cascades (RowTrashCascade
+		// wipes a collection's rows on before_delete_post, for example).
 		$deleted = array();
-		foreach ( array_reverse( $descendants ) as $descendant_id ) {
-			if ( wp_delete_post( $descendant_id, true ) ) {
-				$deleted[] = $descendant_id;
+		$capture = static function ( $deleted_post_id ) use ( &$deleted ): void {
+			$deleted[] = (int) $deleted_post_id;
+		};
+		add_action( 'deleted_post', $capture );
+
+		try {
+			// PageTrashCascade descendants are deleted leaves-first so WP's
+			// hierarchical-delete reparenting has nothing to do for any non-leaf.
+			$descendants = $this->cascade->descendants_for_root( $id );
+			foreach ( array_reverse( $descendants ) as $descendant_id ) {
+				wp_delete_post( $descendant_id, true );
 			}
+
+			$root_deleted = wp_delete_post( $id, true );
+		} finally {
+			remove_action( 'deleted_post', $capture );
 		}
 
-		if ( ! wp_delete_post( $id, true ) ) {
+		if ( ! $root_deleted ) {
 			return new WP_Error(
 				'cortext_document_delete_failed',
 				__( 'Document could not be deleted.', 'cortext' ),
 				array( 'status' => 500 )
 			);
 		}
-		$deleted[] = $id;
 
 		return new WP_REST_Response(
 			array(
-				'deleted' => $deleted,
+				'deleted' => array_values( array_unique( $deleted ) ),
 			),
 			200
 		);

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1103,6 +1103,7 @@ export default function Sidebar( {
 					<SidebarTrash
 						activePages={ pages }
 						selectedId={ selectedId }
+						selectedCollectionId={ selectedCollectionId }
 						onSelect={ onSelect }
 						trashedDocumentsState={ trashedDocumentsState }
 					/>

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -165,6 +165,10 @@ function descendantLabel( rootKind, counts ) {
  * @param {number|null} props.selectedId            Currently-selected page id, used
  *                                                  to highlight a trashed document when
  *                                                  the canvas is showing it.
+ * @param {number|null} props.selectedCollectionId  Currently-selected collection id, so
+ *                                                  permanent delete can navigate away
+ *                                                  when the open collection (or one of
+ *                                                  its rows) is gone.
  * @param {Function}    props.onSelect              Opens a trashed document in
  *                                                  the canvas.
  * @param {Object}      props.trashedDocumentsState Trashed document query state.
@@ -172,6 +176,7 @@ function descendantLabel( rootKind, counts ) {
 export default function SidebarTrash( {
 	activePages,
 	selectedId,
+	selectedCollectionId = null,
 	onSelect,
 	trashedDocumentsState = EMPTY_TRASHED_DOCUMENTS_STATE,
 } ) {
@@ -329,12 +334,14 @@ export default function SidebarTrash( {
 				path: `/cortext/v1/documents/${ id }/permanent-delete`,
 				method: 'POST',
 			} );
-			// If the canvas was showing one of the deleted pages, navigate
-			// away. Without this `useEntityRecord` would return undefined
-			// and the canvas would spin forever (the page is genuinely gone
-			// now, not just trashed).
+			// If the canvas was showing one of the deleted documents,
+			// navigate away. Without this `useEntityRecord` would return
+			// undefined and the canvas would spin forever (the document is
+			// genuinely gone now, not just trashed). Collections track via
+			// `selectedCollectionId`, so check both.
 			const deletedIds = response?.deleted ?? [];
-			if ( selectedId && deletedIds.includes( selectedId ) ) {
+			const openId = selectedId ?? selectedCollectionId;
+			if ( openId && deletedIds.includes( openId ) ) {
 				onSelect( null );
 			}
 			if ( kind === 'row' ) {
@@ -361,6 +368,7 @@ export default function SidebarTrash( {
 		refreshRows,
 		refreshTrash,
 		selectedId,
+		selectedCollectionId,
 		onSelect,
 	] );
 

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -28,9 +28,11 @@ const EMPTY_TRASHED_DOCUMENTS_STATE = {
 	refresh: () => {},
 };
 
-// Keep this in sync with `PageTrashCascade::META_KEY`. The Trash endpoint sends
-// this marker for every document so the sidebar can find cascade roots.
-const MARKER_META = '_cortext_trashed_by_parent';
+// Keep these in sync with the PHP cascade marker meta keys. Trash entries
+// carry a marker pointing at the cascade root (page → subpage, page → owned
+// inline collection) so the sidebar can fold descendants under their root.
+const PARENT_MARKER_META = '_cortext_trashed_by_parent';
+const OWNER_PAGE_MARKER_META = '_cortext_trashed_by_owner_page';
 
 export function computeSidebarTrashRoots( trashedDocuments = [] ) {
 	const all = Array.isArray( trashedDocuments ) ? trashedDocuments : [];
@@ -39,8 +41,17 @@ export function computeSidebarTrashRoots( trashedDocuments = [] ) {
 	);
 	const childrenByMarker = new Map();
 
-	const markerOf = ( document ) =>
-		Number( document.meta?.[ MARKER_META ] ?? 0 );
+	const markerOf = ( document ) => {
+		const meta = document.meta ?? {};
+		// Pages → subpages share the original marker. Pages → owned inline
+		// collections use a different key, but both point at a parent page
+		// that's the cascade root.
+		const parent = Number( meta[ PARENT_MARKER_META ] ?? 0 );
+		if ( parent > 0 ) {
+			return parent;
+		}
+		return Number( meta[ OWNER_PAGE_MARKER_META ] ?? 0 );
+	};
 
 	all.forEach( ( document ) => {
 		const marker = markerOf( document );
@@ -86,7 +97,13 @@ function documentKind( document ) {
 	if ( document?.kind ) {
 		return document.kind;
 	}
-	return document?.type === POST_TYPE ? 'page' : 'document';
+	if ( document?.type === POST_TYPE ) {
+		return 'page';
+	}
+	if ( document?.type === 'crtxt_collection' ) {
+		return 'collection';
+	}
+	return 'document';
 }
 
 function descendantLabel( kind, count ) {
@@ -345,6 +362,11 @@ export default function SidebarTrash( {
 			"Permanently delete this row? You can't undo this.",
 			'cortext'
 		);
+	} else if ( pendingKind === 'collection' ) {
+		pendingDeleteMessage = __(
+			"Permanently delete this collection and all its rows? You can't undo this.",
+			'cortext'
+		);
 	} else if ( pendingKind === 'document' ) {
 		pendingDeleteMessage = __(
 			"Permanently delete this document? You can't undo this.",
@@ -437,6 +459,16 @@ export default function SidebarTrash( {
 										__( 'Collection', 'cortext' )
 								  )
 								: '';
+						// Inline collections that surface as roots (because
+						// their owner page is still active) show the owner's
+						// title so users can tell similar inline tables apart.
+						const ownerTitle =
+							kind === 'collection' && document.owner
+								? titleText(
+										document.owner?.title,
+										__( 'Page', 'cortext' )
+								  )
+								: '';
 						const rowClasses = [ 'cortext-sidebar__row' ];
 						if ( isSelected ) {
 							rowClasses.push( 'is-selected' );
@@ -467,6 +499,7 @@ export default function SidebarTrash( {
 										</span>
 										{ ( breadcrumb.length > 0 ||
 											collectionTitle ||
+											ownerTitle ||
 											meta ) && (
 											<span className="cortext-sidebar__breadcrumb">
 												{ breadcrumb.map(
@@ -497,6 +530,9 @@ export default function SidebarTrash( {
 														</span>
 													)
 												) }
+												{ ownerTitle && (
+													<span>{ ownerTitle }</span>
+												) }
 												{ collectionTitle && (
 													<span>
 														{ collectionTitle }
@@ -506,7 +542,8 @@ export default function SidebarTrash( {
 													<>
 														{ ( breadcrumb.length >
 															0 ||
-															collectionTitle ) && (
+															collectionTitle ||
+															ownerTitle ) && (
 															<span aria-hidden="true">
 																{ ' · ' }
 															</span>

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -71,17 +71,25 @@ export function computeSidebarTrashRoots( trashedDocuments = [] ) {
 
 	const descendantCountById = new Map();
 	roots.forEach( ( root ) => {
-		let count = 0;
+		const counts = { pages: 0, collections: 0, total: 0 };
 		const stack = [ ...( childrenByMarker.get( root.id ) ?? [] ) ];
 		while ( stack.length ) {
 			const node = stack.pop();
-			count++;
+			counts.total++;
+			if ( node.kind === 'page' || node.type === POST_TYPE ) {
+				counts.pages++;
+			} else if (
+				node.kind === 'collection' ||
+				node.type === 'crtxt_collection'
+			) {
+				counts.collections++;
+			}
 			const kids = childrenByMarker.get( node.id );
 			if ( kids ) {
 				stack.push( ...kids );
 			}
 		}
-		descendantCountById.set( root.id, count );
+		descendantCountById.set( root.id, counts );
 	} );
 
 	return { roots, descendantCountById };
@@ -107,19 +115,36 @@ function documentKind( document ) {
 	return 'document';
 }
 
-function descendantLabel( kind, count ) {
-	if ( kind === 'page' ) {
-		return sprintf(
-			/* translators: %d: number of subpages */
-			_n( '%d subpage', '%d subpages', count, 'cortext' ),
-			count
-		);
+function descendantLabel( rootKind, counts ) {
+	// Mixed subtrees (page → subpage + page → owned inline collection) read
+	// as "%d nested items" so the wording stays honest. Pure subtrees keep
+	// the more specific noun.
+	if ( rootKind === 'page' ) {
+		if ( counts.pages > 0 && counts.collections === 0 ) {
+			return sprintf(
+				/* translators: %d: number of subpages */
+				_n( '%d subpage', '%d subpages', counts.pages, 'cortext' ),
+				counts.pages
+			);
+		}
+		if ( counts.collections > 0 && counts.pages === 0 ) {
+			return sprintf(
+				/* translators: %d: number of nested inline collections */
+				_n(
+					'%d collection',
+					'%d collections',
+					counts.collections,
+					'cortext'
+				),
+				counts.collections
+			);
+		}
 	}
 
 	return sprintf(
 		/* translators: %d: number of nested trashed documents */
-		_n( '%d nested item', '%d nested items', count, 'cortext' ),
-		count
+		_n( '%d nested item', '%d nested items', counts.total, 'cortext' ),
+		counts.total
 	);
 }
 
@@ -343,9 +368,14 @@ export default function SidebarTrash( {
 	const hasError = Boolean( trashError && ! hasTrashCache );
 	const hasItems = roots.length > 0;
 	const pendingKind = pendingDelete ? documentKind( pendingDelete ) : null;
-	const pendingDescendantCount = pendingDelete
-		? descendantCountById.get( pendingDelete.id ) ?? 0
-		: 0;
+	const pendingDescendantCounts = pendingDelete
+		? descendantCountById.get( pendingDelete.id ) ?? {
+				pages: 0,
+				collections: 0,
+				total: 0,
+		  }
+		: { pages: 0, collections: 0, total: 0 };
+	const pendingDescendantCount = pendingDescendantCounts.total;
 	const retryTrashFetch = useCallback( () => {
 		invalidateResolution( 'getEntityRecords', [
 			'postType',
@@ -375,16 +405,35 @@ export default function SidebarTrash( {
 			'cortext'
 		);
 	} else if ( pendingDescendantCount > 0 ) {
-		pendingDeleteMessage = sprintf(
-			/* translators: %d: number of subpages that will be deleted along with the page. */
-			_n(
-				"Permanently delete this page and %d subpage? You can't undo this.",
-				"Permanently delete this page and %d subpages? You can't undo this.",
-				pendingDescendantCount,
-				'cortext'
-			),
-			pendingDescendantCount
-		);
+		// Mixed subtrees (subpages + inline collections) use the generic
+		// "nested items" wording so the count stays correct without
+		// pretending an inline collection is a subpage.
+		if (
+			pendingDescendantCounts.pages > 0 &&
+			pendingDescendantCounts.collections === 0
+		) {
+			pendingDeleteMessage = sprintf(
+				/* translators: %d: number of subpages that will be deleted along with the page. */
+				_n(
+					"Permanently delete this page and %d subpage? You can't undo this.",
+					"Permanently delete this page and %d subpages? You can't undo this.",
+					pendingDescendantCounts.pages,
+					'cortext'
+				),
+				pendingDescendantCounts.pages
+			);
+		} else {
+			pendingDeleteMessage = sprintf(
+				/* translators: %d: number of nested trashed items deleted along with the page. */
+				_n(
+					"Permanently delete this page and %d nested item? You can't undo this.",
+					"Permanently delete this page and %d nested items? You can't undo this.",
+					pendingDescendantCount,
+					'cortext'
+				),
+				pendingDescendantCount
+			);
+		}
 	}
 	if ( pendingDescendantCount > 0 && pendingKind === 'row' ) {
 		pendingDeleteMessage = sprintf(
@@ -449,10 +498,15 @@ export default function SidebarTrash( {
 						const isSelected = selectedId === document.id;
 						const error =
 							rowError?.id === document.id ? rowError : null;
-						const descendantCount =
-							descendantCountById.get( document.id ) ?? 0;
-						const meta = descendantCount
-							? descendantLabel( kind, descendantCount )
+						const descendantCounts = descendantCountById.get(
+							document.id
+						) ?? {
+							pages: 0,
+							collections: 0,
+							total: 0,
+						};
+						const meta = descendantCounts.total
+							? descendantLabel( kind, descendantCounts )
 							: '';
 						const collectionTitle =
 							kind === 'row'

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { rotateLeft, trash } from '@wordpress/icons';
+import { useNavigate } from '@tanstack/react-router';
 
 import PageIcon from './PageIcon';
 import {
@@ -149,6 +150,7 @@ export default function SidebarTrash( {
 	onSelect,
 	trashedDocumentsState = EMPTY_TRASHED_DOCUMENTS_STATE,
 } ) {
+	const navigate = useNavigate();
 	const {
 		documents: trashedDocuments,
 		isLoading: isResolvingTrash,
@@ -484,7 +486,12 @@ export default function SidebarTrash( {
 										className="cortext-sidebar__title cortext-sidebar__trash-text"
 										variant="tertiary"
 										onClick={ () =>
-											onSelect( document.id, document )
+											navigate( {
+												to: '/$',
+												params: {
+													_splat: document.path,
+												},
+											} )
 										}
 									>
 										<span className="cortext-sidebar__trash-title">

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -171,6 +171,25 @@ function makeRow( overrides = {} ) {
 	};
 }
 
+function makeCollection( overrides = {} ) {
+	const { meta, owner, ...rest } = overrides;
+	return {
+		id: 201,
+		type: 'crtxt_collection',
+		kind: 'collection',
+		title: { rendered: 'Tasks', raw: 'Tasks' },
+		parent: 0,
+		meta: {
+			cortext_document_icon: '',
+			_cortext_trashed_by_parent: 0,
+			_cortext_trashed_by_owner_page: 0,
+			...( meta ?? {} ),
+		},
+		...( owner !== undefined ? { owner } : {} ),
+		...rest,
+	};
+}
+
 function makeDocumentsState( overrides = {} ) {
 	return {
 		documents: [],
@@ -549,6 +568,94 @@ describe( 'SidebarTrash', () => {
 			42,
 			expect.objectContaining( { id: 42 } )
 		);
+	} );
+
+	it( 'renders a trashed full-page collection with no owner breadcrumb', () => {
+		const collection = makeCollection( {
+			id: 33,
+			title: { rendered: 'Roadmap', raw: 'Roadmap' },
+		} );
+
+		setTrashRecords( { records: [ collection ] } );
+
+		const { container } = renderSidebarTrash();
+
+		expect( screen.getByText( 'Roadmap' ) ).toBeInTheDocument();
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toBeFalsy();
+	} );
+
+	it( 'renders a trashed inline collection with its owner page in the breadcrumb', () => {
+		// Inline collection whose owner page is still active. The trash
+		// list surfaces the owner so users can tell similar inline tables
+		// apart.
+		const inline = makeCollection( {
+			id: 34,
+			title: { rendered: 'Action items', raw: 'Action items' },
+			owner: {
+				id: 99,
+				title: {
+					rendered: 'Quarterly review',
+					raw: 'Quarterly review',
+				},
+				path: 'page/quarterly-99',
+			},
+		} );
+
+		setTrashRecords( { records: [ inline ] } );
+
+		const { container } = renderSidebarTrash();
+
+		expect( screen.getByText( 'Action items' ) ).toBeInTheDocument();
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toHaveTextContent( 'Quarterly review' );
+	} );
+
+	it( 'nests an inline collection under its owner page when both are in trash', () => {
+		// Page → inline collection cascade. The page is the root; the
+		// inline collection should fold under it instead of appearing as a
+		// second root entry.
+		const owner = makePage( {
+			id: 50,
+			title: { rendered: 'Sprint notes', raw: 'Sprint notes' },
+		} );
+		const inline = makeCollection( {
+			id: 51,
+			title: { rendered: 'Action items', raw: 'Action items' },
+			meta: { _cortext_trashed_by_owner_page: 50 },
+		} );
+
+		setTrashRecords( { records: [ owner, inline ] } );
+
+		renderSidebarTrash();
+
+		expect( screen.getByText( 'Sprint notes' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Action items' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'announces collection rows in the permanent-delete confirmation', () => {
+		setTrashRecords( {
+			records: [
+				makeCollection( {
+					id: 60,
+					title: { rendered: 'Library', raw: 'Library' },
+				} ),
+			],
+		} );
+
+		renderSidebarTrash();
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Delete permanently' } )
+		);
+
+		expect(
+			screen.getByText(
+				"Permanently delete this collection and all its rows? You can't undo this."
+			)
+		).toBeInTheDocument();
 	} );
 
 	it( 'announces subtree size in the permanent-delete confirmation', () => {

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -474,6 +474,37 @@ describe( 'SidebarTrash', () => {
 		} );
 	} );
 
+	it( 'navigates the canvas away when the open collection is permanent-deleted', async () => {
+		// Collection routes live in selectedCollectionId, not selectedId.
+		// Without checking both, the canvas would keep pointing at a deleted
+		// collection URL after the row clicks Delete permanently.
+		const onSelect = jest.fn();
+		setTrashRecords( {
+			records: [
+				makeCollection( {
+					id: 73,
+					path: 'collection/library-73',
+				} ),
+			],
+		} );
+		apiFetch.mockResolvedValue( { deleted: [ 73 ] } );
+
+		renderSidebarTrash( {
+			selectedId: null,
+			selectedCollectionId: 73,
+			onSelect,
+		} );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Delete permanently' } )
+		);
+		clickConfirm();
+
+		await waitFor( () => {
+			expect( onSelect ).toHaveBeenCalledWith( null );
+		} );
+	} );
+
 	it( 'leaves the canvas alone when permanent-delete does not include the open page', async () => {
 		const onSelect = jest.fn();
 		setTrashRecords( { records: [ makePage( { id: 1 } ) ] } );

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -544,6 +544,50 @@ describe( 'SidebarTrash', () => {
 		).toHaveTextContent( '2 subpages' );
 	} );
 
+	it( 'shows a collection count when a trashed page owns only inline collections', () => {
+		const root = makePage( {
+			id: 1,
+			title: { rendered: 'Quarterly review', raw: 'Quarterly review' },
+		} );
+		const inline = makeCollection( {
+			id: 2,
+			title: { rendered: 'Action items', raw: 'Action items' },
+			meta: { _cortext_trashed_by_owner_page: 1 },
+		} );
+
+		setTrashRecords( { records: [ root, inline ] } );
+
+		const { container } = renderSidebarTrash();
+
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toHaveTextContent( '1 collection' );
+	} );
+
+	it( 'falls back to nested items when a trashed page mixes subpages and inline collections', () => {
+		const root = makePage( {
+			id: 1,
+			title: { rendered: 'Quarterly review', raw: 'Quarterly review' },
+		} );
+		const subpage = makePage( {
+			id: 2,
+			parent: 1,
+			meta: { _cortext_trashed_by_parent: 1 },
+		} );
+		const inline = makeCollection( {
+			id: 3,
+			meta: { _cortext_trashed_by_owner_page: 1 },
+		} );
+
+		setTrashRecords( { records: [ root, subpage, inline ] } );
+
+		const { container } = renderSidebarTrash();
+
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toHaveTextContent( '2 nested items' );
+	} );
+
 	it( 'promotes orphaned descendants (stale marker) back to roots', () => {
 		// Marker points at a parent no longer in Trash. It may have been
 		// permanently deleted by an older build or a different path; either
@@ -713,6 +757,36 @@ describe( 'SidebarTrash', () => {
 		expect(
 			screen.getByText(
 				"Permanently delete this page and 1 subpage? You can't undo this."
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'falls back to nested items in the confirm when subpages and inline collections mix', () => {
+		const root = makePage( {
+			id: 1,
+			title: { rendered: 'Workspace', raw: 'Workspace' },
+		} );
+		const subpage = makePage( {
+			id: 2,
+			parent: 1,
+			meta: { _cortext_trashed_by_parent: 1 },
+		} );
+		const inline = makeCollection( {
+			id: 3,
+			meta: { _cortext_trashed_by_owner_page: 1 },
+		} );
+
+		setTrashRecords( { records: [ root, subpage, inline ] } );
+
+		renderSidebarTrash();
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Delete permanently' } )
+		);
+
+		expect(
+			screen.getByText(
+				"Permanently delete this page and 2 nested items? You can't undo this."
 			)
 		).toBeInTheDocument();
 	} );

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -85,8 +85,14 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 	default: jest.fn(),
 } ) );
 
+jest.mock( '@tanstack/react-router', () => ( {
+	__esModule: true,
+	useNavigate: jest.fn(),
+} ) );
+
 import { useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+import { useNavigate } from '@tanstack/react-router';
 
 import SidebarTrash from '../../../src/components/SidebarTrash';
 import {
@@ -100,12 +106,17 @@ const dispatchMocks = {
 	invalidateResolution: jest.fn(),
 };
 
+const navigateMock = jest.fn();
+
 beforeEach( () => {
 	useDispatch.mockReset();
 	apiFetch.mockReset();
+	useNavigate.mockReset();
 	dispatchMocks.deleteEntityRecord.mockReset();
 	dispatchMocks.invalidateResolution.mockReset();
+	navigateMock.mockReset();
 	useDispatch.mockReturnValue( dispatchMocks );
+	useNavigate.mockReturnValue( navigateMock );
 	trashState = makeDocumentsState();
 } );
 
@@ -551,23 +562,45 @@ describe( 'SidebarTrash', () => {
 		expect( screen.getByText( 'Stranded' ) ).toBeInTheDocument();
 	} );
 
-	it( 'calls onSelect when a trashed row title is clicked', () => {
-		const onSelect = jest.fn();
+	it( 'navigates to the document path when a trashed page title is clicked', () => {
 		const root = makePage( {
 			id: 42,
 			title: { rendered: 'Stranded', raw: 'Stranded' },
+			path: 'page/stranded-42',
 		} );
 
 		setTrashRecords( { records: [ root ] } );
 
-		renderSidebarTrash( { selectedId: null, onSelect } );
+		renderSidebarTrash( { selectedId: null } );
 
 		fireEvent.click( screen.getByText( 'Stranded' ) );
 
-		expect( onSelect ).toHaveBeenCalledWith(
-			42,
-			expect.objectContaining( { id: 42 } )
-		);
+		expect( navigateMock ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'page/stranded-42' },
+		} );
+	} );
+
+	it( 'navigates with the collection/ prefix when a trashed collection title is clicked', () => {
+		// Documents controller hands back the right path per kind. Without
+		// honoring it, the click would navigate to a bare id and mount the
+		// document Canvas instead of the CollectionPane.
+		const collection = makeCollection( {
+			id: 73,
+			title: { rendered: 'Library', raw: 'Library' },
+			path: 'collection/library-73',
+		} );
+
+		setTrashRecords( { records: [ collection ] } );
+
+		renderSidebarTrash();
+
+		fireEvent.click( screen.getByText( 'Library' ) );
+
+		expect( navigateMock ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'collection/library-73' },
+		} );
 	} );
 
 	it( 'renders a trashed full-page collection with no owner breadcrumb', () => {

--- a/tests/php/test-collection-trash-cascade.php
+++ b/tests/php/test-collection-trash-cascade.php
@@ -220,6 +220,23 @@ final class Test_Collection_Trash_Cascade extends BaseTestCase {
 		);
 	}
 
+	public function test_trashing_a_collection_does_not_invoke_this_cascade(): void {
+		// Collections are documents themselves now, so wp_trash_post for a
+		// collection would otherwise trigger this cascade. The collection →
+		// row direction lives in RowTrashCascade, not here; this cascade
+		// stays as a no-op for collections.
+		$collection_id = $this->create_full_page_collection();
+
+		wp_trash_post( $collection_id );
+
+		$this->assertSame( 'trash', get_post_status( $collection_id ) );
+		$this->assertSame(
+			'',
+			(string) get_post_meta( $collection_id, CollectionTrashCascade::TRASHED_BY_OWNER_META_KEY, true ),
+			'A collection moving to Trash must not stamp itself with the owner-page marker.'
+		);
+	}
+
 	public function test_trashing_a_non_page_post_does_not_touch_owned_inline_collections(): void {
 		$post_id = wp_insert_post(
 			array(

--- a/tests/php/test-documents.php
+++ b/tests/php/test-documents.php
@@ -44,14 +44,18 @@ final class Test_Documents extends BaseTestCase {
 		parent::tear_down();
 	}
 
-	public function test_get_document_post_types_includes_pages_and_rows(): void {
+	public function test_get_document_post_types_includes_pages_rows_and_collections(): void {
 		$this->create_collection( 'projects', 'Projects' );
 
 		$post_types = $this->documents->get_document_post_types();
 
 		$this->assertContains( Page::POST_TYPE, $post_types );
 		$this->assertContains( 'crtxt_projects', $post_types );
-		$this->assertNotContains( Collection::POST_TYPE, $post_types );
+		$this->assertContains(
+			Collection::POST_TYPE,
+			$post_types,
+			'Collections share the document lifecycle as of the documents refactor.'
+		);
 		$this->assertNotContains( Field::POST_TYPE, $post_types );
 	}
 
@@ -101,6 +105,69 @@ final class Test_Documents extends BaseTestCase {
 		$this->assertSame( 'Projects', $document['collection']['title'] );
 		$this->assertSame( "collection/projects-{$collection_id}", $document['collection']['path'] );
 		$this->assertArrayNotHasKey( 'icon', $document );
+	}
+
+	public function test_find_returns_full_page_collection_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'tasks', 'Tasks' );
+
+		$document = $this->documents->find( $collection_id );
+
+		$this->assertNotNull( $document );
+		$this->assertSame( Documents::KIND_COLLECTION, $document['kind'] );
+		$this->assertSame( $collection_id, $document['id'] );
+		$this->assertSame( 'Tasks', $document['title'] );
+		$this->assertSame( "collection/tasks-{$collection_id}", $document['path'] );
+		$this->assertArrayNotHasKey(
+			'owner',
+			$document,
+			'Full-page collections do not carry an owner; they are reachable on their own.'
+		);
+	}
+
+	public function test_find_returns_inline_collection_with_owner_page(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$owner_id  = $this->create_page( array( 'post_title' => 'Quarterly review' ) );
+		$inline_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Action items',
+				'meta_input'  => array(
+					'slug'                            => 'action-items',
+					Collection::MODE_META_KEY         => Collection::MODE_INLINE,
+					Collection::INLINE_OWNER_META_KEY => $owner_id,
+				),
+			)
+		);
+
+		$document = $this->documents->find( $inline_id );
+
+		$this->assertNotNull( $document );
+		$this->assertSame( Documents::KIND_COLLECTION, $document['kind'] );
+		$this->assertSame( $inline_id, $document['id'] );
+		$this->assertSame( 'Action items', $document['title'] );
+		$this->assertArrayHasKey(
+			'owner',
+			$document,
+			'Inline collections surface their owner page so command palette and trash can show breadcrumb context.'
+		);
+		$this->assertSame( $owner_id, $document['owner']['id'] );
+		$this->assertSame( 'Quarterly review', $document['owner']['title'] );
+	}
+
+	public function test_list_can_filter_to_collections_only(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_id       = $this->create_page( array( 'post_title' => 'Welcome' ) );
+		$collection_id = $this->create_collection( 'tasks', 'Tasks' );
+		$row_id        = $this->create_row( 'crtxt_tasks', 'First task' );
+
+		$collections_only = $this->documents->list( array( 'kind' => Documents::KIND_COLLECTION ) );
+
+		$ids = array_map( static fn ( array $doc ): int => $doc['id'], $collections_only['documents'] );
+		$this->assertContains( $collection_id, $ids );
+		$this->assertNotContains( $page_id, $ids );
+		$this->assertNotContains( $row_id, $ids );
 	}
 
 	public function test_find_row_without_slug_falls_back_to_bare_id(): void {

--- a/tests/php/test-documents.php
+++ b/tests/php/test-documents.php
@@ -127,7 +127,12 @@ final class Test_Documents extends BaseTestCase {
 
 	public function test_find_returns_inline_collection_with_owner_page(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$owner_id  = $this->create_page( array( 'post_title' => 'Quarterly review' ) );
+		$owner_id  = $this->create_page(
+			array(
+				'post_title' => 'Quarterly review',
+				'post_name'  => 'quarterly-review',
+			)
+		);
 		$inline_id = (int) wp_insert_post(
 			array(
 				'post_type'   => Collection::POST_TYPE,
@@ -154,6 +159,13 @@ final class Test_Documents extends BaseTestCase {
 		);
 		$this->assertSame( $owner_id, $document['owner']['id'] );
 		$this->assertSame( 'Quarterly review', $document['owner']['title'] );
+		// Inline collections have no workspace route of their own;
+		// clicking one in search/trash should land on the owner page,
+		// not bounce to Not Found through EntityRoute's inline guard.
+		$this->assertSame(
+			"page/quarterly-review-{$owner_id}",
+			$document['path']
+		);
 	}
 
 	public function test_list_can_filter_to_collections_only(): void {

--- a/tests/php/test-post-type-collection.php
+++ b/tests/php/test-post-type-collection.php
@@ -63,7 +63,19 @@ final class Test_Post_Type_Collection extends BaseTestCase {
 			post_type_supports( Collection::POST_TYPE, 'page-attributes' ),
 			'page-attributes exposes parent/menu_order for sidebar nesting and drag/drop.'
 		);
-		$this->assertFalse( post_type_supports( Collection::POST_TYPE, 'editor' ), 'Collections are schema definitions, not documents.' );
+		$this->assertFalse(
+			post_type_supports( Collection::POST_TYPE, 'editor' ),
+			"Collections do not need block-editor content yet. Their canvas is the DataView."
+		);
+	}
+
+	public function test_collections_opt_into_document_lifecycle(): void {
+		( new Collection() )->register_post_type();
+
+		$this->assertTrue(
+			post_type_supports( Collection::POST_TYPE, 'cortext-document' ),
+			'Collections share the document lifecycle (title, identity, trash, restore, search).'
+		);
 	}
 
 	public function test_meta_is_registered(): void {

--- a/tests/php/test-rest-collections-controller.php
+++ b/tests/php/test-rest-collections-controller.php
@@ -333,6 +333,36 @@ final class Test_Rest_Collections_Controller extends BaseTestCase {
 		);
 	}
 
+	public function test_rejects_collection_parent_even_though_collections_are_documents(): void {
+		// Collections opt into the document trait now. Without an explicit
+		// guard, `validate_parent_document` would let this through and a
+		// user could nest a collection under another collection. Reject it.
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_collection_response = $this->create_collection(
+			array(
+				'title' => 'Parent collection',
+				'mode'  => Collection::MODE_FULL_PAGE,
+			)
+		);
+		$this->assertSame( 201, $parent_collection_response->get_status() );
+		$parent_collection_id = (int) $parent_collection_response->get_data()['id'];
+
+		$response = $this->create_collection(
+			array(
+				'title'  => 'Child collection',
+				'mode'   => Collection::MODE_FULL_PAGE,
+				'parent' => $parent_collection_id,
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame(
+			'cortext_collection_parent_invalid_type',
+			$response->get_data()['code']
+		);
+	}
+
 	public function test_query_filter_for_full_page_matches_explicit_full_page_or_missing_meta(): void {
 		// Missing mode means `full_page`, so existing collections stay in the
 		// sidebar after the inline/full-page split. The OR clause covers that

--- a/tests/php/test-rest-documents-controller-mutations.php
+++ b/tests/php/test-rest-documents-controller-mutations.php
@@ -304,6 +304,27 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 		$this->assertNull( get_post( $row_id ), 'Rows go with their collection on permanent delete.' );
 	}
 
+	public function test_permanent_delete_response_includes_cascaded_row_ids(): void {
+		// Without this, the sidebar can't tell that an open row from the
+		// deleted collection is gone and the canvas stays on a phantom URL.
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$collection_id = $this->create_full_page_collection( 'reported' );
+		$row_id        = $this->create_row_for_collection( 'reported' );
+		wp_trash_post( $collection_id );
+
+		$response = $this->permanent_delete( $collection_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$deleted = $response->get_data()['deleted'];
+		$this->assertContains( $collection_id, $deleted );
+		$this->assertContains(
+			$row_id,
+			$deleted,
+			'The response must list rows deleted by RowTrashCascade so the sidebar can navigate away from them.'
+		);
+	}
+
 	public function test_restore_skips_cascade_walk_for_flat_row_documents(): void {
 		// Row CPTs opt into cortext-document but have no hierarchy today, so
 		// restore should only return the row itself.

--- a/tests/php/test-rest-documents-controller-mutations.php
+++ b/tests/php/test-rest-documents-controller-mutations.php
@@ -14,8 +14,10 @@ declare( strict_types=1 );
 namespace Cortext\Tests;
 
 use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\Page;
 use Cortext\PostType\PageTrashCascade;
+use Cortext\PostType\RowTrashCascade;
 use Cortext\Rest\DocumentsController;
 use WorDBless\BaseTestCase;
 use WP_REST_Request;
@@ -38,6 +40,7 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 		$this->install_in_memory_posts_query();
 
 		( new PageTrashCascade() )->register();
+		( new RowTrashCascade() )->register();
 
 		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
 		( new DocumentsController() )->register();
@@ -271,6 +274,36 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 		$this->assertNull( get_post( $row_id ) );
 	}
 
+	public function test_restores_a_trashed_full_page_collection(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$collection_id = $this->create_full_page_collection( 'restorable' );
+		wp_trash_post( $collection_id );
+		$this->assertSame( 'trash', get_post_status( $collection_id ) );
+
+		$response = $this->restore( $collection_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotSame( 'trash', get_post_status( $collection_id ) );
+		$this->assertSame( array( $collection_id ), $response->get_data()['restored'] );
+	}
+
+	public function test_permanent_delete_removes_a_trashed_collection_and_its_rows(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$collection_id = $this->create_full_page_collection( 'wipeable' );
+		$row_id        = $this->create_row_for_collection( 'wipeable' );
+		wp_trash_post( $collection_id );
+
+		// After trash, the dynamic CPT may not be re-registered next request.
+		// Confirm the cascade still walks rows on permanent delete.
+		$response = $this->permanent_delete( $collection_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNull( get_post( $collection_id ) );
+		$this->assertNull( get_post( $row_id ), 'Rows go with their collection on permanent delete.' );
+	}
+
 	public function test_restore_skips_cascade_walk_for_flat_row_documents(): void {
 		// Row CPTs opt into cortext-document but have no hierarchy today, so
 		// restore should only return the row itself.
@@ -331,6 +364,39 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 		);
 
 		$id = wp_insert_post( array_merge( $defaults, $args ) );
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+		return (int) $id;
+	}
+
+	private function create_full_page_collection( string $slug ): int {
+		$id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Collection ' . $slug,
+				'meta_input'  => array(
+					'slug'                    => $slug,
+					Collection::MODE_META_KEY => Collection::MODE_FULL_PAGE,
+				),
+			)
+		);
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+
+		( new CollectionEntries() )->register_for_collection( get_post( (int) $id ) );
+
+		return (int) $id;
+	}
+
+	private function create_row_for_collection( string $slug ): int {
+		$id = wp_insert_post(
+			array(
+				'post_type'   => CollectionEntries::CPT_PREFIX . $slug,
+				'post_status' => 'private',
+				'post_title'  => 'Row ' . wp_generate_uuid4(),
+			)
+		);
 		$this->assertIsInt( $id );
 		$this->assertGreaterThan( 0, $id );
 		return (int) $id;

--- a/tests/php/test-rest-documents-controller.php
+++ b/tests/php/test-rest-documents-controller.php
@@ -11,6 +11,7 @@ namespace Cortext\Tests;
 
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\CollectionTrashCascade;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
 use Cortext\PostType\Page;
@@ -171,6 +172,38 @@ final class Test_Rest_Documents_Controller extends BaseTestCase {
 		$this->assertSame( 'row', $row['kind'] );
 		$this->assertSame( $collection_id, $row['collection']['id'] );
 		$this->assertSame( 'Albums', $row['collection']['title'] );
+	}
+
+	public function test_status_trash_surfaces_owner_marker_on_inline_collections(): void {
+		// Without this marker in the response, the sidebar can't tell which
+		// inline collection was trashed by which page, so the inline entries
+		// would render as roots instead of nesting under their owner page.
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$owner_page = $this->create_page( array( 'post_title' => 'Owner' ) );
+		$inline_id  = (int) wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Action items',
+				'meta_input'  => array(
+					'slug'                                       => 'action-items',
+					Collection::MODE_META_KEY                    => Collection::MODE_INLINE,
+					Collection::INLINE_OWNER_META_KEY            => $owner_page,
+					CollectionTrashCascade::TRASHED_BY_OWNER_META_KEY => $owner_page,
+				),
+			)
+		);
+		wp_trash_post( $inline_id );
+
+		$response = $this->query( array( 'status' => 'trash' ) );
+
+		$by_id = array_column( $response->get_data()['documents'], null, 'id' );
+		$this->assertArrayHasKey( $inline_id, $by_id );
+		$this->assertSame(
+			$owner_page,
+			$by_id[ $inline_id ]['meta'][ CollectionTrashCascade::TRASHED_BY_OWNER_META_KEY ]
+		);
 	}
 
 	public function test_status_trash_excerpt_is_excluded(): void {

--- a/tests/php/test-rest-favorites-controller.php
+++ b/tests/php/test-rest-favorites-controller.php
@@ -302,6 +302,37 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 		);
 	}
 
+	public function test_get_drops_favorites_for_a_permanently_deleted_collection(): void {
+		// Self-heal contract: when a collection is force-deleted, the next
+		// favorites read filters its entry out via format_target's not-found
+		// branch. No eager scrub on delete is needed for correctness.
+		$user_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_id );
+		$kept_id    = $this->create_collection( 'kept', 'Kept' );
+		$deleted_id = $this->create_collection( 'doomed', 'Doomed' );
+		update_post_meta( $kept_id, Collection::MODE_META_KEY, Collection::MODE_FULL_PAGE );
+		update_post_meta( $deleted_id, Collection::MODE_META_KEY, Collection::MODE_FULL_PAGE );
+
+		update_user_meta(
+			$user_id,
+			self::META_KEY,
+			array(
+				"collection:{$kept_id}",
+				"collection:{$deleted_id}",
+			)
+		);
+
+		wp_delete_post( $deleted_id, true );
+
+		$response = $this->get_favorites();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array( $kept_id ),
+			array_column( $response->get_data()['favorites'], 'id' )
+		);
+	}
+
 	public function test_get_drops_stale_inline_collection_favorites(): void {
 		$user_id = $this->create_user( 'administrator' );
 		wp_set_current_user( $user_id );

--- a/tests/php/test-row-trash-cascade.php
+++ b/tests/php/test-row-trash-cascade.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Tests for Cortext\PostType\RowTrashCascade.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\RowTrashCascade;
+use WorDBless\BaseTestCase;
+
+final class Test_Row_Trash_Cascade extends BaseTestCase {
+
+	use InMemoryPostsQuery;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Collection() )->register_post_type();
+
+		remove_all_actions( 'wp_trash_post' );
+		remove_all_actions( 'untrashed_post' );
+		remove_all_actions( 'before_delete_post' );
+
+		$this->install_in_memory_posts_query();
+
+		( new RowTrashCascade() )->register();
+	}
+
+	public function tear_down(): void {
+		$this->uninstall_in_memory_posts_query();
+		parent::tear_down();
+	}
+
+	public function test_register_hooks_trash_untrash_and_delete_actions(): void {
+		$this->assertNotFalse( has_action( 'wp_trash_post' ) );
+		$this->assertNotFalse( has_action( 'untrashed_post' ) );
+		$this->assertNotFalse( has_action( 'before_delete_post' ) );
+	}
+
+	public function test_trashing_collection_trashes_its_rows_and_stamps_marker(): void {
+		[ $collection_id, $row_ids ] = $this->create_collection_with_rows( 'tasks', 3 );
+
+		wp_trash_post( $collection_id );
+
+		foreach ( $row_ids as $row_id ) {
+			$this->assertSame( 'trash', get_post_status( $row_id ) );
+			$this->assertSame(
+				(string) $collection_id,
+				(string) get_post_meta( $row_id, RowTrashCascade::TRASHED_BY_OWNER_META_KEY, true ),
+				'Each row trashed by the cascade carries the collection id as its owner marker.'
+			);
+		}
+	}
+
+	public function test_restoring_collection_revives_only_rows_its_cascade_trashed(): void {
+		[ $collection_id, $row_ids ] = $this->create_collection_with_rows( 'restore', 2 );
+		$independently_trashed       = $this->create_row_for_collection( 'restore' );
+
+		// Trash one row independently. It carries no marker.
+		wp_trash_post( $independently_trashed );
+
+		wp_trash_post( $collection_id );
+		wp_untrash_post( $collection_id );
+
+		foreach ( $row_ids as $row_id ) {
+			$this->assertNotSame( 'trash', get_post_status( $row_id ), 'Cascade-trashed rows come back on restore.' );
+			$this->assertSame(
+				'',
+				(string) get_post_meta( $row_id, RowTrashCascade::TRASHED_BY_OWNER_META_KEY, true ),
+				'Marker is cleared so a future cascade restore does not revive the row twice.'
+			);
+		}
+
+		$this->assertSame(
+			'trash',
+			get_post_status( $independently_trashed ),
+			'Rows that were already in trash without the marker stay there after the collection restore.'
+		);
+	}
+
+	public function test_permanent_delete_of_collection_removes_all_rows(): void {
+		[ $collection_id, $row_ids ] = $this->create_collection_with_rows( 'wiped', 2 );
+
+		wp_delete_post( $collection_id, true );
+
+		foreach ( $row_ids as $row_id ) {
+			$this->assertNull( get_post( $row_id ), 'Rows must be gone after a collection force-delete.' );
+		}
+	}
+
+	public function test_permanent_delete_of_already_trashed_collection_still_force_deletes_rows(): void {
+		// A trashed collection's dynamic row CPT is not registered by the
+		// normal init pass (it queries active statuses). The cascade has to
+		// register it on demand before walking rows; without that, the
+		// row query returns empty and the rows leak.
+		[ $collection_id, $row_ids ] = $this->create_collection_with_rows( 'two-step', 2 );
+
+		wp_trash_post( $collection_id );
+		// Simulate a fresh request: tear down the dynamic CPT so the cascade
+		// must register it from the collection meta to see the rows.
+		unregister_post_type( CollectionEntries::CPT_PREFIX . 'two-step' );
+
+		wp_delete_post( $collection_id, true );
+
+		foreach ( $row_ids as $row_id ) {
+			$this->assertNull( get_post( $row_id ) );
+		}
+	}
+
+	public function test_trashing_a_non_collection_post_is_a_noop(): void {
+		// The cascade is bound to crtxt_collection only. Trashing anything
+		// else should not invoke the row walk.
+		register_post_type(
+			'some_other_post_type',
+			array(
+				'public'   => false,
+				'supports' => array( 'title' ),
+			)
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'some_other_post_type',
+				'post_status' => 'private',
+				'post_title'  => 'Not a collection',
+			)
+		);
+
+		$this->assertIsInt( $post_id );
+		wp_trash_post( $post_id );
+
+		$this->assertSame( 'trash', get_post_status( $post_id ), 'Trash itself still applies.' );
+	}
+
+	/**
+	 * Creates a full-page collection with a registered row CPT and seeded
+	 * rows.
+	 *
+	 * @return array{0:int,1:int[]} Collection id, row ids.
+	 */
+	private function create_collection_with_rows( string $slug, int $row_count ): array {
+		$collection_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Collection ' . $slug,
+				'meta_input'  => array(
+					'slug'                    => $slug,
+					Collection::MODE_META_KEY => Collection::MODE_FULL_PAGE,
+				),
+			)
+		);
+
+		$collection = get_post( $collection_id );
+		( new CollectionEntries() )->register_for_collection( $collection );
+
+		$row_ids = array();
+		for ( $i = 0; $i < $row_count; $i++ ) {
+			$row_ids[] = $this->create_row_for_collection( $slug, "Row {$slug} {$i}" );
+		}
+
+		return array( $collection_id, $row_ids );
+	}
+
+	private function create_row_for_collection( string $slug, string $title = '' ): int {
+		$id = (int) wp_insert_post(
+			array(
+				'post_type'   => CollectionEntries::CPT_PREFIX . $slug,
+				'post_status' => 'private',
+				'post_title'  => '' === $title ? "Row {$slug} " . wp_generate_uuid4() : $title,
+			)
+		);
+		$this->assertGreaterThan( 0, $id );
+
+		return $id;
+	}
+}


### PR DESCRIPTION
## What
Closes #219.

Opts `crtxt_collection` into the `cortext-document` trait so collections behave like pages and rows in code that handles documents.

## Why
Issue #180 adds new actions to the collection sidebar menu, including Trash. Building that without this change would mean reimplementing the document trash and search code from scratch. The command palette now also finds collections by title.

## How
- Opting `crtxt_collection` into the `cortext-document` trait through `DocumentIdentity` and handling a new `KIND_COLLECTION` in `Documents::format_document`. Inline collections carry an `owner` field for their host page and use the owner's path, so command palette results open the host page instead of dying at `EntityRoute`'s inline guard.
- Adding `RowTrashCascade` for the collection → row direction. The three cascade classes (`PageTrashCascade`, `CollectionTrashCascade`, `RowTrashCascade`) are each named after the post type they trash.
- Capturing every `deleted_post` during `permanent_delete` so the response lists cascade-deleted ids, and using that list in `SidebarTrash` to close the canvas when the open document is gone.
- Splitting descendant counts by kind, so a trash entry reads "1 subpage" when all the descendants are subpages, "1 collection" when they're all inline collections, and "N nested items" when the subtree mixes both.
- Rejecting `crtxt_collection` as a parent in `validate_parent_document` so REST can't nest a collection under another collection.

## Testing Instructions

1. Open the command palette and search for a full-page collection by title. The result appears. Clicking it opens the collection.
2. Open the command palette and search for an inline collection (one embedded as a DataView block inside a page). The result shows the owner page in the breadcrumb. Clicking it opens the owner page.
3. Trash a page that contains an inline collection. In Sidebar Trash, the page shows as a root with the inline nested under it as "1 collection". Restoring the page brings both back. Permanently deleting the page wipes both.