### PR TITLE
Try: Run perf benchmarks on main only

### DIFF
--- a/.github/scripts/write-perf-comment.php
+++ b/.github/scripts/write-perf-comment.php
@@ -29,15 +29,21 @@ require_once __DIR__ . '/perf-ui-scenario-labels.php';
 
 $args = parse_args( $argv );
 
-$bench_current = $args['bench-current'] ?? '';
-$bench_base    = $args['bench-base'] ?? '';
-$ui_current    = $args['ui-current'] ?? '';
-$ui_base       = $args['ui-base'] ?? '';
-$base_label    = $args['base-label'] ?? 'base';
-$run_url       = $args['run-url'] ?? '';
+$bench_current      = $args['bench-current'] ?? '';
+$bench_base         = $args['bench-base'] ?? '';
+$ui_current         = $args['ui-current'] ?? '';
+$ui_base            = $args['ui-base'] ?? '';
+$base_label         = $args['base-label'] ?? 'base';
+$run_url            = $args['run-url'] ?? '';
+$exit_on_regression = isset( $args['exit-on-regression'] );
 
+$result = build_comment( $bench_current, $bench_base, $ui_current, $ui_base, $base_label, $run_url );
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CLI markdown output for GitHub PR comments stays unescaped.
-echo build_comment( $bench_current, $bench_base, $ui_current, $ui_base, $base_label, $run_url );
+echo $result['comment'];
+
+if ( $exit_on_regression && $result['has_regression'] ) {
+	exit( 1 );
+}
 
 /**
  * @param array<int,string> $argv
@@ -59,7 +65,10 @@ function parse_args( array $argv ): array {
 	return $args;
 }
 
-function build_comment( string $bench_current_path, string $bench_base_path, string $ui_current_path, string $ui_base_path, string $base_label, string $run_url ): string {
+/**
+ * @return array{comment:string,has_regression:bool}
+ */
+function build_comment( string $bench_current_path, string $bench_base_path, string $ui_current_path, string $ui_base_path, string $base_label, string $run_url ): array {
 	$rows               = array();
 	$missing_baselines  = array();
 
@@ -122,7 +131,29 @@ function build_comment( string $bench_current_path, string $bench_base_path, str
 		$lines[] = '_Full numbers in the [job summary](' . $run_url . ')._';
 	}
 
-	return implode( "\n", $lines ) . "\n";
+	return array(
+		'comment'        => implode( "\n", $lines ) . "\n",
+		'has_regression' => rows_have_regression( $rows ),
+	);
+}
+
+/**
+ * Returns true if any row has a positive (regression) delta in workload or
+ * timing. Improvements (delta with `-` prefix) don't count, so the workflow
+ * doesn't fail on a -20% timing or a -2 SQL queries change.
+ *
+ * @param array<int,array{label:string,workload:string,timing:string}> $rows
+ */
+function rows_have_regression( array $rows ): bool {
+	foreach ( $rows as $row ) {
+		if ( 1 === preg_match( '/\+\d/', $row['workload'] ) ) {
+			return true;
+		}
+		if ( 1 === preg_match( '/\+\d/', $row['timing'] ) ) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function build_headline( int $workload_scenarios, int $timing_scenarios ): string {

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -10,44 +10,42 @@ on:
             - .github/workflows/perf-bench.yml
             - .github/scripts/write-perf-bench-summary.php
             - .github/scripts/write-perf-ui-summary.php
-    pull_request:
-        branches: [main]
-        paths:
-            - includes/CLI/**
-            - src/**
-            - tests/e2e/specs/perf-ui.spec.js
-            - .github/workflows/perf-bench.yml
-            - .github/scripts/write-perf-bench-summary.php
-            - .github/scripts/write-perf-ui-summary.php
+            - .github/scripts/write-perf-comment.php
     workflow_dispatch:
 
 permissions:
     actions: read
-    contents: read
-    pull-requests: write
-
-env:
-    CORTEXT_PERF_UI: ${{ vars.CORTEXT_PERF_UI || '0' }}
+    # Lets the workflow post commit comments after main pushes.
+    contents: write
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
-    performance-bench:
-        name: Performance benchmark
+    main-perf:
+        name: Performance benchmark on main
         runs-on: ubuntu-latest
         timeout-minutes: 40
         steps:
             - uses: actions/checkout@v4
+              with:
+                  # The job benchmarks HEAD and HEAD^ in the same runner.
+                  fetch-depth: 2
 
-            - name: Capture PR HEAD and fetch main
-              if: github.event_name == 'pull_request'
+            - name: Capture HEAD and HEAD^ SHAs
               id: refs
               run: |
                   set -euo pipefail
-                  echo "pr_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-                  git fetch origin main --depth=1
+                  head_sha="$(git rev-parse HEAD)"
+                  echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+                  if parent_sha="$(git rev-parse HEAD^ 2>/dev/null)"; then
+                    echo "parent_sha=$parent_sha" >> "$GITHUB_OUTPUT"
+                    echo "has_parent=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has_parent=false" >> "$GITHUB_OUTPUT"
+                    echo "No HEAD^ available; running HEAD only."
+                  fi
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -70,22 +68,15 @@ jobs:
                   node-version: '24.15'
                   cache: 'pnpm'
 
-            - name: Check out main for baseline
-              if: github.event_name == 'pull_request'
-              run: git checkout --detach origin/main
-
-            - name: Install dependencies (baseline)
-              if: github.event_name == 'pull_request'
+            - name: Install dependencies (HEAD)
               run: |
                   composer install --no-interaction --prefer-dist --no-dev
                   pnpm install --frozen-lockfile
 
-            - name: Start wp-env (baseline)
-              if: github.event_name == 'pull_request'
+            - name: Start wp-env (HEAD)
               run: pnpm run env:start
 
-            - name: Seed dataset (baseline)
-              if: github.event_name == 'pull_request'
+            - name: Seed dataset (HEAD)
               run: >
                   pnpm exec wp-env run cli wp cortext perf-seed
                   --reset
@@ -97,74 +88,7 @@ jobs:
                   --relations=1
                   --rollups=1
 
-            - name: Run baseline benchmark
-              if: github.event_name == 'pull_request'
-              continue-on-error: true
-              run: |
-                  set -euo pipefail
-                  mkdir -p artifacts
-                  pnpm exec wp-env run cli wp cortext perf-bench \
-                    --iterations=10 \
-                    --warmup=1 \
-                    --pretty | tee artifacts/perf-bench-base.json
-
-            - name: Run baseline UI performance benchmark
-              if: github.event_name == 'pull_request'
-              continue-on-error: true
-              env:
-                  CORTEXT_PERF_UI: '1'
-                  # The benchmark workflow starts the dev wp-env, which serves WordPress on 8888.
-                  WP_BASE_URL: http://localhost:8888
-              run: |
-                  set -euo pipefail
-
-                  if [ ! -f tests/e2e/specs/perf-ui.spec.js ]; then
-                    echo "No UI performance spec found."
-                    exit 0
-                  fi
-
-                  pnpm exec playwright install --with-deps chromium
-                  pnpm run build
-                  set +e
-                  pnpm exec wp-scripts test-playwright --config playwright.config.js tests/e2e/specs/perf-ui.spec.js
-                  status="$?"
-                  set -e
-
-                  if [ -s artifacts/perf-ui.json ]; then
-                    mv artifacts/perf-ui.json artifacts/perf-ui-base.json
-                  fi
-
-                  exit "$status"
-
-            - name: Destroy wp-env between runs
-              if: github.event_name == 'pull_request'
-              run: printf 'y\n' | pnpm exec wp-env destroy
-
-            - name: Restore PR HEAD
-              if: github.event_name == 'pull_request'
-              run: git checkout --detach ${{ steps.refs.outputs.pr_sha }}
-
-            - name: Install dependencies
-              run: |
-                  composer install --no-interaction --prefer-dist --no-dev
-                  pnpm install --frozen-lockfile
-
-            - name: Start wp-env
-              run: pnpm run env:start
-
-            - name: Seed benchmark dataset
-              run: >
-                  pnpm exec wp-env run cli wp cortext perf-seed
-                  --reset
-                  --force
-                  --collections=3
-                  --rows=1250
-                  --fields=8
-                  --wide-fields=40
-                  --relations=1
-                  --rollups=1
-
-            - name: Run benchmark
+            - name: Run backend benchmark (HEAD)
               run: |
                   set -euo pipefail
                   mkdir -p artifacts
@@ -199,11 +123,10 @@ jobs:
 
                   exit "$status"
 
-            - name: Run UI performance benchmark
-              if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || env.CORTEXT_PERF_UI == '1'
+            - name: Run UI benchmark (HEAD)
               env:
                   CORTEXT_PERF_UI: '1'
-                  # The benchmark workflow starts the dev wp-env, which serves WordPress on 8888.
+                  # wp-env serves WordPress on 8888.
                   WP_BASE_URL: http://localhost:8888
               run: |
                   set -euo pipefail
@@ -217,6 +140,79 @@ jobs:
                   pnpm run build
                   pnpm exec wp-scripts test-playwright --config playwright.config.js tests/e2e/specs/perf-ui.spec.js
 
+            - name: Destroy wp-env before HEAD^ pass
+              if: steps.refs.outputs.has_parent == 'true'
+              run: printf 'y\n' | pnpm exec wp-env destroy
+
+            - name: Check out HEAD^
+              if: steps.refs.outputs.has_parent == 'true'
+              run: git checkout --detach ${{ steps.refs.outputs.parent_sha }}
+
+            - name: Install dependencies (HEAD^)
+              if: steps.refs.outputs.has_parent == 'true'
+              run: |
+                  composer install --no-interaction --prefer-dist --no-dev
+                  pnpm install --frozen-lockfile
+
+            - name: Start wp-env (HEAD^)
+              if: steps.refs.outputs.has_parent == 'true'
+              run: pnpm run env:start
+
+            - name: Seed dataset (HEAD^)
+              if: steps.refs.outputs.has_parent == 'true'
+              run: >
+                  pnpm exec wp-env run cli wp cortext perf-seed
+                  --reset
+                  --force
+                  --collections=3
+                  --rows=1250
+                  --fields=8
+                  --wide-fields=40
+                  --relations=1
+                  --rollups=1
+
+            - name: Run backend benchmark (HEAD^)
+              if: steps.refs.outputs.has_parent == 'true'
+              continue-on-error: true
+              run: |
+                  set -euo pipefail
+                  mkdir -p artifacts
+                  pnpm exec wp-env run cli wp cortext perf-bench \
+                    --iterations=10 \
+                    --warmup=1 \
+                    --pretty | tee artifacts/perf-bench-base.json
+
+            - name: Run UI benchmark (HEAD^)
+              if: steps.refs.outputs.has_parent == 'true'
+              continue-on-error: true
+              env:
+                  CORTEXT_PERF_UI: '1'
+                  WP_BASE_URL: http://localhost:8888
+              run: |
+                  set -euo pipefail
+
+                  if [ ! -f tests/e2e/specs/perf-ui.spec.js ]; then
+                    echo "No UI performance spec found."
+                    exit 0
+                  fi
+
+                  pnpm exec playwright install --with-deps chromium
+                  pnpm run build
+                  set +e
+                  pnpm exec wp-scripts test-playwright --config playwright.config.js tests/e2e/specs/perf-ui.spec.js
+                  status="$?"
+                  set -e
+
+                  if [ -s artifacts/perf-ui.json ]; then
+                    mv artifacts/perf-ui.json artifacts/perf-ui-base.json
+                  fi
+
+                  exit "$status"
+
+            - name: Restore HEAD
+              if: steps.refs.outputs.has_parent == 'true'
+              run: git checkout --detach ${{ steps.refs.outputs.head_sha }}
+
             - name: Write benchmark summaries
               if: always()
               run: |
@@ -228,30 +224,35 @@ jobs:
                     php .github/scripts/write-perf-ui-summary.php --current=artifacts/perf-ui.json | tee artifacts/perf-ui-summary.md
                   fi
 
-            - name: Build PR comment body
-              if: always() && github.event_name == 'pull_request'
+            - name: Build commit comment body
+              id: comment_body
+              if: always() && steps.refs.outputs.has_parent == 'true'
               run: |
+                  set +e
                   mkdir -p artifacts
 
                   comment_args=(
                     --bench-current=artifacts/perf-bench.json
                     --bench-base=artifacts/perf-bench-base.json
-                    --base-label=main
+                    --base-label="previous main commit"
                     --run-url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
                   )
                   if [ -s artifacts/perf-ui.json ] && [ -s artifacts/perf-ui-base.json ]; then
                     comment_args+=(--ui-current=artifacts/perf-ui.json --ui-base=artifacts/perf-ui-base.json)
                   fi
 
-                  php .github/scripts/write-perf-comment.php "${comment_args[@]}" > artifacts/perf-bench-comment-body.md
+                  php .github/scripts/write-perf-comment.php "${comment_args[@]}" --exit-on-regression > artifacts/perf-bench-comment-body.md
+                  status="$?"
+                  echo "regression_status=$status" >> "$GITHUB_OUTPUT"
+                  exit 0
 
-            - name: Post PR benchmark comment
-              if: always() && github.event_name == 'pull_request'
+            - name: Post commit comment
+              if: always() && steps.refs.outputs.has_parent == 'true'
               continue-on-error: true
               env:
                   GH_TOKEN: ${{ github.token }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
                   REPOSITORY: ${{ github.repository }}
+                  HEAD_SHA: ${{ steps.refs.outputs.head_sha }}
               run: |
                   set -euo pipefail
 
@@ -266,25 +267,16 @@ jobs:
                     cat artifacts/perf-bench-comment-body.md
                   } > "$comment_file"
 
-                  if ! comment_id="$(gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
-                    --paginate \
-                    --jq '.[] | select(.user.type == "Bot" and (.body | contains("<!-- cortext-perf-bench-comment -->"))) | .id' \
-                    | tail -n 1)"; then
-                    echo "Could not read existing PR benchmark comments; skipping comment."
-                    exit 0
+                  if ! gh api --method POST "repos/$REPOSITORY/commits/$HEAD_SHA/comments" \
+                    --field "body=@$comment_file" >/dev/null; then
+                    echo "Could not post commit benchmark comment; skipping."
                   fi
 
-                  if [ -n "$comment_id" ]; then
-                    if ! gh api --method PATCH "repos/$REPOSITORY/issues/comments/$comment_id" \
-                      --field "body=@$comment_file" >/dev/null; then
-                      echo "Could not update PR benchmark comment; skipping comment."
-                    fi
-                  else
-                    if ! gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
-                      --field "body=@$comment_file" >/dev/null; then
-                      echo "Could not create PR benchmark comment; skipping comment."
-                    fi
-                  fi
+            - name: Fail job if regression detected
+              if: steps.refs.outputs.has_parent == 'true' && steps.comment_body.outputs.regression_status != '0'
+              run: |
+                  echo "Comment script flagged a regression vs HEAD^. See the commit comment."
+                  exit 1
 
             - if: failure()
               uses: actions/upload-artifact@v4
@@ -292,5 +284,6 @@ jobs:
                   name: perf-bench
                   path: |
                       artifacts/perf-bench*.json
+                      artifacts/perf-ui*.json
                       playwright-report/
                   retention-days: 7


### PR DESCRIPTION
## What

Follow-up to #213.

Perf benchmarks now only run on pushes to main; PRs no longer trigger the workflow.

On main, the workflow benchmarks HEAD and HEAD^ on the same runner, then compares them and posts a comment on the new commit. The job fails when the comparison flags a regression.

## Why

The results were unreliable, and if we want to increase the number of runs to reduce noise, it would take too long to run them on every PR commit.