### PR TITLE
Bugfix: Keep side peek above the inspector

### DIFF
--- a/src/components/DocumentPeekProvider.js
+++ b/src/components/DocumentPeekProvider.js
@@ -78,9 +78,12 @@ export function DocumentPeekProvider( { children } ) {
 	const peekRef = useRef( peek );
 	peekRef.current = peek;
 
-	// In-memory pin. Resets when the peek closes or a different row opens.
-	// Survives side/modal flips so enlarging the peek doesn't drop it.
+	// In-memory pin. Resets when the peek closes or goes full-page. It
+	// survives side/modal flips and row switches that happen while pinned, so
+	// route navigation does not briefly drop the panel.
 	const [ isPinned, setIsPinned ] = useState( false );
+	const isPinnedRef = useRef( isPinned );
+	isPinnedRef.current = isPinned;
 
 	// RowDetailView exposes flush/discard through onApi. Run it before close or
 	// row switches so unsaved edits do not vanish.
@@ -127,7 +130,9 @@ export function DocumentPeekProvider( { children } ) {
 			} else if ( transition.type === 'peek' ) {
 				clearModeSurfaceTransition();
 				setPeek( transition.peek );
-				setIsPinned( false );
+				setIsPinned( ( current ) =>
+					transition.preservePin ? current : false
+				);
 			} else if ( transition.type === 'mode' ) {
 				setPeek( ( current ) =>
 					current ? { ...current, mode: transition.mode } : current
@@ -208,6 +213,7 @@ export function DocumentPeekProvider( { children } ) {
 			const nextMode = isSticky
 				? currentMode
 				: normalizeRowDetailMode( preferredMode );
+			const preservePin = isSticky && isPinnedRef.current;
 
 			if ( nextMode === 'full' ) {
 				const uri = rowRoute( { id, slug } );
@@ -219,6 +225,7 @@ export function DocumentPeekProvider( { children } ) {
 
 			runTransition( {
 				type: 'peek',
+				preservePin,
 				peek: {
 					docId: id,
 					slug,
@@ -306,6 +313,7 @@ export function DocumentPeekProvider( { children } ) {
 			}
 			runTransition( {
 				type: 'peek',
+				preservePin: true,
 				peek: {
 					...current,
 					docId: nextRow.id,

--- a/src/components/DocumentPeekProvider.js
+++ b/src/components/DocumentPeekProvider.js
@@ -78,9 +78,8 @@ export function DocumentPeekProvider( { children } ) {
 	const peekRef = useRef( peek );
 	peekRef.current = peek;
 
-	// In-memory pin. Resets when the peek closes or goes full-page. It
-	// survives side/modal flips and row switches that happen while pinned, so
-	// route navigation does not briefly drop the panel.
+	// The pin lives in memory. Closing the peek or opening it full-page clears
+	// it, but row-to-row moves keep it so a pinned peek stays put.
 	const [ isPinned, setIsPinned ] = useState( false );
 	const isPinnedRef = useRef( isPinned );
 	isPinnedRef.current = isPinned;

--- a/src/index.scss
+++ b/src/index.scss
@@ -105,11 +105,12 @@ body.cortext-fullscreen {
 }
 
 .cortext-shell {
+	--cortext-shell-sidebar-track-width: var(--cortext-sidebar-width);
+
+	position: relative;
+	isolation: isolate;
 	display: grid;
-	// The trailing `auto` track is reserved for the side peek panel
-	// (RowDetailSidebarSlot). It collapses to 0 when no peek is mounted and
-	// follows the panel's own width animation when it is.
-	grid-template-columns: var(--cortext-sidebar-width) minmax(0, 1fr) auto;
+	grid-template-columns: var(--cortext-shell-sidebar-track-width) minmax(0, 1fr);
 	height: 100vh;
 	transition: grid-template-columns 160ms ease;
 }
@@ -123,11 +124,12 @@ body.cortext-fullscreen {
 // Collapsed: pin to rail width but keep the saved expanded width on the
 // root, so toggling back restores it.
 .cortext-root[data-sidebar-collapsed="true"] .cortext-shell {
-	grid-template-columns: var(--cortext-sidebar-width-rail) minmax(0, 1fr) auto;
+	--cortext-shell-sidebar-track-width: var(--cortext-sidebar-width-rail);
 }
 
 .cortext-sidebar {
 	position: relative;
+	z-index: 3;
 	display: flex;
 	flex-direction: column;
 	background: var(--cortext-sidebar-surface);
@@ -1021,6 +1023,7 @@ body.cortext-sidebar-resizing {
 
 .cortext-shell__canvas {
 	position: relative;
+	z-index: 1;
 	overflow: hidden;
 	display: flex;
 	flex-direction: column;
@@ -1044,6 +1047,27 @@ body.cortext-sidebar-resizing {
 		inset: 0;
 		min-height: 0;
 	}
+}
+
+// Keep the global side peek visually above canvas route transitions. Without
+// its own named layer, the canvas snapshot can briefly paint over the overlay,
+// which reads as the pinned peek closing and reopening.
+::view-transition-group(cortext-canvas) {
+	z-index: 1;
+}
+
+::view-transition-group(cortext-row-detail-sidebar) {
+	z-index: 2;
+	animation: none;
+}
+
+::view-transition-old(cortext-row-detail-sidebar) {
+	display: none;
+}
+
+::view-transition-new(cortext-row-detail-sidebar) {
+	animation: none;
+	mix-blend-mode: normal;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -3926,18 +3950,22 @@ tr:has(.cortext-title-cell--is-open)
 }
 
 .cortext-row-detail-sidebar-shell {
-	position: relative;
+	position: absolute;
+	z-index: 2;
+	inset-block: 0;
+	inset-inline-end: 0;
 	flex: 0 0 var(--cortext-row-detail-sidebar-width, 560px);
 	width: var(--cortext-row-detail-sidebar-width, 560px);
 	height: 100%;
 	min-width: 0;
 	min-height: 0;
-	max-width: min(840px, 66vw);
+	max-width: min(840px, 66vw, calc(100% - var(--cortext-shell-sidebar-track-width)));
 	background: $white;
 	border-left: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
 	box-shadow: -18px 0 36px rgba(0, 0, 0, 0.12);
 	overflow: hidden;
 	will-change: width;
+	view-transition-name: cortext-row-detail-sidebar;
 	animation:
 		cortext-row-detail-sidebar-open 300ms
 		cubic-bezier(0.6, 0, 0.4, 1) both;

--- a/src/index.scss
+++ b/src/index.scss
@@ -5345,6 +5345,14 @@ body.cortext-hide-block-settings-menu .block-editor-block-switcher {
 	}
 }
 
+::view-transition-group(cortext-alpha-notice-overlay) {
+	z-index: 3;
+}
+
+::view-transition-group(cortext-alpha-notice-frame) {
+	z-index: 4;
+}
+
 ::view-transition-old(cortext-alpha-notice-overlay),
 ::view-transition-old(cortext-alpha-notice-frame) {
 	animation: none;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1049,9 +1049,8 @@ body.cortext-sidebar-resizing {
 	}
 }
 
-// Keep the global side peek visually above canvas route transitions. Without
-// its own named layer, the canvas snapshot can briefly paint over the overlay,
-// which reads as the pinned peek closing and reopening.
+// The side peek lives outside the canvas. Give it its own transition layer so
+// the canvas cross-fade never flashes over it.
 ::view-transition-group(cortext-canvas) {
 	z-index: 1;
 }

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1711,7 +1711,7 @@ test.describe( 'Collection view block', () => {
 				method: 'POST',
 				path: '/wp/v2/crtxt_pages',
 				data: {
-					title: 'Pinned peek route target',
+					title: 'Pinned peek target',
 					status: 'private',
 				},
 			} );

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -51,6 +51,156 @@ function tableFooterDataCells( footer ) {
 	return footer.locator( TABLE_FOOTER_DATA_CELL_SELECTOR );
 }
 
+async function expectSidePeekCoversPageInspector( page ) {
+	await expect
+		.poll( async () =>
+			page.evaluate( () => {
+				const inspector = document.querySelector(
+					'.cortext-shell__canvas .cortext-workspace__pane[data-active="true"] .interface-interface-skeleton__sidebar'
+				);
+				const peek = document.querySelector(
+					'.cortext-row-detail-sidebar-shell:not(.cortext-row-detail-sidebar-shell--closing)'
+				);
+
+				if ( ! inspector || ! peek ) {
+					return false;
+				}
+
+				const inspectorRect = inspector.getBoundingClientRect();
+				const peekRect = peek.getBoundingClientRect();
+				const overlapLeft = Math.max(
+					inspectorRect.left,
+					peekRect.left
+				);
+				const overlapRight = Math.min(
+					inspectorRect.right,
+					peekRect.right
+				);
+				const overlapTop = Math.max( inspectorRect.top, peekRect.top );
+				const overlapBottom = Math.min(
+					inspectorRect.bottom,
+					peekRect.bottom
+				);
+
+				if (
+					overlapRight <= overlapLeft ||
+					overlapBottom <= overlapTop
+				) {
+					return false;
+				}
+
+				const topElement = document.elementFromPoint(
+					( overlapLeft + overlapRight ) / 2,
+					( overlapTop + overlapBottom ) / 2
+				);
+				return Boolean(
+					topElement?.closest( '.cortext-row-detail-sidebar-shell' )
+				);
+			} )
+		)
+		.toBe( true );
+}
+
+async function expectPageInspectorIsTopmost( page ) {
+	await expect
+		.poll( async () =>
+			page.evaluate( () => {
+				const inspector = document.querySelector(
+					'.cortext-shell__canvas .cortext-workspace__pane[data-active="true"] .interface-interface-skeleton__sidebar'
+				);
+
+				if ( ! inspector ) {
+					return false;
+				}
+
+				const rect = inspector.getBoundingClientRect();
+				const topElement = document.elementFromPoint(
+					( rect.left + rect.right ) / 2,
+					( rect.top + rect.bottom ) / 2
+				);
+				return Boolean(
+					topElement?.closest(
+						'.interface-interface-skeleton__sidebar'
+					)
+				);
+			} )
+		)
+		.toBe( true );
+}
+
+async function startSidePeekShellStabilityLog( page ) {
+	await page.evaluate( () => {
+		window.__cortextSidePeekShellEvents = [];
+		window.__cortextSidePeekShellCleanup?.();
+
+		const shell = document.querySelector(
+			'.cortext-row-detail-sidebar-shell'
+		);
+		const logEvent = ( eventName ) => {
+			window.__cortextSidePeekShellEvents.push( eventName );
+		};
+
+		if ( ! shell ) {
+			logEvent( 'missing' );
+			return;
+		}
+
+		const onAnimationStart = ( event ) => {
+			if (
+				event.target === shell &&
+				[
+					'cortext-row-detail-sidebar-open',
+					'cortext-row-detail-sidebar-close',
+				].includes( event.animationName )
+			) {
+				logEvent( event.animationName );
+			}
+		};
+		const observer = new window.MutationObserver( ( records ) => {
+			for ( const record of records ) {
+				if (
+					record.type === 'attributes' &&
+					shell.classList.contains(
+						'cortext-row-detail-sidebar-shell--closing'
+					) &&
+					! window.__cortextSidePeekShellEvents.includes(
+						'closing-class'
+					)
+				) {
+					logEvent( 'closing-class' );
+				}
+				for ( const node of record.removedNodes ) {
+					if ( node === shell || node.contains?.( shell ) ) {
+						logEvent( 'removed' );
+					}
+				}
+			}
+		} );
+
+		shell.addEventListener( 'animationstart', onAnimationStart );
+		observer.observe( shell, {
+			attributes: true,
+			attributeFilter: [ 'class' ],
+		} );
+		observer.observe( document.body, {
+			childList: true,
+			subtree: true,
+		} );
+
+		window.__cortextSidePeekShellCleanup = () => {
+			shell.removeEventListener( 'animationstart', onAnimationStart );
+			observer.disconnect();
+		};
+	} );
+}
+
+async function expectSidePeekShellStayedOpen( page ) {
+	await page.waitForTimeout( 450 );
+	expect(
+		await page.evaluate( () => window.__cortextSidePeekShellEvents ?? [] )
+	).toEqual( [] );
+}
+
 async function createCollectionFixture( requestUtils ) {
 	const suffix = Date.now().toString( 36 ).slice( -4 );
 	const slug = `e2ebooks${ suffix }`;
@@ -1557,6 +1707,15 @@ test.describe( 'Collection view block', () => {
 				},
 			} );
 
+			fixture.otherPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Pinned peek route target',
+					status: 'private',
+				},
+			} );
+
 			await admin.visitAdminPage(
 				'admin.php',
 				`page=cortext&p=/${ fixture.page.id }`
@@ -1618,6 +1777,16 @@ test.describe( 'Collection view block', () => {
 				name: 'Row detail',
 			} );
 			await expect( detail ).toBeVisible();
+			await expect(
+				page.locator( '.cortext-row-detail-sidebar-shell' )
+			).toHaveCSS( 'view-transition-name', 'cortext-row-detail-sidebar' );
+			await expectSidePeekCoversPageInspector( page );
+			await detail.getByRole( 'button', { name: 'Close' } ).click();
+			await expect( detail ).toBeHidden();
+			await expectPageInspectorIsTopmost( page );
+			await firstRow.hover();
+			await titleCellOpenButton.click();
+			await expect( detail ).toBeVisible();
 			await detail.hover();
 			await expect( firstRow ).toHaveCSS(
 				'background-color',
@@ -1656,6 +1825,11 @@ test.describe( 'Collection view block', () => {
 			).toHaveCount( 2 );
 			await detailTitle.click();
 			await expect( optionsPopover ).toBeHidden();
+			await detail.getByRole( 'button', { name: 'Pin' } ).click();
+			await expect(
+				detail.getByRole( 'button', { name: 'Unpin' } )
+			).toBeVisible();
+			await startSidePeekShellStabilityLog( page );
 
 			const delayedSecondRowPattern = new RegExp(
 				`/wp-json/wp/v2/crtxt_${ fixture.slug }/${ fixture.secondEntry.id }(\\?|$)`
@@ -1672,6 +1846,9 @@ test.describe( 'Collection view block', () => {
 			// Side and modal panes are local React state, not URL state,
 			// so verify the navigation via the detail title rather than ?row.
 			await expect( detailTitle ).toHaveText( 'Kindred' );
+			await expect(
+				detail.getByRole( 'button', { name: 'Unpin' } )
+			).toBeVisible();
 			// The second row keeps the same field layout (still in the same
 			// collection), so its property panel still renders the Tags label.
 			await expect(
@@ -1686,6 +1863,10 @@ test.describe( 'Collection view block', () => {
 			await expect( detailTitle ).toHaveText(
 				'The Left Hand of Darkness'
 			);
+			await expect(
+				detail.getByRole( 'button', { name: 'Unpin' } )
+			).toBeVisible();
+			await expectSidePeekShellStayedOpen( page );
 			// Side and modal panes are local React state, not URL state, so
 			// browser Back/Forward doesn't navigate between rows anymore.
 			// The Row above / Row below buttons above already cover that.
@@ -1742,6 +1923,27 @@ test.describe( 'Collection view block', () => {
 			await expect(
 				detail.getByRole( 'button', { name: 'Change layout' } )
 			).toHaveCount( 0 );
+			await startSidePeekShellStabilityLog( page );
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: fixture.otherPage.title.raw,
+					exact: true,
+				} )
+				.click();
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.otherPage.id,
+				{ timeout: 15_000 }
+			);
+			await expect( detail ).toBeVisible();
+			await expect(
+				detail.getByRole( 'button', { name: 'Unpin' } )
+			).toBeVisible();
+			await expectSidePeekShellStayedOpen( page );
 			await detail
 				.getByRole( 'button', { name: 'Center modal' } )
 				.click();
@@ -1831,6 +2033,11 @@ test.describe( 'Collection view block', () => {
 			await deleteIfCreated(
 				requestUtils,
 				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.otherPage &&
+					`/wp/v2/crtxt_pages/${ fixture.otherPage.id }`
 			);
 			await deleteIfCreated(
 				requestUtils,

--- a/tests/js/components/DocumentPeekProvider.test.js
+++ b/tests/js/components/DocumentPeekProvider.test.js
@@ -167,7 +167,7 @@ describe( 'DocumentPeekProvider', () => {
 		expect( result.current.state.peek?.docId ).toBe( 10 );
 	} );
 
-	it( 'keeps a pinned side peek pinned while walking adjacent rows', async () => {
+	it( 'keeps the pin while moving to the next row', async () => {
 		const rows = [
 			{ id: 10, slug: 'first' },
 			{ id: 20, slug: 'second' },

--- a/tests/js/components/DocumentPeekProvider.test.js
+++ b/tests/js/components/DocumentPeekProvider.test.js
@@ -31,6 +31,14 @@ function useBoth() {
 	};
 }
 
+function useHarness() {
+	return {
+		state: useDocumentPeekState(),
+		actions: useDocumentPeekActions(),
+		surface: useDocumentPeekSurface(),
+	};
+}
+
 beforeEach( () => {
 	mockNavigate.mockReset();
 } );
@@ -157,6 +165,38 @@ describe( 'DocumentPeekProvider', () => {
 		} );
 
 		expect( result.current.state.peek?.docId ).toBe( 10 );
+	} );
+
+	it( 'keeps a pinned side peek pinned while walking adjacent rows', async () => {
+		const rows = [
+			{ id: 10, slug: 'first' },
+			{ id: 20, slug: 'second' },
+		];
+		const { result } = renderHook( useHarness, { wrapper } );
+
+		await act( async () => {
+			result.current.actions.openDocument( {
+				id: 10,
+				slug: 'first',
+				postType: 'crtxt_a',
+				collectionId: 1,
+				preferredMode: 'side',
+				source: { kind: 'collection', getRowList: () => rows },
+			} );
+		} );
+		act( () => {
+			result.current.surface.togglePin();
+		} );
+		await act( async () => {
+			result.current.surface.goToAdjacentDocument( 1 );
+		} );
+
+		expect( result.current.state.peek ).toMatchObject( {
+			docId: 20,
+			slug: 'second',
+			mode: 'side',
+		} );
+		expect( result.current.state.isPinned ).toBe( true );
 	} );
 
 	it( 'requestMode keeps the row slug when switching to full mode', async () => {


### PR DESCRIPTION
## What

Related to #218.

Keeps the side peek above the document inspector without moving it back into the editor. Pinned peeks now stay open when moving between rows or navigating to another page.

## Why

#218 moved the peek out of the document so navigation would not reload it. This keeps that fix intact and handles the visual layering problem separately.

## How

- Turns the side peek into an overlay over the canvas instead of a reserved shell column.
- Keeps the pin when moving from one row to the next.
- Gives the side peek its own view-transition layer so canvas transitions cannot flash over it.

## Testing Instructions

1. Open a page with the inspector sidebar visible.
2. Open a row in side peek mode and confirm the peek covers the inspector.
3. Close the peek and confirm the inspector is still visible and interactive.
4. Open the side peek again, pin it, then move between rows.
5. With the peek still pinned, navigate to another page from the sidebar and confirm the peek stays open.

## Before / After

| Before | After |
| --- | --- |
| <img width="1912" height="1337" alt="image" src="https://github.com/user-attachments/assets/ed71325d-7d42-482b-97f1-be1b789911d0" /> | <img width="1914" height="1343" alt="image" src="https://github.com/user-attachments/assets/21e5f1bd-c40c-4458-a2d5-1e3499da9f4c" /> |
