### PR TITLE
Documents: a class per page, collection, and row

### DIFF
--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -3,9 +3,13 @@
  * Finds and lists Cortext documents.
  *
  * "Document" is the union of post types that opt into the `cortext-document`
- * trait: pages (`crtxt_page`) and collection rows (`crtxt_<slug>`). Code that
- * needs all Cortext documents should use this service instead of rebuilding the
- * post-type list.
+ * trait: pages (`crtxt_page`), collections (`crtxt_collection`), and rows
+ * (`crtxt_<slug>`). Code that needs all Cortext documents should use this
+ * service instead of rebuilding the post-type list.
+ *
+ * Per-kind specifics (path, owner relation, icon presence) live in
+ * `Cortext\Documents\DocumentKind` implementations, resolved through the
+ * `KindRegistry` this service constructs by default.
  *
  * This service only reads; writes still go through `wp/v2` and the collection
  * row controllers.
@@ -17,12 +21,16 @@ declare( strict_types=1 );
 
 namespace Cortext;
 
+use Cortext\Documents\CollectionKind;
+use Cortext\Documents\DocumentKind;
+use Cortext\Documents\KindRegistry;
+use Cortext\Documents\PageKind;
+use Cortext\Documents\RowKind;
 use Cortext\Fields\FieldTypeRegistry;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\CollectionTrashCascade;
 use Cortext\PostType\DocumentIdentity;
-use Cortext\PostType\Page;
 use Cortext\PostType\PageTrashCascade;
 use Cortext\Rest\RowsFilterQuery;
 use WP_Post;
@@ -51,8 +59,27 @@ final class Documents {
 
 	private RowsFilterQuery $rows_filter_query;
 
-	public function __construct( ?RowsFilterQuery $rows_filter_query = null ) {
+	private KindRegistry $kinds;
+
+	public function __construct(
+		?RowsFilterQuery $rows_filter_query = null,
+		?KindRegistry $kinds = null
+	) {
 		$this->rows_filter_query = $rows_filter_query ?? new RowsFilterQuery();
+		$this->kinds             = $kinds ?? $this->build_default_kind_registry();
+	}
+
+	/**
+	 * Builds the default kind registry. Page and collection kinds are
+	 * self-contained; row kind needs the documents service to resolve a row
+	 * CPT to its parent collection, so it receives `$this`.
+	 */
+	private function build_default_kind_registry(): KindRegistry {
+		$registry = new KindRegistry();
+		$registry->register( new PageKind() );
+		$registry->register( new CollectionKind() );
+		$registry->register( new RowKind( $this ) );
+		return $registry;
 	}
 
 	/**
@@ -255,42 +282,27 @@ final class Documents {
 	 * Narrows the post-type set based on the requested kind, or returns the
 	 * full document set when no kind is requested.
 	 *
-	 * @param string $kind Document kind (`page`, `row`, or empty for any).
+	 * @param string $kind Document kind id (`page`, `collection`, `row`), or empty for any.
 	 * @return string[]
 	 */
 	private function post_types_for_kind( string $kind ): array {
 		$post_types = $this->get_document_post_types();
 
-		if ( self::KIND_PAGE === $kind ) {
-			return array_values(
-				array_filter(
-					$post_types,
-					static fn( string $post_type ): bool => Page::POST_TYPE === $post_type
-				)
-			);
+		if ( '' === $kind ) {
+			return $post_types;
 		}
 
-		if ( self::KIND_COLLECTION === $kind ) {
-			return array_values(
-				array_filter(
-					$post_types,
-					static fn( string $post_type ): bool => Collection::POST_TYPE === $post_type
-				)
-			);
+		$target = $this->kinds->by_id( $kind );
+		if ( null === $target ) {
+			return array();
 		}
 
-		if ( self::KIND_ROW === $kind ) {
-			return array_values(
-				array_filter(
-					$post_types,
-					static fn( string $post_type ): bool => Page::POST_TYPE !== $post_type
-						&& Collection::POST_TYPE !== $post_type
-						&& str_starts_with( $post_type, CollectionEntries::CPT_PREFIX )
-				)
-			);
-		}
-
-		return $post_types;
+		return array_values(
+			array_filter(
+				$post_types,
+				static fn( string $post_type ): bool => $target->owns_post_type( $post_type )
+			)
+		);
 	}
 
 	/**
@@ -303,43 +315,30 @@ final class Documents {
 	 * @return array<string,mixed>|null
 	 */
 	public function format_document( WP_Post $post, array $opts = array() ): ?array {
-		$kind = $this->kind_for_post_type( $post->post_type );
+		$kind = $this->kind_object_for_post_type( $post->post_type );
 		if ( null === $kind ) {
 			return null;
 		}
 
-		$collection = self::KIND_ROW === $kind
-			? $this->find_collection_by_row_post_type( $post->post_type )
-			: null;
+		$owner_context = $kind->owner_context( $post );
 
-		if ( self::KIND_ROW === $kind && ! $collection instanceof WP_Post ) {
-			// A row without its parent collection cannot be opened in the UI.
+		// A row without its parent collection cannot be opened in the UI.
+		if ( 'row' === $kind->id() && null === $owner_context ) {
 			return null;
 		}
 
-		// An inline collection's owner page is the breadcrumb users see in
-		// search and trash. Without it the collection feels like an unmoored
-		// row, since inline collections don't have a sidebar entry of their
-		// own.
-		$owner_page = null;
-		if ( self::KIND_COLLECTION === $kind && Collection::is_inline( (int) $post->ID ) ) {
-			$owner_id   = (int) get_post_meta( $post->ID, Collection::INLINE_OWNER_META_KEY, true );
-			$owner_post = $owner_id > 0 ? get_post( $owner_id ) : null;
-			if ( $owner_post instanceof WP_Post && Page::POST_TYPE === $owner_post->post_type ) {
-				$owner_page = $owner_post;
+		// Inline collections have no workspace route of their own; the kind
+		// context flags that and the owner's path replaces the document's.
+		$path = $kind->path_for( $post );
+		if ( $owner_context && $owner_context->use_as_document_path ) {
+			$owner_kind = $this->kinds->by_post_type( $owner_context->post->post_type );
+			if ( null !== $owner_kind ) {
+				$path = $owner_kind->path_for( $owner_context->post );
 			}
 		}
 
-		// Inline collections have no workspace route of their own. Set their
-		// path to the owner page so command palette results and trash-row
-		// clicks land on the page that contains them instead of bouncing to
-		// Not Found through `EntityRoute`'s inline-collection guard.
-		$path = $owner_page instanceof WP_Post
-			? $this->page_path( $owner_page )
-			: $this->document_path( $post, $kind );
-
 		$document = array(
-			'kind'   => $kind,
+			'kind'   => $kind->id(),
 			'id'     => (int) $post->ID,
 			'title'  => $this->post_title( $post ),
 			'path'   => $path,
@@ -351,26 +350,19 @@ final class Documents {
 		}
 
 		$icon = '';
-		if ( self::KIND_PAGE === $kind || self::KIND_COLLECTION === $kind ) {
+		if ( $kind->has_icon() ) {
 			$icon = (string) get_post_meta( $post->ID, DocumentIdentity::META_KEY, true );
 			if ( '' !== $icon ) {
 				$document['icon'] = $icon;
 			}
 		}
 
-		if ( $collection instanceof WP_Post ) {
-			$document['collection'] = array(
-				'id'    => (int) $collection->ID,
-				'title' => $this->post_title( $collection ),
-				'path'  => $this->collection_path( $collection ),
-			);
-		}
-
-		if ( $owner_page instanceof WP_Post ) {
-			$document['owner'] = array(
-				'id'    => (int) $owner_page->ID,
-				'title' => $this->post_title( $owner_page ),
-				'path'  => $this->page_path( $owner_page ),
+		if ( $owner_context ) {
+			$owner_kind                        = $this->kinds->by_post_type( $owner_context->post->post_type );
+			$document[ $owner_context->field ] = array(
+				'id'    => (int) $owner_context->post->ID,
+				'title' => $this->post_title( $owner_context->post ),
+				'path'  => null !== $owner_kind ? $owner_kind->path_for( $owner_context->post ) : '',
 			);
 		}
 
@@ -383,7 +375,7 @@ final class Documents {
 			// Inline collections trashed alongside their owner page carry a
 			// separate marker. The sidebar uses it to nest them under the
 			// page's trash entry instead of listing them as siblings.
-			if ( self::KIND_COLLECTION === $kind ) {
+			if ( 'collection' === $kind->id() ) {
 				$document['meta'][ CollectionTrashCascade::TRASHED_BY_OWNER_META_KEY ] = (int) get_post_meta(
 					$post->ID,
 					CollectionTrashCascade::TRASHED_BY_OWNER_META_KEY,
@@ -395,49 +387,38 @@ final class Documents {
 		return $document;
 	}
 
-	/**
-	 * Routes a document to its URL path based on its kind.
-	 *
-	 * @param WP_Post $post Document post.
-	 * @param string  $kind Document kind constant.
-	 */
-	private function document_path( WP_Post $post, string $kind ): string {
-		if ( self::KIND_ROW === $kind ) {
-			return $this->row_path( $post );
-		}
-		if ( self::KIND_COLLECTION === $kind ) {
-			return $this->collection_path( $post );
-		}
-		return $this->page_path( $post );
-	}
-
 	private function format_gmt_date( string $mysql_gmt ): string {
 		$timestamp = strtotime( $mysql_gmt . ' UTC' );
 		return false === $timestamp ? '' : gmdate( 'c', $timestamp );
 	}
 
 	/**
-	 * Maps a post type to its document kind, or null when the post type is not
-	 * a Cortext document. Public so trash, breadcrumbs, and similar code can
-	 * branch on the same classification.
+	 * Maps a post type to its document kind id, or null when the post type
+	 * is not a Cortext document. Public so trash, breadcrumbs, and similar
+	 * code can branch on the same classification.
 	 *
 	 * @param string $post_type Post type slug.
 	 */
 	public function kind_for_post_type( string $post_type ): ?string {
 		// Only post types that opt into the document trait count here. That
-		// keeps `crtxt_field` out of document handling. `crtxt_collection`
-		// opts in too: collections are documents whose canvas is a DataView
-		// rather than block-editor content.
+		// keeps `crtxt_field` out of document handling.
 		if ( ! post_type_supports( $post_type, 'cortext-document' ) ) {
 			return null;
 		}
-		if ( Page::POST_TYPE === $post_type ) {
-			return self::KIND_PAGE;
+		return $this->kinds->by_post_type( $post_type )?->id();
+	}
+
+	/**
+	 * Resolves the kind object for a post type, or null when no kind claims
+	 * it. Internal helper for format_document and the listing search filter.
+	 *
+	 * @param string $post_type Post type slug.
+	 */
+	private function kind_object_for_post_type( string $post_type ): ?DocumentKind {
+		if ( ! post_type_supports( $post_type, 'cortext-document' ) ) {
+			return null;
 		}
-		if ( Collection::POST_TYPE === $post_type ) {
-			return self::KIND_COLLECTION;
-		}
-		return self::KIND_ROW;
+		return $this->kinds->by_post_type( $post_type );
 	}
 
 	/**
@@ -483,24 +464,6 @@ final class Documents {
 		);
 
 		return $collections[0] ?? null;
-	}
-
-	private function page_path( WP_Post $post ): string {
-		$slug = trim( $post->post_name );
-		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
-		return "page/{$tail}";
-	}
-
-	private function row_path( WP_Post $post ): string {
-		$slug = trim( $post->post_name );
-		return '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
-	}
-
-	private function collection_path( WP_Post $collection ): string {
-		$slug = get_post_meta( (int) $collection->ID, 'slug', true );
-		$slug = is_string( $slug ) ? trim( $slug ) : '';
-		$tail = '' === $slug ? (string) $collection->ID : "{$slug}-{$collection->ID}";
-		return "collection/{$tail}";
 	}
 
 	private function post_title( WP_Post $post ): string {
@@ -553,7 +516,8 @@ final class Documents {
 
 		$row_text_keys_by_cpt = array();
 		foreach ( $post_types as $post_type ) {
-			if ( Page::POST_TYPE === $post_type ) {
+			$kind = $this->kind_object_for_post_type( $post_type );
+			if ( null === $kind || 'row' !== $kind->id() ) {
 				continue;
 			}
 			$collection = $this->find_collection_by_row_post_type( $post_type );

--- a/includes/Documents/CollectionKind.php
+++ b/includes/Documents/CollectionKind.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Collection document kind. Full-page collections sit in the sidebar as their
+ * own workspace entry; inline collections are owned by a page and have no
+ * workspace route of their own, so their document path resolves to the owner
+ * page.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Documents;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\Page;
+use WP_Post;
+
+final class CollectionKind implements DocumentKind {
+
+	public function id(): string {
+		return 'collection';
+	}
+
+	public function owns_post_type( string $post_type ): bool {
+		return Collection::POST_TYPE === $post_type;
+	}
+
+	public function path_for( WP_Post $post ): string {
+		$slug = get_post_meta( (int) $post->ID, 'slug', true );
+		$slug = is_string( $slug ) ? trim( $slug ) : '';
+		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
+		return "collection/{$tail}";
+	}
+
+	public function has_icon(): bool {
+		return true;
+	}
+
+	public function owner_context( WP_Post $post ): ?KindOwnerContext {
+		if ( ! Collection::is_inline( (int) $post->ID ) ) {
+			return null;
+		}
+
+		$owner_id   = (int) get_post_meta( $post->ID, Collection::INLINE_OWNER_META_KEY, true );
+		$owner_post = $owner_id > 0 ? get_post( $owner_id ) : null;
+		if ( ! $owner_post instanceof WP_Post || Page::POST_TYPE !== $owner_post->post_type ) {
+			return null;
+		}
+
+		// Inline collections route through the owner page in search/trash, so
+		// the owner's path replaces the document's own path.
+		return new KindOwnerContext( 'owner', $owner_post, true );
+	}
+}

--- a/includes/Documents/DocumentKind.php
+++ b/includes/Documents/DocumentKind.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * A Cortext document kind: page, collection, or row. Each implementation
+ * answers a few questions about its kind: which post type, what URL path,
+ * whether it has an identity icon, and what (if anything) owns it.
+ *
+ * Adding a new kind means writing an implementation and registering it with
+ * `KindRegistry`. Documents and the REST surface read from the registry
+ * instead of branching on post-type slugs.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Documents;
+
+use WP_Post;
+
+interface DocumentKind {
+
+	/**
+	 * Stable identifier used across PHP and REST responses. Matches the
+	 * `Documents::KIND_*` string constants the React shell already speaks.
+	 */
+	public function id(): string;
+
+	/**
+	 * Whether this kind claims the given post type. Row CPTs are dynamic
+	 * (`crtxt_<slug>`), so the row kind matches by prefix while page/collection
+	 * match exact slugs.
+	 *
+	 * @param string $post_type Post type slug to test.
+	 */
+	public function owns_post_type( string $post_type ): bool;
+
+	/**
+	 * Workspace path for the document, used by command palette, breadcrumbs,
+	 * and trash rows. Returned without a leading slash, e.g. `page/about-12`.
+	 *
+	 * @param WP_Post $post Document post to route.
+	 */
+	public function path_for( WP_Post $post ): string;
+
+	/**
+	 * Whether documents of this kind carry a `cortext_document_icon`. Pages
+	 * and collections do; rows render their icon from collection schema.
+	 */
+	public function has_icon(): bool;
+
+	/**
+	 * The post that owns this document, or null when the document stands
+	 * alone. Rows always have a parent collection; inline collections have
+	 * an owner page; pages have no owner.
+	 *
+	 * @param WP_Post $post Document whose owner is needed.
+	 */
+	public function owner_context( WP_Post $post ): ?KindOwnerContext;
+}

--- a/includes/Documents/KindOwnerContext.php
+++ b/includes/Documents/KindOwnerContext.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * The post that owns a document, plus the bits the formatter needs to render
+ * it: a row's parent collection, or an inline collection's owner page. Also
+ * names the response field that carries the pointer (`collection` vs `owner`)
+ * and whether the owner's path should replace the document's own.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Documents;
+
+use WP_Post;
+
+final class KindOwnerContext {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string  $field                Response field name ('collection' for a row's parent, 'owner' for an inline collection's page).
+	 * @param WP_Post $post                 The owning post.
+	 * @param bool    $use_as_document_path Whether the owner's path should replace the document's own path
+	 *                                      (true for inline collections, which lack a workspace route of their own).
+	 */
+	public function __construct(
+		public readonly string $field,
+		public readonly WP_Post $post,
+		public readonly bool $use_as_document_path = false
+	) {}
+}

--- a/includes/Documents/KindRegistry.php
+++ b/includes/Documents/KindRegistry.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Lookup for registered document kinds. Callers ask "what kind is this post
+ * type?" or "give me the page kind" instead of branching on post-type slugs.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Documents;
+
+final class KindRegistry {
+
+	/**
+	 * Kinds indexed by id.
+	 *
+	 * @var DocumentKind[]
+	 */
+	private array $kinds = array();
+
+	public function register( DocumentKind $kind ): void {
+		$this->kinds[ $kind->id() ] = $kind;
+	}
+
+	public function by_id( string $id ): ?DocumentKind {
+		return $this->kinds[ $id ] ?? null;
+	}
+
+	/**
+	 * Returns the kind that claims this post type, or null when no kind does.
+	 * Dynamic row CPTs are matched by prefix; pages and collections by exact
+	 * slug.
+	 *
+	 * @param string $post_type Post type slug to resolve.
+	 */
+	public function by_post_type( string $post_type ): ?DocumentKind {
+		foreach ( $this->kinds as $kind ) {
+			if ( $kind->owns_post_type( $post_type ) ) {
+				return $kind;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Every registered kind, in registration order.
+	 *
+	 * @return DocumentKind[]
+	 */
+	public function all(): array {
+		return array_values( $this->kinds );
+	}
+}

--- a/includes/Documents/PageKind.php
+++ b/includes/Documents/PageKind.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Page document kind. Pages own block-editor content, sit in a hierarchical
+ * tree under `post_parent`, and have an identity icon.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Documents;
+
+use Cortext\PostType\Page;
+use WP_Post;
+
+final class PageKind implements DocumentKind {
+
+	public function id(): string {
+		return 'page';
+	}
+
+	public function owns_post_type( string $post_type ): bool {
+		return Page::POST_TYPE === $post_type;
+	}
+
+	public function path_for( WP_Post $post ): string {
+		$slug = trim( $post->post_name );
+		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
+		return "page/{$tail}";
+	}
+
+	public function has_icon(): bool {
+		return true;
+	}
+
+	public function owner_context( WP_Post $post ): ?KindOwnerContext {
+		return null;
+	}
+}

--- a/includes/Documents/RowKind.php
+++ b/includes/Documents/RowKind.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Row document kind. Rows live in the dynamic `crtxt_<slug>` CPT registered
+ * per collection. Each row has a parent collection that gives the row its
+ * schema and workspace breadcrumb.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Documents;
+
+use Cortext\Documents;
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Page;
+use WP_Post;
+
+final class RowKind implements DocumentKind {
+
+	private Documents $documents;
+
+	public function __construct( Documents $documents ) {
+		$this->documents = $documents;
+	}
+
+	public function id(): string {
+		return 'row';
+	}
+
+	public function owns_post_type( string $post_type ): bool {
+		// Page and Collection share the `cortext-document` trait but are not
+		// rows. Row CPTs all start with the shared prefix.
+		if ( Page::POST_TYPE === $post_type || Collection::POST_TYPE === $post_type ) {
+			return false;
+		}
+		if ( ! str_starts_with( $post_type, CollectionEntries::CPT_PREFIX ) ) {
+			return false;
+		}
+		return post_type_supports( $post_type, 'cortext-document' );
+	}
+
+	public function path_for( WP_Post $post ): string {
+		$slug = trim( $post->post_name );
+		return '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
+	}
+
+	public function has_icon(): bool {
+		return false;
+	}
+
+	public function owner_context( WP_Post $post ): ?KindOwnerContext {
+		$collection = $this->documents->find_collection_by_row_post_type( $post->post_type );
+		if ( ! $collection instanceof WP_Post ) {
+			return null;
+		}
+		return new KindOwnerContext( 'collection', $collection );
+	}
+}


### PR DESCRIPTION
## What

Part of #226.

This pulls the per-post-type logic out of the documents service. Pages, collections, and rows now each have their own class for path handling, owner relations, and icons, and the service resolves them through a registry.

There should be no user-facing changes here. REST responses, paths, search, and breadcrumbs should behave the same as before.

## Why

Groundwork for the rest of the refactor in #226.

## Testing Instructions

1. Open Cortext and confirm pages, collections, and rows render in the sidebar.
2. Use the command palette to search across all three types and confirm results show up.
3. Open a row from a collection and confirm the breadcrumb shows the parent collection.
4. Open an inline collection from the command palette and confirm it opens on the owner page.
5. Move a page to trash and confirm it appears in the sidebar Trash list.