### PR TITLE
Make Cortext feel less jumpy while loading

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -516,11 +516,3 @@ The brittle bit is the sizing. The skeleton copies DataViews row heights for com
 **Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/index.scss`.
 
 **Solution.** DataViews exposes a table loading slot, or at least row-height CSS variables. Then Cortext can follow the table instead of copying its constants. Until then, keep the skeleton rules next to the DataViews table rules and check for visual drift after DataViews upgrades.
-
-## 56. View-transition target is too broad `[soft]`
-
-**What.** `view-transition-name: cortext-canvas` lives on `.cortext-shell__canvas`, one level above the content that needs the fade. That pulls the topbar into the canvas snapshot. The canvas transition also paints a backdrop to cover dark-mode flashes, so the topbar gets tinted for a frame. For now we name the topbar separately and cancel its animation.
-
-**Where.** `src/index.scss`: `.cortext-shell__canvas`, `.cortext-topbar`, and the `cortext-topbar` view-transition pseudo rules next to the canvas backdrop rules.
-
-**Solution.** Put `view-transition-name: cortext-canvas` on `.cortext-workspace` instead. The topbar stays outside the fade, the backdrop only covers the workspace, and the `cortext-topbar` opt-out can go away. If the title or breadcrumbs need animation later, name those pieces directly.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -498,3 +498,13 @@ Drag/drop and `menu_order` accounting look at both pages and collections through
 **Where.** `ACTIVE_PAGES_QUERY` in `src/components/page-queries.js`, `FULL_PAGE_COLLECTION_QUERY` in `src/collections.js`, `nestedCollections` / `topLevelCollections`, `treeRecords`, `handleDragOver`, and the shared `DndContext` in `src/components/Sidebar.js`, the `renderCollectionRow` bridge in `src/components/PageRow.js`, `CollectionRow`'s drag/drop zones, `computeDropTarget` in `src/components/pages-tree.js`, and the `Collection::hierarchical` / `CollectionsController::validate_parent_document` setup on the PHP side.
 
 **Solution.** Add a workspace-tree REST endpoint that returns navigable nodes with `kind`, `id`, `parent`, `menu_order`, and visibility in one shape. Row-owned collections could then appear under their row, missing parents would not look top-level by accident, and page/collection branching would move out of every consumer. The Collections section then becomes a view over the same model with the user's chosen filter, instead of a separate flat list.
+
+## 54. Loading table skeleton mirrors DataViews layout `[upstream, soft]`
+
+**What.** DataViews gives us no place to render placeholder rows inside its table. Cortext draws `CollectionRowsSkeleton` beside `<DataViews>` and lays it over the table body while the first page loads, otherwise the collection pane collapses and then jumps when rows arrive.
+
+The awkward part is the geometry. The skeleton copies DataViews row heights for compact, balanced, and comfortable density, and the overlay uses a fixed offset for the current DataViews header. Good enough for now, but if DataViews changes its density spacing or header markup, the loading table can drift away from the real one.
+
+**Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, the block editor loading state in `src/blocks/data-view/edit.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/index.scss`.
+
+**Solution.** DataViews exposes a table loading slot, or at least row-height and header-height CSS variables. Then Cortext can follow the table instead of copying its constants. Until then, keep the skeleton rules next to the DataViews table rules and treat visual drift after a DataViews upgrade as the tripwire.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -511,8 +511,8 @@ The awkward part is the geometry. The skeleton copies DataViews row heights for 
 
 ## 55. View-transition target is too broad `[soft]`
 
-**What.** `.cortext-shell__canvas` carries `view-transition-name: cortext-canvas`, but the canvas contains both the topbar (chrome that doesn't change between routes) and the workspace (the actual content). The cross-fade therefore drags the topbar into the snapshot, and the backdrop fill we paint on the canvas group to keep dark mode from flashing black washes the topbar's warm surface to grey for a frame. The patch we shipped gives the topbar its own `view-transition-name: cortext-topbar` and silences its animation, so the navigator creates a transition piece just to discard it.
+**What.** `view-transition-name: cortext-canvas` lives on `.cortext-shell__canvas`, one level above the content that actually needs the fade. That pulls the topbar into the canvas snapshot. Since the canvas transition also paints a backdrop to cover dark-mode flashes, the topbar gets tinted for a frame. We work around it by naming the topbar separately and disabling that animation.
 
-**Where.** `.cortext-shell__canvas` and `.cortext-topbar` rules in `src/index.scss`, plus the `::view-transition-group/old/new(cortext-topbar) { animation: none }` block right next to the canvas group backdrop fix.
+**Where.** `src/index.scss`: `.cortext-shell__canvas`, `.cortext-topbar`, and the `cortext-topbar` view-transition pseudo rules next to the canvas backdrop rules.
 
-**Solution.** Move `view-transition-name` from `.cortext-shell__canvas` to `.cortext-workspace`. The topbar then sits outside the transition naturally, the backdrop fill applies only over the workspace, and the topbar opt-out (name + suppressed animation) goes away. Any future chrome added between shell-canvas and workspace stays out of the transition for free. The only thing lost is the option of cross-fading topbar text (title, breadcrumbs) along with the document swap; opt that back in per-element with its own name if desired.
+**Solution.** Put `view-transition-name: cortext-canvas` on `.cortext-workspace` instead. The topbar stays outside the fade, the backdrop only covers the workspace, and the `cortext-topbar` opt-out can be deleted. If the title or breadcrumbs need animation later, name those pieces directly.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -499,20 +499,20 @@ Drag/drop and `menu_order` accounting look at both pages and collections through
 
 **Solution.** Add a workspace-tree REST endpoint that returns navigable nodes with `kind`, `id`, `parent`, `menu_order`, and visibility in one shape. Row-owned collections could then appear under their row, missing parents would not look top-level by accident, and page/collection branching would move out of every consumer. The Collections section then becomes a view over the same model with the user's chosen filter, instead of a separate flat list.
 
-## 54. Loading table skeleton mirrors DataViews layout `[upstream, soft]`
+## 54. Loading table skeleton tracks DataViews layout `[upstream, soft]`
 
-**What.** DataViews gives us no place to render placeholder rows inside its table. Cortext draws `CollectionRowsSkeleton` beside `<DataViews>` and lays it over the table body while the first page loads, otherwise the collection pane collapses and then jumps when rows arrive.
+**What.** DataViews does not give us a table-body loading slot. Cortext renders `CollectionRowsSkeleton` beside `<DataViews>` and covers the table while the first page loads; without that, the collection pane collapses and jumps when rows show up.
 
-The awkward part is the geometry. The skeleton copies DataViews row heights for compact, balanced, and comfortable density, and the overlay uses a fixed offset for the current DataViews header. Good enough for now, but if DataViews changes its density spacing or header markup, the loading table can drift away from the real one.
+The brittle bit is the sizing. The skeleton copies DataViews row heights for compact, balanced, and comfortable density. It lines up in the current build, but a DataViews density change could make the placeholder drift from the real table.
 
-**Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, the block editor loading state in `src/blocks/data-view/edit.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/index.scss`.
+**Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/index.scss`.
 
-**Solution.** DataViews exposes a table loading slot, or at least row-height and header-height CSS variables. Then Cortext can follow the table instead of copying its constants. Until then, keep the skeleton rules next to the DataViews table rules and treat visual drift after a DataViews upgrade as the tripwire.
+**Solution.** DataViews exposes a table loading slot, or at least row-height CSS variables. Then Cortext can follow the table instead of copying its constants. Until then, keep the skeleton rules next to the DataViews table rules and check for visual drift after DataViews upgrades.
 
 ## 55. View-transition target is too broad `[soft]`
 
-**What.** `view-transition-name: cortext-canvas` lives on `.cortext-shell__canvas`, one level above the content that actually needs the fade. That pulls the topbar into the canvas snapshot. Since the canvas transition also paints a backdrop to cover dark-mode flashes, the topbar gets tinted for a frame. We work around it by naming the topbar separately and disabling that animation.
+**What.** `view-transition-name: cortext-canvas` lives on `.cortext-shell__canvas`, one level above the content that needs the fade. That pulls the topbar into the canvas snapshot. The canvas transition also paints a backdrop to cover dark-mode flashes, so the topbar gets tinted for a frame. For now we name the topbar separately and cancel its animation.
 
 **Where.** `src/index.scss`: `.cortext-shell__canvas`, `.cortext-topbar`, and the `cortext-topbar` view-transition pseudo rules next to the canvas backdrop rules.
 
-**Solution.** Put `view-transition-name: cortext-canvas` on `.cortext-workspace` instead. The topbar stays outside the fade, the backdrop only covers the workspace, and the `cortext-topbar` opt-out can be deleted. If the title or breadcrumbs need animation later, name those pieces directly.
+**Solution.** Put `view-transition-name: cortext-canvas` on `.cortext-workspace` instead. The topbar stays outside the fade, the backdrop only covers the workspace, and the `cortext-topbar` opt-out can go away. If the title or breadcrumbs need animation later, name those pieces directly.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -508,3 +508,11 @@ The awkward part is the geometry. The skeleton copies DataViews row heights for 
 **Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, the block editor loading state in `src/blocks/data-view/edit.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/index.scss`.
 
 **Solution.** DataViews exposes a table loading slot, or at least row-height and header-height CSS variables. Then Cortext can follow the table instead of copying its constants. Until then, keep the skeleton rules next to the DataViews table rules and treat visual drift after a DataViews upgrade as the tripwire.
+
+## 55. View-transition target is too broad `[soft]`
+
+**What.** `.cortext-shell__canvas` carries `view-transition-name: cortext-canvas`, but the canvas contains both the topbar (chrome that doesn't change between routes) and the workspace (the actual content). The cross-fade therefore drags the topbar into the snapshot, and the backdrop fill we paint on the canvas group to keep dark mode from flashing black washes the topbar's warm surface to grey for a frame. The patch we shipped gives the topbar its own `view-transition-name: cortext-topbar` and silences its animation, so the navigator creates a transition piece just to discard it.
+
+**Where.** `.cortext-shell__canvas` and `.cortext-topbar` rules in `src/index.scss`, plus the `::view-transition-group/old/new(cortext-topbar) { animation: none }` block right next to the canvas group backdrop fix.
+
+**Solution.** Move `view-transition-name` from `.cortext-shell__canvas` to `.cortext-workspace`. The topbar then sits outside the transition naturally, the backdrop fill applies only over the workspace, and the topbar opt-out (name + suppressed animation) goes away. Any future chrome added between shell-canvas and workspace stays out of the transition for free. The only thing lost is the option of cross-fading topbar text (title, breadcrumbs) along with the document swap; opt that back in per-element with its own name if desired.

--- a/includes/Theming/Preferences.php
+++ b/includes/Theming/Preferences.php
@@ -68,6 +68,15 @@ final class Preferences {
 	if ( document.body ) {
 		document.body.setAttribute( 'data-cortext-theme', resolved );
 	}
+	// Mirror on html itself for the view-transition pseudo, which can't
+	// read vars scoped to #cortext-root. Matches the JS path in
+	// src/hooks/useColorScheme.js.
+	if ( document.documentElement ) {
+		document.documentElement.style.setProperty(
+			'--cortext-canvas-frame-surface-root',
+			resolved === 'dark' ? '#2a2a2a' : '#ffffff'
+		);
+	}
 
 	window.cortextBootstrap = {
 		colorScheme: pref,

--- a/includes/Theming/Preferences.php
+++ b/includes/Theming/Preferences.php
@@ -68,9 +68,8 @@ final class Preferences {
 	if ( document.body ) {
 		document.body.setAttribute( 'data-cortext-theme', resolved );
 	}
-	// Mirror on html itself for the view-transition pseudo, which can't
-	// read vars scoped to #cortext-root. Matches the JS path in
-	// src/hooks/useColorScheme.js.
+	// Keep the fallback color on html too. View-transition pseudos cannot
+	// read vars scoped to #cortext-root, and the JS hook writes the same var.
 	if ( document.documentElement ) {
 		document.documentElement.style.setProperty(
 			'--cortext-canvas-frame-surface-root',

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -642,7 +642,12 @@ export default function Edit( { attributes, setAttributes } ) {
 					onChangeView={ setView }
 					revealFieldId={ revealFieldId }
 					onFieldRevealed={ onFieldRevealed }
-					loading={ <CollectionRowsSkeleton /> }
+					loading={
+						<CollectionRowsSkeleton
+							rowCount={ view?.perPage ?? 8 }
+							density={ view?.layout?.density ?? 'compact' }
+						/>
+					}
 					invalid={
 						<Notice status="warning" isDismissible={ false }>
 							{ __(

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -31,6 +31,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { cog, plus, replace } from '@wordpress/icons';
 
 import CollectionDataViews from '../../components/CollectionDataViews';
+import { CollectionRowsSkeleton } from '../../components/Skeleton';
 import AddFieldPopover from '../../components/fields/AddFieldPopover';
 import { FULL_PAGE_COLLECTION_QUERY } from '../../collections';
 import { toDataViewId } from '../../hooks/fieldIds';
@@ -641,7 +642,7 @@ export default function Edit( { attributes, setAttributes } ) {
 					onChangeView={ setView }
 					revealFieldId={ revealFieldId }
 					onFieldRevealed={ onFieldRevealed }
-					loading={ <Spinner /> }
+					loading={ <CollectionRowsSkeleton /> }
 					invalid={
 						<Notice status="warning" isDismissible={ false }>
 							{ __(

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -31,7 +31,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { cog, plus, replace } from '@wordpress/icons';
 
 import CollectionDataViews from '../../components/CollectionDataViews';
-import { CollectionRowsSkeleton } from '../../components/Skeleton';
 import AddFieldPopover from '../../components/fields/AddFieldPopover';
 import { FULL_PAGE_COLLECTION_QUERY } from '../../collections';
 import { toDataViewId } from '../../hooks/fieldIds';
@@ -642,12 +641,6 @@ export default function Edit( { attributes, setAttributes } ) {
 					onChangeView={ setView }
 					revealFieldId={ revealFieldId }
 					onFieldRevealed={ onFieldRevealed }
-					loading={
-						<CollectionRowsSkeleton
-							rowCount={ view?.perPage ?? 8 }
-							density={ view?.layout?.density ?? 'compact' }
-						/>
-					}
 					invalid={
 						<Notice status="warning" isDismissible={ false }>
 							{ __(

--- a/src/blocks/document-cover/edit.js
+++ b/src/blocks/document-cover/edit.js
@@ -8,6 +8,7 @@ import {
 import MediaPicker, { MediaUploadCheck } from '../../components/MediaPicker';
 import { useEntityProp, useEntityRecord } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import {
 	Button,
@@ -79,6 +80,14 @@ export default function Edit( { context, clientId } ) {
 		media?.media_details?.sizes?.large?.source_url ??
 		media?.source_url ??
 		null;
+
+	// Fade the cover in once the bytes have actually decoded. Without this the
+	// image pops in cold against the canvas, especially on page-to-page nav
+	// where the new cover lands a beat after the iframe re-parses blocks.
+	const [ hasImagePainted, setHasImagePainted ] = useState( false );
+	useEffect( () => {
+		setHasImagePainted( false );
+	}, [ src ] );
 
 	const ensureIconBlock = () => {
 		if ( hasIconBlock || ! clientId ) {
@@ -172,8 +181,14 @@ export default function Edit( { context, clientId } ) {
 						className="cortext-document-cover-block__image"
 						src={ src }
 						alt={ media?.alt_text ?? '' }
-						loading="lazy"
+						// Cover is always above the fold; eager fetch beats the
+						// iframe paint, otherwise the slot stays blank for a beat
+						// after the editor swaps documents.
+						loading="eager"
 						decoding="async"
+						onLoad={ () => setHasImagePainted( true ) }
+						onError={ () => setHasImagePainted( true ) }
+						style={ { opacity: hasImagePainted ? 1 : 0 } }
 					/>
 				) }
 				<div className="cortext-document-cover-block__controls">

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -23,7 +23,6 @@ import './Canvas.scss';
 import './initEditor';
 import useAutosave from '../hooks/useAutosave';
 import useDelayedFlag from '../hooks/useDelayedFlag';
-import { withViewTransition } from '../hooks/viewTransition';
 import { POST_TYPE } from './page-queries';
 import EditorBody from './EditorBody';
 import PublishToggle from './PublishToggle';
@@ -224,10 +223,7 @@ function CanvasEditor( {
 		async function switchAfterSave() {
 			const didFlush = await flushNow();
 			if ( ! cancelled && didFlush ) {
-				// Document-to-document swaps don't change EntityRoute's
-				// `active`, so the surface-level cross-fade can't see them.
-				// Trigger one here instead.
-				withViewTransition( () => onSwitchPost( pendingPost ) );
+				onSwitchPost( pendingPost );
 			}
 		}
 

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -384,10 +384,9 @@ export default function Canvas( {
 			requestedPost.id !== renderedPost.id )
 			? requestedPost
 			: null;
-	// `pendingPost` only fires once the new record has resolved and is
-	// waiting for the editor to flush, which is too late on a slow network.
-	// Comparing the request props directly catches the whole window from
-	// "user clicked another page" until the displayed post catches up.
+	// `pendingPost` is set only after the new record resolves, which can be
+	// too late on a slow network. Compare the requested post to the one still
+	// on screen so the progress bar covers the full wait after a click.
 	const isCrossDocNav = Boolean(
 		renderedPost &&
 			postId &&

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -7,7 +7,7 @@ import {
 	InterfaceSkeleton,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import { Button, Disabled, SnackbarList, Spinner } from '@wordpress/components';
+import { Button, Disabled, SnackbarList } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
 import { chevronDown, chevronUp, cog, seen, unseen } from '@wordpress/icons';
 import { useCallback, useEffect, useState } from '@wordpress/element';
@@ -19,6 +19,7 @@ import EditorBody from './EditorBody';
 import PublishToggle from './PublishToggle';
 import { RowDetailSidebarSlot } from './RowDetailSidebarSlot';
 import RowProperties from './RowProperties';
+import { DocumentSkeleton } from './Skeleton';
 import { TopBarActionsFill } from './WorkspaceTopBar';
 import PageInspectorSidebar, {
 	BLOCK_INSPECTOR,
@@ -377,8 +378,8 @@ export default function Canvas( {
 
 	if ( ! renderedPost ) {
 		return (
-			<div className="cortext-canvas__loading">
-				<Spinner />
+			<div className="cortext-canvas__loading cortext-canvas__loading--document">
+				<DocumentSkeleton />
 			</div>
 		);
 	}

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -20,7 +20,7 @@ import EditorBody from './EditorBody';
 import PublishToggle from './PublishToggle';
 import { RowDetailSidebarSlot } from './RowDetailSidebarSlot';
 import RowProperties from './RowProperties';
-import { DocumentSkeleton } from './Skeleton';
+import { CanvasProgressBar } from './Skeleton';
 import { TopBarActionsFill } from './WorkspaceTopBar';
 import PageInspectorSidebar, {
 	BLOCK_INSPECTOR,
@@ -377,11 +377,11 @@ export default function Canvas( {
 		} );
 	}, [ requestedPost ] );
 
-	const showLoadingSkeleton = useDelayedFlag( ! renderedPost );
+	const showProgress = useDelayedFlag( ! renderedPost );
 	if ( ! renderedPost ) {
 		return (
 			<div className="cortext-canvas__loading cortext-canvas__loading--document">
-				{ showLoadingSkeleton ? <DocumentSkeleton /> : null }
+				{ showProgress ? <CanvasProgressBar /> : null }
 			</div>
 		);
 	}

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -384,11 +384,17 @@ export default function Canvas( {
 			requestedPost.id !== renderedPost.id )
 			? requestedPost
 			: null;
-	// Active for first-load (no rendered post yet) AND for cross-doc swaps
-	// where the current post is still visible while the new one loads.
-	const showProgress = useDelayedFlag(
-		! renderedPost || pendingPost !== null
+	// `pendingPost` only fires once the new record has resolved and is
+	// waiting for the editor to flush, which is too late on a slow network.
+	// Comparing the request props directly catches the whole window from
+	// "user clicked another page" until the displayed post catches up.
+	const isCrossDocNav = Boolean(
+		renderedPost &&
+			postId &&
+			( String( postId ) !== String( renderedPost.id ) ||
+				( postType && postType !== renderedPost.type ) )
 	);
+	const showProgress = useDelayedFlag( ! renderedPost || isCrossDocNav );
 	if ( ! renderedPost ) {
 		return (
 			<div className="cortext-canvas__loading cortext-canvas__loading--document">

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -384,9 +384,9 @@ export default function Canvas( {
 			requestedPost.id !== renderedPost.id )
 			? requestedPost
 			: null;
-	// `pendingPost` is set only after the new record resolves, which can be
-	// too late on a slow network. Compare the requested post to the one still
-	// on screen so the progress bar covers the full wait after a click.
+	// `pendingPost` appears only after the next record resolves. On a slow
+	// network that is too late, so compare the requested post to the one still
+	// on screen and cover the whole wait after a click.
 	const isCrossDocNav = Boolean(
 		renderedPost &&
 			postId &&

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -13,6 +13,7 @@ import { chevronDown, chevronUp, cog, seen, unseen } from '@wordpress/icons';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 
 import useAutosave from '../hooks/useAutosave';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import { withViewTransition } from '../hooks/viewTransition';
 import { POST_TYPE } from './page-queries';
 import EditorBody from './EditorBody';
@@ -376,10 +377,11 @@ export default function Canvas( {
 		} );
 	}, [ requestedPost ] );
 
+	const showLoadingSkeleton = useDelayedFlag( ! renderedPost );
 	if ( ! renderedPost ) {
 		return (
 			<div className="cortext-canvas__loading cortext-canvas__loading--document">
-				<DocumentSkeleton />
+				{ showLoadingSkeleton ? <DocumentSkeleton /> : null }
 			</div>
 		);
 	}

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -377,7 +377,18 @@ export default function Canvas( {
 		} );
 	}, [ requestedPost ] );
 
-	const showProgress = useDelayedFlag( ! renderedPost );
+	const pendingPost =
+		renderedPost &&
+		requestedPost &&
+		( requestedPost.type !== renderedPost.type ||
+			requestedPost.id !== renderedPost.id )
+			? requestedPost
+			: null;
+	// Active for first-load (no rendered post yet) AND for cross-doc swaps
+	// where the current post is still visible while the new one loads.
+	const showProgress = useDelayedFlag(
+		! renderedPost || pendingPost !== null
+	);
 	if ( ! renderedPost ) {
 		return (
 			<div className="cortext-canvas__loading cortext-canvas__loading--document">
@@ -386,35 +397,35 @@ export default function Canvas( {
 		);
 	}
 
-	const pendingPost =
-		requestedPost &&
-		( requestedPost.type !== renderedPost.type ||
-			requestedPost.id !== renderedPost.id )
-			? requestedPost
-			: null;
-
 	return (
-		<EditorProvider
-			post={ renderedPost }
-			settings={ window.cortextEditorSettings ?? {} }
-			useSubRegistry={ useSubRegistry }
-		>
-			<CanvasEditor
+		<>
+			{ showProgress && (
+				<div className="cortext-canvas__pending-progress">
+					<CanvasProgressBar />
+				</div>
+			) }
+			<EditorProvider
 				post={ renderedPost }
-				postType={ renderedPost.type }
-				fields={ fields }
-				row={ row }
-				pendingPost={ pendingPost }
-				onSwitchPost={ setDisplayedPost }
-				onDisplayedPost={ onDisplayedPost }
-				isActive={ isActive }
-				topBarActions={ topBarActions }
-				notice={ notice }
-				onApi={ onApi }
-				onSaved={ onSaved }
-				onRestored={ onRestored }
-				recentTarget={ recentTarget }
-			/>
-		</EditorProvider>
+				settings={ window.cortextEditorSettings ?? {} }
+				useSubRegistry={ useSubRegistry }
+			>
+				<CanvasEditor
+					post={ renderedPost }
+					postType={ renderedPost.type }
+					fields={ fields }
+					row={ row }
+					pendingPost={ pendingPost }
+					onSwitchPost={ setDisplayedPost }
+					onDisplayedPost={ onDisplayedPost }
+					isActive={ isActive }
+					topBarActions={ topBarActions }
+					notice={ notice }
+					onApi={ onApi }
+					onSaved={ onSaved }
+					onRestored={ onRestored }
+					recentTarget={ recentTarget }
+				/>
+			</EditorProvider>
+		</>
 	);
 }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -23,6 +23,7 @@ import './Canvas.scss';
 import './initEditor';
 import useAutosave from '../hooks/useAutosave';
 import useDelayedFlag from '../hooks/useDelayedFlag';
+import { withViewTransition } from '../hooks/viewTransition';
 import { POST_TYPE } from './page-queries';
 import EditorBody from './EditorBody';
 import PublishToggle from './PublishToggle';
@@ -223,7 +224,10 @@ function CanvasEditor( {
 		async function switchAfterSave() {
 			const didFlush = await flushNow();
 			if ( ! cancelled && didFlush ) {
-				onSwitchPost( pendingPost );
+				// Document-to-document swaps don't change EntityRoute's
+				// `active`, so the surface-level cross-fade can't see them.
+				// Trigger one here instead.
+				withViewTransition( () => onSwitchPost( pendingPost ) );
 			}
 		}
 

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1598,13 +1598,30 @@ export default function CollectionDataViews( {
 							data-rows-loading={
 								isRowsLoadingShell ? 'true' : undefined
 							}
-							style={
-								measuredHeaderHeight
-									? {
-											'--cortext-data-view-header-height': `${ measuredHeaderHeight }px`,
-									  }
-									: undefined
-							}
+							style={ ( () => {
+								const styles = {};
+								if ( measuredHeaderHeight ) {
+									styles[
+										'--cortext-data-view-header-height'
+									] = `${ measuredHeaderHeight }px`;
+								}
+								if ( isRowsLoadingShell ) {
+									// Keep the wrapper at skeleton height so
+									// the rows-skeleton overlay doesn't clip
+									// when DataViews mounts with an empty
+									// tbody. Capped at 15 to match the
+									// skeleton row cap.
+									styles[
+										'--cortext-data-view-loading-rows'
+									] = Math.max(
+										1,
+										Math.min( view?.perPage ?? 8, 15 )
+									);
+								}
+								return Object.keys( styles ).length > 0
+									? styles
+									: undefined;
+							} )() }
 						>
 							{ rowActionError && (
 								<Notice

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -30,7 +30,9 @@ import { CurrentViewModeProvider } from './CurrentViewModeContext';
 import EditableCell, { RowMutationContext } from './EditableCell';
 import PageIcon from './PageIcon';
 import { CollectionRowsSkeleton } from './Skeleton';
-import useDelayedFlag from '../hooks/useDelayedFlag';
+import useDelayedFlag, {
+	SKELETON_MIN_VISIBLE_MS,
+} from '../hooks/useDelayedFlag';
 import allSettledWithConcurrency from './allSettledWithConcurrency';
 import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
@@ -573,7 +575,11 @@ export default function CollectionDataViews( {
 	// so the user does not see three quick states: generic placeholder, empty
 	// DataViews chrome, then real rows.
 	const isShellLoading = isResolving || isRowsLoadingShell;
-	const showLoadingShell = useDelayedFlag( isShellLoading );
+	const showLoadingShell = useDelayedFlag(
+		isShellLoading,
+		120,
+		SKELETON_MIN_VISIBLE_MS
+	);
 
 	const tableWrapperRef = useRef( null );
 	const [ localRevealFieldId, setLocalRevealFieldId ] = useState( null );

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -87,12 +87,40 @@ const OpenRowActionContext = createContext( {
 	requestOpenRow: null,
 } );
 
+// The peek panel needs the editor to mount before its content paints, which
+// is enough work that the row click otherwise feels unresponsive for the
+// first frames. Showing an "opening" highlight on the row immediately on
+// pointerdown gives the user feedback before the panel is ready.
+const OPENING_FEEDBACK_TIMEOUT_MS = 600;
+
 function TitleCell( { item } ) {
 	const { enabled, icon, openRowId, requestOpenRow } =
 		useContext( OpenRowActionContext );
 	const canOpenRow = Boolean( enabled && requestOpenRow );
 	const isOpenRow = canOpenRow && String( item?.id ) === String( openRowId );
 	const documentIcon = item?.meta?.cortext_document_icon ?? '';
+	const [ isOpening, setIsOpening ] = useState( false );
+	const openingTimeoutRef = useRef( null );
+
+	const clearOpeningTimeout = useCallback( () => {
+		if ( openingTimeoutRef.current ) {
+			clearTimeout( openingTimeoutRef.current );
+			openingTimeoutRef.current = null;
+		}
+	}, [] );
+
+	useEffect( () => clearOpeningTimeout, [ clearOpeningTimeout ] );
+
+	// Once the row is the open peek, the --is-open class takes over the
+	// highlight. Drop the transient opening state so it doesn't linger if the
+	// user closes the panel quickly.
+	useEffect( () => {
+		if ( isOpenRow && isOpening ) {
+			clearOpeningTimeout();
+			setIsOpening( false );
+		}
+	}, [ clearOpeningTimeout, isOpening, isOpenRow ] );
+
 	const openRow = useCallback(
 		( event ) => {
 			event.preventDefault();
@@ -100,6 +128,21 @@ function TitleCell( { item } ) {
 			requestOpenRow?.( item );
 		},
 		[ item, requestOpenRow ]
+	);
+	const handleOpenPointerDown = useCallback(
+		( event ) => {
+			event.stopPropagation();
+			if ( ! canOpenRow || isOpenRow ) {
+				return;
+			}
+			setIsOpening( true );
+			clearOpeningTimeout();
+			openingTimeoutRef.current = setTimeout( () => {
+				openingTimeoutRef.current = null;
+				setIsOpening( false );
+			}, OPENING_FEEDBACK_TIMEOUT_MS );
+		},
+		[ canOpenRow, clearOpeningTimeout, isOpenRow ]
 	);
 	const stopPropagation = useCallback( ( event ) => {
 		event.stopPropagation();
@@ -110,7 +153,10 @@ function TitleCell( { item } ) {
 			className={
 				'cortext-title-cell' +
 				( canOpenRow ? ' cortext-title-cell--with-open-action' : '' ) +
-				( isOpenRow ? ' cortext-title-cell--is-open' : '' )
+				( isOpenRow ? ' cortext-title-cell--is-open' : '' ) +
+				( isOpening && ! isOpenRow
+					? ' cortext-title-cell--is-opening'
+					: '' )
 			}
 		>
 			{ documentIcon ? (
@@ -136,6 +182,7 @@ function TitleCell( { item } ) {
 					variant="tertiary"
 					onClick={ openRow }
 					onMouseDown={ stopPropagation }
+					onPointerDown={ handleOpenPointerDown }
 				>
 					{ __( 'Open', 'cortext' ) }
 				</Button>

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -89,10 +89,9 @@ const OpenRowActionContext = createContext( {
 	requestOpenRow: null,
 } );
 
-// The peek panel needs the editor to mount before its content paints, which
-// is enough work that the row click otherwise feels unresponsive for the
-// first frames. Showing an "opening" highlight on the row immediately on
-// pointerdown gives the user feedback before the panel is ready.
+// The peek panel waits for the editor before it can paint content. On slower
+// loads, that makes a row click feel dead for a beat, so pointerdown gives the
+// row a short "opening" state right away.
 const OPENING_FEEDBACK_TIMEOUT_MS = 600;
 
 function TitleCell( { item } ) {
@@ -113,9 +112,9 @@ function TitleCell( { item } ) {
 
 	useEffect( () => clearOpeningTimeout, [ clearOpeningTimeout ] );
 
-	// Once the row is the open peek, the --is-open class takes over the
-	// highlight. Drop the transient opening state so it doesn't linger if the
-	// user closes the panel quickly.
+	// Once this row owns the open peek, --is-open handles the highlight. Clear
+	// the short-lived opening state so it cannot hang around after a quick
+	// close.
 	useEffect( () => {
 		if ( isOpenRow && isOpening ) {
 			clearOpeningTimeout();
@@ -569,9 +568,9 @@ export default function CollectionDataViews( {
 	const supportsRowSelection = isTableLayout || isGridLayout;
 	const isServerPaginated = queryMode === 'server';
 	const dataViewFields = availableFields;
-	const showRowsSkeleton = useDelayedFlag(
-		isLoading && data.length === 0 && isTableLayout
-	);
+	const isRowsLoadingShell =
+		! rowsResolved && data.length === 0 && isTableLayout;
+	const showRowsSkeleton = useDelayedFlag( isRowsLoadingShell );
 	const showFieldsLoading = useDelayedFlag( isResolving );
 
 	const tableWrapperRef = useRef( null );
@@ -1410,11 +1409,9 @@ export default function CollectionDataViews( {
 	] );
 
 	useEffect( () => {
-		// Signal ready as soon as fields have resolved so the entity route can
-		// cross-fade to this pane while the rows skeleton is still painted.
-		// Waiting for `rowsResolved` here used to defer the swap until the
-		// table was fully populated, which is exactly the window the skeleton
-		// is designed to cover.
+		// Mark the pane ready once fields resolve. Rows can keep loading behind
+		// the skeleton; waiting for them here leaves the old pane on screen for
+		// too long.
 		if ( ! isResolving ) {
 			onReady?.( collectionId );
 		}
@@ -1535,7 +1532,7 @@ export default function CollectionDataViews( {
 							ref={ tableWrapperRef }
 							onClickCapture={ captureSelectionIntent }
 							data-rows-loading={
-								showRowsSkeleton ? 'true' : undefined
+								isRowsLoadingShell ? 'true' : undefined
 							}
 						>
 							{ rowActionError && (

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -30,6 +30,7 @@ import { CurrentViewModeProvider } from './CurrentViewModeContext';
 import EditableCell, { RowMutationContext } from './EditableCell';
 import PageIcon from './PageIcon';
 import { CollectionRowsSkeleton } from './Skeleton';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import allSettledWithConcurrency from './allSettledWithConcurrency';
 import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
@@ -568,6 +569,9 @@ export default function CollectionDataViews( {
 	const supportsRowSelection = isTableLayout || isGridLayout;
 	const isServerPaginated = queryMode === 'server';
 	const dataViewFields = availableFields;
+	const showRowsSkeleton = useDelayedFlag(
+		isLoading && data.length === 0 && isTableLayout
+	);
 
 	const tableWrapperRef = useRef( null );
 	const [ localRevealFieldId, setLocalRevealFieldId ] = useState( null );
@@ -1525,11 +1529,7 @@ export default function CollectionDataViews( {
 							ref={ tableWrapperRef }
 							onClickCapture={ captureSelectionIntent }
 							data-rows-loading={
-								isLoading &&
-								dataFiltered.length === 0 &&
-								isTableLayout
-									? 'true'
-									: undefined
+								showRowsSkeleton ? 'true' : undefined
 							}
 						>
 							{ rowActionError && (
@@ -1541,18 +1541,15 @@ export default function CollectionDataViews( {
 									{ rowActionError }
 								</Notice>
 							) }
-							{ isLoading &&
-								dataFiltered.length === 0 &&
-								isTableLayout && (
-									<div className="cortext-data-view__rows-skeleton">
-										<CollectionRowsSkeleton
-											columnCount={
-												( view?.fields?.length ?? 0 ) +
-												1
-											}
-										/>
-									</div>
-								) }
+							{ showRowsSkeleton && (
+								<div className="cortext-data-view__rows-skeleton">
+									<CollectionRowsSkeleton
+										columnCount={
+											( view?.fields?.length ?? 0 ) + 1
+										}
+									/>
+								</div>
+							) }
 							<DataViews
 								data={ dataFiltered }
 								fields={ dataViewFields }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -29,6 +29,7 @@ import {
 import { CurrentViewModeProvider } from './CurrentViewModeContext';
 import EditableCell, { RowMutationContext } from './EditableCell';
 import PageIcon from './PageIcon';
+import { CollectionRowsSkeleton } from './Skeleton';
 import allSettledWithConcurrency from './allSettledWithConcurrency';
 import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
@@ -1523,6 +1524,13 @@ export default function CollectionDataViews( {
 							className="cortext-data-view"
 							ref={ tableWrapperRef }
 							onClickCapture={ captureSelectionIntent }
+							data-rows-loading={
+								isLoading &&
+								dataFiltered.length === 0 &&
+								isTableLayout
+									? 'true'
+									: undefined
+							}
 						>
 							{ rowActionError && (
 								<Notice
@@ -1533,6 +1541,18 @@ export default function CollectionDataViews( {
 									{ rowActionError }
 								</Notice>
 							) }
+							{ isLoading &&
+								dataFiltered.length === 0 &&
+								isTableLayout && (
+									<div className="cortext-data-view__rows-skeleton">
+										<CollectionRowsSkeleton
+											columnCount={
+												( view?.fields?.length ?? 0 ) +
+												1
+											}
+										/>
+									</div>
+								) }
 							<DataViews
 								data={ dataFiltered }
 								fields={ dataViewFields }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -574,6 +574,11 @@ export default function CollectionDataViews( {
 	const showFieldsLoading = useDelayedFlag( isResolving );
 
 	const tableWrapperRef = useRef( null );
+	// Measure DataViews' real header to size the rows-skeleton overlay. The
+	// CSS fallback is 56px; once we have a real number we hand it back to
+	// the SCSS rule via an inline CSS variable on the shell. ResizeObserver
+	// catches the filters bar collapsing/expanding without a re-render.
+	const [ measuredHeaderHeight, setMeasuredHeaderHeight ] = useState( null );
 	const [ localRevealFieldId, setLocalRevealFieldId ] = useState( null );
 	const pendingRevealFieldId = revealFieldId ?? localRevealFieldId;
 	const requestRevealCreatedField = useCallback( ( created ) => {
@@ -1463,6 +1468,65 @@ export default function CollectionDataViews( {
 		return () => node.removeEventListener( 'mousedown', onMouseDown, true );
 	}, [ isResolving, rowsResolved, rowError ] );
 
+	useLayoutEffect( () => {
+		const wrapper = tableWrapperRef.current;
+		if ( ! wrapper || isResolving ) {
+			return undefined;
+		}
+		let cancelled = false;
+		let observer = null;
+		// Skeleton overlay needs to start where `tbody` does, not where the
+		// column headers do: the chrome above `tbody` also includes the
+		// search bar, view actions, and (when expanded) the filters strip.
+		// Measuring tbody position relative to the data-view shell covers
+		// everything above it in one shot.
+		const update = () => {
+			if ( cancelled ) {
+				return;
+			}
+			const tbody = wrapper.querySelector(
+				'.dataviews-view-table tbody'
+			);
+			if ( ! tbody ) {
+				return;
+			}
+			const wrapperTop = wrapper.getBoundingClientRect().top;
+			const tbodyTop = tbody.getBoundingClientRect().top;
+			const offset = tbodyTop - wrapperTop;
+			if ( offset > 0 ) {
+				setMeasuredHeaderHeight( Math.round( offset ) );
+			}
+		};
+		const attach = () => {
+			if ( cancelled ) {
+				return;
+			}
+			const tbody = wrapper.querySelector(
+				'.dataviews-view-table tbody'
+			);
+			if ( ! tbody ) {
+				// tbody can mount a frame later than this effect; retry.
+				window.requestAnimationFrame( attach );
+				return;
+			}
+			update();
+			if ( typeof window.ResizeObserver === 'function' ) {
+				observer = new window.ResizeObserver( update );
+				// Observing the wrapper catches both header chrome resizes
+				// (filters strip opening, view actions changing) and tbody
+				// movement.
+				observer.observe( wrapper );
+			}
+		};
+		attach();
+		return () => {
+			cancelled = true;
+			if ( observer ) {
+				observer.disconnect();
+			}
+		};
+	}, [ isResolving, isTableLayout ] );
+
 	if ( isResolving ) {
 		return showFieldsLoading ? loading : null;
 	}
@@ -1533,6 +1597,13 @@ export default function CollectionDataViews( {
 							onClickCapture={ captureSelectionIntent }
 							data-rows-loading={
 								isRowsLoadingShell ? 'true' : undefined
+							}
+							style={
+								measuredHeaderHeight
+									? {
+											'--cortext-data-view-header-height': `${ measuredHeaderHeight }px`,
+									  }
+									: undefined
 							}
 						>
 							{ rowActionError && (

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1545,8 +1545,12 @@ export default function CollectionDataViews( {
 							{ showRowsSkeleton && (
 								<div className="cortext-data-view__rows-skeleton">
 									<CollectionRowsSkeleton
+										rowCount={ view?.perPage ?? 8 }
 										columnCount={
 											( view?.fields?.length ?? 0 ) + 1
+										}
+										density={
+											view?.layout?.density ?? 'compact'
 										}
 									/>
 								</div>

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -572,6 +572,7 @@ export default function CollectionDataViews( {
 	const showRowsSkeleton = useDelayedFlag(
 		isLoading && data.length === 0 && isTableLayout
 	);
+	const showFieldsLoading = useDelayedFlag( isResolving );
 
 	const tableWrapperRef = useRef( null );
 	const [ localRevealFieldId, setLocalRevealFieldId ] = useState( null );
@@ -1461,7 +1462,7 @@ export default function CollectionDataViews( {
 	}, [ isResolving, rowsResolved, rowError ] );
 
 	if ( isResolving ) {
-		return loading;
+		return showFieldsLoading ? loading : null;
 	}
 
 	if ( collectionId && ! collection ) {

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1410,10 +1410,15 @@ export default function CollectionDataViews( {
 	] );
 
 	useEffect( () => {
-		if ( ! isResolving && rowsResolved ) {
+		// Signal ready as soon as fields have resolved so the entity route can
+		// cross-fade to this pane while the rows skeleton is still painted.
+		// Waiting for `rowsResolved` here used to defer the swap until the
+		// table was fully populated, which is exactly the window the skeleton
+		// is designed to cover.
+		if ( ! isResolving ) {
 			onReady?.( collectionId );
 		}
-	}, [ collectionId, isResolving, rowsResolved, onReady ] );
+	}, [ collectionId, isResolving, onReady ] );
 
 	// tech-debt.md#22: Gutenberg selects on any mousedown that bubbles up.
 	// Dragging the dataviews scrollbar lands in the gutter (offset past the

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -89,9 +89,9 @@ const OpenRowActionContext = createContext( {
 	requestOpenRow: null,
 } );
 
-// The peek panel waits for the editor before it can paint content. On slower
-// loads, that makes a row click feel dead for a beat, so pointerdown gives the
-// row a short "opening" state right away.
+// The peek panel cannot render until the editor is ready. On slower loads a
+// row click can feel like nothing happened, so pointerdown applies a short
+// "opening" state immediately.
 const OPENING_FEEDBACK_TIMEOUT_MS = 600;
 
 function TitleCell( { item } ) {
@@ -112,9 +112,8 @@ function TitleCell( { item } ) {
 
 	useEffect( () => clearOpeningTimeout, [ clearOpeningTimeout ] );
 
-	// Once this row owns the open peek, --is-open handles the highlight. Clear
-	// the short-lived opening state so it cannot hang around after a quick
-	// close.
+	// Once this row owns the open peek, --is-open handles the visual state.
+	// Drop the short-lived opening state so it cannot linger after a quick close.
 	useEffect( () => {
 		if ( isOpenRow && isOpening ) {
 			clearOpeningTimeout();
@@ -514,7 +513,6 @@ export default function CollectionDataViews( {
 	collectionId,
 	view,
 	onChangeView,
-	loading = null,
 	empty,
 	invalid,
 	error,
@@ -570,15 +568,14 @@ export default function CollectionDataViews( {
 	const dataViewFields = availableFields;
 	const isRowsLoadingShell =
 		! rowsResolved && data.length === 0 && isTableLayout;
-	const showRowsSkeleton = useDelayedFlag( isRowsLoadingShell );
-	const showFieldsLoading = useDelayedFlag( isResolving );
+	// Treat field loading and first-page row loading as one shell state. While
+	// either is still running, hide DataViews chrome and show the rows skeleton
+	// so the user does not see three quick states: generic placeholder, empty
+	// DataViews chrome, then real rows.
+	const isShellLoading = isResolving || isRowsLoadingShell;
+	const showLoadingShell = useDelayedFlag( isShellLoading );
 
 	const tableWrapperRef = useRef( null );
-	// Measure DataViews' real header to size the rows-skeleton overlay. The
-	// CSS fallback is 56px; once we have a real number we hand it back to
-	// the SCSS rule via an inline CSS variable on the shell. ResizeObserver
-	// catches the filters bar collapsing/expanding without a re-render.
-	const [ measuredHeaderHeight, setMeasuredHeaderHeight ] = useState( null );
 	const [ localRevealFieldId, setLocalRevealFieldId ] = useState( null );
 	const pendingRevealFieldId = revealFieldId ?? localRevealFieldId;
 	const requestRevealCreatedField = useCallback( ( created ) => {
@@ -1414,9 +1411,8 @@ export default function CollectionDataViews( {
 	] );
 
 	useEffect( () => {
-		// Mark the pane ready once fields resolve. Rows can keep loading behind
-		// the skeleton; waiting for them here leaves the old pane on screen for
-		// too long.
+		// Fields are enough to mount the pane. Rows can keep loading behind the
+		// skeleton; waiting for them leaves the old pane around too long.
 		if ( ! isResolving ) {
 			onReady?.( collectionId );
 		}
@@ -1468,70 +1464,7 @@ export default function CollectionDataViews( {
 		return () => node.removeEventListener( 'mousedown', onMouseDown, true );
 	}, [ isResolving, rowsResolved, rowError ] );
 
-	useLayoutEffect( () => {
-		const wrapper = tableWrapperRef.current;
-		if ( ! wrapper || isResolving ) {
-			return undefined;
-		}
-		let cancelled = false;
-		let observer = null;
-		// Skeleton overlay needs to start where `tbody` does, not where the
-		// column headers do: the chrome above `tbody` also includes the
-		// search bar, view actions, and (when expanded) the filters strip.
-		// Measuring tbody position relative to the data-view shell covers
-		// everything above it in one shot.
-		const update = () => {
-			if ( cancelled ) {
-				return;
-			}
-			const tbody = wrapper.querySelector(
-				'.dataviews-view-table tbody'
-			);
-			if ( ! tbody ) {
-				return;
-			}
-			const wrapperTop = wrapper.getBoundingClientRect().top;
-			const tbodyTop = tbody.getBoundingClientRect().top;
-			const offset = tbodyTop - wrapperTop;
-			if ( offset > 0 ) {
-				setMeasuredHeaderHeight( Math.round( offset ) );
-			}
-		};
-		const attach = () => {
-			if ( cancelled ) {
-				return;
-			}
-			const tbody = wrapper.querySelector(
-				'.dataviews-view-table tbody'
-			);
-			if ( ! tbody ) {
-				// tbody can mount a frame later than this effect; retry.
-				window.requestAnimationFrame( attach );
-				return;
-			}
-			update();
-			if ( typeof window.ResizeObserver === 'function' ) {
-				observer = new window.ResizeObserver( update );
-				// Observing the wrapper catches both header chrome resizes
-				// (filters strip opening, view actions changing) and tbody
-				// movement.
-				observer.observe( wrapper );
-			}
-		};
-		attach();
-		return () => {
-			cancelled = true;
-			if ( observer ) {
-				observer.disconnect();
-			}
-		};
-	}, [ isResolving, isTableLayout ] );
-
-	if ( isResolving ) {
-		return showFieldsLoading ? loading : null;
-	}
-
-	if ( collectionId && ! collection ) {
+	if ( ! isResolving && collectionId && ! collection ) {
 		return (
 			invalid ?? (
 				<p>
@@ -1544,7 +1477,7 @@ export default function CollectionDataViews( {
 		);
 	}
 
-	if ( rowError ) {
+	if ( ! isResolving && rowError ) {
 		return (
 			error ?? (
 				<p>
@@ -1595,33 +1528,35 @@ export default function CollectionDataViews( {
 							className="cortext-data-view"
 							ref={ tableWrapperRef }
 							onClickCapture={ captureSelectionIntent }
-							data-rows-loading={
-								isRowsLoadingShell ? 'true' : undefined
+							data-loading-shell={
+								isShellLoading ? 'true' : undefined
 							}
-							style={ ( () => {
-								const styles = {};
-								if ( measuredHeaderHeight ) {
-									styles[
-										'--cortext-data-view-header-height'
-									] = `${ measuredHeaderHeight }px`;
-								}
-								if ( isRowsLoadingShell ) {
-									// Keep the wrapper at skeleton height so
-									// the rows-skeleton overlay doesn't clip
-									// when DataViews mounts with an empty
-									// tbody. Capped at 15 to match the
-									// skeleton row cap.
-									styles[
-										'--cortext-data-view-loading-rows'
-									] = Math.max(
-										1,
-										Math.min( view?.perPage ?? 8, 15 )
-									);
-								}
-								return Object.keys( styles ).length > 0
-									? styles
-									: undefined;
-							} )() }
+							style={
+								isShellLoading
+									? {
+											// Hold the wrapper at skeleton
+											// height so content below does not
+											// jump when chrome and rows appear.
+											// Cap matches the skeleton row cap.
+											// Use the saved density too, so
+											// balanced and comfortable tables
+											// reserve enough room and do not
+											// clip the skeleton.
+											'--cortext-data-view-loading-rows':
+												Math.max(
+													1,
+													Math.min(
+														view?.perPage ?? 8,
+														15
+													)
+												),
+											'--cortext-data-view-loading-row-height': `var(--cortext-data-view-row-height-${
+												view?.layout?.density ??
+												'compact'
+											})`,
+									  }
+									: undefined
+							}
 						>
 							{ rowActionError && (
 								<Notice
@@ -1632,7 +1567,7 @@ export default function CollectionDataViews( {
 									{ rowActionError }
 								</Notice>
 							) }
-							{ showRowsSkeleton && (
+							{ showLoadingShell && (
 								<div className="cortext-data-view__rows-skeleton">
 									<CollectionRowsSkeleton
 										rowCount={ view?.perPage ?? 8 }
@@ -1645,76 +1580,90 @@ export default function CollectionDataViews( {
 									/>
 								</div>
 							) }
-							<DataViews
-								data={ dataFiltered }
-								fields={ dataViewFields }
-								view={ view }
-								onChangeView={ onChangeView }
-								paginationInfo={ activePaginationInfo }
-								defaultLayouts={ DEFAULT_LAYOUTS }
-								getItemId={ ( item ) => String( item.id ) }
-								isLoading={ isLoading }
-								empty={ empty }
-								actions={ dataViewActions }
-								{ ...( supportsRowSelection
-									? {
-											selection: selectedRowIds,
-											onChangeSelection,
-									  }
-									: {} ) }
-							>
-								<DataViewsChrome footer={ dataViewsFooter } />
-							</DataViews>
-							<DataViewRowReorder
-								wrapperRef={ tableWrapperRef }
-								view={ view }
-								onChangeView={ onChangeView }
-								collectionId={ collectionId }
-								rows={ dataFiltered }
-								data={ data }
-								mutateRows={ mutateRows }
-								onReordered={ refresh }
-							/>
-							{ isTableLayout && (
-								<TableCalculationsFooter
-									wrapperRef={ tableWrapperRef }
-									view={ view }
-									fields={ availableFields }
-									data={ dataFilteredForCalculations }
-									onChangeView={ onChangeView }
-									hasSelectionColumn={ hasSelectionColumn }
-									bulkActions={ tableBulkActions }
-								/>
+							{ ! isResolving && (
+								<>
+									<DataViews
+										data={ dataFiltered }
+										fields={ dataViewFields }
+										view={ view }
+										onChangeView={ onChangeView }
+										paginationInfo={ activePaginationInfo }
+										defaultLayouts={ DEFAULT_LAYOUTS }
+										getItemId={ ( item ) =>
+											String( item.id )
+										}
+										isLoading={ isLoading }
+										empty={ empty }
+										actions={ dataViewActions }
+										{ ...( supportsRowSelection
+											? {
+													selection: selectedRowIds,
+													onChangeSelection,
+											  }
+											: {} ) }
+									>
+										<DataViewsChrome
+											footer={ dataViewsFooter }
+										/>
+									</DataViews>
+									<DataViewRowReorder
+										wrapperRef={ tableWrapperRef }
+										view={ view }
+										onChangeView={ onChangeView }
+										collectionId={ collectionId }
+										rows={ dataFiltered }
+										data={ data }
+										mutateRows={ mutateRows }
+										onReordered={ refresh }
+									/>
+									{ isTableLayout && (
+										<TableCalculationsFooter
+											wrapperRef={ tableWrapperRef }
+											view={ view }
+											fields={ availableFields }
+											data={ dataFilteredForCalculations }
+											onChangeView={ onChangeView }
+											hasSelectionColumn={
+												hasSelectionColumn
+											}
+											bulkActions={ tableBulkActions }
+										/>
+									) }
+									{ isTableLayout && (
+										<DataViewColumnInteractions
+											wrapperRef={ tableWrapperRef }
+											view={ view }
+											fields={ availableFields }
+											onChangeView={ onChangeView }
+										/>
+									) }
+									{ isTableLayout && (
+										<ColumnHeaderActions
+											collectionId={ collectionId }
+											view={ view }
+											onChangeView={ onChangeView }
+											onFieldOptionsSaved={
+												updateFieldOptions
+											}
+											onFieldCreated={
+												requestRevealCreatedField
+											}
+											onRowsChanged={ refresh }
+										/>
+									) }
+									{ /* tech-debt.md#7: DataViews has no footer slot, so the
+									   New-row affordance and its CSS layout sit outside the
+									   component instead of inside its layout chrome. */ }
+									<div className="cortext-data-view__footer">
+										<NewRowButton
+											slug={ slug }
+											view={ view }
+											fields={ fields }
+											onCreated={ onCreated }
+										/>
+									</div>
+								</>
 							) }
-							{ isTableLayout && (
-								<DataViewColumnInteractions
-									wrapperRef={ tableWrapperRef }
-									view={ view }
-									fields={ availableFields }
-									onChangeView={ onChangeView }
-								/>
-							) }
-							{ isTableLayout && (
-								<ColumnHeaderActions
-									collectionId={ collectionId }
-									view={ view }
-									onChangeView={ onChangeView }
-									onFieldOptionsSaved={ updateFieldOptions }
-									onFieldCreated={ requestRevealCreatedField }
-									onRowsChanged={ refresh }
-								/>
-							) }
-							{ /* tech-debt.md#7: DataViews has no footer slot, so the
-							   New-row affordance and its CSS layout sit outside the
-							   component instead of inside its layout chrome. */ }
-							<div className="cortext-data-view__footer">
-								<NewRowButton
-									slug={ slug }
-									view={ view }
-									fields={ fields }
-									onCreated={ onCreated }
-								/>
-							</div>
 						</div>
 					</div>
 				</OpenRowActionContext.Provider>

--- a/src/components/DocumentPeekHost.js
+++ b/src/components/DocumentPeekHost.js
@@ -67,9 +67,8 @@ export default function DocumentPeekHost() {
 	const canGoPrevious = Boolean(
 		peek.source && adjacentRowId( rowList, peek.docId, -1 )
 	);
-	// Show the row from the table immediately so the panel can paint title
-	// and icon before useEntityRecord resolves. RowDetailView prefers `record`
-	// once it arrives, so this is only used by LoadingDetail.
+	// Use the table row until useEntityRecord catches up. That lets the
+	// loading pane show the title and icon instead of starting blank.
 	const tentativeRow = rowList.find(
 		( candidate ) => String( candidate?.id ) === String( peek.docId )
 	);

--- a/src/components/DocumentPeekHost.js
+++ b/src/components/DocumentPeekHost.js
@@ -67,8 +67,8 @@ export default function DocumentPeekHost() {
 	const canGoPrevious = Boolean(
 		peek.source && adjacentRowId( rowList, peek.docId, -1 )
 	);
-	// Use the table row until useEntityRecord catches up. That lets the
-	// loading pane show the title and icon instead of starting blank.
+	// Use the current table row as a stopgap while useEntityRecord catches up.
+	// The loading pane can show a title and icon instead of opening blank.
 	const tentativeRow = rowList.find(
 		( candidate ) => String( candidate?.id ) === String( peek.docId )
 	);

--- a/src/components/DocumentPeekHost.js
+++ b/src/components/DocumentPeekHost.js
@@ -67,6 +67,12 @@ export default function DocumentPeekHost() {
 	const canGoPrevious = Boolean(
 		peek.source && adjacentRowId( rowList, peek.docId, -1 )
 	);
+	// Show the row from the table immediately so the panel can paint title
+	// and icon before useEntityRecord resolves. RowDetailView prefers `record`
+	// once it arrives, so this is only used by LoadingDetail.
+	const tentativeRow = rowList.find(
+		( candidate ) => String( candidate?.id ) === String( peek.docId )
+	);
 	const handleSaved = () => peek.source?.refresh?.();
 	const handleRestored = () => peek.source?.refresh?.();
 
@@ -88,7 +94,7 @@ export default function DocumentPeekHost() {
 				onRetryPending={ retryPendingTransition }
 				onSaved={ handleSaved }
 				postType={ peek.postType }
-				row={ undefined }
+				row={ tentativeRow }
 				rowId={ peek.docId }
 				saveError={ saveError }
 			/>

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -68,10 +68,9 @@ function ImageIcon( { id, size, alt, className } ) {
 		record?.media_details?.sizes?.thumbnail?.source_url ??
 		record?.source_url ??
 		null;
-	// Two-phase wait: we don't consider the icon ready until the REST
-	// record has the URL AND the browser has actually painted the image.
-	// Without the second phase the swatch unmounts the moment `src` is
-	// set, leaving an empty gap until the network fetch finishes.
+	// Keep the swatch until both the media record has a URL and the browser has
+	// painted the image. Otherwise `src` appears first, the swatch disappears,
+	// and the icon slot goes empty while the image bytes load.
 	const [ hasImagePainted, setHasImagePainted ] = useState( false );
 	useEffect( () => {
 		setHasImagePainted( false );

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -68,9 +68,9 @@ function ImageIcon( { id, size, alt, className } ) {
 		record?.media_details?.sizes?.thumbnail?.source_url ??
 		record?.source_url ??
 		null;
-	// Keep the swatch until both the media record has a URL and the browser has
-	// painted the image. Otherwise `src` appears first, the swatch disappears,
-	// and the icon slot goes empty while the image bytes load.
+	// Keep the swatch until REST has a URL and the browser has loaded it.
+	// Otherwise the swatch disappears first and the icon slot looks empty
+	// while the image bytes arrive.
 	const [ hasImagePainted, setHasImagePainted ] = useState( false );
 	useEffect( () => {
 		setHasImagePainted( false );

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -3,6 +3,7 @@ import { Icon, page as pageGlyph } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 
 import PageIconWp from './PageIconWp';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 
 // Three shapes are persisted in the cortext_document_icon meta:
 //   { type: 'emoji', value: '📘' }
@@ -67,17 +68,27 @@ function ImageIcon( { id, size, alt, className } ) {
 		record?.media_details?.sizes?.thumbnail?.source_url ??
 		record?.source_url ??
 		null;
+	// Only paint the loading swatch if the fetch takes long enough to
+	// matter. Cache hits resolve before the timer fires, so a square skeleton
+	// never flashes in those.
+	const showLoadingSwatch = useDelayedFlag( ! src );
 	const classes = [ 'cortext-document-icon' ];
 	if ( className ) {
 		classes.push( className );
 	}
 
 	if ( ! src ) {
+		const loadingClasses = classes.concat(
+			'cortext-document-icon--image-loading'
+		);
+		if ( showLoadingSwatch ) {
+			loadingClasses.push(
+				'cortext-document-icon--image-loading-visible'
+			);
+		}
 		return (
 			<span
-				className={ classes
-					.concat( 'cortext-document-icon--image-loading' )
-					.join( ' ' ) }
+				className={ loadingClasses.join( ' ' ) }
 				style={ { width: size, height: size } }
 				aria-hidden="true"
 			/>

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -1,6 +1,6 @@
 import { useEntityRecord } from '@wordpress/core-data';
 import { Icon, page as pageGlyph } from '@wordpress/icons';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 
 import PageIconWp from './PageIconWp';
 import useDelayedFlag from '../hooks/useDelayedFlag';
@@ -68,45 +68,54 @@ function ImageIcon( { id, size, alt, className } ) {
 		record?.media_details?.sizes?.thumbnail?.source_url ??
 		record?.source_url ??
 		null;
-	// Only paint the loading swatch if the fetch takes long enough to
-	// matter. Cache hits resolve before the timer fires, so a square skeleton
-	// never flashes in those.
-	const showLoadingSwatch = useDelayedFlag( ! src );
+	// Two-phase wait: we don't consider the icon ready until the REST
+	// record has the URL AND the browser has actually painted the image.
+	// Without the second phase the swatch unmounts the moment `src` is
+	// set, leaving an empty gap until the network fetch finishes.
+	const [ hasImagePainted, setHasImagePainted ] = useState( false );
+	useEffect( () => {
+		setHasImagePainted( false );
+	}, [ src ] );
+
+	const isLoading = ! src || ! hasImagePainted;
+	const showLoadingSwatch = useDelayedFlag( isLoading );
 	const classes = [ 'cortext-document-icon' ];
 	if ( className ) {
 		classes.push( className );
 	}
 
-	if ( ! src ) {
-		const loadingClasses = classes.concat(
-			'cortext-document-icon--image-loading'
-		);
-		if ( showLoadingSwatch ) {
-			loadingClasses.push(
-				'cortext-document-icon--image-loading-visible'
-			);
-		}
-		return (
-			<span
-				className={ loadingClasses.join( ' ' ) }
-				style={ { width: size, height: size } }
-				aria-hidden="true"
-			/>
-		);
-	}
+	const wrapperClasses = classes
+		.concat( 'cortext-document-icon--image-wrap' )
+		.join( ' ' );
+	const swatchClasses = [
+		'cortext-document-icon--image-loading',
+		showLoadingSwatch && 'cortext-document-icon--image-loading-visible',
+	]
+		.filter( Boolean )
+		.join( ' ' );
 
 	return (
-		<img
-			className={ classes
-				.concat( 'cortext-document-icon--image' )
-				.join( ' ' ) }
-			src={ src }
-			alt={ alt ?? '' }
-			width={ size }
-			height={ size }
-			loading="lazy"
-			decoding="async"
-		/>
+		<span
+			className={ wrapperClasses }
+			style={ { width: size, height: size } }
+		>
+			{ isLoading && (
+				<span className={ swatchClasses } aria-hidden="true" />
+			) }
+			{ src && (
+				<img
+					className="cortext-document-icon--image"
+					src={ src }
+					alt={ alt ?? '' }
+					width={ size }
+					height={ size }
+					loading="lazy"
+					decoding="async"
+					onLoad={ () => setHasImagePainted( true ) }
+					style={ { opacity: hasImagePainted ? 1 : 0 } }
+				/>
+			) }
+		</span>
 	);
 }
 

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -111,6 +111,10 @@ function ImageIcon( { id, size, alt, className } ) {
 					loading="lazy"
 					decoding="async"
 					onLoad={ () => setHasImagePainted( true ) }
+					// Drop the swatch on a failed fetch too. Without this the
+					// swatch pulses forever for 404s or deleted media; we'd
+					// rather show the browser's broken-image fallback.
+					onError={ () => setHasImagePainted( true ) }
 					style={ { opacity: hasImagePainted ? 1 : 0 } }
 				/>
 			) }

--- a/src/components/PageInspectorSidebar.js
+++ b/src/components/PageInspectorSidebar.js
@@ -45,7 +45,9 @@ import MediaPicker, { MediaUploadCheck } from './MediaPicker';
 import PageIcon from './PageIcon';
 import DocumentIdentityControls from './DocumentIdentityControls';
 import { SkeletonBlock } from './Skeleton';
-import useDelayedFlag from '../hooks/useDelayedFlag';
+import useDelayedFlag, {
+	SKELETON_MIN_VISIBLE_MS,
+} from '../hooks/useDelayedFlag';
 import { filterFavoritesForTrashedPage } from './SidebarFavorites';
 import {
 	ACTIVE_PAGES_QUERY,
@@ -383,7 +385,11 @@ function PageFeaturedImageInspectorControls( { postId } ) {
 		media?.media_details?.sizes?.medium?.source_url ??
 		media?.source_url ??
 		null;
-	const showMediaSkeleton = useDelayedFlag( isResolvingMedia && ! src );
+	const showMediaSkeleton = useDelayedFlag(
+		isResolvingMedia && ! src,
+		120,
+		SKELETON_MIN_VISIBLE_MS
+	);
 	let featuredImagePreview = (
 		<span>{ __( 'Featured image is not available.', 'cortext' ) }</span>
 	);

--- a/src/components/PageInspectorSidebar.js
+++ b/src/components/PageInspectorSidebar.js
@@ -45,6 +45,7 @@ import MediaPicker, { MediaUploadCheck } from './MediaPicker';
 import PageIcon from './PageIcon';
 import DocumentIdentityControls from './DocumentIdentityControls';
 import { SkeletonBlock } from './Skeleton';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import { filterFavoritesForTrashedPage } from './SidebarFavorites';
 import {
 	ACTIVE_PAGES_QUERY,
@@ -382,13 +383,14 @@ function PageFeaturedImageInspectorControls( { postId } ) {
 		media?.media_details?.sizes?.medium?.source_url ??
 		media?.source_url ??
 		null;
+	const showMediaSkeleton = useDelayedFlag( isResolvingMedia && ! src );
 	let featuredImagePreview = (
 		<span>{ __( 'Featured image is not available.', 'cortext' ) }</span>
 	);
 	if ( isResolvingMedia && ! src ) {
-		featuredImagePreview = (
+		featuredImagePreview = showMediaSkeleton ? (
 			<SkeletonBlock className="cortext-page-inspector__featured-image-skeleton" />
-		);
+		) : null;
 	} else if ( src ) {
 		featuredImagePreview = (
 			<img

--- a/src/components/PageInspectorSidebar.js
+++ b/src/components/PageInspectorSidebar.js
@@ -8,7 +8,6 @@ import {
 	Disabled,
 	Notice,
 	PanelBody,
-	Spinner,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import {
@@ -45,6 +44,7 @@ import apiFetch from '@wordpress/api-fetch';
 import MediaPicker, { MediaUploadCheck } from './MediaPicker';
 import PageIcon from './PageIcon';
 import DocumentIdentityControls from './DocumentIdentityControls';
+import { SkeletonBlock } from './Skeleton';
 import { filterFavoritesForTrashedPage } from './SidebarFavorites';
 import {
 	ACTIVE_PAGES_QUERY,
@@ -386,7 +386,9 @@ function PageFeaturedImageInspectorControls( { postId } ) {
 		<span>{ __( 'Featured image is not available.', 'cortext' ) }</span>
 	);
 	if ( isResolvingMedia && ! src ) {
-		featuredImagePreview = <Spinner />;
+		featuredImagePreview = (
+			<SkeletonBlock className="cortext-page-inspector__featured-image-skeleton" />
+		);
 	} else if ( src ) {
 		featuredImagePreview = (
 			<img

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -388,14 +388,14 @@ function DetailShell( {
 	);
 }
 
-// While useEntityRecord and the editor catch up, show the row title and icon
-// from the list plus a properties skeleton. That keeps the peek panel from
-// opening as an empty box.
+// While useEntityRecord and the editor spin up, reuse the row title and icon
+// from the list and show a properties skeleton. The peek panel should not open
+// as an empty box.
 function LoadingDetail( { onClose, row, fieldCount } ) {
 	const tentativeTitle = titleFromRow( row );
 	const documentIcon = row?.meta?.cortext_document_icon ?? '';
 	// Cap the placeholder rows so large collections do not fill the panel with
-	// grey lines. Six gives enough shape without crowding the pane.
+	// grey lines. Six gives the pane shape without crowding it.
 	const skeletonRows = Math.max( 1, Math.min( fieldCount ?? 0, 6 ) );
 
 	return (
@@ -404,7 +404,7 @@ function LoadingDetail( { onClose, row, fieldCount } ) {
 				<div
 					className="cortext-row-detail__toolbar"
 					role="toolbar"
-					aria-label={ __( 'Row detail tools', 'cortext' ) }
+					aria-label={ __( 'Row detail actions', 'cortext' ) }
 				>
 					<div className="cortext-row-detail__toolbar-group cortext-row-detail__toolbar-group--end">
 						<Button

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -25,6 +25,7 @@ import useAutosave from '../hooks/useAutosave';
 import EditorBody from './EditorBody';
 import PageIcon from './PageIcon';
 import RowProperties from './RowProperties';
+import { SkeletonFieldRow } from './Skeleton';
 import { getRowDetailMode } from './rowDetailUtils';
 
 export const ROW_DETAIL_MODE_ICONS = {
@@ -428,22 +429,16 @@ function LoadingDetail( { onClose, row, fieldCount } ) {
 				</div>
 			</div>
 			<div className="cortext-row-detail__body cortext-row-detail__body--loading">
-				<ul
-					className="cortext-row-detail__loading-fields"
+				<div
+					className="cortext-row-detail__skeleton-fields"
 					aria-hidden="true"
 				>
 					{ Array.from( { length: skeletonRows } ).map(
 						( _, idx ) => (
-							<li
-								key={ idx }
-								className="cortext-row-detail__loading-field"
-							>
-								<span className="cortext-row-detail__loading-field-label" />
-								<span className="cortext-row-detail__loading-field-value" />
-							</li>
+							<SkeletonFieldRow key={ idx } />
 						)
 					) }
-				</ul>
+				</div>
 				<div
 					className="cortext-row-detail__loading-status"
 					role="status"

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -22,7 +22,9 @@ import {
 } from '@wordpress/icons';
 
 import useAutosave from '../hooks/useAutosave';
-import useDelayedFlag from '../hooks/useDelayedFlag';
+import useDelayedFlag, {
+	SKELETON_MIN_VISIBLE_MS,
+} from '../hooks/useDelayedFlag';
 import EditorBody from './EditorBody';
 import PageIcon from './PageIcon';
 import RowProperties from './RowProperties';
@@ -665,7 +667,11 @@ export default function RowDetailView( {
 	);
 
 	const isLoadingPane = ! activeDetail && detailPanes.length === 0;
-	const showLoadingDetail = useDelayedFlag( isLoadingPane );
+	const showLoadingDetail = useDelayedFlag(
+		isLoadingPane,
+		120,
+		SKELETON_MIN_VISIBLE_MS
+	);
 
 	let content;
 	if ( isLoadingPane ) {

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -388,14 +388,14 @@ function DetailShell( {
 	);
 }
 
-// Paints the row's title and icon (taken from the list) plus a properties
-// skeleton while useEntityRecord resolves and the editor mounts. Keeps the
-// peek panel from looking empty during the first frames after a row click.
+// While useEntityRecord and the editor catch up, show the row title and icon
+// from the list plus a properties skeleton. That keeps the peek panel from
+// opening as an empty box.
 function LoadingDetail( { onClose, row, fieldCount } ) {
 	const tentativeTitle = titleFromRow( row );
 	const documentIcon = row?.meta?.cortext_document_icon ?? '';
-	// Cap the placeholder rows so a collection with many fields doesn't paint
-	// a wall of grey lines. Six is enough to hint at the structure.
+	// Cap the placeholder rows so large collections do not fill the panel with
+	// grey lines. Six gives enough shape without crowding the pane.
 	const skeletonRows = Math.max( 1, Math.min( fieldCount ?? 0, 6 ) );
 
 	return (

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -22,6 +22,7 @@ import {
 } from '@wordpress/icons';
 
 import useAutosave from '../hooks/useAutosave';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import EditorBody from './EditorBody';
 import PageIcon from './PageIcon';
 import RowProperties from './RowProperties';
@@ -663,14 +664,20 @@ export default function RowDetailView( {
 			String( activeDetail.rowId ) === String( rowId )
 	);
 
-	const content =
-		! activeDetail && detailPanes.length === 0 ? (
+	const isLoadingPane = ! activeDetail && detailPanes.length === 0;
+	const showLoadingDetail = useDelayedFlag( isLoadingPane );
+
+	let content;
+	if ( isLoadingPane ) {
+		content = showLoadingDetail ? (
 			<LoadingDetail
 				onClose={ requestClose }
 				row={ row }
 				fieldCount={ propertyFields.length }
 			/>
-		) : (
+		) : null;
+	} else {
+		content = (
 			<DetailShell
 				arePropertiesVisible={ arePropertiesVisible }
 				canGoNext={ canUseRowControls && canGoNext }
@@ -762,6 +769,7 @@ export default function RowDetailView( {
 				</div>
 			</DetailShell>
 		);
+	}
 
 	if ( normalizedMode === 'modal' ) {
 		return (

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -23,6 +23,7 @@ import {
 
 import useAutosave from '../hooks/useAutosave';
 import EditorBody from './EditorBody';
+import PageIcon from './PageIcon';
 import RowProperties from './RowProperties';
 import { getRowDetailMode } from './rowDetailUtils';
 
@@ -385,17 +386,71 @@ function DetailShell( {
 	);
 }
 
-function LoadingDetail( { onClose } ) {
+// Paints the row's title and icon (taken from the list) plus a properties
+// skeleton while useEntityRecord resolves and the editor mounts. Keeps the
+// peek panel from looking empty during the first frames after a row click.
+function LoadingDetail( { onClose, row, fieldCount } ) {
+	const tentativeTitle = titleFromRow( row );
+	const documentIcon = row?.meta?.cortext_document_icon ?? '';
+	// Cap the placeholder rows so a collection with many fields doesn't paint
+	// a wall of grey lines. Six is enough to hint at the structure.
+	const skeletonRows = Math.max( 1, Math.min( fieldCount ?? 0, 6 ) );
+
 	return (
-		<div className="cortext-row-detail__frame">
+		<div className="cortext-row-detail__frame cortext-row-detail__frame--loading">
 			<div className="cortext-row-detail__header">
-				<Spinner />
-				<Button
-					icon={ closeSmall }
-					label={ __( 'Close', 'cortext' ) }
-					size="compact"
-					onClick={ onClose }
-				/>
+				<div
+					className="cortext-row-detail__toolbar"
+					role="toolbar"
+					aria-label={ __( 'Row detail tools', 'cortext' ) }
+				>
+					<div className="cortext-row-detail__toolbar-group cortext-row-detail__toolbar-group--end">
+						<Button
+							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--close"
+							icon={ closeSmall }
+							label={ __( 'Close', 'cortext' ) }
+							onClick={ onClose }
+						/>
+					</div>
+				</div>
+				<div className="cortext-row-detail__identity">
+					<h2 className="cortext-row-detail__title">
+						{ documentIcon ? (
+							<span
+								className="cortext-row-detail__title-icon"
+								aria-hidden="true"
+							>
+								<PageIcon icon={ documentIcon } size={ 24 } />
+							</span>
+						) : null }
+						{ tentativeTitle || __( 'Untitled', 'cortext' ) }
+					</h2>
+				</div>
+			</div>
+			<div className="cortext-row-detail__body cortext-row-detail__body--loading">
+				<ul
+					className="cortext-row-detail__loading-fields"
+					aria-hidden="true"
+				>
+					{ Array.from( { length: skeletonRows } ).map(
+						( _, idx ) => (
+							<li
+								key={ idx }
+								className="cortext-row-detail__loading-field"
+							>
+								<span className="cortext-row-detail__loading-field-label" />
+								<span className="cortext-row-detail__loading-field-value" />
+							</li>
+						)
+					) }
+				</ul>
+				<div
+					className="cortext-row-detail__loading-status"
+					role="status"
+					aria-live="polite"
+				>
+					<Spinner />
+				</div>
 			</div>
 		</div>
 	);
@@ -615,7 +670,11 @@ export default function RowDetailView( {
 
 	const content =
 		! activeDetail && detailPanes.length === 0 ? (
-			<LoadingDetail onClose={ requestClose } />
+			<LoadingDetail
+				onClose={ requestClose }
+				row={ row }
+				fieldCount={ propertyFields.length }
+			/>
 		) : (
 			<DetailShell
 				arePropertiesVisible={ arePropertiesVisible }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -123,7 +123,9 @@ import {
 	parseSplatUri,
 } from '../router/useResolveEntity';
 import { FULL_PAGE_COLLECTION_QUERY } from '../collections';
-import useDelayedFlag from '../hooks/useDelayedFlag';
+import useDelayedFlag, {
+	SKELETON_MIN_VISIBLE_MS,
+} from '../hooks/useDelayedFlag';
 import { useFavorites } from '../hooks/useFavorites';
 import { useRecents } from '../hooks/useRecents';
 import useSidebarSections from '../hooks/useSidebarSections';
@@ -170,7 +172,9 @@ export default function Sidebar( {
 		isUpdating: isHomeUpdating,
 	} = useWorkspaceHomePath();
 	const showPagesSkeleton = useDelayedFlag(
-		isResolvingPages && pages.length === 0
+		isResolvingPages && pages.length === 0,
+		120,
+		SKELETON_MIN_VISIBLE_MS
 	);
 	const {
 		favorites,
@@ -387,7 +391,9 @@ export default function Sidebar( {
 	}, [ pages, collections ] );
 
 	const showCollectionsSkeleton = useDelayedFlag(
-		isResolvingCollections && topLevelCollections.length === 0
+		isResolvingCollections && topLevelCollections.length === 0,
+		120,
+		SKELETON_MIN_VISIBLE_MS
 	);
 
 	const tree = useMemo(

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,7 +9,7 @@ import {
 	useCallback,
 	useEffect,
 } from '@wordpress/element';
-import { Button, Icon, Notice, Spinner } from '@wordpress/components';
+import { Button, Icon, Notice } from '@wordpress/components';
 import { displayShortcut } from '@wordpress/keycodes';
 import {
 	home as homeIcon,
@@ -101,6 +101,7 @@ import SidebarFavorites, {
 import SidebarResizeHandle from './SidebarResizeHandle';
 import SidebarRecents from './SidebarRecents';
 import SidebarSection from './SidebarSection';
+import { SidebarListSkeleton } from './Skeleton';
 import SidebarTrash, { computeSidebarTrashRoots } from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
 import {
@@ -122,6 +123,7 @@ import {
 	parseSplatUri,
 } from '../router/useResolveEntity';
 import { FULL_PAGE_COLLECTION_QUERY } from '../collections';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import { useFavorites } from '../hooks/useFavorites';
 import { useRecents } from '../hooks/useRecents';
 import useSidebarSections from '../hooks/useSidebarSections';
@@ -167,6 +169,9 @@ export default function Sidebar( {
 		isResolvingPages,
 		isUpdating: isHomeUpdating,
 	} = useWorkspaceHomePath();
+	const showPagesSkeleton = useDelayedFlag(
+		isResolvingPages && pages.length === 0
+	);
 	const {
 		favorites,
 		setFavorites,
@@ -380,6 +385,10 @@ export default function Sidebar( {
 		} );
 		return { nestedCollections: nested, topLevelCollections: topLevel };
 	}, [ pages, collections ] );
+
+	const showCollectionsSkeleton = useDelayedFlag(
+		isResolvingCollections && topLevelCollections.length === 0
+	);
 
 	const tree = useMemo(
 		() => buildTree( [ ...pages, ...nestedCollections ] ),
@@ -980,11 +989,11 @@ export default function Sidebar( {
 								/>
 							}
 						>
-							{ isResolvingPages && pages.length === 0 && (
-								<div className="cortext-sidebar__loading">
-									<Spinner />
-								</div>
-							) }
+							{ isResolvingPages &&
+								pages.length === 0 &&
+								showPagesSkeleton && (
+									<SidebarListSkeleton itemCount={ 5 } />
+								) }
 							{ ! isResolvingPages && pages.length === 0 && (
 								<p className="cortext-sidebar__empty">
 									{ __( 'No pages yet.', 'cortext' ) }
@@ -1055,10 +1064,9 @@ export default function Sidebar( {
 							}
 						>
 							{ isResolvingCollections &&
-								topLevelCollections.length === 0 && (
-									<div className="cortext-sidebar__loading">
-										<Spinner />
-									</div>
+								topLevelCollections.length === 0 &&
+								showCollectionsSkeleton && (
+									<SidebarListSkeleton itemCount={ 3 } />
 								) }
 							{ ! isResolvingCollections &&
 								topLevelCollections.length === 0 && (

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Icon, Spinner } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
 import {
 	useCallback,
 	useEffect,
@@ -23,6 +23,7 @@ import {
 } from '@dnd-kit/sortable';
 
 import PageIcon from './PageIcon';
+import { SidebarListSkeleton } from './Skeleton';
 import { collectionTitle } from './CollectionRow';
 import { collectDescendants } from './pages-tree';
 import {
@@ -459,9 +460,7 @@ export default function SidebarFavorites( {
 	return (
 		<div className="cortext-sidebar__favorites">
 			{ isLoading ? (
-				<div className="cortext-sidebar__loading">
-					<Spinner />
-				</div>
+				<SidebarListSkeleton itemCount={ favorites.length || 3 } />
 			) : null }
 			{ isEmpty ? (
 				<p className="cortext-sidebar__empty cortext-sidebar__empty--inline">

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -25,7 +25,9 @@ import {
 import PageIcon from './PageIcon';
 import { SidebarListSkeleton } from './Skeleton';
 import { collectionTitle } from './CollectionRow';
-import useDelayedFlag from '../hooks/useDelayedFlag';
+import useDelayedFlag, {
+	SKELETON_MIN_VISIBLE_MS,
+} from '../hooks/useDelayedFlag';
 import { collectDescendants } from './pages-tree';
 import {
 	computeCollectionUri,
@@ -456,7 +458,11 @@ export default function SidebarFavorites( {
 	const isLoading =
 		isResolving ||
 		( hasFavorites && isResolvingItems && items.length === 0 );
-	const showSkeleton = useDelayedFlag( isLoading );
+	const showSkeleton = useDelayedFlag(
+		isLoading,
+		120,
+		SKELETON_MIN_VISIBLE_MS
+	);
 	const isEmpty = ! isLoading && ! hasFavorites;
 
 	return (

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -25,6 +25,7 @@ import {
 import PageIcon from './PageIcon';
 import { SidebarListSkeleton } from './Skeleton';
 import { collectionTitle } from './CollectionRow';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import { collectDescendants } from './pages-tree';
 import {
 	computeCollectionUri,
@@ -455,11 +456,12 @@ export default function SidebarFavorites( {
 	const isLoading =
 		isResolving ||
 		( hasFavorites && isResolvingItems && items.length === 0 );
+	const showSkeleton = useDelayedFlag( isLoading );
 	const isEmpty = ! isLoading && ! hasFavorites;
 
 	return (
 		<div className="cortext-sidebar__favorites">
-			{ isLoading ? (
+			{ isLoading && showSkeleton ? (
 				<SidebarListSkeleton itemCount={ favorites.length || 3 } />
 			) : null }
 			{ isEmpty ? (

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -1,10 +1,12 @@
 import { useNavigate } from '@tanstack/react-router';
-import { Button, Icon, Spinner } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
 import { useCallback, useLayoutEffect, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { listItem, table } from '@wordpress/icons';
 
 import PageIcon from './PageIcon';
+import { SidebarListSkeleton } from './Skeleton';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import { useRecents } from '../hooks/useRecents';
 
 const RECENT_REPOSITION_OPTIONS = {
@@ -152,12 +154,12 @@ export default function SidebarRecents() {
 		}
 	}, [ isResolving, recents ] );
 
+	const showSkeleton = useDelayedFlag( isResolving && recents.length === 0 );
+
 	return (
 		<>
-			{ isResolving && recents.length === 0 && (
-				<div className="cortext-sidebar__loading">
-					<Spinner />
-				</div>
+			{ isResolving && recents.length === 0 && showSkeleton && (
+				<SidebarListSkeleton itemCount={ 3 } />
 			) }
 			{ ! isResolving && recents.length === 0 && (
 				<p className="cortext-sidebar__empty">

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -6,7 +6,9 @@ import { listItem, table } from '@wordpress/icons';
 
 import PageIcon from './PageIcon';
 import { SidebarListSkeleton } from './Skeleton';
-import useDelayedFlag from '../hooks/useDelayedFlag';
+import useDelayedFlag, {
+	SKELETON_MIN_VISIBLE_MS,
+} from '../hooks/useDelayedFlag';
 import { useRecents } from '../hooks/useRecents';
 
 const RECENT_REPOSITION_OPTIONS = {
@@ -154,7 +156,11 @@ export default function SidebarRecents() {
 		}
 	}, [ isResolving, recents ] );
 
-	const showSkeleton = useDelayedFlag( isResolving && recents.length === 0 );
+	const showSkeleton = useDelayedFlag(
+		isResolving && recents.length === 0,
+		120,
+		SKELETON_MIN_VISIBLE_MS
+	);
 
 	return (
 		<>

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -3,7 +3,6 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import {
 	Button,
-	Spinner,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
@@ -11,6 +10,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { rotateLeft, trash } from '@wordpress/icons';
 
 import PageIcon from './PageIcon';
+import { SidebarListSkeleton } from './Skeleton';
 import {
 	ACTIVE_PAGES_QUERY,
 	POST_TYPE,
@@ -388,11 +388,7 @@ export default function SidebarTrash( {
 
 	return (
 		<>
-			{ isLoading && (
-				<div className="cortext-sidebar__loading">
-					<Spinner />
-				</div>
-			) }
+			{ isLoading && <SidebarListSkeleton itemCount={ 4 } /> }
 
 			{ ! isLoading && hasError && (
 				<div className="cortext-sidebar__error" role="alert">

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -16,6 +16,7 @@ import {
 	POST_TYPE,
 	TRASHED_PAGES_QUERY,
 } from './page-queries';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import { FULL_PAGE_COLLECTION_QUERY } from '../collections';
 import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
 
@@ -321,6 +322,7 @@ export default function SidebarTrash( {
 	] );
 
 	const isLoading = isResolvingTrash && ! hasTrashCache;
+	const showSkeleton = useDelayedFlag( isLoading );
 	const hasError = Boolean( trashError && ! hasTrashCache );
 	const hasItems = roots.length > 0;
 	const pendingKind = pendingDelete ? documentKind( pendingDelete ) : null;
@@ -388,7 +390,9 @@ export default function SidebarTrash( {
 
 	return (
 		<>
-			{ isLoading && <SidebarListSkeleton itemCount={ 4 } /> }
+			{ isLoading && showSkeleton && (
+				<SidebarListSkeleton itemCount={ 4 } />
+			) }
 
 			{ ! isLoading && hasError && (
 				<div className="cortext-sidebar__error" role="alert">

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -16,7 +16,9 @@ import {
 	POST_TYPE,
 	TRASHED_PAGES_QUERY,
 } from './page-queries';
-import useDelayedFlag from '../hooks/useDelayedFlag';
+import useDelayedFlag, {
+	SKELETON_MIN_VISIBLE_MS,
+} from '../hooks/useDelayedFlag';
 import { FULL_PAGE_COLLECTION_QUERY } from '../collections';
 import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
 
@@ -322,7 +324,11 @@ export default function SidebarTrash( {
 	] );
 
 	const isLoading = isResolvingTrash && ! hasTrashCache;
-	const showSkeleton = useDelayedFlag( isLoading );
+	const showSkeleton = useDelayedFlag(
+		isLoading,
+		120,
+		SKELETON_MIN_VISIBLE_MS
+	);
 	const hasError = Boolean( trashError && ! hasTrashCache );
 	const hasItems = roots.length > 0;
 	const pendingKind = pendingDelete ? documentKind( pendingDelete ) : null;

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -73,6 +73,37 @@ export function SkeletonFieldRow( { valueWidth, className } ) {
 	);
 }
 
+// Roughly table-shaped rows shown while useCollectionRows fetches the
+// first page. Sized so the canvas pane stays the same height as it will
+// be once rows arrive, instead of growing from zero.
+export function CollectionRowsSkeleton( { rowCount = 8, columnCount = 4 } ) {
+	const safeColumns = Math.max( 1, columnCount );
+	return (
+		<div className="cortext-collection-skeleton" aria-hidden="true">
+			{ Array.from( { length: rowCount } ).map( ( _, rowIndex ) => (
+				<div
+					key={ rowIndex }
+					className="cortext-collection-skeleton__row"
+				>
+					{ Array.from( { length: safeColumns } ).map(
+						( __, colIndex ) => (
+							<SkeletonLine
+								key={ colIndex }
+								className={ joinClassName(
+									'cortext-collection-skeleton__cell',
+									colIndex === 0
+										? 'cortext-collection-skeleton__cell--first'
+										: null
+								) }
+							/>
+						)
+					) }
+				</div>
+			) ) }
+		</div>
+	);
+}
+
 // Approximates the full-page editor's title-plus-content layout so the
 // canvas area keeps its size while useResolveDocument and the editor
 // mount. Cover and icon are intentionally omitted (most documents don't

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -73,6 +73,31 @@ export function SkeletonFieldRow( { valueWidth, className } ) {
 	);
 }
 
+// Sidebar list rows (Favorites, Trash, etc.) while the underlying entity
+// records resolve. The width pattern keeps the rows from looking like a
+// uniform stack of identical bars.
+const SIDEBAR_SKELETON_WIDTHS = [ '72%', '58%', '84%', '46%', '68%', '52%' ];
+
+export function SidebarListSkeleton( { itemCount = 5 } ) {
+	return (
+		<div className="cortext-sidebar-skeleton" aria-hidden="true">
+			{ Array.from( { length: itemCount } ).map( ( _, idx ) => (
+				<div key={ idx } className="cortext-sidebar-skeleton__row">
+					<SkeletonBlock className="cortext-sidebar-skeleton__icon" />
+					<SkeletonLine
+						className="cortext-sidebar-skeleton__label"
+						width={
+							SIDEBAR_SKELETON_WIDTHS[
+								idx % SIDEBAR_SKELETON_WIDTHS.length
+							]
+						}
+					/>
+				</div>
+			) ) }
+		</div>
+	);
+}
+
 // Roughly table-shaped rows shown while useCollectionRows fetches the
 // first page. Sized so the canvas pane stays the same height as it will
 // be once rows arrive, instead of growing from zero.

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -129,27 +129,17 @@ export function CollectionRowsSkeleton( { rowCount = 8, columnCount = 4 } ) {
 	);
 }
 
-// Approximates the full-page editor's title-plus-content layout so the
-// canvas area keeps its size while useResolveDocument and the editor
-// mount. Cover and icon are intentionally omitted (most documents don't
-// have them and reserving space for both would create the opposite shift).
-export function DocumentSkeleton( { className } ) {
+// Thin indeterminate progress bar shown at the top of the canvas while
+// the entity route resolves and the editor mounts. Honest about the
+// uncertainty — a canvas document can be a page, a row, a fresh blank,
+// with or without cover and icon, so a skeleton that mimics one shape
+// inevitably misleads for the others. The bar just signals "working on
+// it" without promising structure.
+export function CanvasProgressBar( { className } ) {
 	return (
 		<div
-			className={ joinClassName(
-				'cortext-document-skeleton',
-				className
-			) }
+			className={ joinClassName( 'cortext-canvas-progress', className ) }
 			aria-hidden="true"
-		>
-			<SkeletonLine className="cortext-document-skeleton__title" />
-			<div className="cortext-document-skeleton__content">
-				<SkeletonLine />
-				<SkeletonLine className="cortext-document-skeleton__line--medium" />
-				<SkeletonLine className="cortext-document-skeleton__line--short" />
-				<SkeletonLine />
-				<SkeletonLine className="cortext-document-skeleton__line--medium" />
-			</div>
-		</div>
+		/>
 	);
 }

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -1,10 +1,9 @@
 /**
- * Small skeleton primitives shared by loading states across Cortext.
+ * Small skeleton pieces shared by Cortext loading states.
  *
- * The goal is to reserve the same space the real content will occupy so
- * that when data arrives there's no layout shift. All primitives render
- * an `aria-hidden` element with a low-cost opacity pulse that respects
- * `prefers-reduced-motion`.
+ * They reserve the space the real content will use, so data arriving later
+ * does not shove the layout around. Each primitive is `aria-hidden` and uses
+ * a light opacity pulse that respects `prefers-reduced-motion`.
  */
 
 function toLength( value ) {
@@ -45,8 +44,8 @@ export function SkeletonBlock( {
 	);
 }
 
-// A horizontal bar; defaults to the title/label size. Width can be tuned
-// per use to vary the rhythm of stacked lines.
+// A horizontal bar. Callers can pass a width so stacked lines do not all look
+// identical.
 export function SkeletonLine( { className, ...rest } ) {
 	return (
 		<SkeletonBlock
@@ -56,8 +55,7 @@ export function SkeletonLine( { className, ...rest } ) {
 	);
 }
 
-// Label + value pair used wherever a list of properties is rendered while
-// loading (row peek, full-page document, inspector sidebars).
+// Label and value placeholders for property lists while they load.
 export function SkeletonFieldRow( { valueWidth, className } ) {
 	return (
 		<div
@@ -73,9 +71,8 @@ export function SkeletonFieldRow( { valueWidth, className } ) {
 	);
 }
 
-// Sidebar list rows (Favorites, Trash, etc.) while the underlying entity
-// records resolve. The width pattern keeps the rows from looking like a
-// uniform stack of identical bars.
+// Sidebar rows for Favorites, Trash, and similar lists. The width pattern keeps
+// the placeholder labels from lining up like identical bars.
 const SIDEBAR_SKELETON_WIDTHS = [ '72%', '58%', '84%', '46%', '68%', '52%' ];
 
 export function SidebarListSkeleton( { itemCount = 5 } ) {
@@ -98,12 +95,9 @@ export function SidebarListSkeleton( { itemCount = 5 } ) {
 	);
 }
 
-// Roughly table-shaped rows shown while useCollectionRows fetches the
-// first page. Sized so the canvas pane stays the same height as it will
-// be once rows arrive, instead of growing from zero. Density mirrors
-// DataViews v6 row heights (compact 40px / balanced 64px / comfortable
-// 72px); the row count is capped because perPage of 25+ would paint a
-// skeleton longer than the viewport for no extra value.
+// tech-debt.md#54: mirror DataViews row heights so the loading table does not
+// jump when real rows arrive. Cap the row count so perPage=25 does not draw
+// past the viewport.
 const COLLECTION_SKELETON_ROW_CAP = 15;
 
 export function CollectionRowsSkeleton( {
@@ -148,12 +142,9 @@ export function CollectionRowsSkeleton( {
 	);
 }
 
-// Thin indeterminate progress bar shown at the top of the canvas while
-// the entity route resolves and the editor mounts. Honest about the
-// uncertainty — a canvas document can be a page, a row, a fresh blank,
-// with or without cover and icon, so a skeleton that mimics one shape
-// inevitably misleads for the others. The bar just signals "working on
-// it" without promising structure.
+// Thin progress bar for route and editor loads. A document can be a page, row,
+// or blank draft, with or without cover and icon; a shaped skeleton would be
+// wrong often enough to be distracting.
 export function CanvasProgressBar( { className } ) {
 	return (
 		<div

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -72,3 +72,28 @@ export function SkeletonFieldRow( { valueWidth, className } ) {
 		</div>
 	);
 }
+
+// Approximates the full-page editor's title-plus-content layout so the
+// canvas area keeps its size while useResolveDocument and the editor
+// mount. Cover and icon are intentionally omitted (most documents don't
+// have them and reserving space for both would create the opposite shift).
+export function DocumentSkeleton( { className } ) {
+	return (
+		<div
+			className={ joinClassName(
+				'cortext-document-skeleton',
+				className
+			) }
+			aria-hidden="true"
+		>
+			<SkeletonLine className="cortext-document-skeleton__title" />
+			<div className="cortext-document-skeleton__content">
+				<SkeletonLine />
+				<SkeletonLine className="cortext-document-skeleton__line--medium" />
+				<SkeletonLine className="cortext-document-skeleton__line--short" />
+				<SkeletonLine />
+				<SkeletonLine className="cortext-document-skeleton__line--medium" />
+			</div>
+		</div>
+	);
+}

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -1,9 +1,9 @@
 /**
- * Small skeleton pieces shared by Cortext loading states.
+ * Shared loading placeholders for Cortext.
  *
- * They reserve the space the real content will use, so data arriving later
- * does not shove the layout around. Each primitive is `aria-hidden` and uses
- * a light opacity pulse that respects `prefers-reduced-motion`.
+ * They reserve the space real content will use, so late data does not shove
+ * the layout around. Each primitive is `aria-hidden` and uses a light opacity
+ * pulse that respects `prefers-reduced-motion`.
  */
 
 function toLength( value ) {
@@ -44,8 +44,7 @@ export function SkeletonBlock( {
 	);
 }
 
-// A horizontal bar. Callers can pass a width so stacked lines do not all look
-// identical.
+// Horizontal bar. Callers can pass a width so stacked lines do not all match.
 export function SkeletonLine( { className, ...rest } ) {
 	return (
 		<SkeletonBlock
@@ -71,8 +70,8 @@ export function SkeletonFieldRow( { valueWidth, className } ) {
 	);
 }
 
-// Sidebar rows for Favorites, Trash, and similar lists. The width pattern keeps
-// the placeholder labels from lining up like identical bars.
+// Sidebar rows for Favorites, Trash, and similar lists. Varied widths keep the
+// placeholder labels from lining up like identical bars.
 const SIDEBAR_SKELETON_WIDTHS = [ '72%', '58%', '84%', '46%', '68%', '52%' ];
 
 export function SidebarListSkeleton( { itemCount = 5 } ) {
@@ -95,9 +94,8 @@ export function SidebarListSkeleton( { itemCount = 5 } ) {
 	);
 }
 
-// tech-debt.md#54: mirror DataViews row heights so the loading table does not
-// jump when real rows arrive. Cap the row count so perPage=25 does not draw
-// past the viewport.
+// tech-debt.md#54: match DataViews row heights so the loading table holds the
+// same space as real rows. Cap the row count so perPage=25 stays reasonable.
 const COLLECTION_SKELETON_ROW_CAP = 15;
 
 export function CollectionRowsSkeleton( {
@@ -142,9 +140,9 @@ export function CollectionRowsSkeleton( {
 	);
 }
 
-// Thin progress bar for route and editor loads. A document can be a page, row,
-// or blank draft, with or without cover and icon; a shaped skeleton would be
-// wrong often enough to be distracting.
+// Thin progress bar for route and editor loads. Documents can be pages, rows,
+// or blank drafts, with or without covers and icons; a shaped skeleton would
+// be wrong often enough to distract.
 export function CanvasProgressBar( { className } ) {
 	return (
 		<div

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -1,0 +1,74 @@
+/**
+ * Small skeleton primitives shared by loading states across Cortext.
+ *
+ * The goal is to reserve the same space the real content will occupy so
+ * that when data arrives there's no layout shift. All primitives render
+ * an `aria-hidden` element with a low-cost opacity pulse that respects
+ * `prefers-reduced-motion`.
+ */
+
+function toLength( value ) {
+	if ( value === undefined || value === null ) {
+		return undefined;
+	}
+	return typeof value === 'number' ? `${ value }px` : value;
+}
+
+function joinClassName( ...parts ) {
+	return parts.filter( Boolean ).join( ' ' );
+}
+
+export function SkeletonBlock( {
+	className,
+	width,
+	height,
+	style,
+	as: Tag = 'span',
+	...rest
+} ) {
+	const finalStyle = { ...( style ?? {} ) };
+	const w = toLength( width );
+	const h = toLength( height );
+	if ( w !== undefined ) {
+		finalStyle.width = w;
+	}
+	if ( h !== undefined ) {
+		finalStyle.height = h;
+	}
+	return (
+		<Tag
+			className={ joinClassName( 'cortext-skeleton', className ) }
+			style={ finalStyle }
+			aria-hidden="true"
+			{ ...rest }
+		/>
+	);
+}
+
+// A horizontal bar; defaults to the title/label size. Width can be tuned
+// per use to vary the rhythm of stacked lines.
+export function SkeletonLine( { className, ...rest } ) {
+	return (
+		<SkeletonBlock
+			className={ joinClassName( 'cortext-skeleton--line', className ) }
+			{ ...rest }
+		/>
+	);
+}
+
+// Label + value pair used wherever a list of properties is rendered while
+// loading (row peek, full-page document, inspector sidebars).
+export function SkeletonFieldRow( { valueWidth, className } ) {
+	return (
+		<div
+			className={ joinClassName( 'cortext-skeleton-field', className ) }
+			aria-hidden="true"
+		>
+			<SkeletonLine className="cortext-skeleton-field__label" />
+			<SkeletonLine
+				className="cortext-skeleton-field__value"
+				width={ valueWidth }
+			/>
+		</div>
+	);
+}

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -100,12 +100,31 @@ export function SidebarListSkeleton( { itemCount = 5 } ) {
 
 // Roughly table-shaped rows shown while useCollectionRows fetches the
 // first page. Sized so the canvas pane stays the same height as it will
-// be once rows arrive, instead of growing from zero.
-export function CollectionRowsSkeleton( { rowCount = 8, columnCount = 4 } ) {
+// be once rows arrive, instead of growing from zero. Density mirrors
+// DataViews v6 row heights (compact 40px / balanced 64px / comfortable
+// 72px); the row count is capped because perPage of 25+ would paint a
+// skeleton longer than the viewport for no extra value.
+const COLLECTION_SKELETON_ROW_CAP = 15;
+
+export function CollectionRowsSkeleton( {
+	rowCount = 8,
+	columnCount = 4,
+	density = 'compact',
+} ) {
 	const safeColumns = Math.max( 1, columnCount );
+	const safeRows = Math.max(
+		1,
+		Math.min( rowCount, COLLECTION_SKELETON_ROW_CAP )
+	);
 	return (
-		<div className="cortext-collection-skeleton" aria-hidden="true">
-			{ Array.from( { length: rowCount } ).map( ( _, rowIndex ) => (
+		<div
+			className={ joinClassName(
+				'cortext-collection-skeleton',
+				`cortext-collection-skeleton--${ density }`
+			) }
+			aria-hidden="true"
+		>
+			{ Array.from( { length: safeRows } ).map( ( _, rowIndex ) => (
 				<div
 					key={ rowIndex }
 					className="cortext-collection-skeleton__row"

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -10,7 +10,6 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { unlock } from '../../lock-unlock';
-import { useEntityRecord } from '@wordpress/core-data';
 import {
 	createPortal,
 	useCallback,
@@ -36,7 +35,6 @@ import EditOptionsPopover from './EditOptionsPopover';
 import FieldFormatPopover from './FieldFormatPopover';
 import RenameFieldInline from './RenameFieldInline';
 import { useCollectionFieldsContext } from '../CollectionFieldsContext';
-import { elementsFromOptions } from '../../hooks/fieldMapping';
 import { TableCalculationPopover } from '../TableCalculationMenu';
 import {
 	useDeleteField,
@@ -204,18 +202,24 @@ function FieldActions( {
 	const duplicate = useDuplicateField( collectionId );
 	const remove = useDeleteField( collectionId );
 	const { fields } = useCollectionFieldsContext();
-	const { record } = useEntityRecord( 'postType', 'crtxt_field', recordId );
-	const fieldType = record?.meta?.type;
+	// `useCollectionFields` already fetched these records with `context: 'edit'`
+	// and ran them through `mapField`. Read label/type/options from that cached
+	// field so we stay on one cache slot. Calling `useEntityRecord(...)` here
+	// would use the `default` context, start a second resolver trip, and briefly
+	// flash `#${ recordId }` in the header before the real title arrives. See
+	// the tech-debt note in `useCollectionFields`.
+	const fieldEntry = useMemo(
+		() => fields.find( ( f ) => f.cortextRecordId === recordId ) ?? null,
+		[ fields, recordId ]
+	);
+	const fieldType = fieldEntry?.cortextType;
 	const canFormat = FORMATTABLE_TYPES.has( fieldType );
 	const supportsOptions = TYPES_WITH_OPTIONS.has( fieldType );
 	const canChangeType =
 		Boolean( fieldType ) && ! UNCONVERTIBLE_SOURCE_TYPES.has( fieldType );
 	const initialOptions = useMemo(
-		() =>
-			supportsOptions
-				? elementsFromOptions( record?.meta?.options ) || []
-				: [],
-		[ supportsOptions, record?.meta?.options ]
+		() => ( supportsOptions ? fieldEntry?.cortextElements ?? [] : [] ),
+		[ supportsOptions, fieldEntry?.cortextElements ]
 	);
 
 	// Format submenu uses a hover-with-grace pattern: the panel stays
@@ -386,8 +390,7 @@ function FieldActions( {
 	}, [ isMenuOpen, closeMenu, hideMenuOnInteractOutside ] );
 
 	const dataViewId = `field-${ recordId }`;
-	const label =
-		record?.title?.raw || record?.title?.rendered || `#${ recordId }`;
+	const label = fieldEntry?.label || `#${ recordId }`;
 	const calculationField = useMemo(
 		() => ( {
 			id: dataViewId,

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -23,8 +23,11 @@ export function buildFieldListQuery( fieldIds ) {
 // of `crtxt_field` post IDs in display order. Fetch those records, then
 // map each to a DataViews field. Row meta keys are `field-<post_id>`.
 export default function useCollectionFields( collectionId ) {
-	const { record: collection, isResolving: collectionResolving } =
-		useEntityRecord( 'postType', 'crtxt_collection', collectionId ?? 0 );
+	const {
+		record: collection,
+		isResolving: collectionResolving,
+		hasResolved: collectionHasResolved,
+	} = useEntityRecord( 'postType', 'crtxt_collection', collectionId ?? 0 );
 
 	const fieldIds = useMemo( () => {
 		const raw = collection?.meta?.fields;
@@ -107,11 +110,13 @@ export default function useCollectionFields( collectionId ) {
 		// fields for the current collection (`hasStableFieldsForCollection`),
 		// subsequent refetches (after a mutation that changes the field
 		// list) keep this false so the table doesn't unmount and remount.
-		// The collection 404 path stays handled because
-		// `collectionResolving` flips back to false on resolution failure.
+		// The collection 404 path stays handled because `hasResolved` flips
+		// to true on resolution failure too, dropping us back to the normal
+		// path so the invalid-collection notice renders.
 		isResolving:
 			Boolean( collectionId ) &&
-			( ( ! collection && collectionResolving ) ||
+			( ! collectionHasResolved ||
+				( ! collection && collectionResolving ) ||
 				( !! collection &&
 					fieldIds.length > 0 &&
 					! hasStableFieldsForCollection ) ),

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -77,12 +77,11 @@ export default function useCollectionFields( collectionId ) {
 	// guard the sync would treat all custom fields as "removed" and
 	// strip them from `view.fields`.
 	//
-	// Core-data can hand back stubs (`{ id }` only) when another caller has
-	// referenced the records but not hydrated them. `mapField` falls back to
-	// `#${id}` when neither `title.raw` nor `title.rendered` resolves to a
-	// non-empty string, which flashes raw field IDs in column headers. Match
-	// that same condition so we hold the loading state until the title the
-	// table will actually paint has arrived.
+	// Core-data can return stubs (`{ id }` only) when another caller has touched
+	// the records but has not hydrated them. `mapField` falls back to `#${id}`
+	// without `title.raw` or `title.rendered`, which flashes raw field IDs in
+	// column headers. Use the same check here and keep loading until the title
+	// the table will paint is available.
 	const fieldRecordsHydrated =
 		Array.isArray( fieldRecords ) &&
 		fieldRecords.length === fieldIds.length &&
@@ -127,8 +126,8 @@ export default function useCollectionFields( collectionId ) {
 		// fields for the current collection (`hasStableFieldsForCollection`),
 		// subsequent refetches (after a mutation that changes the field
 		// list) keep this false so the table doesn't unmount and remount.
-		// A collection 404 still works: `hasResolved` flips to true on failure
-		// too, so the invalid-collection notice can render.
+		// Collection 404s still work: `hasResolved` flips to true on failure too,
+		// so the invalid-collection notice can render.
 		isResolving:
 			Boolean( collectionId ) &&
 			( ! collectionHasResolved ||

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -76,10 +76,23 @@ export default function useCollectionFields( collectionId ) {
 	// field) `fieldRecords` briefly returns an empty array; without this
 	// guard the sync would treat all custom fields as "removed" and
 	// strip them from `view.fields`.
+	//
+	// Records can be returned as stubs (`{ id }` only, no `title`) when
+	// they're referenced in the store by another caller but not yet
+	// hydrated. `mapField` falls back to `#${id}` for missing titles, so
+	// rendering on stubs flashes the field IDs in the column headers
+	// before the real names arrive. Require every record to carry a
+	// `title` payload before considering the fields list authoritative.
+	const fieldRecordsHydrated =
+		Array.isArray( fieldRecords ) &&
+		fieldRecords.length === fieldIds.length &&
+		fieldRecords.every( ( record ) => record?.title !== undefined );
 	const fieldsResolvedFlag =
 		fieldIds.length === 0
 			? Boolean( collection )
-			: ! fieldsResolving && Boolean( fieldsResolved );
+			: ! fieldsResolving &&
+			  Boolean( fieldsResolved ) &&
+			  fieldRecordsHydrated;
 
 	// Latch the last authoritative `fields` snapshot scoped to the
 	// collection that produced it. When the user adds or deletes a

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -79,12 +79,18 @@ export default function useCollectionFields( collectionId ) {
 	//
 	// Core-data can hand back stubs (`{ id }` only) when another caller has
 	// referenced the records but not hydrated them. `mapField` falls back to
-	// `#${id}` without a title, which flashes raw field IDs in column headers.
-	// Wait until every record has a title payload.
+	// `#${id}` when neither `title.raw` nor `title.rendered` resolves to a
+	// non-empty string, which flashes raw field IDs in column headers. Match
+	// that same condition so we hold the loading state until the title the
+	// table will actually paint has arrived.
 	const fieldRecordsHydrated =
 		Array.isArray( fieldRecords ) &&
 		fieldRecords.length === fieldIds.length &&
-		fieldRecords.every( ( record ) => record?.title !== undefined );
+		fieldRecords.every(
+			( record ) =>
+				Boolean( record?.title?.raw ) ||
+				Boolean( record?.title?.rendered )
+		);
 	const fieldsResolvedFlag =
 		fieldIds.length === 0
 			? Boolean( collection )

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -77,12 +77,10 @@ export default function useCollectionFields( collectionId ) {
 	// guard the sync would treat all custom fields as "removed" and
 	// strip them from `view.fields`.
 	//
-	// Records can be returned as stubs (`{ id }` only, no `title`) when
-	// they're referenced in the store by another caller but not yet
-	// hydrated. `mapField` falls back to `#${id}` for missing titles, so
-	// rendering on stubs flashes the field IDs in the column headers
-	// before the real names arrive. Require every record to carry a
-	// `title` payload before considering the fields list authoritative.
+	// Core-data can hand back stubs (`{ id }` only) when another caller has
+	// referenced the records but not hydrated them. `mapField` falls back to
+	// `#${id}` without a title, which flashes raw field IDs in column headers.
+	// Wait until every record has a title payload.
 	const fieldRecordsHydrated =
 		Array.isArray( fieldRecords ) &&
 		fieldRecords.length === fieldIds.length &&
@@ -123,9 +121,8 @@ export default function useCollectionFields( collectionId ) {
 		// fields for the current collection (`hasStableFieldsForCollection`),
 		// subsequent refetches (after a mutation that changes the field
 		// list) keep this false so the table doesn't unmount and remount.
-		// The collection 404 path stays handled because `hasResolved` flips
-		// to true on resolution failure too, dropping us back to the normal
-		// path so the invalid-collection notice renders.
+		// A collection 404 still works: `hasResolved` flips to true on failure
+		// too, so the invalid-collection notice can render.
 		isResolving:
 			Boolean( collectionId ) &&
 			( ! collectionHasResolved ||

--- a/src/hooks/useColorScheme.js
+++ b/src/hooks/useColorScheme.js
@@ -24,11 +24,9 @@ function applyToRoot( resolved ) {
 	if ( typeof document !== 'undefined' && document.body ) {
 		document.body.setAttribute( 'data-cortext-theme', resolved );
 	}
-	// Stamp the canvas frame surface on html itself so the view-transition
-	// pseudo (which lives on the html element and can't see vars scoped to
-	// .cortext-root) has something to read for its background fill during
-	// the cross-fade. Without this dark mode flashes black through the
-	// transition's transparent midpoint.
+	// Put the canvas frame surface on html too. View-transition pseudos live
+	// there and cannot see vars scoped to .cortext-root; without this, dark
+	// mode flashes black through the transparent midpoint of the cross-fade.
 	if ( typeof document !== 'undefined' && document.documentElement ) {
 		document.documentElement.style.setProperty(
 			'--cortext-canvas-frame-surface-root',

--- a/src/hooks/useColorScheme.js
+++ b/src/hooks/useColorScheme.js
@@ -24,6 +24,17 @@ function applyToRoot( resolved ) {
 	if ( typeof document !== 'undefined' && document.body ) {
 		document.body.setAttribute( 'data-cortext-theme', resolved );
 	}
+	// Stamp the canvas frame surface on html itself so the view-transition
+	// pseudo (which lives on the html element and can't see vars scoped to
+	// .cortext-root) has something to read for its background fill during
+	// the cross-fade. Without this dark mode flashes black through the
+	// transition's transparent midpoint.
+	if ( typeof document !== 'undefined' && document.documentElement ) {
+		document.documentElement.style.setProperty(
+			'--cortext-canvas-frame-surface-root',
+			resolved === 'dark' ? '#2a2a2a' : '#ffffff'
+		);
+	}
 }
 
 // Single source of truth for shell color scheme. The PHP bootstrap script

--- a/src/hooks/useDelayedFlag.js
+++ b/src/hooks/useDelayedFlag.js
@@ -1,17 +1,17 @@
 import { useEffect, useState } from '@wordpress/element';
 
 /**
- * Returns true only after `active` has stayed true for `delayMs`. Returns to
- * false as soon as `active` does.
+ * Returns true only after `active` has stayed true for `delayMs`, and resets
+ * immediately when `active` clears.
  *
- * This keeps loading skeletons from flickering when the covered work finishes
- * faster than a person can really notice. Under roughly 100 ms, a couple of
- * skeleton frames feel worse than showing nothing.
+ * This keeps loading skeletons from flashing for work that finishes before the
+ * user can register it. Under about 100 ms, showing nothing feels calmer than
+ * showing one or two placeholder frames.
  *
  * @param {boolean} active  Whether the underlying condition (e.g. loading)
  *                          is currently true.
  * @param {number}  delayMs Milliseconds to wait before reflecting `active`.
- * @return {boolean} `active` after it has stayed true for `delayMs`.
+ * @return {boolean} Whether `active` has stayed true for `delayMs`.
  */
 export default function useDelayedFlag( active, delayMs = 120 ) {
 	const [ delayed, setDelayed ] = useState( false );

--- a/src/hooks/useDelayedFlag.js
+++ b/src/hooks/useDelayedFlag.js
@@ -1,29 +1,61 @@
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+// Skeletons that flash on and off in under ~250ms read as a glitch. Pair this
+// with the 120ms delay (delay-then-min-duration) so a skeleton is either not
+// shown at all, or visible long enough to register as a deliberate state.
+export const SKELETON_MIN_VISIBLE_MS = 300;
 
 /**
- * Returns true only after `active` has stayed true for `delayMs`, and resets
- * immediately when `active` clears.
+ * Returns true only after `active` has stayed true for `delayMs`, and keeps
+ * it true for at least `minVisibleMs` once raised so the result does not
+ * flicker on borderline-fast loads.
  *
- * This keeps loading skeletons from flashing for work that finishes before the
- * user can register it. Under about 100 ms, showing nothing feels calmer than
- * showing one or two placeholder frames.
- *
- * @param {boolean} active  Whether the underlying condition (e.g. loading)
- *                          is currently true.
- * @param {number}  delayMs Milliseconds to wait before reflecting `active`.
- * @return {boolean} Whether `active` has stayed true for `delayMs`.
+ * @param {boolean} active       Whether the underlying condition (e.g. loading)
+ *                               is currently true.
+ * @param {number}  delayMs      Milliseconds to wait before reflecting `active`.
+ * @param {number}  minVisibleMs Once the flag has flipped true, keep it true
+ *                               for at least this many milliseconds. Defaults
+ *                               to 0 (clear as soon as `active` clears).
+ * @return {boolean} The eventually-true flag.
  */
-export default function useDelayedFlag( active, delayMs = 120 ) {
-	const [ delayed, setDelayed ] = useState( false );
+export default function useDelayedFlag(
+	active,
+	delayMs = 120,
+	minVisibleMs = 0
+) {
+	const [ visible, setVisible ] = useState( false );
+	const shownAtRef = useRef( null );
 
 	useEffect( () => {
-		if ( ! active ) {
-			setDelayed( false );
+		if ( active ) {
+			if ( visible ) {
+				return undefined;
+			}
+			const handle = setTimeout( () => {
+				shownAtRef.current = Date.now();
+				setVisible( true );
+			}, delayMs );
+			return () => clearTimeout( handle );
+		}
+
+		if ( ! visible ) {
 			return undefined;
 		}
-		const handle = setTimeout( () => setDelayed( true ), delayMs );
-		return () => clearTimeout( handle );
-	}, [ active, delayMs ] );
 
-	return delayed;
+		const elapsed = Date.now() - ( shownAtRef.current ?? 0 );
+		const remaining = Math.max( 0, minVisibleMs - elapsed );
+		if ( remaining === 0 ) {
+			shownAtRef.current = null;
+			setVisible( false );
+			return undefined;
+		}
+
+		const handle = setTimeout( () => {
+			shownAtRef.current = null;
+			setVisible( false );
+		}, remaining );
+		return () => clearTimeout( handle );
+	}, [ active, delayMs, minVisibleMs, visible ] );
+
+	return visible;
 }

--- a/src/hooks/useDelayedFlag.js
+++ b/src/hooks/useDelayedFlag.js
@@ -1,13 +1,12 @@
 import { useEffect, useState } from '@wordpress/element';
 
 /**
- * Returns true only after `active` has stayed true for `delayMs`. Resets
- * to false immediately when `active` flips back to false.
+ * Returns true only after `active` has stayed true for `delayMs`. Returns to
+ * false as soon as `active` does.
  *
- * Used to keep loading skeletons from flickering in and out when the work
- * they cover completes faster than the eye can register. Below ~100 ms a
- * user reads the transition as "instant" and a skeleton appearing for a
- * couple of frames feels worse than nothing.
+ * This keeps loading skeletons from flickering when the covered work finishes
+ * faster than a person can really notice. Under roughly 100 ms, a couple of
+ * skeleton frames feel worse than showing nothing.
  *
  * @param {boolean} active  Whether the underlying condition (e.g. loading)
  *                          is currently true.

--- a/src/hooks/useDelayedFlag.js
+++ b/src/hooks/useDelayedFlag.js
@@ -1,0 +1,30 @@
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Returns true only after `active` has stayed true for `delayMs`. Resets
+ * to false immediately when `active` flips back to false.
+ *
+ * Used to keep loading skeletons from flickering in and out when the work
+ * they cover completes faster than the eye can register. Below ~100 ms a
+ * user reads the transition as "instant" and a skeleton appearing for a
+ * couple of frames feels worse than nothing.
+ *
+ * @param {boolean} active  Whether the underlying condition (e.g. loading)
+ *                          is currently true.
+ * @param {number}  delayMs Milliseconds to wait before reflecting `active`.
+ * @return {boolean} `active` after it has stayed true for `delayMs`.
+ */
+export default function useDelayedFlag( active, delayMs = 120 ) {
+	const [ delayed, setDelayed ] = useState( false );
+
+	useEffect( () => {
+		if ( ! active ) {
+			setDelayed( false );
+			return undefined;
+		}
+		const handle = setTimeout( () => setDelayed( true ), delayMs );
+		return () => clearTimeout( handle );
+	}, [ active, delayMs ] );
+
+	return delayed;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -1341,6 +1341,18 @@ body.cortext-sidebar-resizing {
 		overflow: auto;
 	}
 
+	// Overlay shown during cross-doc navigation: the previous post stays
+	// visible (Canvas's hold pattern, to not lose unsaved edits), so the
+	// bar sits on top of it to signal "new content on the way".
+	&__pending-progress {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 5;
+		pointer-events: none;
+	}
+
 	// The trashed-page banner stacks above the BlockCanvas. Make the
 	// content slot a flex column so the canvas keeps its `height: 100%`
 	// behavior (it now fills the remaining space). Couples to a

--- a/src/index.scss
+++ b/src/index.scss
@@ -1094,7 +1094,7 @@ body.cortext-sidebar-resizing {
 }
 
 .cortext-workspace[data-target-kind="collection"] {
-	background: $white;
+	background: var(--cortext-canvas-surface);
 }
 
 .cortext-workspace__pane {
@@ -1119,7 +1119,7 @@ body.cortext-sidebar-resizing {
 
 .cortext-workspace[data-target-kind="collection"]
 .cortext-workspace__pane[data-active="true"] {
-	background: $white;
+	background: var(--cortext-canvas-surface);
 }
 
 .cortext-collection-pane {
@@ -1127,7 +1127,7 @@ body.cortext-sidebar-resizing {
 	display: flex;
 	height: 100%;
 	min-height: 0;
-	background: $white;
+	background: var(--cortext-canvas-surface);
 }
 
 .cortext-topbar {
@@ -1472,12 +1472,6 @@ body.cortext-sidebar-resizing {
 	}
 
 	&__table {
-		--cortext-canvas-frame-surface: #{$white};
-		--cortext-chrome-border: #{$gray-200};
-		--cortext-state-hover-strong: rgba(0, 0, 0, 0.09);
-		--cortext-text: #{$gray-900};
-		--cortext-text-muted: #{$gray-700};
-
 		// DataViews' `.dataviews-wrapper` is `height: 100%`, so the wrapper
 		// must have an explicit height or it falls back to 0 + internal
 		// scroll. Fill the canvas column: DataViews already owns the internal
@@ -4046,7 +4040,7 @@ tr:has(.cortext-title-cell--is-opening)
 		gap: $grid-unit-30;
 		padding: 0 $grid-unit-20;
 		height: $grid-unit-50 + 2 * $grid-unit-15; // 64 (balanced default)
-		border-bottom: $border-width solid var(--cortext-chrome-border, #e0e0e0);
+		border-bottom: $border-width solid var(--cortext-canvas-border, #e0e0e0);
 	}
 
 	&--compact &__row {
@@ -4371,7 +4365,7 @@ body.cortext-row-detail-sidebar-resizing {
 		inset: 56px 0 0 0;
 		z-index: 1;
 		overflow: hidden;
-		background: $white;
+		background: var(--cortext-canvas-surface);
 		pointer-events: none;
 	}
 
@@ -4588,8 +4582,6 @@ body.cortext-row-detail-sidebar-resizing {
 
 .cortext-canvas__table .cortext-data-view-shell,
 .cortext-canvas__table .cortext-data-view {
-	background: $white;
-	color: var(--cortext-text);
 	height: 100%;
 }
 
@@ -5653,26 +5645,3 @@ body.cortext-hide-block-settings-menu .block-editor-block-switcher {
 	animation: none;
 	opacity: 1;
 }
-
-/* stylelint-disable no-descending-specificity */
-.cortext-canvas__table .cortext-data-view {
-
-	> .dataviews-wrapper,
-	.dataviews__view-actions,
-	.dataviews-filters__container,
-	.dataviews-view-table,
-	.dataviews-view-table thead,
-	.dataviews-view-table thead tr,
-	.dataviews-view-table thead th {
-		background: $white;
-		background-color: $white;
-		color: var(--cortext-text, #1e1e1e);
-	}
-
-	.dataviews-view-table th,
-	.dataviews-view-table td {
-		border-color: $gray-200;
-		color: var(--cortext-text, #1e1e1e);
-	}
-}
-/* stylelint-enable no-descending-specificity */

--- a/src/index.scss
+++ b/src/index.scss
@@ -1063,6 +1063,18 @@ body.cortext-sidebar-resizing {
 	position: relative;
 	flex: 1 1 auto;
 	min-height: 0;
+
+	// Top progress bar shown while the URL has moved to a new doc/collection
+	// but the workspace still paints the previous one. Sits above all the
+	// panes so it's visible regardless of which one is currently active.
+	&__progress {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 10;
+		pointer-events: none;
+	}
 }
 
 .cortext-workspace__pane {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1319,6 +1319,14 @@ body.cortext-sidebar-resizing {
 		height: 100%;
 	}
 
+	// While the document/editor mounts we fill the canvas with a skeleton
+	// instead of a centered spinner so the layout matches what's coming.
+	&__loading--document {
+		align-items: stretch;
+		justify-content: flex-start;
+		overflow: auto;
+	}
+
 	// The trashed-page banner stacks above the BlockCanvas. Make the
 	// content slot a flex column so the canvas keeps its `height: 100%`
 	// behavior (it now fills the remaining space). Couples to a
@@ -3925,6 +3933,38 @@ tr:has(.cortext-title-cell--is-opening)
 .cortext-skeleton-field__value {
 	max-width: 280px;
 	animation-delay: 0.2s;
+}
+
+// Approximates the full-page editor layout so the canvas area doesn't
+// collapse and re-expand when the editor finishes mounting.
+.cortext-document-skeleton {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-30;
+	width: 100%;
+	max-width: 760px;
+	margin: 0 auto;
+	padding: $grid-unit-30 $grid-unit-40 $grid-unit-50;
+
+	&__title {
+		height: 32px;
+		width: 55%;
+		border-radius: 6px;
+	}
+
+	&__content {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-15;
+	}
+
+	&__line--medium {
+		width: 85%;
+	}
+
+	&__line--short {
+		width: 60%;
+	}
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -3941,6 +3941,35 @@ tr:has(.cortext-title-cell--is-opening)
 	animation-delay: 0.2s;
 }
 
+// Sidebar list skeleton (Favorites, Trash, etc.). Matches the height of
+// the real rows so the sidebar's vertical layout stays put when items
+// resolve.
+.cortext-sidebar-skeleton {
+	display: flex;
+	flex-direction: column;
+	padding: $grid-unit-10 0;
+
+	&__row {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+		height: $grid-unit-40;
+		padding: 0 $grid-unit-15;
+	}
+
+	&__icon {
+		flex: 0 0 16px;
+		width: 16px;
+		height: 16px;
+		border-radius: 3px;
+	}
+
+	&__label {
+		flex: 1 1 0;
+		min-width: 0;
+	}
+}
+
 // Approximates a data view table while useCollectionRows fetches. Sits
 // inside .cortext-data-view as a sibling to <DataViews>; the surrounding
 // container handles vertical placement.

--- a/src/index.scss
+++ b/src/index.scss
@@ -3889,34 +3889,10 @@ tr:has(.cortext-title-cell--is-opening)
 		padding: $grid-unit-20 $grid-unit-30;
 	}
 
-	&__loading-fields {
+	&__skeleton-fields {
 		display: flex;
 		flex-direction: column;
 		gap: $grid-unit-15;
-		margin: 0;
-		padding: 0;
-		list-style: none;
-	}
-
-	&__loading-field {
-		display: grid;
-		grid-template-columns: minmax(96px, 140px) minmax(0, 1fr);
-		gap: $grid-unit-20;
-		align-items: center;
-	}
-
-	&__loading-field-label,
-	&__loading-field-value {
-		display: block;
-		height: 12px;
-		border-radius: 4px;
-		background: rgba(0, 0, 0, 0.06);
-		animation: cortext-row-detail-loading-pulse 1.4s ease-in-out infinite;
-	}
-
-	&__loading-field-value {
-		max-width: 280px;
-		animation-delay: 0.2s;
 	}
 
 	&__loading-status {
@@ -3927,15 +3903,38 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 }
 
+// Shared skeleton primitives — see src/components/Skeleton.js.
+.cortext-skeleton {
+	display: block;
+	background: rgba(0, 0, 0, 0.06);
+	border-radius: 4px;
+	animation: cortext-skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.cortext-skeleton--line {
+	height: 12px;
+}
+
+.cortext-skeleton-field {
+	display: grid;
+	grid-template-columns: minmax(96px, 140px) minmax(0, 1fr);
+	gap: $grid-unit-20;
+	align-items: center;
+}
+
+.cortext-skeleton-field__value {
+	max-width: 280px;
+	animation-delay: 0.2s;
+}
+
 @media (prefers-reduced-motion: reduce) {
 
-	.cortext-row-detail__loading-field-label,
-	.cortext-row-detail__loading-field-value {
+	.cortext-skeleton {
 		animation: none;
 	}
 }
 
-@keyframes cortext-row-detail-loading-pulse {
+@keyframes cortext-skeleton-pulse {
 
 	0%,
 	100% {

--- a/src/index.scss
+++ b/src/index.scss
@@ -2289,6 +2289,11 @@ tr:hover
 .dataviews-view-table
 tbody
 tr:has(.cortext-title-cell--is-open)
+.cortext-title-cell__open.components-button,
+.cortext-data-view
+.dataviews-view-table
+tbody
+tr:has(.cortext-title-cell--is-opening)
 .cortext-title-cell__open.components-button {
 	opacity: 1;
 	pointer-events: auto;
@@ -2302,8 +2307,18 @@ tr:has(.cortext-title-cell--is-open),
 .dataviews-view-table
 tbody
 tr:has(.cortext-title-cell--is-open)
+.dataviews-view-table__actions-column--sticky,
+.cortext-data-view
+.dataviews-view-table
+tbody
+tr:has(.cortext-title-cell--is-opening),
+.cortext-data-view
+.dataviews-view-table
+tbody
+tr:has(.cortext-title-cell--is-opening)
 .dataviews-view-table__actions-column--sticky {
 	background-color: #f8f8f8;
+	transition: background-color 80ms ease-out;
 }
 
 .cortext-cell-readonly {
@@ -3845,6 +3860,90 @@ tr:has(.cortext-title-cell--is-open)
 	&__frame[data-properties-visible="false"] &__fields-indicator-wrap {
 		grid-template-rows: 1fr;
 		opacity: 1;
+	}
+
+	// Painted while useEntityRecord resolves and the editor mounts. The title
+	// and icon come from the table row, so the panel doesn't look empty for
+	// the first frames after a click.
+	&__frame--loading {
+
+		.cortext-row-detail__title {
+			display: flex;
+			align-items: center;
+			gap: $grid-unit-10;
+		}
+
+		.cortext-row-detail__title-icon {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 24px;
+			height: 24px;
+		}
+	}
+
+	&__body--loading {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-20;
+		padding: $grid-unit-20 $grid-unit-30;
+	}
+
+	&__loading-fields {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-15;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	&__loading-field {
+		display: grid;
+		grid-template-columns: minmax(96px, 140px) minmax(0, 1fr);
+		gap: $grid-unit-20;
+		align-items: center;
+	}
+
+	&__loading-field-label,
+	&__loading-field-value {
+		display: block;
+		height: 12px;
+		border-radius: 4px;
+		background: rgba(0, 0, 0, 0.06);
+		animation: cortext-row-detail-loading-pulse 1.4s ease-in-out infinite;
+	}
+
+	&__loading-field-value {
+		max-width: 280px;
+		animation-delay: 0.2s;
+	}
+
+	&__loading-status {
+		display: flex;
+		justify-content: center;
+		padding: $grid-unit-20 0;
+		opacity: 0.6;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.cortext-row-detail__loading-field-label,
+	.cortext-row-detail__loading-field-value {
+		animation: none;
+	}
+}
+
+@keyframes cortext-row-detail-loading-pulse {
+
+	0%,
+	100% {
+		opacity: 1;
+	}
+
+	50% {
+		opacity: 0.55;
 	}
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1224,6 +1224,12 @@ body.cortext-sidebar-resizing {
 		height: 100%;
 		object-fit: cover;
 	}
+
+	.cortext-page-inspector__featured-image-skeleton {
+		width: 100%;
+		height: 100%;
+		border-radius: 0;
+	}
 }
 
 .cortext-breadcrumbs {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1061,10 +1061,55 @@ body.cortext-sidebar-resizing {
 	}
 }
 
+// During the cross-fade, both snapshots briefly dip to about 50% opacity. The
+// pseudo overlay sits above the DOM, so read the canvas surface from :root
+// instead of letting the user-agent background show through.
+::view-transition-group(cortext-canvas),
+::view-transition-image-pair(cortext-canvas),
+::view-transition-old(cortext-canvas),
+::view-transition-new(cortext-canvas) {
+	background: var(--cortext-canvas-frame-surface-root, #fff);
+}
+
+// Keep the canvas layer below the side peek so the canvas cross-fade never
+// flashes over the row-detail panel.
+::view-transition-group(cortext-canvas) {
+	z-index: 1;
+}
+
+// The side peek lives outside the canvas. Give it its own transition layer so
+// the canvas cross-fade never flashes over it.
+::view-transition-group(cortext-row-detail-sidebar) {
+	z-index: 2;
+	animation: none;
+}
+
+::view-transition-old(cortext-row-detail-sidebar) {
+	display: none;
+}
+
+::view-transition-new(cortext-row-detail-sidebar) {
+	animation: none;
+	mix-blend-mode: normal;
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	::view-transition-group(cortext-canvas),
+	::view-transition-old(cortext-canvas),
+	::view-transition-new(cortext-canvas) {
+		animation: none !important;
+	}
+}
+
 .cortext-workspace {
 	position: relative;
 	flex: 1 1 auto;
 	min-height: 0;
+	// Cross-fade only the workspace, not the topbar or the side peek (both
+	// live outside this subtree). Scoping here keeps the canvas backdrop
+	// from tinting the topbar during a route change in dark mode.
+	view-transition-name: cortext-canvas;
 
 	// Progress bar for the gap where the URL points at the next item but the
 	// workspace is still painting the previous pane.

--- a/src/index.scss
+++ b/src/index.scss
@@ -1061,55 +1061,10 @@ body.cortext-sidebar-resizing {
 	}
 }
 
-// During the cross-fade, both snapshots briefly dip to about 50% opacity. The
-// pseudo overlay sits above the DOM, so read the canvas surface from :root
-// instead of letting the user-agent background show through.
-::view-transition-group(cortext-canvas),
-::view-transition-image-pair(cortext-canvas),
-::view-transition-old(cortext-canvas),
-::view-transition-new(cortext-canvas) {
-	background: var(--cortext-canvas-frame-surface-root, #fff);
-}
-
-// Keep the canvas layer below the side peek so the canvas cross-fade never
-// flashes over the row-detail panel.
-::view-transition-group(cortext-canvas) {
-	z-index: 1;
-}
-
-// The side peek lives outside the canvas. Give it its own transition layer so
-// the canvas cross-fade never flashes over it.
-::view-transition-group(cortext-row-detail-sidebar) {
-	z-index: 2;
-	animation: none;
-}
-
-::view-transition-old(cortext-row-detail-sidebar) {
-	display: none;
-}
-
-::view-transition-new(cortext-row-detail-sidebar) {
-	animation: none;
-	mix-blend-mode: normal;
-}
-
-@media (prefers-reduced-motion: reduce) {
-
-	::view-transition-group(cortext-canvas),
-	::view-transition-old(cortext-canvas),
-	::view-transition-new(cortext-canvas) {
-		animation: none !important;
-	}
-}
-
 .cortext-workspace {
 	position: relative;
 	flex: 1 1 auto;
 	min-height: 0;
-	// Cross-fade only the workspace, not the topbar or the side peek (both
-	// live outside this subtree). Scoping here keeps the canvas backdrop
-	// from tinting the topbar during a route change in dark mode.
-	view-transition-name: cortext-canvas;
 
 	// Progress bar for the gap where the URL points at the next item but the
 	// workspace is still painting the previous pane.

--- a/src/index.scss
+++ b/src/index.scss
@@ -1050,6 +1050,17 @@ body.cortext-sidebar-resizing {
 	}
 }
 
+// During the cross-fade both snapshots drop to ~50% opacity for a frame
+// or two. The pseudo overlay sits above the DOM, and the original canvas
+// element is hidden by the browser for the duration, so anything visible
+// through the snapshots' transparent pixels falls all the way through to
+// the user-agent background (which is black in dark mode). Pinning a
+// solid frame surface on the group covers that gap with the same color
+// the canvas paints natively.
+::view-transition-group(cortext-canvas) {
+	background: var(--cortext-canvas-frame-surface);
+}
+
 @media (prefers-reduced-motion: reduce) {
 
 	::view-transition-group(cortext-canvas),

--- a/src/index.scss
+++ b/src/index.scss
@@ -1046,8 +1046,6 @@ body.cortext-sidebar-resizing {
 	// --cortext-canvas-frame-surface. The iframe interior is painted by the active
 	// block theme, not by this token.
 	background: var(--cortext-canvas-frame-surface);
-	// Named so the cross-fade is scoped to this column.
-	view-transition-name: cortext-canvas;
 
 	&:focus {
 		outline: none;
@@ -1079,14 +1077,6 @@ body.cortext-sidebar-resizing {
 	z-index: 1;
 }
 
-// Name the topbar only so we can cancel its canvas fade. Both snapshots match,
-// so skip the animation.
-::view-transition-group(cortext-topbar),
-::view-transition-old(cortext-topbar),
-::view-transition-new(cortext-topbar) {
-	animation: none !important;
-}
-
 // The side peek lives outside the canvas. Give it its own transition layer so
 // the canvas cross-fade never flashes over it.
 ::view-transition-group(cortext-row-detail-sidebar) {
@@ -1116,6 +1106,10 @@ body.cortext-sidebar-resizing {
 	position: relative;
 	flex: 1 1 auto;
 	min-height: 0;
+	// Cross-fade only the workspace, not the topbar or the side peek (both
+	// live outside this subtree). Scoping here keeps the canvas backdrop
+	// from tinting the topbar during a route change in dark mode.
+	view-transition-name: cortext-canvas;
 
 	// Progress bar for the gap where the URL points at the next item but the
 	// workspace is still painting the previous pane.
@@ -1177,9 +1171,6 @@ body.cortext-sidebar-resizing {
 	color: var(--cortext-text);
 	border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	min-height: 0;
-	// Keep this chrome out of the canvas fade; otherwise the canvas backdrop
-	// tints it for a frame.
-	view-transition-name: cortext-topbar;
 
 	&__lead {
 		flex: 1 1 auto;

--- a/src/index.scss
+++ b/src/index.scss
@@ -3980,7 +3980,10 @@ tr:has(.cortext-title-cell--is-opening)
 
 // Approximates a data view table while useCollectionRows fetches. Sits
 // inside .cortext-data-view as a sibling to <DataViews>; the surrounding
-// container handles vertical placement.
+// container handles vertical placement. Row heights mirror DataViews v6
+// per-density (see .cortext-data-view .dataviews-view-table rules
+// further down) so the skeleton occupies the eventual table height
+// closely and the page doesn't shift when rows arrive.
 .cortext-collection-skeleton {
 	display: flex;
 	flex-direction: column;
@@ -3991,8 +3994,17 @@ tr:has(.cortext-title-cell--is-opening)
 		display: flex;
 		align-items: center;
 		gap: $grid-unit-30;
-		padding: $grid-unit-15 $grid-unit-20;
+		padding: 0 $grid-unit-20;
+		height: $grid-unit-50 + 2 * $grid-unit-15; // 64 (balanced default)
 		border-bottom: $border-width solid var(--cortext-chrome-border, #e0e0e0);
+	}
+
+	&--compact &__row {
+		height: $grid-unit-50; // 40
+	}
+
+	&--comfortable &__row {
+		height: $grid-unit-50 + 2 * $grid-unit-20; // 72
 	}
 
 	&__cell {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1067,6 +1067,16 @@ body.cortext-sidebar-resizing {
 	background: var(--cortext-canvas-frame-surface-root, #fff);
 }
 
+// The topbar is excluded from the canvas snapshot above, so its own pseudos
+// would otherwise still cross-fade in place. Snapshots are identical
+// before/after the swap, so silencing the animation makes the named transition
+// invisible.
+::view-transition-group(cortext-topbar),
+::view-transition-old(cortext-topbar),
+::view-transition-new(cortext-topbar) {
+	animation: none !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
 
 	::view-transition-group(cortext-canvas),
@@ -1141,6 +1151,11 @@ body.cortext-sidebar-resizing {
 	color: var(--cortext-text);
 	border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	min-height: 0;
+	// Pull the topbar out of the canvas cross-fade so the backdrop the
+	// group paints during the swap doesn't wash its warm surface to grey.
+	// The snapshots are identical before/after, so the named transition
+	// stays invisible.
+	view-transition-name: cortext-topbar;
 
 	&__lead {
 		flex: 1 1 auto;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1334,7 +1334,8 @@ body.cortext-sidebar-resizing {
 
 	// While the document/editor mounts we fill the canvas with a skeleton
 	// instead of a centered spinner so the layout matches what's coming.
-	&__loading--document {
+	&__loading--document,
+	&__loading--collection {
 		align-items: stretch;
 		justify-content: flex-start;
 		overflow: auto;

--- a/src/index.scss
+++ b/src/index.scss
@@ -5228,6 +5228,14 @@ thead > tr > th {
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
+		// Pair with the inline `opacity: hasImagePainted ? 1 : 0` on the
+		// img so the cover fades in instead of popping after the bytes
+		// decode. Reduced motion ignores the fade.
+		transition: opacity 180ms ease-out;
+
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
 	}
 
 	&__controls {

--- a/src/index.scss
+++ b/src/index.scss
@@ -3928,7 +3928,7 @@ tr:has(.cortext-title-cell--is-opening)
 // Shared skeleton primitives — see src/components/Skeleton.js.
 .cortext-skeleton {
 	display: block;
-	background: rgba(0, 0, 0, 0.06);
+	background: var(--cortext-state-hover-strong, rgba(0, 0, 0, 0.09));
 	border-radius: 4px;
 	animation: cortext-skeleton-pulse 1.4s ease-in-out infinite;
 }
@@ -3992,7 +3992,7 @@ tr:has(.cortext-title-cell--is-opening)
 		align-items: center;
 		gap: $grid-unit-30;
 		padding: $grid-unit-15 $grid-unit-20;
-		border-bottom: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
+		border-bottom: $border-width solid var(--cortext-chrome-border, #e0e0e0);
 	}
 
 	&__cell {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1067,10 +1067,8 @@ body.cortext-sidebar-resizing {
 	background: var(--cortext-canvas-frame-surface-root, #fff);
 }
 
-// The topbar is excluded from the canvas snapshot above, so its own pseudos
-// would otherwise still cross-fade in place. Snapshots are identical
-// before/after the swap, so silencing the animation makes the named transition
-// invisible.
+// The topbar is named only so we can cancel its canvas fade. Both snapshots
+// match, so skip the animation.
 ::view-transition-group(cortext-topbar),
 ::view-transition-old(cortext-topbar),
 ::view-transition-new(cortext-topbar) {
@@ -1151,10 +1149,8 @@ body.cortext-sidebar-resizing {
 	color: var(--cortext-text);
 	border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	min-height: 0;
-	// Pull the topbar out of the canvas cross-fade so the backdrop the
-	// group paints during the swap doesn't wash its warm surface to grey.
-	// The snapshots are identical before/after, so the named transition
-	// stays invisible.
+	// Keep this chrome out of the canvas fade; the canvas backdrop tints it
+	// for a frame otherwise.
 	view-transition-name: cortext-topbar;
 
 	&__lead {

--- a/src/index.scss
+++ b/src/index.scss
@@ -4050,16 +4050,20 @@ tr:has(.cortext-title-cell--is-opening)
 		align-items: center;
 		gap: $grid-unit-30;
 		padding: 0 $grid-unit-20;
-		height: $grid-unit-50 + 2 * $grid-unit-15; // 64 (balanced default)
+		// Fallbacks are required because the block-editor iframe doesn't
+		// inherit CSS variables scoped to .cortext-root. Without them the
+		// row collapses to the cell height (12px) and the skeleton stops
+		// looking like a table.
+		height: var(--cortext-data-view-row-height-balanced, #{$grid-unit-50 + 2 * $grid-unit-15});
 		border-bottom: $border-width solid var(--cortext-canvas-border, #e0e0e0);
 	}
 
 	&--compact &__row {
-		height: $grid-unit-50; // 40
+		height: var(--cortext-data-view-row-height-compact, #{$grid-unit-50});
 	}
 
 	&--comfortable &__row {
-		height: $grid-unit-50 + 2 * $grid-unit-20; // 72
+		height: var(--cortext-data-view-row-height-comfortable, #{$grid-unit-50 + 2 * $grid-unit-20});
 	}
 
 	&__cell {
@@ -4373,10 +4377,12 @@ body.cortext-row-detail-sidebar-resizing {
 	// differences.
 	&__rows-skeleton {
 		position: absolute;
-		inset: 56px 0 0 0;
+		// Iframe block editor doesn't inherit .cortext-root vars; fallback
+		// stops the overlay from collapsing to inset:0 inside the block.
+		inset: var(--cortext-data-view-header-height, 56px) 0 0 0;
 		z-index: 1;
 		overflow: hidden;
-		background: var(--cortext-canvas-surface);
+		background: var(--cortext-canvas-surface, #fff);
 		pointer-events: none;
 	}
 
@@ -4475,20 +4481,22 @@ body.cortext-row-detail-sidebar-resizing {
 			background: $gray-100;
 		}
 
+		// Fallbacks repeated for the block-editor iframe, which doesn't
+		// inherit the .cortext-root tokens.
 		.cortext-editable-cell__shell,
 		.cortext-cell-checkbox {
-			min-height: $grid-unit-50 + 2 * $grid-unit-15; // 64 (balanced)
+			min-height: var(--cortext-data-view-row-height-balanced, #{$grid-unit-50 + 2 * $grid-unit-15});
 		}
 
 		&.has-compact-density .cortext-editable-cell__shell,
 		&.has-compact-density .cortext-cell-checkbox {
-			min-height: $grid-unit-50; // 40 (compact, the editor's floor)
+			min-height: var(--cortext-data-view-row-height-compact, #{$grid-unit-50});
 			padding-block: 0;
 		}
 
 		&.has-comfortable-density .cortext-editable-cell__shell,
 		&.has-comfortable-density .cortext-cell-checkbox {
-			min-height: $grid-unit-50 + 2 * $grid-unit-20; // 72 (comfortable)
+			min-height: var(--cortext-data-view-row-height-comfortable, #{$grid-unit-50 + 2 * $grid-unit-20});
 		}
 	}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -18,6 +18,13 @@
 
 .commands-command-menu__container {
 
+	// cmdk only sets max-height on the list. Match it as min-height so the
+	// modal doesn't shrink to "No results found." (or the pending state)
+	// and back up to a full list. Mirrors the upstream max-height value.
+	[cmdk-root] > [cmdk-list] {
+		min-height: min(328px, 70vh - 48px);
+	}
+
 	.commands-command-menu__item {
 		display: flex;
 		align-items: center;

--- a/src/index.scss
+++ b/src/index.scss
@@ -5132,13 +5132,34 @@ thead > tr > th {
 		border-radius: 3px;
 	}
 
+	// Wrapper around an image-type icon: stacks the skeleton swatch
+	// underneath the <img> so the swatch keeps the slot painted until
+	// the actual image bytes arrive, not just until the REST record
+	// returns a URL.
+	&--image-wrap {
+		position: relative;
+		display: inline-block;
+		flex: 0 0 auto;
+		vertical-align: middle;
+	}
+
+	&--image-wrap .cortext-document-icon--image {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		transition: opacity 80ms ease-out;
+	}
+
 	// Reserves the icon slot the moment an image-type icon is parsed but
 	// before the media record resolves. Stays transparent for the first
 	// useDelayedFlag window so a cache hit never flashes a swatch; the
 	// `--visible` modifier paints the skeleton appearance once the wait
 	// crosses the threshold.
 	&--image-loading {
-		display: inline-block;
+		position: absolute;
+		inset: 0;
+		display: block;
 		border-radius: 3px;
 	}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -5132,10 +5132,26 @@ thead > tr > th {
 		border-radius: 3px;
 	}
 
+	// Reserves the icon slot the moment an image-type icon is parsed but
+	// before the media record resolves. Stays transparent for the first
+	// useDelayedFlag window so a cache hit never flashes a swatch; the
+	// `--visible` modifier paints the skeleton appearance once the wait
+	// crosses the threshold.
 	&--image-loading {
 		display: inline-block;
-		background: var(--cortext-chrome-border);
 		border-radius: 3px;
+	}
+
+	&--image-loading-visible {
+		background: var(--cortext-state-hover-strong, rgba(0, 0, 0, 0.09));
+		animation: cortext-skeleton-pulse 1.4s ease-in-out infinite;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.cortext-document-icon--image-loading-visible {
+		animation: none;
 	}
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -3941,6 +3941,34 @@ tr:has(.cortext-title-cell--is-opening)
 	animation-delay: 0.2s;
 }
 
+// Approximates a data view table while useCollectionRows fetches. Sits
+// inside .cortext-data-view as a sibling to <DataViews>; the surrounding
+// container handles vertical placement.
+.cortext-collection-skeleton {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	padding: $grid-unit-10 0;
+
+	&__row {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-30;
+		padding: $grid-unit-15 $grid-unit-20;
+		border-bottom: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
+	}
+
+	&__cell {
+		flex: 1 1 0;
+		min-width: 0;
+		height: 12px;
+	}
+
+	&__cell--first {
+		flex: 0 0 28%;
+	}
+}
+
 // Approximates the full-page editor layout so the canvas area doesn't
 // collapse and re-expand when the editor finishes mounting.
 .cortext-document-skeleton {
@@ -4222,6 +4250,19 @@ body.cortext-row-detail-sidebar-resizing {
 	flex-direction: column;
 	width: 100%;
 	min-width: 0;
+
+	// Sits over the dataviews-wrapper while the first page loads so the
+	// table area keeps roughly its eventual height. Offset assumes the
+	// DataViews header is around 56px tall; the skeleton's own borders
+	// soak up minor differences.
+	&__rows-skeleton {
+		position: absolute;
+		inset: 56px 0 0 0;
+		z-index: 1;
+		overflow: hidden;
+		background: var(--cortext-canvas-frame-surface, #fff);
+		pointer-events: none;
+	}
 
 	// Let the wrapper grow to fill whatever height the parent provides, so
 	// our footer sits below the table instead of getting pushed off by the

--- a/src/index.scss
+++ b/src/index.scss
@@ -4386,6 +4386,15 @@ body.cortext-row-detail-sidebar-resizing {
 		pointer-events: none;
 	}
 
+	// Hold the table area at skeleton height while the first page loads.
+	// Without this DataViews mounts with an empty tbody and the wrapper
+	// collapses to the chrome height (~100px), which clips the absolute
+	// overlay to the first few rows and shifts everything below the table
+	// upward.
+	&[data-rows-loading="true"] {
+		min-height: calc(var(--cortext-data-view-header-height, 56px) + var(--cortext-data-view-loading-rows, 8) * var(--cortext-data-view-row-height-compact, 40px));
+	}
+
 	// Let the wrapper grow to fill whatever height the parent provides, so
 	// our footer sits below the table instead of getting pushed off by the
 	// wrapper's own `height: 100%`. Parents own the height per-context: the

--- a/src/index.scss
+++ b/src/index.scss
@@ -1017,10 +1017,10 @@ body.cortext-sidebar-resizing {
 	user-select: none;
 }
 
-// Skip the default root snapshot so the sidebar and top bar stay live during
-// the swap. Only the canvas opts in below. The canvas surface also lives here
-// because the view-transition pseudo cannot read shell tokens from
-// .cortext-root; :has() handles dark mode.
+// Leave the default root snapshot out so the sidebar and topbar stay live
+// during the swap. Only the canvas opts in below. The fallback canvas surface
+// also lives here because view-transition pseudos cannot read shell tokens
+// from .cortext-root; :has() handles dark mode.
 :root {
 	view-transition-name: none;
 	--cortext-canvas-frame-surface-root: #{$white};
@@ -1057,9 +1057,9 @@ body.cortext-sidebar-resizing {
 	}
 }
 
-// During the cross-fade, both snapshots drop to about 50% opacity for a frame
-// or two. The pseudo overlay sits above the DOM, so read the canvas surface
-// from :root instead of exposing the user-agent background in the middle.
+// During the cross-fade, both snapshots briefly dip to about 50% opacity. The
+// pseudo overlay sits above the DOM, so read the canvas surface from :root
+// instead of letting the user-agent background show through.
 ::view-transition-group(cortext-canvas),
 ::view-transition-image-pair(cortext-canvas),
 ::view-transition-old(cortext-canvas),
@@ -1067,8 +1067,8 @@ body.cortext-sidebar-resizing {
 	background: var(--cortext-canvas-frame-surface-root, #fff);
 }
 
-// The topbar is named only so we can cancel its canvas fade. Both snapshots
-// match, so skip the animation.
+// Name the topbar only so we can cancel its canvas fade. Both snapshots match,
+// so skip the animation.
 ::view-transition-group(cortext-topbar),
 ::view-transition-old(cortext-topbar),
 ::view-transition-new(cortext-topbar) {
@@ -1089,8 +1089,8 @@ body.cortext-sidebar-resizing {
 	flex: 1 1 auto;
 	min-height: 0;
 
-	// Top progress bar for the gap where the URL points at the next item but
-	// the workspace is still painting the previous pane.
+	// Progress bar for the gap where the URL points at the next item but the
+	// workspace is still painting the previous pane.
 	&__progress {
 		position: absolute;
 		top: 0;
@@ -1149,8 +1149,8 @@ body.cortext-sidebar-resizing {
 	color: var(--cortext-text);
 	border-bottom: var(--cortext-shell-border-width) solid var(--cortext-chrome-border);
 	min-height: 0;
-	// Keep this chrome out of the canvas fade; the canvas backdrop tints it
-	// for a frame otherwise.
+	// Keep this chrome out of the canvas fade; otherwise the canvas backdrop
+	// tints it for a frame.
 	view-transition-name: cortext-topbar;
 
 	&__lead {
@@ -1381,8 +1381,8 @@ body.cortext-sidebar-resizing {
 		height: 100%;
 	}
 
-	// While the document or editor mounts, stretch the loading area so
-	// skeletons can occupy the same space as the incoming content.
+	// While the document or editor mounts, stretch the loading area so the
+	// placeholder can occupy the same space as the incoming content.
 	&__loading--document,
 	&__loading--collection {
 		align-items: stretch;
@@ -3984,7 +3984,7 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 }
 
-// Shared skeleton pieces; see src/components/Skeleton.js.
+// Shared loading placeholders; see src/components/Skeleton.js.
 .cortext-skeleton {
 	display: block;
 	background: var(--cortext-state-hover-strong, rgba(0, 0, 0, 0.09));
@@ -4008,7 +4008,7 @@ tr:has(.cortext-title-cell--is-opening)
 	animation-delay: 0.2s;
 }
 
-// Sidebar list skeleton for Favorites, Trash, and similar lists. It matches
+// Sidebar list skeleton for Favorites, Trash, and similar lists. It uses the
 // real row height so the sidebar does not jump when items arrive.
 .cortext-sidebar-skeleton {
 	display: flex;
@@ -4037,8 +4037,8 @@ tr:has(.cortext-title-cell--is-opening)
 }
 
 // tech-debt.md#54: table-shaped placeholder while useCollectionRows fetches.
-// It sits beside <DataViews>; the wrapper handles placement. Heights track the
-// DataViews v6 density rules below closely enough to keep the page steady.
+// It sits beside <DataViews>; the wrapper handles placement. Heights follow
+// the DataViews v6 density rules closely enough to keep the page steady.
 .cortext-collection-skeleton {
 	display: flex;
 	flex-direction: column;
@@ -4050,10 +4050,9 @@ tr:has(.cortext-title-cell--is-opening)
 		align-items: center;
 		gap: $grid-unit-30;
 		padding: 0 $grid-unit-20;
-		// Fallbacks are required because the block-editor iframe doesn't
-		// inherit CSS variables scoped to .cortext-root. Without them the
-		// row collapses to the cell height (12px) and the skeleton stops
-		// looking like a table.
+		// The block-editor iframe does not inherit CSS variables scoped to
+		// .cortext-root. Keep fallbacks here so rows do not collapse to the
+		// 12px cell height in the block.
 		height: var(--cortext-data-view-row-height-balanced, #{$grid-unit-50 + 2 * $grid-unit-15});
 		border-bottom: $border-width solid var(--cortext-canvas-border, #e0e0e0);
 	}
@@ -4371,28 +4370,25 @@ body.cortext-row-detail-sidebar-resizing {
 	width: 100%;
 	min-width: 0;
 
-	// tech-debt.md#54: sit over the dataviews-wrapper while the first page
-	// loads and keep the table area near its final height. The offset tracks
-	// the DataViews header closely enough; the skeleton borders cover small
-	// differences.
+	// tech-debt.md#54: cover the table area while the shell loads, so search,
+	// filters, header, and rows appear together instead of in two beats.
 	&__rows-skeleton {
 		position: absolute;
-		// Iframe block editor doesn't inherit .cortext-root vars; fallback
-		// stops the overlay from collapsing to inset:0 inside the block.
-		inset: var(--cortext-data-view-header-height, 56px) 0 0 0;
+		inset: 0;
 		z-index: 1;
 		overflow: hidden;
 		background: var(--cortext-canvas-surface, #fff);
 		pointer-events: none;
 	}
 
-	// Hold the table area at skeleton height while the first page loads.
-	// Without this DataViews mounts with an empty tbody and the wrapper
-	// collapses to the chrome height (~100px), which clips the absolute
-	// overlay to the first few rows and shifts everything below the table
-	// upward.
-	&[data-rows-loading="true"] {
-		min-height: calc(var(--cortext-data-view-header-height, 56px) + var(--cortext-data-view-loading-rows, 8) * var(--cortext-data-view-row-height-compact, 40px));
+	// During the shell load, hold the area at skeleton height so blocks below
+	// do not jump when chrome and rows appear. The matching wrapper/footer rule
+	// sits later to keep descending-specificity clean.
+	// `--cortext-data-view-loading-row-height` is set inline from
+	// `view.layout.density`, so balanced and comfortable tables reserve their
+	// real row height and the skeleton matches the incoming rows.
+	&[data-loading-shell="true"] {
+		min-height: calc(var(--cortext-data-view-loading-rows, 8) * var(--cortext-data-view-loading-row-height, var(--cortext-data-view-row-height-compact, 40px)));
 	}
 
 	// Let the wrapper grow to fill whatever height the parent provides, so
@@ -4490,7 +4486,7 @@ body.cortext-row-detail-sidebar-resizing {
 			background: $gray-100;
 		}
 
-		// Fallbacks repeated for the block-editor iframe, which doesn't
+		// Repeat the fallbacks for the block-editor iframe, which does not
 		// inherit the .cortext-root tokens.
 		.cortext-editable-cell__shell,
 		.cortext-cell-checkbox {
@@ -4524,6 +4520,14 @@ body.cortext-row-detail-sidebar-resizing {
 			background: $gray-100;
 			color: $gray-900;
 		}
+	}
+
+	// Loading shell hides DataViews chrome and the new-row footer so the rows
+	// skeleton stands alone. Keep this after the wrapper/footer rules above to
+	// satisfy descending-specificity.
+	&[data-loading-shell="true"] > .dataviews-wrapper,
+	&[data-loading-shell="true"] > &__footer {
+		display: none;
 	}
 }
 
@@ -5191,7 +5195,7 @@ thead > tr > th {
 	}
 
 	// Wrapper for image icons. The swatch stays under the <img> until the image
-	// has actually loaded, not just until REST returns a URL.
+	// has loaded; REST returning a URL is not enough.
 	&--image-wrap {
 		position: relative;
 		display: inline-block;
@@ -5209,7 +5213,7 @@ thead > tr > th {
 
 	// Reserve the icon slot as soon as an image icon is parsed. Keep it
 	// transparent during the useDelayedFlag window so cache hits do not flash a
-	// swatch; `--visible` paints it after the wait crosses the threshold.
+	// swatch; `--visible` paints it after the delay.
 	&--image-loading {
 		position: absolute;
 		inset: 0;

--- a/src/index.scss
+++ b/src/index.scss
@@ -4048,7 +4048,7 @@ tr:has(.cortext-title-cell--is-opening)
 .cortext-canvas-progress {
 	position: relative;
 	width: 100%;
-	height: 2px;
+	height: 3px;
 	overflow: hidden;
 	background: transparent;
 	flex: 0 0 auto;
@@ -4060,10 +4060,9 @@ tr:has(.cortext-title-cell--is-opening)
 		left: -40%;
 		width: 40%;
 		height: 100%;
-		background: var(--cortext-text, #1e1e1e);
-		opacity: 0.55;
+		background: var(--wp-admin-theme-color, #007cba);
 		border-radius: 2px;
-		animation: cortext-canvas-progress-slide 1.6s ease-in-out infinite;
+		animation: cortext-canvas-progress-slide 1.4s ease-in-out infinite;
 	}
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -4006,35 +4006,49 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 }
 
-// Approximates the full-page editor layout so the canvas area doesn't
-// collapse and re-expand when the editor finishes mounting.
-.cortext-document-skeleton {
-	display: flex;
-	flex-direction: column;
-	gap: $grid-unit-30;
+// Thin sliding bar at the top of the canvas while the route + editor
+// resolve. Sits in `.cortext-canvas__loading--document`, which is
+// stretched to the canvas frame so the bar can pin to the top.
+.cortext-canvas-progress {
+	position: relative;
 	width: 100%;
-	max-width: 760px;
-	margin: 0 auto;
-	padding: $grid-unit-30 $grid-unit-40 $grid-unit-50;
+	height: 2px;
+	overflow: hidden;
+	background: transparent;
+	flex: 0 0 auto;
 
-	&__title {
-		height: 32px;
-		width: 55%;
-		border-radius: 6px;
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: -40%;
+		width: 40%;
+		height: 100%;
+		background: var(--cortext-text, #1e1e1e);
+		opacity: 0.55;
+		border-radius: 2px;
+		animation: cortext-canvas-progress-slide 1.6s ease-in-out infinite;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.cortext-canvas-progress::before {
+		animation: none;
+		left: 0;
+		width: 100%;
+		opacity: 0.25;
+	}
+}
+
+@keyframes cortext-canvas-progress-slide {
+
+	0% {
+		left: -40%;
 	}
 
-	&__content {
-		display: flex;
-		flex-direction: column;
-		gap: $grid-unit-15;
-	}
-
-	&__line--medium {
-		width: 85%;
-	}
-
-	&__line--short {
-		width: 60%;
+	100% {
+		left: 100%;
 	}
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1018,9 +1018,17 @@ body.cortext-sidebar-resizing {
 }
 
 // Skip the default root snapshot so the sidebar and top bar stay live
-// during the swap. Only the canvas opts in below.
+// during the swap. Only the canvas opts in below. The canvas frame
+// surface also lives here so the view-transition pseudo (which sits
+// above .cortext-root and can't see our shell tokens) has a fill
+// during the cross-fade; dark mode is matched via :has() below.
 :root {
 	view-transition-name: none;
+	--cortext-canvas-frame-surface-root: #{$white};
+}
+
+:root:has(.cortext-root[data-theme="dark"]) {
+	--cortext-canvas-frame-surface-root: #2a2a2a;
 }
 
 .cortext-shell__canvas {
@@ -1051,14 +1059,12 @@ body.cortext-sidebar-resizing {
 }
 
 // During the cross-fade both snapshots drop to ~50% opacity for a frame
-// or two. The pseudo overlay sits above the DOM, and the original canvas
-// element is hidden by the browser for the duration, so anything visible
-// through the snapshots' transparent pixels falls all the way through to
-// the user-agent background (which is black in dark mode). Pinning a
-// solid frame surface on the group covers that gap with the same color
-// the canvas paints natively.
+// or two. The pseudo overlay sits above the DOM and our shell-scoped CSS
+// vars don't reach it, so we read the canvas surface from the :root
+// declaration above. Without this the cross-fade's transparent midpoint
+// reveals the user-agent background (black in dark mode).
 ::view-transition-group(cortext-canvas) {
-	background: var(--cortext-canvas-frame-surface);
+	background: var(--cortext-canvas-frame-surface-root, #fff);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -18,9 +18,9 @@
 
 .commands-command-menu__container {
 
-	// cmdk only sets max-height on the list. Match it as min-height so the
-	// modal doesn't shrink to "No results found." (or the pending state)
-	// and back up to a full list. Mirrors the upstream max-height value.
+	// cmdk only sets max-height on the list. Give it the same min-height so the
+	// modal does not collapse to "No results found." or a pending state, then
+	// jump back to a full list.
 	[cmdk-root] > [cmdk-list] {
 		min-height: min(328px, 70vh - 48px);
 	}
@@ -1017,11 +1017,10 @@ body.cortext-sidebar-resizing {
 	user-select: none;
 }
 
-// Skip the default root snapshot so the sidebar and top bar stay live
-// during the swap. Only the canvas opts in below. The canvas frame
-// surface also lives here so the view-transition pseudo (which sits
-// above .cortext-root and can't see our shell tokens) has a fill
-// during the cross-fade; dark mode is matched via :has() below.
+// Skip the default root snapshot so the sidebar and top bar stay live during
+// the swap. Only the canvas opts in below. The canvas surface also lives here
+// because the view-transition pseudo cannot read shell tokens from
+// .cortext-root; :has() handles dark mode.
 :root {
 	view-transition-name: none;
 	--cortext-canvas-frame-surface-root: #{$white};
@@ -1058,12 +1057,13 @@ body.cortext-sidebar-resizing {
 	}
 }
 
-// During the cross-fade both snapshots drop to ~50% opacity for a frame
-// or two. The pseudo overlay sits above the DOM and our shell-scoped CSS
-// vars don't reach it, so we read the canvas surface from the :root
-// declaration above. Without this the cross-fade's transparent midpoint
-// reveals the user-agent background (black in dark mode).
-::view-transition-group(cortext-canvas) {
+// During the cross-fade, both snapshots drop to about 50% opacity for a frame
+// or two. The pseudo overlay sits above the DOM, so read the canvas surface
+// from :root instead of exposing the user-agent background in the middle.
+::view-transition-group(cortext-canvas),
+::view-transition-image-pair(cortext-canvas),
+::view-transition-old(cortext-canvas),
+::view-transition-new(cortext-canvas) {
 	background: var(--cortext-canvas-frame-surface-root, #fff);
 }
 
@@ -1081,9 +1081,8 @@ body.cortext-sidebar-resizing {
 	flex: 1 1 auto;
 	min-height: 0;
 
-	// Top progress bar shown while the URL has moved to a new doc/collection
-	// but the workspace still paints the previous one. Sits above all the
-	// panes so it's visible regardless of which one is currently active.
+	// Top progress bar for the gap where the URL points at the next item but
+	// the workspace is still painting the previous pane.
 	&__progress {
 		position: absolute;
 		top: 0;
@@ -1092,6 +1091,10 @@ body.cortext-sidebar-resizing {
 		z-index: 10;
 		pointer-events: none;
 	}
+}
+
+.cortext-workspace[data-target-kind="collection"] {
+	background: $white;
 }
 
 .cortext-workspace__pane {
@@ -1114,11 +1117,17 @@ body.cortext-sidebar-resizing {
 	z-index: 1;
 }
 
+.cortext-workspace[data-target-kind="collection"]
+.cortext-workspace__pane[data-active="true"] {
+	background: $white;
+}
+
 .cortext-collection-pane {
 	position: relative;
 	display: flex;
 	height: 100%;
 	min-height: 0;
+	background: $white;
 }
 
 .cortext-topbar {
@@ -1361,8 +1370,8 @@ body.cortext-sidebar-resizing {
 		height: 100%;
 	}
 
-	// While the document/editor mounts we fill the canvas with a skeleton
-	// instead of a centered spinner so the layout matches what's coming.
+	// While the document or editor mounts, stretch the loading area so
+	// skeletons can occupy the same space as the incoming content.
 	&__loading--document,
 	&__loading--collection {
 		align-items: stretch;
@@ -1370,9 +1379,8 @@ body.cortext-sidebar-resizing {
 		overflow: auto;
 	}
 
-	// Overlay shown during cross-doc navigation: the previous post stays
-	// visible (Canvas's hold pattern, to not lose unsaved edits), so the
-	// bar sits on top of it to signal "new content on the way".
+	// Cross-document navigation keeps the previous post visible until autosave
+	// finishes. Put the progress bar over it while the next document loads.
 	&__pending-progress {
 		position: absolute;
 		top: 0;
@@ -1464,6 +1472,12 @@ body.cortext-sidebar-resizing {
 	}
 
 	&__table {
+		--cortext-canvas-frame-surface: #{$white};
+		--cortext-chrome-border: #{$gray-200};
+		--cortext-state-hover-strong: rgba(0, 0, 0, 0.09);
+		--cortext-text: #{$gray-900};
+		--cortext-text-muted: #{$gray-700};
+
 		// DataViews' `.dataviews-wrapper` is `height: 100%`, so the wrapper
 		// must have an explicit height or it falls back to 0 + internal
 		// scroll. Fill the canvas column: DataViews already owns the internal
@@ -3925,9 +3939,8 @@ tr:has(.cortext-title-cell--is-opening)
 		opacity: 1;
 	}
 
-	// Painted while useEntityRecord resolves and the editor mounts. The title
-	// and icon come from the table row, so the panel doesn't look empty for
-	// the first frames after a click.
+	// Loading frame for row detail. The title and icon come from the table row,
+	// so the panel does not open blank while useEntityRecord catches up.
 	&__frame--loading {
 
 		.cortext-row-detail__title {
@@ -3966,7 +3979,7 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 }
 
-// Shared skeleton primitives — see src/components/Skeleton.js.
+// Shared skeleton pieces; see src/components/Skeleton.js.
 .cortext-skeleton {
 	display: block;
 	background: var(--cortext-state-hover-strong, rgba(0, 0, 0, 0.09));
@@ -3990,9 +4003,8 @@ tr:has(.cortext-title-cell--is-opening)
 	animation-delay: 0.2s;
 }
 
-// Sidebar list skeleton (Favorites, Trash, etc.). Matches the height of
-// the real rows so the sidebar's vertical layout stays put when items
-// resolve.
+// Sidebar list skeleton for Favorites, Trash, and similar lists. It matches
+// real row height so the sidebar does not jump when items arrive.
 .cortext-sidebar-skeleton {
 	display: flex;
 	flex-direction: column;
@@ -4019,12 +4031,9 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 }
 
-// Approximates a data view table while useCollectionRows fetches. Sits
-// inside .cortext-data-view as a sibling to <DataViews>; the surrounding
-// container handles vertical placement. Row heights mirror DataViews v6
-// per-density (see .cortext-data-view .dataviews-view-table rules
-// further down) so the skeleton occupies the eventual table height
-// closely and the page doesn't shift when rows arrive.
+// tech-debt.md#54: table-shaped placeholder while useCollectionRows fetches.
+// It sits beside <DataViews>; the wrapper handles placement. Heights track the
+// DataViews v6 density rules below closely enough to keep the page steady.
 .cortext-collection-skeleton {
 	display: flex;
 	flex-direction: column;
@@ -4059,9 +4068,8 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 }
 
-// Thin sliding bar at the top of the canvas while the route + editor
-// resolve. Sits in `.cortext-canvas__loading--document`, which is
-// stretched to the canvas frame so the bar can pin to the top.
+// Thin sliding bar while the route and editor resolve. The document loading
+// frame stretches to the canvas, so the bar can pin to the top.
 .cortext-canvas-progress {
 	position: relative;
 	width: 100%;
@@ -4354,16 +4362,16 @@ body.cortext-row-detail-sidebar-resizing {
 	width: 100%;
 	min-width: 0;
 
-	// Sits over the dataviews-wrapper while the first page loads so the
-	// table area keeps roughly its eventual height. Offset assumes the
-	// DataViews header is around 56px tall; the skeleton's own borders
-	// soak up minor differences.
+	// tech-debt.md#54: sit over the dataviews-wrapper while the first page
+	// loads and keep the table area near its final height. The offset tracks
+	// the DataViews header closely enough; the skeleton borders cover small
+	// differences.
 	&__rows-skeleton {
 		position: absolute;
 		inset: 56px 0 0 0;
 		z-index: 1;
 		overflow: hidden;
-		background: var(--cortext-canvas-frame-surface, #fff);
+		background: $white;
 		pointer-events: none;
 	}
 
@@ -4580,6 +4588,8 @@ body.cortext-row-detail-sidebar-resizing {
 
 .cortext-canvas__table .cortext-data-view-shell,
 .cortext-canvas__table .cortext-data-view {
+	background: $white;
+	color: var(--cortext-text);
 	height: 100%;
 }
 
@@ -5160,10 +5170,8 @@ thead > tr > th {
 		border-radius: 3px;
 	}
 
-	// Wrapper around an image-type icon: stacks the skeleton swatch
-	// underneath the <img> so the swatch keeps the slot painted until
-	// the actual image bytes arrive, not just until the REST record
-	// returns a URL.
+	// Wrapper for image icons. The swatch stays under the <img> until the image
+	// has actually loaded, not just until REST returns a URL.
 	&--image-wrap {
 		position: relative;
 		display: inline-block;
@@ -5179,11 +5187,9 @@ thead > tr > th {
 		transition: opacity 80ms ease-out;
 	}
 
-	// Reserves the icon slot the moment an image-type icon is parsed but
-	// before the media record resolves. Stays transparent for the first
-	// useDelayedFlag window so a cache hit never flashes a swatch; the
-	// `--visible` modifier paints the skeleton appearance once the wait
-	// crosses the threshold.
+	// Reserve the icon slot as soon as an image icon is parsed. Keep it
+	// transparent during the useDelayedFlag window so cache hits do not flash a
+	// swatch; `--visible` paints it after the wait crosses the threshold.
 	&--image-loading {
 		position: absolute;
 		inset: 0;
@@ -5647,3 +5653,26 @@ body.cortext-hide-block-settings-menu .block-editor-block-switcher {
 	animation: none;
 	opacity: 1;
 }
+
+/* stylelint-disable no-descending-specificity */
+.cortext-canvas__table .cortext-data-view {
+
+	> .dataviews-wrapper,
+	.dataviews__view-actions,
+	.dataviews-filters__container,
+	.dataviews-view-table,
+	.dataviews-view-table thead,
+	.dataviews-view-table thead tr,
+	.dataviews-view-table thead th {
+		background: $white;
+		background-color: $white;
+		color: var(--cortext-text, #1e1e1e);
+	}
+
+	.dataviews-view-table th,
+	.dataviews-view-table td {
+		border-color: $gray-200;
+		color: var(--cortext-text, #1e1e1e);
+	}
+}
+/* stylelint-enable no-descending-specificity */

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -18,6 +18,7 @@ import { CollectionFieldsProvider } from '../components/CollectionFieldsContext'
 import { RowMutationContext } from '../components/EditableCell';
 import { RowDetailSidebarSlot } from '../components/RowDetailSidebarSlot';
 import { DocumentSkeleton } from '../components/Skeleton';
+import useDelayedFlag from '../hooks/useDelayedFlag';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
 import {
 	ACTIVE_PAGES_QUERY,
@@ -92,10 +93,11 @@ function CollectionPane( { collectionId, onReady } ) {
 	);
 }
 
-function LoadingPane() {
+function LoadingPane( { active } ) {
+	const showSkeleton = useDelayedFlag( active );
 	return (
 		<div className="cortext-canvas__loading cortext-canvas__loading--document">
-			<DocumentSkeleton />
+			{ showSkeleton ? <DocumentSkeleton /> : null }
 		</div>
 	);
 }
@@ -510,7 +512,7 @@ export default function EntityRoute( { history } ) {
 					<NotFoundPane type="collection" />
 				</WorkspacePane>
 				<WorkspacePane active={ active.kind === 'loading' }>
-					<LoadingPane />
+					<LoadingPane active={ active.kind === 'loading' } />
 				</WorkspacePane>
 			</div>
 		</>

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -1,5 +1,4 @@
 import { useNavigate, useParams } from '@tanstack/react-router';
-import { Spinner } from '@wordpress/components';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -17,7 +16,10 @@ import CollectionDataViews from '../components/CollectionDataViews';
 import { CollectionFieldsProvider } from '../components/CollectionFieldsContext';
 import { RowMutationContext } from '../components/EditableCell';
 import { RowDetailSidebarSlot } from '../components/RowDetailSidebarSlot';
-import { DocumentSkeleton } from '../components/Skeleton';
+import {
+	CollectionRowsSkeleton,
+	DocumentSkeleton,
+} from '../components/Skeleton';
 import useDelayedFlag from '../hooks/useDelayedFlag';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
 import {
@@ -64,8 +66,8 @@ function CollectionView( { collectionId, onReady } ) {
 			onChangeView={ setView }
 			onReady={ onReady }
 			loading={
-				<div className="cortext-canvas__loading">
-					<Spinner />
+				<div className="cortext-canvas__loading cortext-canvas__loading--collection">
+					<CollectionRowsSkeleton />
 				</div>
 			}
 			empty={

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -10,6 +10,7 @@ import {
 	useLayoutEffect,
 	useMemo,
 	useReducer,
+	useRef,
 	useState,
 } from '@wordpress/element';
 
@@ -41,6 +42,7 @@ import {
 } from '../components/page-queries';
 import { firstPageInTree } from '../components/pages-tree';
 import { COLLECTION_QUERY } from '../collections';
+import { withViewTransition } from '../hooks/viewTransition';
 import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 import useCollectionFields from '../hooks/useCollectionFields';
@@ -181,7 +183,33 @@ export default function EntityRoute( { history } ) {
 			! readyCollectionIds.has( target.id ) );
 	const showWorkspaceProgress = useDelayedFlag( isWorkspaceNavigating );
 
-	const dispatch = rawDispatch;
+	// Run the reducer ahead of time so we only wrap the dispatch when
+	// `active` actually flips. Otherwise every DOCUMENT_RESOLVED or
+	// COLLECTION_RESOLVED would pin the canvas for the cross-fade
+	// duration even though nothing visible changed.
+	const stateRef = useRef( state );
+	stateRef.current = state;
+	const dispatch = useCallback( ( action ) => {
+		const before = stateRef.current;
+		const after = reducer( before, action );
+		const visualChanged =
+			before.active.kind !== after.active.kind ||
+			( before.active.id ?? null ) !== ( after.active.id ?? null );
+		if ( ! visualChanged ) {
+			rawDispatch( action );
+			return;
+		}
+		const touchesCollection =
+			action.target?.kind === 'collection' ||
+			before.active.kind === 'collection' ||
+			after.active.kind === 'collection' ||
+			action.type.startsWith( 'COLLECTION_' );
+		if ( touchesCollection ) {
+			rawDispatch( action );
+			return;
+		}
+		withViewTransition( () => rawDispatch( action ) );
+	}, [] );
 
 	const documentResolution = useResolveDocument(
 		target.kind === 'document' ? target.tail : ''

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -164,7 +164,21 @@ export default function EntityRoute( { history } ) {
 		mountedDocumentType,
 		displayedDocumentId,
 		mountedCollectionIds,
+		readyCollectionIds,
 	} = state;
+
+	// The reducer holds `active` on the previous pane until DOCUMENT_RESOLVED
+	// or COLLECTION_READY fires, so neither Canvas nor LoadingPane can tell
+	// they're in a navigation. Comparing the URL target to the displayed/ready
+	// snapshot is the only place that knows the new doc is on its way.
+	const isWorkspaceNavigating =
+		( target.kind === 'document' &&
+			target.id !== null &&
+			target.id !== displayedDocumentId ) ||
+		( target.kind === 'collection' &&
+			target.id !== null &&
+			! readyCollectionIds.has( target.id ) );
+	const showWorkspaceProgress = useDelayedFlag( isWorkspaceNavigating );
 
 	// Run the reducer ahead of time so we only wrap the dispatch when
 	// `active` actually flips. Otherwise every DOCUMENT_RESOLVED or
@@ -477,6 +491,11 @@ export default function EntityRoute( { history } ) {
 				paintedRoute={ paintedRoute }
 			/>
 			<div className="cortext-workspace">
+				{ showWorkspaceProgress && (
+					<div className="cortext-workspace__progress">
+						<CanvasProgressBar />
+					</div>
+				) }
 				{ editorCanvas !== null && (
 					<WorkspacePane active={ isDocumentActive } preservePaint>
 						{ isRow ? (

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -17,8 +17,8 @@ import { CollectionFieldsProvider } from '../components/CollectionFieldsContext'
 import { RowMutationContext } from '../components/EditableCell';
 import { RowDetailSidebarSlot } from '../components/RowDetailSidebarSlot';
 import {
+	CanvasProgressBar,
 	CollectionRowsSkeleton,
-	DocumentSkeleton,
 } from '../components/Skeleton';
 import useDelayedFlag from '../hooks/useDelayedFlag';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
@@ -96,10 +96,10 @@ function CollectionPane( { collectionId, onReady } ) {
 }
 
 function LoadingPane( { active } ) {
-	const showSkeleton = useDelayedFlag( active );
+	const showProgress = useDelayedFlag( active );
 	return (
 		<div className="cortext-canvas__loading cortext-canvas__loading--document">
-			{ showSkeleton ? <DocumentSkeleton /> : null }
+			{ showProgress ? <CanvasProgressBar /> : null }
 		</div>
 	);
 }

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -17,6 +17,7 @@ import CollectionDataViews from '../components/CollectionDataViews';
 import { CollectionFieldsProvider } from '../components/CollectionFieldsContext';
 import { RowMutationContext } from '../components/EditableCell';
 import { RowDetailSidebarSlot } from '../components/RowDetailSidebarSlot';
+import { DocumentSkeleton } from '../components/Skeleton';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
 import {
 	ACTIVE_PAGES_QUERY,
@@ -93,8 +94,8 @@ function CollectionPane( { collectionId, onReady } ) {
 
 function LoadingPane() {
 	return (
-		<div className="cortext-canvas__loading">
-			<Spinner />
+		<div className="cortext-canvas__loading cortext-canvas__loading--document">
+			<DocumentSkeleton />
 		</div>
 	);
 }

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -10,7 +10,6 @@ import {
 	useLayoutEffect,
 	useMemo,
 	useReducer,
-	useRef,
 	useState,
 } from '@wordpress/element';
 
@@ -42,7 +41,6 @@ import {
 } from '../components/page-queries';
 import { firstPageInTree } from '../components/pages-tree';
 import { COLLECTION_QUERY } from '../collections';
-import { withViewTransition } from '../hooks/viewTransition';
 import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 import useCollectionFields from '../hooks/useCollectionFields';
@@ -183,33 +181,7 @@ export default function EntityRoute( { history } ) {
 			! readyCollectionIds.has( target.id ) );
 	const showWorkspaceProgress = useDelayedFlag( isWorkspaceNavigating );
 
-	// Run the reducer ahead of time so we only wrap the dispatch when
-	// `active` actually flips. Otherwise every DOCUMENT_RESOLVED or
-	// COLLECTION_RESOLVED would pin the canvas for the cross-fade
-	// duration even though nothing visible changed.
-	const stateRef = useRef( state );
-	stateRef.current = state;
-	const dispatch = useCallback( ( action ) => {
-		const before = stateRef.current;
-		const after = reducer( before, action );
-		const visualChanged =
-			before.active.kind !== after.active.kind ||
-			( before.active.id ?? null ) !== ( after.active.id ?? null );
-		if ( ! visualChanged ) {
-			rawDispatch( action );
-			return;
-		}
-		const touchesCollection =
-			action.target?.kind === 'collection' ||
-			before.active.kind === 'collection' ||
-			after.active.kind === 'collection' ||
-			action.type.startsWith( 'COLLECTION_' );
-		if ( touchesCollection ) {
-			rawDispatch( action );
-			return;
-		}
-		withViewTransition( () => rawDispatch( action ) );
-	}, [] );
+	const dispatch = rawDispatch;
 
 	const documentResolution = useResolveDocument(
 		target.kind === 'document' ? target.tail : ''

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useReducer,
 	useRef,
@@ -16,10 +17,7 @@ import CollectionDataViews from '../components/CollectionDataViews';
 import { CollectionFieldsProvider } from '../components/CollectionFieldsContext';
 import { RowMutationContext } from '../components/EditableCell';
 import { RowDetailSidebarSlot } from '../components/RowDetailSidebarSlot';
-import {
-	CanvasProgressBar,
-	CollectionRowsSkeleton,
-} from '../components/Skeleton';
+import { CanvasProgressBar } from '../components/Skeleton';
 import useDelayedFlag from '../hooks/useDelayedFlag';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
 import {
@@ -65,14 +63,6 @@ function CollectionView( { collectionId, onReady } ) {
 			view={ view }
 			onChangeView={ setView }
 			onReady={ onReady }
-			loading={
-				<div className="cortext-canvas__loading cortext-canvas__loading--collection">
-					<CollectionRowsSkeleton
-						rowCount={ view?.perPage ?? 8 }
-						density={ view?.layout?.density ?? 'compact' }
-					/>
-				</div>
-			}
 			empty={
 				<span className="cortext-canvas__empty-text">
 					{ __( 'No entries yet.', 'cortext' ) }
@@ -167,10 +157,9 @@ export default function EntityRoute( { history } ) {
 		readyCollectionIds,
 	} = state;
 
-	// The reducer holds `active` on the previous pane until DOCUMENT_RESOLVED
-	// or COLLECTION_READY fires, so neither Canvas nor LoadingPane can tell
-	// they're in a navigation. Comparing the URL target to the displayed/ready
-	// snapshot is the only place that knows the new doc is on its way.
+	// Document navigations keep the previous pane visible until the next one
+	// can paint. Collections can activate before rows are ready, so compare the
+	// URL target with the displayed/ready snapshot here.
 	const isWorkspaceNavigating =
 		( target.kind === 'document' &&
 			target.id !== null &&
@@ -193,6 +182,15 @@ export default function EntityRoute( { history } ) {
 			before.active.kind !== after.active.kind ||
 			( before.active.id ?? null ) !== ( after.active.id ?? null );
 		if ( ! visualChanged ) {
+			rawDispatch( action );
+			return;
+		}
+		const touchesCollection =
+			action.target?.kind === 'collection' ||
+			before.active.kind === 'collection' ||
+			after.active.kind === 'collection' ||
+			action.type.startsWith( 'COLLECTION_' );
+		if ( touchesCollection ) {
 			rawDispatch( action );
 			return;
 		}
@@ -265,7 +263,7 @@ export default function EntityRoute( { history } ) {
 		];
 	}, [ rowCollectionSlug, rowFieldsState?.fields ] );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		dispatch( { type: 'TARGET_CHANGED', target } );
 	}, [ target, dispatch ] );
 
@@ -490,7 +488,7 @@ export default function EntityRoute( { history } ) {
 				history={ history }
 				paintedRoute={ paintedRoute }
 			/>
-			<div className="cortext-workspace">
+			<div className="cortext-workspace" data-target-kind={ target.kind }>
 				{ showWorkspaceProgress && (
 					<div className="cortext-workspace__progress">
 						<CanvasProgressBar />

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -157,9 +157,9 @@ export default function EntityRoute( { history } ) {
 		readyCollectionIds,
 	} = state;
 
-	// Document navigations keep the previous pane visible until the next one
-	// can paint. Collections can activate before rows are ready, so compare the
-	// URL target with the displayed/ready snapshot here.
+	// Document navigations keep the previous pane visible until the next one can
+	// paint. Collections can activate before rows are ready, so compare the URL
+	// target with the displayed/ready snapshot here.
 	const isWorkspaceNavigating =
 		( target.kind === 'document' &&
 			target.id !== null &&

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -67,7 +67,10 @@ function CollectionView( { collectionId, onReady } ) {
 			onReady={ onReady }
 			loading={
 				<div className="cortext-canvas__loading cortext-canvas__loading--collection">
-					<CollectionRowsSkeleton />
+					<CollectionRowsSkeleton
+						rowCount={ view?.perPage ?? 8 }
+						density={ view?.layout?.density ?? 'compact' }
+					/>
 				</div>
 			}
 			empty={

--- a/src/router/entityRouteReducer.js
+++ b/src/router/entityRouteReducer.js
@@ -88,6 +88,8 @@ export function reducer( state, action ) {
 					state.readyCollectionIds.has( target.id )
 				) {
 					active = { kind: 'collection', id: target.id };
+				} else {
+					active = { kind: 'loading' };
 				}
 			}
 
@@ -146,10 +148,11 @@ export function reducer( state, action ) {
 			)
 				? state.mountedCollectionIds
 				: [ ...state.mountedCollectionIds, action.id ];
-			const next = { ...state, mountedCollectionIds };
-			if ( state.readyCollectionIds.has( action.id ) ) {
-				next.active = { kind: 'collection', id: action.id };
-			}
+			const next = {
+				...state,
+				mountedCollectionIds,
+				active: { kind: 'collection', id: action.id },
+			};
 			return pruneCollections( next );
 		}
 

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -72,8 +72,7 @@
 	// Hairline top-edge highlight on the active row to suggest a soft "lift".
 	--cortext-state-selected-highlight: rgba(255, 255, 255, 0.6);
 	--cortext-canvas-frame-surface: #{colors.$white};
-	// The document/table canvas itself. This stays light in dark mode until
-	// the editor canvas and DataViews have a real dark theme.
+	// Light canvas behind the editor iframe and full-page tables.
 	--cortext-canvas-surface: #{colors.$white};
 	--cortext-canvas-border: #{colors.$gray-200};
 	--cortext-chrome-border: #{colors.$gray-200};

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -72,6 +72,10 @@
 	// Hairline top-edge highlight on the active row to suggest a soft "lift".
 	--cortext-state-selected-highlight: rgba(255, 255, 255, 0.6);
 	--cortext-canvas-frame-surface: #{colors.$white};
+	// The document/table canvas itself. This stays light in dark mode until
+	// the editor canvas and DataViews have a real dark theme.
+	--cortext-canvas-surface: #{colors.$white};
+	--cortext-canvas-border: #{colors.$gray-200};
 	--cortext-chrome-border: #{colors.$gray-200};
 	--cortext-text: #{colors.$gray-900};
 	--cortext-text-muted: #{colors.$gray-700};

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -75,14 +75,11 @@
 	// Light canvas behind the editor iframe and full-page tables.
 	--cortext-canvas-surface: #{colors.$white};
 	--cortext-canvas-border: #{colors.$gray-200};
-	// DataViews table density heights. The skeleton mirrors these so the
-	// loading table occupies the same space the real rows will. Header height
-	// is a fallback; CollectionDataViews measures the real thead at runtime
-	// and overrides this on the data-view shell.
+	// DataViews table density heights. The skeleton uses these so the loading
+	// table holds the same space as the real rows.
 	--cortext-data-view-row-height-compact: #{variables.$grid-unit-50};
 	--cortext-data-view-row-height-balanced: #{variables.$grid-unit-50 + 2 * variables.$grid-unit-15};
 	--cortext-data-view-row-height-comfortable: #{variables.$grid-unit-50 + 2 * variables.$grid-unit-20};
-	--cortext-data-view-header-height: 56px;
 	--cortext-chrome-border: #{colors.$gray-200};
 	--cortext-text: #{colors.$gray-900};
 	--cortext-text-muted: #{colors.$gray-700};

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -75,6 +75,14 @@
 	// Light canvas behind the editor iframe and full-page tables.
 	--cortext-canvas-surface: #{colors.$white};
 	--cortext-canvas-border: #{colors.$gray-200};
+	// DataViews table density heights. The skeleton mirrors these so the
+	// loading table occupies the same space the real rows will. Header height
+	// is a fallback; CollectionDataViews measures the real thead at runtime
+	// and overrides this on the data-view shell.
+	--cortext-data-view-row-height-compact: #{variables.$grid-unit-50};
+	--cortext-data-view-row-height-balanced: #{variables.$grid-unit-50 + 2 * variables.$grid-unit-15};
+	--cortext-data-view-row-height-comfortable: #{variables.$grid-unit-50 + 2 * variables.$grid-unit-20};
+	--cortext-data-view-header-height: 56px;
 	--cortext-chrome-border: #{colors.$gray-200};
 	--cortext-text: #{colors.$gray-900};
 	--cortext-text-muted: #{colors.$gray-700};

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -147,7 +147,7 @@ test.describe( 'Navigation lifecycle', () => {
 		}
 	} );
 
-	test( 'keeps the mounted page canvas while collection rows load', async ( {
+	test( 'keeps the current page canvas visible while collection rows load', async ( {
 		admin,
 		page,
 		requestUtils,

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -248,7 +248,7 @@ test.describe( 'Navigation lifecycle', () => {
 
 			await expect(
 				page.locator(
-					'.cortext-workspace__pane[data-active="true"] .cortext-data-view[data-rows-loading="true"]'
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view[data-loading-shell="true"]'
 				)
 			).toBeVisible();
 			await expect(

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -147,7 +147,7 @@ test.describe( 'Navigation lifecycle', () => {
 		}
 	} );
 
-	test( 'preserves the mounted page canvas and waits for collection rows', async ( {
+	test( 'keeps the mounted page canvas while collection rows load', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -248,14 +248,14 @@ test.describe( 'Navigation lifecycle', () => {
 
 			await expect(
 				page.locator(
-					'.cortext-workspace__pane[data-active="true"] .cortext-canvas'
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view[data-rows-loading="true"]'
 				)
 			).toBeVisible();
 			await expect(
 				page.locator(
-					'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view__rows-skeleton'
 				)
-			).toHaveCount( 0 );
+			).toBeVisible();
 
 			releaseRows();
 

--- a/tests/js/components/CollectionRow.test.js
+++ b/tests/js/components/CollectionRow.test.js
@@ -50,9 +50,7 @@ describe( 'CollectionRow', () => {
 		const { container, props } = renderRow();
 		// dnd-kit gives the draggable wrapper button semantics, so there are
 		// two "Books" buttons here. Click the title button directly.
-		fireEvent.click(
-			container.querySelector( '.cortext-sidebar__title' )
-		);
+		fireEvent.click( container.querySelector( '.cortext-sidebar__title' ) );
 
 		expect( props.onSelect ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -6,7 +6,7 @@
  * and assert the REST calls SidebarTrash makes.
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // Stub @wordpress/components so the test does not transitively pull in
 // rich-text → block-editor → parsel-js (an ESM-only package the jest CJS
@@ -191,14 +191,25 @@ describe( 'SidebarTrash', () => {
 			status: 'RESOLVING',
 		} );
 
-		const { container } = renderSidebarTrash();
+		jest.useFakeTimers();
+		try {
+			const { container } = renderSidebarTrash();
 
-		expect(
-			container.querySelector( '.cortext-sidebar-skeleton' )
-		).toBeTruthy();
-		expect(
-			container.querySelector( '.cortext-sidebar__empty' )
-		).toBeFalsy();
+			// Skeletons are delayed so fast loads don't flicker; advance
+			// past the threshold to assert the loading visual.
+			act( () => {
+				jest.advanceTimersByTime( 200 );
+			} );
+
+			expect(
+				container.querySelector( '.cortext-sidebar-skeleton' )
+			).toBeTruthy();
+			expect(
+				container.querySelector( '.cortext-sidebar__empty' )
+			).toBeFalsy();
+		} finally {
+			jest.useRealTimers();
+		}
 	} );
 
 	it( 'shows the empty state when the trash is empty', () => {

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -6,7 +6,13 @@
  * and assert the REST calls SidebarTrash makes.
  */
 
-import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+	act,
+	render,
+	screen,
+	fireEvent,
+	waitFor,
+} from '@testing-library/react';
 
 // Stub @wordpress/components so the test does not transitively pull in
 // rich-text → block-editor → parsel-js (an ESM-only package the jest CJS
@@ -184,7 +190,7 @@ function makeDocumentsState( overrides = {} ) {
 }
 
 describe( 'SidebarTrash', () => {
-	it( 'shows a skeleton while the trash query resolves', () => {
+	it( 'shows a skeleton when the trash query takes long enough', () => {
 		setTrashRecords( {
 			records: undefined,
 			hasResolved: false,
@@ -195,8 +201,8 @@ describe( 'SidebarTrash', () => {
 		try {
 			const { container } = renderSidebarTrash();
 
-			// Skeletons are delayed so fast loads don't flicker; advance
-			// past the threshold to assert the loading visual.
+			// Skeletons wait out fast loads; advance past the threshold before
+			// checking the loading visual.
 			act( () => {
 				jest.advanceTimersByTime( 200 );
 			} );

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -184,7 +184,7 @@ function makeDocumentsState( overrides = {} ) {
 }
 
 describe( 'SidebarTrash', () => {
-	it( 'shows a spinner while the trash query resolves', () => {
+	it( 'shows a skeleton while the trash query resolves', () => {
 		setTrashRecords( {
 			records: undefined,
 			hasResolved: false,
@@ -194,7 +194,7 @@ describe( 'SidebarTrash', () => {
 		const { container } = renderSidebarTrash();
 
 		expect(
-			container.querySelector( '.cortext-sidebar__loading' )
+			container.querySelector( '.cortext-sidebar-skeleton' )
 		).toBeTruthy();
 		expect(
 			container.querySelector( '.cortext-sidebar__empty' )

--- a/tests/js/entityRouteReducer.test.js
+++ b/tests/js/entityRouteReducer.test.js
@@ -82,6 +82,19 @@ describe( 'EntityRoute reducer', () => {
 			expect( next.active ).toEqual( { kind: 'document', id: 1 } );
 		} );
 
+		it( 'switches to loading when navigating to a not-yet-ready collection', () => {
+			const state = activate(
+				init( documentTarget( 1 ) ),
+				documentTarget( 1 )
+			);
+			const next = reducer( state, {
+				type: 'TARGET_CHANGED',
+				target: collectionTarget( 5 ),
+			} );
+			expect( next.target ).toEqual( collectionTarget( 5 ) );
+			expect( next.active ).toEqual( { kind: 'loading' } );
+		} );
+
 		it( 'reactivates a document that is already mounted and displayed', () => {
 			let state = activate(
 				init( documentTarget( 1 ) ),
@@ -256,7 +269,7 @@ describe( 'EntityRoute reducer', () => {
 	} );
 
 	describe( 'COLLECTION_RESOLVED', () => {
-		it( 'adds to mountedCollectionIds without activating before ready', () => {
+		it( 'mounts and activates the collection before rows are ready', () => {
 			let state = init( collectionTarget( 5 ) );
 			state = reducer( state, {
 				type: 'TARGET_CHANGED',
@@ -264,17 +277,6 @@ describe( 'EntityRoute reducer', () => {
 			} );
 			state = reducer( state, { type: 'COLLECTION_RESOLVED', id: 5 } );
 			expect( state.mountedCollectionIds ).toEqual( [ 5 ] );
-			expect( state.active ).toEqual( { kind: 'loading' } );
-		} );
-
-		it( 'activates when the collection was already ready', () => {
-			let state = init( collectionTarget( 5 ) );
-			state = reducer( state, {
-				type: 'TARGET_CHANGED',
-				target: collectionTarget( 5 ),
-			} );
-			state = reducer( state, { type: 'COLLECTION_READY', id: 5 } );
-			state = reducer( state, { type: 'COLLECTION_RESOLVED', id: 5 } );
 			expect( state.active ).toEqual( { kind: 'collection', id: 5 } );
 		} );
 
@@ -317,7 +319,7 @@ describe( 'EntityRoute reducer', () => {
 	} );
 
 	describe( 'pruning', () => {
-		it( 'keeps the active and target collections, drops the rest', () => {
+		it( 'drops the previous collection once the next collection activates', () => {
 			let state = activate(
 				init( collectionTarget( 5 ) ),
 				collectionTarget( 5 )
@@ -327,7 +329,7 @@ describe( 'EntityRoute reducer', () => {
 				target: collectionTarget( 7 ),
 			} );
 			state = reducer( state, { type: 'COLLECTION_RESOLVED', id: 7 } );
-			expect( state.mountedCollectionIds.sort() ).toEqual( [ 5, 7 ] );
+			expect( state.mountedCollectionIds ).toEqual( [ 7 ] );
 			state = reducer( state, { type: 'COLLECTION_READY', id: 7 } );
 			expect( state.mountedCollectionIds ).toEqual( [ 7 ] );
 		} );

--- a/tests/js/entityRouteReducer.test.js
+++ b/tests/js/entityRouteReducer.test.js
@@ -82,7 +82,7 @@ describe( 'EntityRoute reducer', () => {
 			expect( next.active ).toEqual( { kind: 'document', id: 1 } );
 		} );
 
-		it( 'switches to loading when navigating to a not-yet-ready collection', () => {
+		it( 'goes to loading for a collection that is not ready yet', () => {
 			const state = activate(
 				init( documentTarget( 1 ) ),
 				documentTarget( 1 )
@@ -269,7 +269,7 @@ describe( 'EntityRoute reducer', () => {
 	} );
 
 	describe( 'COLLECTION_RESOLVED', () => {
-		it( 'mounts and activates the collection before rows are ready', () => {
+		it( 'mounts the collection before row data is ready', () => {
 			let state = init( collectionTarget( 5 ) );
 			state = reducer( state, {
 				type: 'TARGET_CHANGED',
@@ -319,7 +319,7 @@ describe( 'EntityRoute reducer', () => {
 	} );
 
 	describe( 'pruning', () => {
-		it( 'drops the previous collection once the next collection activates', () => {
+		it( 'drops the previous collection after the next one activates', () => {
 			let state = activate(
 				init( collectionTarget( 5 ) ),
 				collectionTarget( 5 )

--- a/tests/js/hooks/useDelayedFlag.test.js
+++ b/tests/js/hooks/useDelayedFlag.test.js
@@ -59,4 +59,50 @@ describe( 'useDelayedFlag', () => {
 		rerender( { active: false } );
 		expect( result.current ).toBe( false );
 	} );
+
+	it( 'holds the flag for the minimum visible duration', () => {
+		const { result, rerender } = renderHook(
+			( { active } ) => useDelayedFlag( active, 120, 300 ),
+			{ initialProps: { active: true } }
+		);
+
+		// Past the delay -> flag flips true, min-visible window starts.
+		act( () => {
+			jest.advanceTimersByTime( 120 );
+		} );
+		expect( result.current ).toBe( true );
+
+		// active clears while we're still inside the min window.
+		act( () => {
+			jest.advanceTimersByTime( 100 );
+		} );
+		rerender( { active: false } );
+		expect( result.current ).toBe( true );
+
+		// Run out the rest of the min window -> flag clears.
+		act( () => {
+			jest.advanceTimersByTime( 199 );
+		} );
+		expect( result.current ).toBe( true );
+
+		act( () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'clears immediately once min-visible has elapsed', () => {
+		const { result, rerender } = renderHook(
+			( { active } ) => useDelayedFlag( active, 120, 300 ),
+			{ initialProps: { active: true } }
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 120 + 300 + 50 );
+		} );
+		expect( result.current ).toBe( true );
+
+		rerender( { active: false } );
+		expect( result.current ).toBe( false );
+	} );
 } );

--- a/tests/js/hooks/useDelayedFlag.test.js
+++ b/tests/js/hooks/useDelayedFlag.test.js
@@ -1,0 +1,62 @@
+import { act, renderHook } from '@testing-library/react';
+
+import useDelayedFlag from '../../../src/hooks/useDelayedFlag';
+
+beforeEach( () => {
+	jest.useFakeTimers();
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
+describe( 'useDelayedFlag', () => {
+	it( 'stays false until the delay elapses', () => {
+		const { result } = renderHook( () => useDelayedFlag( true, 120 ) );
+
+		expect( result.current ).toBe( false );
+
+		act( () => {
+			jest.advanceTimersByTime( 119 );
+		} );
+		expect( result.current ).toBe( false );
+
+		act( () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'never flips to true if the active flag clears first', () => {
+		const { result, rerender } = renderHook(
+			( { active } ) => useDelayedFlag( active, 120 ),
+			{ initialProps: { active: true } }
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 80 );
+		} );
+		expect( result.current ).toBe( false );
+
+		rerender( { active: false } );
+		act( () => {
+			jest.advanceTimersByTime( 200 );
+		} );
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'resets to false the moment active flips back', () => {
+		const { result, rerender } = renderHook(
+			( { active } ) => useDelayedFlag( active, 120 ),
+			{ initialProps: { active: true } }
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 200 );
+		} );
+		expect( result.current ).toBe( true );
+
+		rerender( { active: false } );
+		expect( result.current ).toBe( false );
+	} );
+} );

--- a/tests/js/hooks/useDelayedFlag.test.js
+++ b/tests/js/hooks/useDelayedFlag.test.js
@@ -11,7 +11,7 @@ afterEach( () => {
 } );
 
 describe( 'useDelayedFlag', () => {
-	it( 'stays false until the delay elapses', () => {
+	it( 'waits out the delay before returning true', () => {
 		const { result } = renderHook( () => useDelayedFlag( true, 120 ) );
 
 		expect( result.current ).toBe( false );
@@ -27,7 +27,7 @@ describe( 'useDelayedFlag', () => {
 		expect( result.current ).toBe( true );
 	} );
 
-	it( 'never flips to true if the active flag clears first', () => {
+	it( 'stays false if active clears before the delay', () => {
 		const { result, rerender } = renderHook(
 			( { active } ) => useDelayedFlag( active, 120 ),
 			{ initialProps: { active: true } }
@@ -45,7 +45,7 @@ describe( 'useDelayedFlag', () => {
 		expect( result.current ).toBe( false );
 	} );
 
-	it( 'resets to false the moment active flips back', () => {
+	it( 'goes false immediately when active clears', () => {
 		const { result, rerender } = renderHook(
 			( { active } ) => useDelayedFlag( active, 120 ),
 			{ initialProps: { active: true } }


### PR DESCRIPTION
## What

Closes #144.

Makes the app better at maintaining the UI in place while things load. Collection tables keep their shape; sidebars and featured images show lightweight placeholders; row peek reacts right away; and document switches keep the current canvas visible with a small progress bar. This also fixes a few visual flashes around dark mode, image icons, and collection field headers.

## Why

On slower connections or cold caches, the app could feel like it blinked, collapsed, or briefly showed the wrong thing. This makes those moments feel steadier.

## How

- Avoiding loading flashes by skipping placeholders for quick loads and holding them briefly when they do appear.
- Reserving space for tables, sidebars, images, and row details while data loads.
- Keeping the current document on screen while the next one gets ready.
- Holding image placeholders until the image has actually loaded.

## Testing Instructions

1. Open Cortext with the network throttled.
2. Navigate between two pages and confirm the current canvas stays visible while a small progress bar appears.
3. Open a collection on a cold load and confirm the table skeleton keeps the layout stable.
4. Confirm collection field headers do not flash raw field IDs.
5. Open Pages, Collections, Favorites, Recents, and Trash, and confirm skeleton rows appear only after a short wait.
6. Switch to dark mode and navigate between documents; confirm there is no black flash.
7. Open a row peek and confirm the clicked row responds immediately while the pane loads.

## Screen recording

https://github.com/user-attachments/assets/a763a798-f173-4737-a29c-8eae7f21b89a

