### PR TITLE
Document types: one registration helper

### DIFF
--- a/includes/PostType/Collection.php
+++ b/includes/PostType/Collection.php
@@ -24,7 +24,11 @@ final class Collection {
 	}
 
 	public function register_post_type(): void {
-		register_post_type(
+		// Collections use the shared document lifecycle: title, identity,
+		// trash, restore, permanent delete, and command palette search.
+		// DataView is their editing surface, so block-editor content support
+		// stays off for now.
+		DocumentTypeRegistrar::register(
 			self::POST_TYPE,
 			array(
 				'labels'             => array(
@@ -56,11 +60,6 @@ final class Collection {
 				'delete_with_user'   => false,
 			)
 		);
-
-		// Collections share the document lifecycle: title, identity, trash,
-		// restore, permanent delete, command palette search. The DataView is
-		// their canvas; block-editor content support stays off for now.
-		DocumentIdentity::register_for_post_type( self::POST_TYPE );
 
 		$this->register_meta();
 	}

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -451,7 +451,7 @@ final class CollectionEntries {
 		// a slug (e.g. duplicate seed entries) all contribute their field
 		// keys to the shared CPT instead of silently dropping at REST.
 		if ( ! post_type_exists( $post_type ) ) {
-			register_post_type(
+			DocumentTypeRegistrar::register(
 				$post_type,
 				array(
 					'labels'             => array(
@@ -476,8 +476,6 @@ final class CollectionEntries {
 					'delete_with_user'   => false,
 				)
 			);
-
-			DocumentIdentity::register_for_post_type( $post_type );
 		}
 
 		$this->register_field_meta( $post_type, $collection->ID );

--- a/includes/PostType/DocumentIdentity.php
+++ b/includes/PostType/DocumentIdentity.php
@@ -3,10 +3,9 @@
  * Per-document icon (emoji or uploaded image) for any post type that opts into
  * the `cortext-document` capability.
  *
- * Each opted-in CPT calls `DocumentIdentity::register_for_post_type()` from its
- * own registration site, instead of this class iterating over post types at
- * `init`. That keeps page registration and dynamic row CPT registration on the
- * same code path and avoids any ordering dependency.
+ * `DocumentTypeRegistrar::register()` calls `register_for_post_type()` while
+ * registering each Cortext document post type. That keeps pages and dynamic
+ * row CPTs on the same path and avoids ordering assumptions.
  *
  * @package Cortext
  */
@@ -40,8 +39,9 @@ final class DocumentIdentity {
 
 	/**
 	 * Opts a post type into the `cortext-document` capability and registers the
-	 * document icon meta on it. Call from the post type's own registration site,
-	 * after `register_post_type()` has run for that type.
+	 * document icon meta on it. `DocumentTypeRegistrar::register()` calls this
+	 * right after `register_post_type()`; external callers should leave it
+	 * alone.
 	 *
 	 * @param string $post_type Post type slug.
 	 */

--- a/includes/PostType/DocumentTypeRegistrar.php
+++ b/includes/PostType/DocumentTypeRegistrar.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Registers a post type as a Cortext document. This keeps the plain WordPress
+ * registration and the Cortext document wiring together for pages,
+ * collections, and dynamic row CPTs.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\PostType;
+
+final class DocumentTypeRegistrar {
+
+	/**
+	 * Registers a Cortext document post type. Forwards `$args` to
+	 * `register_post_type`, then adds the `cortext-document` trait and
+	 * identity icon meta through `DocumentIdentity`.
+	 *
+	 * Call once per document post type during the `init` action.
+	 *
+	 * @param string              $post_type Post type slug.
+	 * @param array<string,mixed> $args      Arguments for `register_post_type`.
+	 */
+	public static function register( string $post_type, array $args ): void {
+		register_post_type( $post_type, $args );
+		DocumentIdentity::register_for_post_type( $post_type );
+	}
+}

--- a/includes/PostType/Page.php
+++ b/includes/PostType/Page.php
@@ -18,7 +18,7 @@ final class Page {
 	}
 
 	public function register_post_type(): void {
-		register_post_type(
+		DocumentTypeRegistrar::register(
 			self::POST_TYPE,
 			array(
 				'labels'                => array(
@@ -74,7 +74,5 @@ final class Page {
 				'delete_with_user'      => false,
 			)
 		);
-
-		DocumentIdentity::register_for_post_type( self::POST_TYPE );
 	}
 }


### PR DESCRIPTION
## What

Part of #226.

Cortext document types (pages, collections, dynamic row CPTs) now register through one shared helper. Adding a new document type is one call instead of two that needed to stay in sync by hand.

There should be no user-facing changes here.

## Why

Setup for the rest of the refactor in #226.

## Testing Instructions

1. Create a new page and confirm it appears in the sidebar.
2. Create a new collection and confirm it appears in the sidebar.
3. Add a row to that collection and confirm it shows up in Recents.
4. Set an emoji icon on a page and confirm it survives a reload.
5. Set an emoji icon on a collection and confirm it survives a reload.