### PR TITLE
Bugfix: Keep document headers fixed above body blocks

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -516,3 +516,11 @@ The brittle bit is the sizing. The skeleton copies DataViews row heights for com
 **Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/index.scss`.
 
 **Solution.** DataViews exposes a table loading slot, or at least row-height CSS variables. Then Cortext can follow the table instead of copying its constants. Until then, keep the skeleton rules next to the DataViews table rules and check for visual drift after DataViews upgrades.
+
+## 56. Block movers do not understand Cortext's header boundary `[upstream]`
+
+**What.** Gutenberg block locks keep cover, icon, and title from moving, but they do not stop other root blocks from being inserted or moved above that locked prefix. Cortext can repair the root order with block-editor store actions and can hide protected insertion points, but the first body block's "move up" button is still rendered by Gutenberg as if moving above the title were allowed. To leave the button visible but greyed out, Cortext watches the active root selection, finds `.block-editor-block-mover-button.is-up-button` when the toolbar mounts, and toggles `disabled` / `aria-disabled` itself. If Gutenberg renames that class or changes where the mover renders, the guard will need another pass.
+
+**Where.** `HeaderPrefixToolbarGuard`, `syncHeaderBoundaryMoveUpButtons`, and the header-prefix correction in `src/components/EditorBody.js`, with coverage in `tests/e2e/specs/editor-header-blocks.spec.js`.
+
+**Solution.** Gutenberg exposes a block-list boundary policy for root lists: a minimum insertion index, a minimum move target, and mover button state derived from that policy. Then Cortext can declare "body blocks start after the title" once and drop the toolbar DOM query, the mutation observer, and the local button-state restoration.

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -161,9 +161,10 @@ function HideHeaderBlockKebab() {
 	return null;
 }
 
-function VisualCanvas( { postId, postType, onReady, onRestored } ) {
+function VisualCanvas( { isActive, postId, postType, onReady, onRestored } ) {
 	return (
 		<EditorBody
+			isActive={ isActive }
 			postId={ postId }
 			postType={ postType }
 			onReady={ onReady }
@@ -304,6 +305,7 @@ function CanvasEditor( {
 							rowProperties
 						) }
 						<VisualCanvas
+							isActive={ isActive }
 							postId={ post.id }
 							postType={ postType }
 							onReady={ onDisplayedPost }

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -45,6 +45,11 @@ const DISABLED_BY_HEADER_BOUNDARY_ATTR =
 	'data-cortext-header-boundary-disabled';
 const HEADER_BOUNDARY_MOVE_UP_SELECTOR =
 	'.block-editor-block-mover-button.is-up-button';
+const HEADER_BOUNDARY_MOVE_UP_SCOPE_SELECTOR = [
+	'.block-editor-block-list__block-popover',
+	'.block-editor-block-contextual-toolbar',
+	'.block-editor-block-toolbar',
+].join( ',' );
 const activeHeaderBoundaryMoveUpGuards = new Set();
 const HEADER_BLOCK_NAMES = new Set( [
 	DOCUMENT_COVER_BLOCK,
@@ -63,72 +68,93 @@ function syncHeaderBoundaryMoveUpClass() {
 	);
 }
 
-function syncHeaderBoundaryMoveUpButtons() {
-	// tech-debt.md#56: Gutenberg does not expose boundary-aware mover state.
-	const shouldDisable = activeHeaderBoundaryMoveUpGuards.size > 0;
-	document
-		.querySelectorAll( HEADER_BOUNDARY_MOVE_UP_SELECTOR )
-		.forEach( ( button ) => {
-			if ( ! ( button instanceof window.HTMLButtonElement ) ) {
-				return;
-			}
+function getHeaderBoundaryMoveUpScopes( root ) {
+	if ( ! root ) {
+		return [];
+	}
 
-			if ( shouldDisable ) {
+	const scopes = [
+		...( root.matches?.( HEADER_BOUNDARY_MOVE_UP_SCOPE_SELECTOR )
+			? [ root ]
+			: [] ),
+		...root.querySelectorAll( HEADER_BOUNDARY_MOVE_UP_SCOPE_SELECTOR ),
+	];
+	return scopes.length > 0 ? scopes : [ root ];
+}
+
+function syncHeaderBoundaryMoveUpButtons( root, shouldDisable ) {
+	// tech-debt.md#56: Gutenberg does not expose boundary-aware mover state.
+	const ownerWindow = root?.ownerDocument?.defaultView ?? window;
+	getHeaderBoundaryMoveUpScopes( root ).forEach( ( scope ) => {
+		scope
+			.querySelectorAll( HEADER_BOUNDARY_MOVE_UP_SELECTOR )
+			.forEach( ( button ) => {
+				if ( ! ( button instanceof ownerWindow.HTMLButtonElement ) ) {
+					return;
+				}
+
+				if ( shouldDisable ) {
+					if (
+						! button.hasAttribute(
+							DISABLED_BY_HEADER_BOUNDARY_ATTR
+						)
+					) {
+						button.setAttribute(
+							DISABLED_BY_HEADER_BOUNDARY_ATTR,
+							'true'
+						);
+						button.dataset.cortextPreviousDisabled = button.disabled
+							? 'true'
+							: 'false';
+						const previousAriaDisabled =
+							button.getAttribute( 'aria-disabled' );
+						if ( previousAriaDisabled !== null ) {
+							button.dataset.cortextPreviousAriaDisabled =
+								previousAriaDisabled;
+						} else {
+							delete button.dataset.cortextPreviousAriaDisabled;
+						}
+					}
+
+					button.disabled = true;
+					button.setAttribute( 'aria-disabled', 'true' );
+					return;
+				}
+
 				if (
 					! button.hasAttribute( DISABLED_BY_HEADER_BOUNDARY_ATTR )
 				) {
-					button.setAttribute(
-						DISABLED_BY_HEADER_BOUNDARY_ATTR,
-						'true'
-					);
-					button.dataset.cortextPreviousDisabled = button.disabled
-						? 'true'
-						: 'false';
-					const previousAriaDisabled =
-						button.getAttribute( 'aria-disabled' );
-					if ( previousAriaDisabled !== null ) {
-						button.dataset.cortextPreviousAriaDisabled =
-							previousAriaDisabled;
-					} else {
-						delete button.dataset.cortextPreviousAriaDisabled;
-					}
+					return;
 				}
 
-				button.disabled = true;
-				button.setAttribute( 'aria-disabled', 'true' );
-				return;
-			}
-
-			if ( ! button.hasAttribute( DISABLED_BY_HEADER_BOUNDARY_ATTR ) ) {
-				return;
-			}
-
-			button.disabled = button.dataset.cortextPreviousDisabled === 'true';
-			if (
-				Object.prototype.hasOwnProperty.call(
-					button.dataset,
-					'cortextPreviousAriaDisabled'
-				)
-			) {
-				button.setAttribute(
-					'aria-disabled',
-					button.dataset.cortextPreviousAriaDisabled
-				);
-			} else {
-				button.removeAttribute( 'aria-disabled' );
-			}
-			button.removeAttribute( DISABLED_BY_HEADER_BOUNDARY_ATTR );
-			delete button.dataset.cortextPreviousDisabled;
-			delete button.dataset.cortextPreviousAriaDisabled;
-		} );
+				button.disabled =
+					button.dataset.cortextPreviousDisabled === 'true';
+				if (
+					Object.prototype.hasOwnProperty.call(
+						button.dataset,
+						'cortextPreviousAriaDisabled'
+					)
+				) {
+					button.setAttribute(
+						'aria-disabled',
+						button.dataset.cortextPreviousAriaDisabled
+					);
+				} else {
+					button.removeAttribute( 'aria-disabled' );
+				}
+				button.removeAttribute( DISABLED_BY_HEADER_BOUNDARY_ATTR );
+				delete button.dataset.cortextPreviousDisabled;
+				delete button.dataset.cortextPreviousAriaDisabled;
+			} );
+	} );
 }
 
-function syncHeaderBoundaryMoveUpState() {
+function syncHeaderBoundaryMoveUpState( root, shouldDisable ) {
 	syncHeaderBoundaryMoveUpClass();
-	syncHeaderBoundaryMoveUpButtons();
+	syncHeaderBoundaryMoveUpButtons( root, shouldDisable );
 }
 
-function HeaderPrefixToolbarGuard( { isActive = true } ) {
+function HeaderPrefixToolbarGuard( { isActive = true, toolbarRootRef } ) {
 	const guardId = useRef( Symbol( DISABLE_HEADER_BOUNDARY_MOVE_UP_CLASS ) );
 	const shouldDisableMoveUp = useSelect(
 		( select ) => {
@@ -172,17 +198,18 @@ function HeaderPrefixToolbarGuard( { isActive = true } ) {
 
 	useEffect( () => {
 		const currentGuardId = guardId.current;
+		const toolbarRoot = toolbarRootRef?.current;
 		if ( shouldDisableMoveUp ) {
 			activeHeaderBoundaryMoveUpGuards.add( currentGuardId );
 		} else {
 			activeHeaderBoundaryMoveUpGuards.delete( currentGuardId );
 		}
-		syncHeaderBoundaryMoveUpState();
-		const observer = new window.MutationObserver(
-			syncHeaderBoundaryMoveUpButtons
+		syncHeaderBoundaryMoveUpState( toolbarRoot, shouldDisableMoveUp );
+		const observer = new window.MutationObserver( () =>
+			syncHeaderBoundaryMoveUpButtons( toolbarRoot, shouldDisableMoveUp )
 		);
-		if ( shouldDisableMoveUp ) {
-			observer.observe( document.body, {
+		if ( shouldDisableMoveUp && toolbarRoot ) {
+			observer.observe( toolbarRoot, {
 				childList: true,
 				subtree: true,
 			} );
@@ -190,9 +217,9 @@ function HeaderPrefixToolbarGuard( { isActive = true } ) {
 		return () => {
 			observer.disconnect();
 			activeHeaderBoundaryMoveUpGuards.delete( currentGuardId );
-			syncHeaderBoundaryMoveUpState();
+			syncHeaderBoundaryMoveUpState( toolbarRoot, false );
 		};
-	}, [ shouldDisableMoveUp ] );
+	}, [ shouldDisableMoveUp, toolbarRootRef ] );
 
 	return null;
 }
@@ -669,6 +696,7 @@ export default function EditorBody( {
 		? [ ...( baseStyles ?? [] ), ...extraStyles ]
 		: baseStyles;
 	const [ layout ] = useSettings( 'layout' );
+	const blockCanvasRef = useRef( null );
 	const isTrashed = useSelect(
 		( select ) =>
 			select( editorStore ).getCurrentPostAttribute( 'status' ) ===
@@ -677,14 +705,17 @@ export default function EditorBody( {
 	);
 
 	const blockCanvas = (
-		<div className="cortext-canvas__block-canvas">
+		<div className="cortext-canvas__block-canvas" ref={ blockCanvasRef }>
 			<BlockCanvas height="100%" styles={ styles }>
 				<DocumentIdentityActions
 					postId={ postId }
 					postType={ postType }
 				/>
 				<EnsureHeaderBlocks postId={ postId } postType={ postType } />
-				<HeaderPrefixToolbarGuard isActive={ isActive } />
+				<HeaderPrefixToolbarGuard
+					isActive={ isActive }
+					toolbarRootRef={ blockCanvasRef }
+				/>
 				<div className="cortext-canvas__editor">
 					<BlockList
 						className="wp-block-post-content is-layout-constrained has-global-padding"

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -38,6 +38,163 @@ const DOCUMENT_ICON_BLOCK = 'cortext/document-icon';
 const DOCUMENT_COVER_BLOCK = 'cortext/document-cover';
 const POST_TITLE_BLOCK = 'core/post-title';
 const LEGACY_HEADER_ACTIONS_BLOCK = 'cortext/page-header-actions';
+const ROOT_BLOCK_LIST = '';
+const DISABLE_HEADER_BOUNDARY_MOVE_UP_CLASS =
+	'cortext-disable-header-boundary-move-up';
+const DISABLED_BY_HEADER_BOUNDARY_ATTR =
+	'data-cortext-header-boundary-disabled';
+const HEADER_BOUNDARY_MOVE_UP_SELECTOR =
+	'.block-editor-block-mover-button.is-up-button';
+const activeHeaderBoundaryMoveUpGuards = new Set();
+const HEADER_BLOCK_NAMES = new Set( [
+	DOCUMENT_COVER_BLOCK,
+	DOCUMENT_ICON_BLOCK,
+	POST_TITLE_BLOCK,
+] );
+
+function isHeaderBlock( block ) {
+	return HEADER_BLOCK_NAMES.has( block?.name );
+}
+
+function syncHeaderBoundaryMoveUpClass() {
+	document.body.classList.toggle(
+		DISABLE_HEADER_BOUNDARY_MOVE_UP_CLASS,
+		activeHeaderBoundaryMoveUpGuards.size > 0
+	);
+}
+
+function syncHeaderBoundaryMoveUpButtons() {
+	const shouldDisable = activeHeaderBoundaryMoveUpGuards.size > 0;
+	document
+		.querySelectorAll( HEADER_BOUNDARY_MOVE_UP_SELECTOR )
+		.forEach( ( button ) => {
+			if ( ! ( button instanceof window.HTMLButtonElement ) ) {
+				return;
+			}
+
+			if ( shouldDisable ) {
+				if (
+					! button.hasAttribute( DISABLED_BY_HEADER_BOUNDARY_ATTR )
+				) {
+					button.setAttribute(
+						DISABLED_BY_HEADER_BOUNDARY_ATTR,
+						'true'
+					);
+					button.dataset.cortextPreviousDisabled = button.disabled
+						? 'true'
+						: 'false';
+					const previousAriaDisabled =
+						button.getAttribute( 'aria-disabled' );
+					if ( previousAriaDisabled !== null ) {
+						button.dataset.cortextPreviousAriaDisabled =
+							previousAriaDisabled;
+					} else {
+						delete button.dataset.cortextPreviousAriaDisabled;
+					}
+				}
+
+				button.disabled = true;
+				button.setAttribute( 'aria-disabled', 'true' );
+				return;
+			}
+
+			if ( ! button.hasAttribute( DISABLED_BY_HEADER_BOUNDARY_ATTR ) ) {
+				return;
+			}
+
+			button.disabled = button.dataset.cortextPreviousDisabled === 'true';
+			if (
+				Object.prototype.hasOwnProperty.call(
+					button.dataset,
+					'cortextPreviousAriaDisabled'
+				)
+			) {
+				button.setAttribute(
+					'aria-disabled',
+					button.dataset.cortextPreviousAriaDisabled
+				);
+			} else {
+				button.removeAttribute( 'aria-disabled' );
+			}
+			button.removeAttribute( DISABLED_BY_HEADER_BOUNDARY_ATTR );
+			delete button.dataset.cortextPreviousDisabled;
+			delete button.dataset.cortextPreviousAriaDisabled;
+		} );
+}
+
+function syncHeaderBoundaryMoveUpState() {
+	syncHeaderBoundaryMoveUpClass();
+	syncHeaderBoundaryMoveUpButtons();
+}
+
+function HeaderPrefixToolbarGuard( { isActive = true } ) {
+	const guardId = useRef( Symbol( DISABLE_HEADER_BOUNDARY_MOVE_UP_CLASS ) );
+	const shouldDisableMoveUp = useSelect(
+		( select ) => {
+			if ( ! isActive ) {
+				return false;
+			}
+			const store = select( blockEditorStore );
+			const blocks = store.getBlocks();
+			const selectedClientIds = store.getSelectedBlockClientIds();
+			const titleIndex = blocks.findIndex(
+				( block ) => block.name === POST_TITLE_BLOCK
+			);
+			if ( titleIndex < 0 || selectedClientIds.length === 0 ) {
+				return false;
+			}
+
+			const firstBodyIndex = blocks.findIndex(
+				( block, index ) =>
+					index > titleIndex &&
+					block.name !== LEGACY_HEADER_ACTIONS_BLOCK &&
+					! isHeaderBlock( block )
+			);
+			if ( firstBodyIndex < 0 ) {
+				return false;
+			}
+
+			const rootBlockIndexes = new Map(
+				blocks.map( ( block, index ) => [ block.clientId, index ] )
+			);
+			const selectedRootIndexes = selectedClientIds
+				.map( ( clientId ) => rootBlockIndexes.get( clientId ) )
+				.filter( ( index ) => typeof index === 'number' );
+			if ( selectedRootIndexes.length === 0 ) {
+				return false;
+			}
+
+			return Math.min( ...selectedRootIndexes ) === firstBodyIndex;
+		},
+		[ isActive ]
+	);
+
+	useEffect( () => {
+		const currentGuardId = guardId.current;
+		if ( shouldDisableMoveUp ) {
+			activeHeaderBoundaryMoveUpGuards.add( currentGuardId );
+		} else {
+			activeHeaderBoundaryMoveUpGuards.delete( currentGuardId );
+		}
+		syncHeaderBoundaryMoveUpState();
+		const observer = new window.MutationObserver(
+			syncHeaderBoundaryMoveUpButtons
+		);
+		if ( shouldDisableMoveUp ) {
+			observer.observe( document.body, {
+				childList: true,
+				subtree: true,
+			} );
+		}
+		return () => {
+			observer.disconnect();
+			activeHeaderBoundaryMoveUpGuards.delete( currentGuardId );
+			syncHeaderBoundaryMoveUpState();
+		};
+	}, [ shouldDisableMoveUp ] );
+
+	return null;
+}
 
 function DocumentIdentityActions( { postId, postType } ) {
 	const isInsertingCoverRef = useRef( false );
@@ -218,6 +375,9 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 		hasCover,
 		hasIcon,
 		hasTitle,
+		titleIndex,
+		bodyBlockBeforeTitleId,
+		shouldHideHeaderInsertionPoint,
 		duplicateHeaderIds,
 		legacyActionIds,
 		isTrashed,
@@ -225,6 +385,26 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 		const store = select( blockEditorStore );
 		const blocks = store.getBlocks();
 		const names = blocks.map( ( block ) => block.name );
+		const currentTitleIndex = names.indexOf( POST_TITLE_BLOCK );
+		let currentBodyBlockBeforeTitleId = null;
+		if ( currentTitleIndex > -1 ) {
+			for ( let index = currentTitleIndex - 1; index >= 0; index-- ) {
+				const block = blocks[ index ];
+				if (
+					block.name === LEGACY_HEADER_ACTIONS_BLOCK ||
+					isHeaderBlock( block )
+				) {
+					continue;
+				}
+				currentBodyBlockBeforeTitleId = block.clientId;
+				break;
+			}
+		}
+		const insertionPoint = store.getBlockInsertionPoint();
+		const insertionPointRootClientId =
+			insertionPoint?.rootClientId ?? ROOT_BLOCK_LIST;
+		const insertionPointIndex =
+			insertionPoint?.index ?? Number.POSITIVE_INFINITY;
 		const seenSingletons = new Set();
 		const duplicateIds = [];
 		blocks.forEach( ( block ) => {
@@ -246,6 +426,13 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 			hasCover: names.includes( DOCUMENT_COVER_BLOCK ),
 			hasIcon: names.includes( DOCUMENT_ICON_BLOCK ),
 			hasTitle: names.includes( POST_TITLE_BLOCK ),
+			titleIndex: currentTitleIndex,
+			bodyBlockBeforeTitleId: currentBodyBlockBeforeTitleId,
+			shouldHideHeaderInsertionPoint:
+				store.isBlockInsertionPointVisible() &&
+				currentTitleIndex > -1 &&
+				insertionPointRootClientId === ROOT_BLOCK_LIST &&
+				insertionPointIndex <= currentTitleIndex,
 			duplicateHeaderIds: duplicateIds,
 			legacyActionIds: blocks
 				.filter(
@@ -259,7 +446,9 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 	}, [] );
 	const {
 		insertBlocks,
+		moveBlocksToPosition,
 		removeBlock,
+		hideInsertionPoint,
 		updateBlockAttributes,
 		startTyping,
 		stopTyping,
@@ -281,6 +470,13 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 		removeBlock,
 		updateBlockAttributes,
 	] );
+
+	useLayoutEffect( () => {
+		if ( isTrashed || ! shouldHideHeaderInsertionPoint ) {
+			return;
+		}
+		hideInsertionPoint();
+	}, [ hideInsertionPoint, isTrashed, shouldHideHeaderInsertionPoint ] );
 
 	// useLayoutEffect rather than useEffect: we want the insertion to
 	// happen between render and paint so the user never sees the
@@ -335,13 +531,13 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 			);
 		}
 		if ( needsTitle ) {
-			const titleIndex =
+			const insertTitleIndex =
 				( featuredId > 0 ? 1 : 0 ) + ( iconMeta ? 1 : 0 );
 			insertBlocks(
 				createBlock( POST_TITLE_BLOCK, {
 					lock: { move: true, remove: true },
 				} ),
-				titleIndex,
+				insertTitleIndex,
 				undefined,
 				false
 			);
@@ -362,6 +558,46 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 		isTrashed,
 		startTyping,
 		stopTyping,
+	] );
+
+	useLayoutEffect( () => {
+		if (
+			isTrashed ||
+			! bodyBlockBeforeTitleId ||
+			titleIndex < 0 ||
+			duplicateHeaderIds.length > 0 ||
+			legacyActionIds.length > 0 ||
+			( featuredId > 0 && ! hasCover ) ||
+			( iconMeta && ! hasIcon ) ||
+			! hasTitle
+		) {
+			return;
+		}
+
+		startTyping();
+		moveBlocksToPosition(
+			[ bodyBlockBeforeTitleId ],
+			ROOT_BLOCK_LIST,
+			ROOT_BLOCK_LIST,
+			titleIndex
+		);
+
+		const handle = window.requestAnimationFrame( () => stopTyping() );
+		return () => window.cancelAnimationFrame( handle );
+	}, [
+		bodyBlockBeforeTitleId,
+		duplicateHeaderIds.length,
+		featuredId,
+		hasCover,
+		hasIcon,
+		hasTitle,
+		iconMeta,
+		isTrashed,
+		legacyActionIds.length,
+		moveBlocksToPosition,
+		startTyping,
+		stopTyping,
+		titleIndex,
 	] );
 
 	return null;
@@ -417,6 +653,7 @@ function CanvasReadyEffect( { postId, onReady } ) {
 }
 
 export default function EditorBody( {
+	isActive = true,
 	postId,
 	postType,
 	extraStyles,
@@ -446,6 +683,7 @@ export default function EditorBody( {
 					postType={ postType }
 				/>
 				<EnsureHeaderBlocks postId={ postId } postType={ postType } />
+				<HeaderPrefixToolbarGuard isActive={ isActive } />
 				<div className="cortext-canvas__editor">
 					<BlockList
 						className="wp-block-post-content is-layout-constrained has-global-padding"

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -64,6 +64,7 @@ function syncHeaderBoundaryMoveUpClass() {
 }
 
 function syncHeaderBoundaryMoveUpButtons() {
+	// tech-debt.md#56: Gutenberg does not expose boundary-aware mover state.
 	const shouldDisable = activeHeaderBoundaryMoveUpGuards.size > 0;
 	document
 		.querySelectorAll( HEADER_BOUNDARY_MOVE_UP_SELECTOR )

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -160,6 +160,7 @@ function DetailPaneContent( {
 				visible={ propertiesVisible }
 			/>
 			<EditorBody
+				isActive={ isActive && ! isHidden }
 				postId={ row?.id }
 				postType={ postType }
 				extraStyles={ ROW_DETAIL_EXTRA_STYLES }

--- a/tests/e2e/specs/editor-header-blocks.spec.js
+++ b/tests/e2e/specs/editor-header-blocks.spec.js
@@ -1,0 +1,401 @@
+/**
+ * E2E coverage for the locked document header block prefix.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const DOCUMENT_ICON_BLOCK = 'cortext/document-icon';
+const DOCUMENT_COVER_BLOCK = 'cortext/document-cover';
+const POST_TITLE_BLOCK = 'core/post-title';
+const HEADER_BLOCK_NAMES = [
+	DOCUMENT_COVER_BLOCK,
+	DOCUMENT_ICON_BLOCK,
+	POST_TITLE_BLOCK,
+];
+const EXPECTED_HEADER_PREFIX = [ DOCUMENT_ICON_BLOCK, POST_TITLE_BLOCK ];
+const BODY_A = 'Header guard body A';
+const BODY_B = 'Header guard body B';
+const INSERTED_BODY = 'Header guard inserted at zero';
+const DOCUMENT_ICON_META = JSON.stringify( { type: 'emoji', value: 'P' } );
+const DISABLE_HEADER_BOUNDARY_MOVE_UP_CLASS =
+	'cortext-disable-header-boundary-move-up';
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+async function waitForEditorPost( page, postId ) {
+	await page.waitForFunction(
+		( expectedPostId ) =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ===
+			expectedPostId,
+		postId,
+		{ timeout: 15_000 }
+	);
+}
+
+function bodyMarkup() {
+	return [
+		`<!-- wp:paragraph --><p>${ BODY_A }</p><!-- /wp:paragraph -->`,
+		`<!-- wp:paragraph --><p>${ BODY_B }</p><!-- /wp:paragraph -->`,
+	].join( '\n\n' );
+}
+
+async function readHeaderState( page ) {
+	return page.evaluate( ( headerBlockNames ) => {
+		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+		const titleIndex = blocks.findIndex(
+			( block ) => block.name === 'core/post-title'
+		);
+		if ( titleIndex === -1 ) {
+			return { headerPrefix: [], bodyBeforeTitle: [] };
+		}
+		return {
+			headerPrefix: blocks
+				.slice( 0, titleIndex + 1 )
+				.map( ( block ) => block.name ),
+			bodyBeforeTitle: blocks
+				.slice( 0, titleIndex )
+				.filter(
+					( block ) => ! headerBlockNames.includes( block.name )
+				)
+				.map( ( block ) => block.name ),
+		};
+	}, HEADER_BLOCK_NAMES );
+}
+
+async function expectHeaderPrefix( page ) {
+	await expect
+		.poll( () => readHeaderState( page ) )
+		.toEqual( {
+			headerPrefix: EXPECTED_HEADER_PREFIX,
+			bodyBeforeTitle: [],
+		} );
+}
+
+async function readParagraphsAfterTitle( page ) {
+	return page.evaluate( () => {
+		const getParagraphText = ( block ) => {
+			const content = block.attributes?.content ?? '';
+			if ( typeof content?.text === 'string' ) {
+				return content.text;
+			}
+			const element = document.createElement( 'div' );
+			element.innerHTML = String( content );
+			return element.textContent || String( content );
+		};
+		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+		const titleIndex = blocks.findIndex(
+			( block ) => block.name === 'core/post-title'
+		);
+		return blocks
+			.slice( titleIndex + 1 )
+			.filter( ( block ) => block.name === 'core/paragraph' )
+			.map( getParagraphText );
+	} );
+}
+
+async function expectParagraphsAfterTitle( page, expected ) {
+	await expect
+		.poll( () => readParagraphsAfterTitle( page ) )
+		.toEqual( expected );
+}
+
+async function insertParagraphAt( page, content, index ) {
+	await page.evaluate(
+		( args ) => {
+			const block = window.wp.blocks.createBlock( 'core/paragraph', {
+				content: args.content,
+			} );
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.insertBlocks( block, args.index, undefined, false );
+		},
+		{ content, index }
+	);
+}
+
+async function moveParagraphToIndex( page, content, index ) {
+	await page.evaluate(
+		( args ) => {
+			const getParagraphText = ( candidate ) => {
+				const blockContent = candidate.attributes?.content ?? '';
+				if ( typeof blockContent?.text === 'string' ) {
+					return blockContent.text;
+				}
+				const element = document.createElement( 'div' );
+				element.innerHTML = String( blockContent );
+				return element.textContent || String( blockContent );
+			};
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+			const block = blocks.find(
+				( candidate ) =>
+					candidate.name === 'core/paragraph' &&
+					getParagraphText( candidate ) === args.content
+			);
+			if ( ! block ) {
+				throw new Error( `Paragraph not found: ${ args.content }` );
+			}
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.moveBlocksToPosition( [ block.clientId ], '', '', args.index );
+		},
+		{ content, index }
+	);
+}
+
+async function moveParagraphAfterTitle( page, content ) {
+	await page.evaluate( ( paragraphContent ) => {
+		const getParagraphText = ( candidate ) => {
+			const blockContent = candidate.attributes?.content ?? '';
+			if ( typeof blockContent?.text === 'string' ) {
+				return blockContent.text;
+			}
+			const element = document.createElement( 'div' );
+			element.innerHTML = String( blockContent );
+			return element.textContent || String( blockContent );
+		};
+		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+		const titleIndex = blocks.findIndex(
+			( block ) => block.name === 'core/post-title'
+		);
+		const block = blocks.find(
+			( candidate ) =>
+				candidate.name === 'core/paragraph' &&
+				getParagraphText( candidate ) === paragraphContent
+		);
+		if ( ! block || titleIndex === -1 ) {
+			throw new Error( 'Could not move paragraph after title.' );
+		}
+		window.wp.data
+			.dispatch( 'core/block-editor' )
+			.moveBlocksToPosition( [ block.clientId ], '', '', titleIndex + 1 );
+	}, content );
+}
+
+async function selectParagraph( page, content ) {
+	await page.evaluate( ( paragraphContent ) => {
+		const getParagraphText = ( candidate ) => {
+			const blockContent = candidate.attributes?.content ?? '';
+			if ( typeof blockContent?.text === 'string' ) {
+				return blockContent.text;
+			}
+			const element = document.createElement( 'div' );
+			element.innerHTML = String( blockContent );
+			return element.textContent || String( blockContent );
+		};
+		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+		const block = blocks.find(
+			( candidate ) =>
+				candidate.name === 'core/paragraph' &&
+				getParagraphText( candidate ) === paragraphContent
+		);
+		if ( ! block ) {
+			throw new Error( `Paragraph not found: ${ paragraphContent }` );
+		}
+		window.wp.data
+			.dispatch( 'core/block-editor' )
+			.selectBlock( block.clientId );
+	}, content );
+}
+
+async function expectMoveUpToolbarState( page, content, shouldBeEnabled ) {
+	await selectParagraph( page, content );
+	await expect
+		.poll( () =>
+			page.evaluate(
+				( className ) => document.body.classList.contains( className ),
+				DISABLE_HEADER_BOUNDARY_MOVE_UP_CLASS
+			)
+		)
+		.toBe( ! shouldBeEnabled );
+	await page.evaluate( () => {
+		const button = document.createElement( 'button' );
+		button.className = 'block-editor-block-mover-button is-up-button';
+		button.dataset.testid = 'header-boundary-move-up-probe';
+		button.textContent = 'Move up';
+		document.body.appendChild( button );
+	} );
+	const upButton = page.locator(
+		'[data-testid="header-boundary-move-up-probe"]'
+	);
+	await expect( upButton ).toBeVisible();
+	if ( shouldBeEnabled ) {
+		await expect( upButton ).toBeEnabled();
+	} else {
+		await expect( upButton ).toBeDisabled();
+	}
+	await upButton.evaluate( ( node ) => node.remove() );
+}
+
+async function expectProtectedInsertionPointHidden( page ) {
+	await page.evaluate( () => {
+		window.wp.data
+			.dispatch( 'core/block-editor' )
+			.showInsertionPoint( '', 0 );
+	} );
+	await expect
+		.poll( () =>
+			page.evaluate( () =>
+				window.wp.data
+					.select( 'core/block-editor' )
+					.isBlockInsertionPointVisible()
+			)
+		)
+		.toBe( false );
+}
+
+async function expectInsertionPointAllowedAfterTitle( page ) {
+	const allowedIndex = await page.evaluate( () => {
+		const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+		const titleIndex = blocks.findIndex(
+			( block ) => block.name === 'core/post-title'
+		);
+		const index = titleIndex + 1;
+		window.wp.data
+			.dispatch( 'core/block-editor' )
+			.showInsertionPoint( '', index );
+		return index;
+	} );
+	await expect
+		.poll( () =>
+			page.evaluate( () => {
+				const store = window.wp.data.select( 'core/block-editor' );
+				const insertionPoint = store.getBlockInsertionPoint();
+				return {
+					visible: store.isBlockInsertionPointVisible(),
+					rootClientId: insertionPoint?.rootClientId ?? '',
+					index: insertionPoint?.index ?? -1,
+				};
+			} )
+		)
+		.toEqual( {
+			visible: true,
+			rootClientId: '',
+			index: allowedIndex,
+		} );
+	await page.evaluate( () => {
+		window.wp.data.dispatch( 'core/block-editor' ).hideInsertionPoint();
+	} );
+}
+
+async function exerciseHeaderGuard( page ) {
+	await expectHeaderPrefix( page );
+	await expectParagraphsAfterTitle( page, [ BODY_A, BODY_B ] );
+
+	await moveParagraphAfterTitle( page, BODY_B );
+	await expectHeaderPrefix( page );
+	await expectParagraphsAfterTitle( page, [ BODY_B, BODY_A ] );
+
+	await insertParagraphAt( page, INSERTED_BODY, 0 );
+	await expectHeaderPrefix( page );
+	await expectParagraphsAfterTitle( page, [ INSERTED_BODY, BODY_B, BODY_A ] );
+
+	await moveParagraphToIndex( page, BODY_A, 0 );
+	await expectHeaderPrefix( page );
+	await expectParagraphsAfterTitle( page, [ BODY_A, INSERTED_BODY, BODY_B ] );
+	await expectMoveUpToolbarState( page, BODY_A, false );
+	await expectMoveUpToolbarState( page, INSERTED_BODY, true );
+
+	await expectProtectedInsertionPointHidden( page );
+	await expectInsertionPointAllowedAfterTitle( page );
+}
+
+async function createRowFixture( requestUtils ) {
+	const suffix = Date.now().toString( 36 ).slice( -4 );
+	const slug = `e2ehdr${ suffix }`;
+	const collection = await requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_collections',
+		data: {
+			title: `E2E Header Collection ${ suffix }`,
+			status: 'private',
+			meta: { slug },
+		},
+	} );
+	const row = await requestUtils.rest( {
+		method: 'POST',
+		path: `/wp/v2/crtxt_${ slug }`,
+		data: {
+			title: `E2E Header Row ${ suffix }`,
+			status: 'private',
+			content: bodyMarkup(),
+			meta: { cortext_document_icon: DOCUMENT_ICON_META },
+		},
+	} );
+	return { collection, row, slug };
+}
+
+test.describe( 'editor header blocks', () => {
+	test( 'keeps page body blocks below the locked header prefix', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let createdPage;
+		try {
+			createdPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'E2E Header Guard Page',
+					status: 'private',
+					content: bodyMarkup(),
+					meta: { cortext_document_icon: DOCUMENT_ICON_META },
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ createdPage.id }`
+			);
+			await waitForEditorPost( page, createdPage.id );
+			await exerciseHeaderGuard( page );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				createdPage && `/wp/v2/crtxt_pages/${ createdPage.id }`
+			);
+		}
+	} );
+
+	test( 'keeps row body blocks below the locked header prefix', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let fixture;
+		try {
+			fixture = await createRowFixture( requestUtils );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ fixture.row.id }`
+			);
+			await waitForEditorPost( page, fixture.row.id );
+			await exerciseHeaderGuard( page );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture && `/wp/v2/crtxt_${ fixture.slug }/${ fixture.row.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture && `/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+} );

--- a/tests/e2e/specs/editor-header-blocks.spec.js
+++ b/tests/e2e/specs/editor-header-blocks.spec.js
@@ -223,11 +223,21 @@ async function expectMoveUpToolbarState( page, content, shouldBeEnabled ) {
 		)
 		.toBe( ! shouldBeEnabled );
 	await page.evaluate( () => {
+		const toolbarRoot = document.querySelector(
+			'.cortext-canvas__block-canvas'
+		);
+		if ( ! toolbarRoot ) {
+			throw new Error( 'Header guard toolbar root not found.' );
+		}
+		const probeRoot =
+			toolbarRoot.querySelector(
+				'.block-editor-block-list__block-popover, .block-editor-block-contextual-toolbar, .block-editor-block-toolbar'
+			) || toolbarRoot;
 		const button = document.createElement( 'button' );
 		button.className = 'block-editor-block-mover-button is-up-button';
 		button.dataset.testid = 'header-boundary-move-up-probe';
 		button.textContent = 'Move up';
-		document.body.appendChild( button );
+		probeRoot.appendChild( button );
 	} );
 	const upButton = page.locator(
 		'[data-testid="header-boundary-move-up-probe"]'


### PR DESCRIPTION
## What

Keeps page and row body blocks from landing above the document header. Cover, icon, and title stay at the top of the root block list, insertion points before the title are removed, and the first body block's move-up arrow stays visible but disabled when it would cross that boundary.

## Why

Header blocks were locked, but the content around them was not. A body block could still be dropped above the title, which broke the document layout and made row properties show up in the wrong place.

## How

- Moves any body block that slips above the title back below the header.
- Hides insertion indicators inside the protected header area.
- Disables the first body block's move-up control while leaving normal body-block reordering alone.

## Testing Instructions

1. Open a page with an icon, title, and a few body blocks.
2. Try dragging a body block above the title and confirm it stays below the header.
3. Try adding blocks through the inserter, slash command, and appender; confirm none appear above the title.
4. Select the first body block after the title and confirm the move-up arrow is visible but disabled.
5. Select the next body block and confirm moving up still works.
6. Repeat the same checks for a row in full-page mode and row detail.

## Screen recording

https://github.com/user-attachments/assets/3be86249-d559-44b7-82ed-b333a57848ef

