### PR TITLE
Add Published documents screen

### DIFF
--- a/includes/PostType/Collection.php
+++ b/includes/PostType/Collection.php
@@ -468,15 +468,17 @@ final class Collection {
 			)
 		);
 
-		// Server-only. The editor does not need the owner id, and exposing it
-		// would make it easy to point an inline collection at the wrong page.
+		// Read-only via REST: the Published documents pane resolves the owner
+		// page title for inline collections. Writes stay blocked by
+		// `auth_callback` and by `validate_pre_insert` in CollectionsController,
+		// which rejects re-parenting attempts on inline collections.
 		register_post_meta(
 			self::POST_TYPE,
 			self::INLINE_OWNER_META_KEY,
 			array(
 				'type'              => 'integer',
 				'single'            => true,
-				'show_in_rest'      => false,
+				'show_in_rest'      => true,
 				'sanitize_callback' => 'absint',
 				'auth_callback'     => static function () {
 					return false;

--- a/src/collections.js
+++ b/src/collections.js
@@ -14,3 +14,10 @@ export const FULL_PAGE_COLLECTION_QUERY = {
 	...COLLECTION_QUERY,
 	workspace_mode: 'full_page',
 };
+
+// Used by the Published documents screen. Includes inline collections because
+// publishing an inline collection still exposes its rows via REST.
+export const PUBLISHED_COLLECTIONS_QUERY = {
+	...COLLECTION_QUERY,
+	status: 'publish',
+};

--- a/src/components/Infotip.js
+++ b/src/components/Infotip.js
@@ -1,0 +1,117 @@
+import { Icon, Popover, VisuallyHidden } from '@wordpress/components';
+import { useEffect, useId, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { info } from '@wordpress/icons';
+
+const HOVER_OPEN_DELAY_MS = 200;
+const HOVER_CLOSE_DELAY_MS = 200;
+
+// Accessible hover-triggered info popup.
+//
+// Reach for this instead of `Tooltip` when the trigger's only purpose is to
+// reveal the popup, since tooltips are hidden from touch users and announce as
+// no-op buttons to AT.
+//
+// Mirrors the Gutenberg design system's "Infotip" pattern (Popover with
+// openOnHover on the trigger), reimplemented on top of @wordpress/components
+// since the new @wordpress/ui package isn't a dependency here and is still
+// experimental.
+//
+// @see https://github.com/WordPress/gutenberg/blob/trunk/packages/ui/src/tooltip/stories/usage-guidelines.mdx#infotips
+export default function Infotip( {
+	description,
+	label = __( 'More information', 'cortext' ),
+	placement = 'top',
+} ) {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const triggerRef = useRef( null );
+	const openTimer = useRef( null );
+	const closeTimer = useRef( null );
+	const descriptionId = useId();
+
+	const cancelTimers = () => {
+		if ( openTimer.current ) {
+			clearTimeout( openTimer.current );
+			openTimer.current = null;
+		}
+		if ( closeTimer.current ) {
+			clearTimeout( closeTimer.current );
+			closeTimer.current = null;
+		}
+	};
+
+	useEffect( () => () => cancelTimers(), [] );
+
+	const scheduleOpen = () => {
+		cancelTimers();
+		openTimer.current = setTimeout(
+			() => setIsOpen( true ),
+			HOVER_OPEN_DELAY_MS
+		);
+	};
+	const scheduleClose = () => {
+		cancelTimers();
+		closeTimer.current = setTimeout(
+			() => setIsOpen( false ),
+			HOVER_CLOSE_DELAY_MS
+		);
+	};
+	const openNow = () => {
+		cancelTimers();
+		setIsOpen( true );
+	};
+	const closeNow = () => {
+		cancelTimers();
+		setIsOpen( false );
+	};
+
+	const onKeyDown = ( event ) => {
+		if ( event.key === 'Escape' && isOpen ) {
+			event.preventDefault();
+			event.stopPropagation();
+			closeNow();
+			triggerRef.current?.focus();
+		}
+	};
+
+	return (
+		<>
+			<button
+				ref={ triggerRef }
+				type="button"
+				className="cortext-infotip__trigger"
+				aria-label={ label }
+				aria-expanded={ isOpen }
+				aria-describedby={ isOpen ? descriptionId : undefined }
+				onMouseEnter={ scheduleOpen }
+				onMouseLeave={ scheduleClose }
+				onFocus={ openNow }
+				onBlur={ closeNow }
+				onKeyDown={ onKeyDown }
+			>
+				<Icon icon={ info } size={ 18 } />
+			</button>
+			{ isOpen && (
+				<Popover
+					anchor={ triggerRef.current }
+					placement={ placement }
+					offset={ 8 }
+					shift
+					onClose={ closeNow }
+					focusOnMount={ false }
+					className="cortext-infotip__popup"
+					onMouseEnter={ openNow }
+					onMouseLeave={ scheduleClose }
+				>
+					<VisuallyHidden>{ label }</VisuallyHidden>
+					<div
+						id={ descriptionId }
+						className="cortext-infotip__description"
+					>
+						{ description }
+					</div>
+				</Popover>
+			) }
+		</>
+	);
+}

--- a/src/components/PublishedDocumentsPane.js
+++ b/src/components/PublishedDocumentsPane.js
@@ -16,6 +16,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useNavigate } from '@tanstack/react-router';
 
+import Infotip from './Infotip';
 import PageIcon from './PageIcon';
 import {
 	POST_TYPE as PAGE_POST_TYPE,
@@ -64,6 +65,11 @@ function buildItems( pages, collections ) {
 	const items = [];
 	const untitled = __( '(untitled)', 'cortext' );
 
+	const pagesById = new Map();
+	for ( const page of pages ?? [] ) {
+		pagesById.set( page.id, page );
+	}
+
 	for ( const page of pages ?? [] ) {
 		items.push( {
 			key: `page-${ page.id }`,
@@ -79,6 +85,12 @@ function buildItems( pages, collections ) {
 	}
 
 	for ( const collection of collections ?? [] ) {
+		const mode = collection?.meta?.workspace_mode ?? '';
+		const ownerId = collection?.meta?._cortext_inline_owner_page ?? 0;
+		// Owner page may not be in `pages` when its status is draft/private
+		// while the inline collection is published. The render falls back to
+		// a title-less "Embedded in a page" in that case.
+		const ownerPage = ownerId ? pagesById.get( ownerId ) ?? null : null;
 		items.push( {
 			key: `collection-${ collection.id }`,
 			id: collection.id,
@@ -89,6 +101,8 @@ function buildItems( pages, collections ) {
 			link: '',
 			icon: collection?.meta?.cortext_document_icon ?? '',
 			source: collection,
+			workspaceMode: mode,
+			ownerPage,
 		} );
 	}
 
@@ -187,17 +201,60 @@ export default function PublishedDocumentsPane() {
 				enableGlobalSearch: false,
 				getValue: ( { item } ) => item.link,
 				render: ( { item } ) => {
-					if ( item.kind !== 'page' || ! item.link ) {
+					if ( item.kind === 'page' ) {
+						if ( ! item.link ) {
+							return (
+								<Text variant="muted">
+									{ __( 'N/A', 'cortext' ) }
+								</Text>
+							);
+						}
+						return (
+							<ExternalLink href={ item.link }>
+								{ __( 'View', 'cortext' ) }
+							</ExternalLink>
+						);
+					}
+					if ( item.workspaceMode !== 'inline' ) {
+						return (
+							<span className="cortext-published-pane__na">
+								<Text variant="muted">
+									{ __( 'N/A', 'cortext' ) }
+								</Text>
+								<Infotip
+									description={ __(
+										'While this collection does not have a URL, its data is nevertheless publicly accessible.',
+										'cortext'
+									) }
+								/>
+							</span>
+						);
+					}
+					if ( ! item.ownerPage ) {
 						return (
 							<Text variant="muted">
-								{ __( 'Embedded in pages', 'cortext' ) }
+								{ __( 'Embedded in a page', 'cortext' ) }
 							</Text>
 						);
 					}
+					const ownerTitle =
+						titleText( item.ownerPage ) ||
+						__( '(untitled)', 'cortext' );
 					return (
-						<ExternalLink href={ item.link }>
-							{ __( 'View', 'cortext' ) }
-						</ExternalLink>
+						<Text variant="muted">
+							{ __( 'Embedded in', 'cortext' ) }{ ' ' }
+							<Button
+								variant="link"
+								onClick={ () =>
+									openItem( {
+										kind: 'page',
+										source: item.ownerPage,
+									} )
+								}
+							>
+								{ ownerTitle }
+							</Button>
+						</Text>
 					);
 				},
 			},

--- a/src/components/PublishedDocumentsPane.js
+++ b/src/components/PublishedDocumentsPane.js
@@ -1,0 +1,257 @@
+import { __ } from '@wordpress/i18n';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import {
+	Button,
+	ExternalLink,
+	Spinner,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHeading as Heading,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { useNavigate } from '@tanstack/react-router';
+
+import PageIcon from './PageIcon';
+import {
+	POST_TYPE as PAGE_POST_TYPE,
+	PUBLISHED_PAGES_QUERY,
+} from './page-queries';
+import { PUBLISHED_COLLECTIONS_QUERY } from '../collections';
+import {
+	computeCollectionUri,
+	computeDocumentUri,
+} from '../router/useResolveEntity';
+
+const COLLECTION_POST_TYPE = 'crtxt_collection';
+
+const DEFAULT_LAYOUTS = { table: { density: 'compact' }, grid: {}, list: {} };
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	perPage: 25,
+	page: 1,
+	search: '',
+	fields: [ 'title', 'type', 'modified', 'link' ],
+	sort: { field: 'modified', direction: 'desc' },
+	filters: [],
+	layout: {},
+};
+
+const TYPE_LABELS = {
+	page: __( 'Page', 'cortext' ),
+	collection: __( 'Collection', 'cortext' ),
+};
+
+function titleText( entity ) {
+	const title = entity?.title;
+	if ( typeof title === 'string' ) {
+		return title.trim();
+	}
+	return title?.raw?.trim() || title?.rendered?.trim() || '';
+}
+
+// DataViews can't natively de-duplicate two record sets coming from different
+// post types because ids collide (a page #4 and a collection #4 are unrelated
+// entities). The composite `${kind}-${id}` key keeps them distinct in the
+// table while preserving the underlying record on `.source` for navigation
+// and link rendering.
+function buildItems( pages, collections ) {
+	const items = [];
+	const untitled = __( '(untitled)', 'cortext' );
+
+	for ( const page of pages ?? [] ) {
+		items.push( {
+			key: `page-${ page.id }`,
+			id: page.id,
+			kind: 'page',
+			postType: PAGE_POST_TYPE,
+			title: titleText( page ) || untitled,
+			modified: page.modified ?? page.modified_gmt ?? '',
+			link: page.link ?? '',
+			icon: page?.meta?.cortext_document_icon ?? '',
+			source: page,
+		} );
+	}
+
+	for ( const collection of collections ?? [] ) {
+		items.push( {
+			key: `collection-${ collection.id }`,
+			id: collection.id,
+			kind: 'collection',
+			postType: COLLECTION_POST_TYPE,
+			title: titleText( collection ) || untitled,
+			modified: collection.modified ?? collection.modified_gmt ?? '',
+			link: '',
+			icon: collection?.meta?.cortext_document_icon ?? '',
+			source: collection,
+		} );
+	}
+
+	return items;
+}
+
+function formatModified( value ) {
+	if ( ! value ) {
+		return '';
+	}
+	const dateSettings = getDateSettings();
+	const format = `${ dateSettings.formats.date } ${ dateSettings.formats.time }`;
+	return dateI18n( format, value );
+}
+
+export default function PublishedDocumentsPane() {
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const navigate = useNavigate();
+
+	const { records: pages, isResolving: isResolvingPages } = useEntityRecords(
+		'postType',
+		PAGE_POST_TYPE,
+		PUBLISHED_PAGES_QUERY
+	);
+	const { records: collections, isResolving: isResolvingCollections } =
+		useEntityRecords(
+			'postType',
+			COLLECTION_POST_TYPE,
+			PUBLISHED_COLLECTIONS_QUERY
+		);
+
+	const isLoading = isResolvingPages || isResolvingCollections;
+
+	const openItem = useCallback(
+		( item ) => {
+			const splat =
+				item.kind === 'collection'
+					? computeCollectionUri( item.source )
+					: computeDocumentUri( item.source );
+			navigate( { to: '/$', params: { _splat: splat } } );
+		},
+		[ navigate ]
+	);
+
+	const items = useMemo(
+		() => buildItems( pages, collections ),
+		[ pages, collections ]
+	);
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'title',
+				label: __( 'Title', 'cortext' ),
+				enableHiding: false,
+				enableGlobalSearch: true,
+				getValue: ( { item } ) => item.title,
+				render: ( { item } ) => (
+					<Button
+						className="cortext-published-pane__title"
+						onClick={ () => openItem( item ) }
+					>
+						<span
+							className="cortext-published-pane__title-icon"
+							aria-hidden="true"
+						>
+							<PageIcon icon={ item.icon } size={ 16 } />
+						</span>
+						<span className="cortext-published-pane__title-text">
+							{ item.title }
+						</span>
+					</Button>
+				),
+			},
+			{
+				id: 'type',
+				label: __( 'Type', 'cortext' ),
+				elements: [
+					{ value: 'page', label: TYPE_LABELS.page },
+					{ value: 'collection', label: TYPE_LABELS.collection },
+				],
+				filterBy: { operators: [ 'is', 'isAny' ] },
+				getValue: ( { item } ) => item.kind,
+				render: ( { item } ) => TYPE_LABELS[ item.kind ] ?? item.kind,
+			},
+			{
+				id: 'modified',
+				label: __( 'Modified', 'cortext' ),
+				getValue: ( { item } ) => item.modified,
+				render: ( { item } ) => formatModified( item.modified ),
+			},
+			{
+				id: 'link',
+				label: __( 'Public link', 'cortext' ),
+				enableSorting: false,
+				enableGlobalSearch: false,
+				getValue: ( { item } ) => item.link,
+				render: ( { item } ) => {
+					if ( item.kind !== 'page' || ! item.link ) {
+						return (
+							<Text variant="muted">
+								{ __( 'Embedded in pages', 'cortext' ) }
+							</Text>
+						);
+					}
+					return (
+						<ExternalLink href={ item.link }>
+							{ __( 'View', 'cortext' ) }
+						</ExternalLink>
+					);
+				},
+			},
+		],
+		[ openItem ]
+	);
+
+	const { data: filteredItems, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( items, view, fields ),
+		[ items, view, fields ]
+	);
+
+	if ( isLoading && items.length === 0 ) {
+		return (
+			<VStack className="cortext-published-pane" spacing={ 5 }>
+				<Heading level={ 2 }>
+					{ __( 'Published documents', 'cortext' ) }
+				</Heading>
+				<Spinner />
+			</VStack>
+		);
+	}
+
+	return (
+		<VStack className="cortext-published-pane" spacing={ 5 }>
+			<VStack spacing={ 1 }>
+				<Heading level={ 2 }>
+					{ __( 'Published documents', 'cortext' ) }
+				</Heading>
+				<Text variant="muted">
+					{ __(
+						'Pages and collections that are currently public.',
+						'cortext'
+					) }
+				</Text>
+			</VStack>
+			<DataViews
+				data={ filteredItems }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				getItemId={ ( item ) => item.key }
+				isLoading={ isLoading }
+				empty={
+					<Text variant="muted">
+						{ __(
+							'No documents are currently public.',
+							'cortext'
+						) }
+					</Text>
+				}
+			/>
+		</VStack>
+	);
+}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -6,6 +6,7 @@ import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 import { Button, Icon, Notice } from '@wordpress/components';
 import { displayShortcut } from '@wordpress/keycodes';
 import {
+	globe,
 	home as homeIcon,
 	plus,
 	search,
@@ -96,7 +97,10 @@ import {
 	POST_TYPE,
 	TRASHED_PAGES_QUERY,
 } from './page-queries';
-import { computeCollectionUri } from '../router/useResolveEntity';
+import {
+	PUBLISHED_DOCUMENTS_URI,
+	computeCollectionUri,
+} from '../router/useResolveEntity';
 import { FULL_PAGE_COLLECTION_QUERY } from '../collections';
 import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
@@ -149,8 +153,14 @@ export default function Sidebar( {
 	const { touchRecent } = useRecents();
 	const { saveEntityRecord, invalidateResolution, receiveEntityRecords } =
 		useDispatch( 'core' );
-	const { navigate, selectedId, selectedCollectionId, onSelect, goHome } =
-		useSidebarNavigation( { pages, homePath } );
+	const {
+		navigate,
+		activeUri,
+		selectedId,
+		selectedCollectionId,
+		onSelect,
+		goHome,
+	} = useSidebarNavigation( { pages, homePath } );
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
 	const userName = window.cortextSettings?.userDisplayName ?? '';
 	const commandPaletteShortcut = displayShortcut.primary( 'k' );
@@ -167,6 +177,13 @@ export default function Sidebar( {
 	const areFavoriteActionsDisabled =
 		isResolvingFavorites || isUpdatingFavorites;
 	const { isSectionCollapsed, toggleSection } = useSidebarSections();
+	const goPublished = useCallback( () => {
+		navigate( {
+			to: '/$',
+			params: { _splat: PUBLISHED_DOCUMENTS_URI },
+		} );
+	}, [ navigate ] );
+	const isPublishedActive = activeUri === PUBLISHED_DOCUMENTS_URI;
 	const toggleTrashPanel = useCallback( () => {
 		if ( collapsed ) {
 			setIsTrashPanelOpen( true );
@@ -716,6 +733,17 @@ export default function Sidebar( {
 				>
 					<Icon icon={ homeIcon } size={ 16 } />
 					{ ! collapsed && <span>{ __( 'Home', 'cortext' ) }</span> }
+				</Button>
+				<Button
+					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--published"
+					label={ __( 'Published documents', 'cortext' ) }
+					isPressed={ isPublishedActive }
+					onClick={ goPublished }
+				>
+					<Icon icon={ globe } size={ 16 } />
+					{ ! collapsed && (
+						<span>{ __( 'Published documents', 'cortext' ) }</span>
+					) }
 				</Button>
 			</div>
 			{ ! collapsed && (

--- a/src/components/page-queries.js
+++ b/src/components/page-queries.js
@@ -18,3 +18,12 @@ export const TRASHED_PAGES_QUERY = {
 	status: 'trash',
 	context: 'edit',
 };
+
+// Used by the Published documents screen. Same shape as ACTIVE_PAGES_QUERY so
+// it deep-matches alongside it for invalidation when a page is published or
+// unpublished.
+export const PUBLISHED_PAGES_QUERY = {
+	per_page: 100,
+	status: 'publish',
+	context: 'edit',
+};

--- a/src/index.scss
+++ b/src/index.scss
@@ -220,8 +220,9 @@ body.cortext-fullscreen {
 		background: var(--cortext-control-hover-surface);
 	}
 
-	&__quick-action--home.components-button:hover:not(:disabled),
-	&__quick-action--home.components-button:focus:not(:disabled) {
+	&__quick-actions > .components-button:hover:not(:disabled),
+	&__quick-actions > .components-button:focus:not(:disabled),
+	&__quick-actions > .components-button.is-pressed {
 		background: var(--cortext-state-hover);
 		color: var(--cortext-text-strong);
 	}
@@ -1158,6 +1159,37 @@ body.cortext-sidebar-resizing {
 	height: 100%;
 	min-height: 0;
 	background: var(--cortext-canvas-surface);
+}
+
+.cortext-published-pane {
+	flex: 1 1 auto;
+	min-height: 0;
+	height: 100%;
+	padding: $grid-unit-30 $grid-unit-40;
+	overflow: auto;
+
+	&__title.components-button {
+		display: inline-flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		padding: 0;
+		height: auto;
+		min-height: 0;
+		text-align: start;
+	}
+
+	&__title-icon {
+		display: inline-flex;
+		align-items: center;
+		flex: 0 0 auto;
+	}
+
+	&__title-text {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 }
 
 .cortext-topbar {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1190,6 +1190,40 @@ body.cortext-sidebar-resizing {
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
+
+	&__na {
+		display: inline-flex;
+		align-items: center;
+		gap: $grid-unit-05;
+	}
+}
+
+.cortext-infotip {
+
+	&__trigger {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+		margin: 0;
+		background: none;
+		border: 0;
+		color: var(--wp-components-color-foreground-muted, currentColor);
+		cursor: help;
+		border-radius: 2px;
+
+		&:focus-visible {
+			outline: 2px solid var(--wp-admin-theme-color, #3858e9);
+			outline-offset: 1px;
+		}
+	}
+
+	&__description {
+		max-width: 280px;
+		padding: $grid-unit-15;
+		font-size: 12px;
+		line-height: 1.4;
+	}
 }
 
 .cortext-topbar {

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -32,6 +32,7 @@ import CanvasSkeleton from '../components/CanvasSkeleton';
 import CollectionDataViews from '../components/CollectionDataViews';
 import { CollectionFieldsProvider } from '../components/CollectionFieldsContext';
 import { RowMutationContext } from '../components/EditableCell';
+import PublishedDocumentsPane from '../components/PublishedDocumentsPane';
 import { CanvasProgressBar } from '../components/Skeleton';
 import useDelayedFlag from '../hooks/useDelayedFlag';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
@@ -421,7 +422,8 @@ export default function EntityRoute( { history } ) {
 	} else if (
 		active.kind === 'empty' ||
 		active.kind === 'document-not-found' ||
-		active.kind === 'collection-not-found'
+		active.kind === 'collection-not-found' ||
+		active.kind === 'published'
 	) {
 		paintedRoute = { kind: active.kind };
 	}
@@ -536,6 +538,9 @@ export default function EntityRoute( { history } ) {
 					</WorkspacePane>
 				) ) }
 
+				<WorkspacePane active={ active.kind === 'published' }>
+					<PublishedDocumentsPane />
+				</WorkspacePane>
 				<WorkspacePane active={ active.kind === 'empty' }>
 					<EmptyState />
 				</WorkspacePane>

--- a/src/router/entityRouteReducer.js
+++ b/src/router/entityRouteReducer.js
@@ -1,10 +1,15 @@
-import { parseIdFromUri, parseSplatUri } from './useResolveEntity';
+import {
+	PUBLISHED_DOCUMENTS_URI,
+	parseIdFromUri,
+	parseSplatUri,
+} from './useResolveEntity';
 
 // A null id means the URL was malformed (e.g. /collection/foo).
 //
-// Two kinds in the splat:
+// Kinds in the splat:
 //   - `collection`: explicit `collection/<slug>-<id>` prefix. Collections
 //     are schema containers, not documents.
+//   - `published`: singleton splat for the Published documents screen.
 //   - `document`: anything else with an id. Pages and rows both fall here;
 //     the resolver discovers the actual post type via the document
 //     locator endpoint.
@@ -12,6 +17,9 @@ export function parseTarget( splat ) {
 	const { prefix, tail } = parseSplatUri( splat );
 	if ( prefix === 'collection' ) {
 		return { kind: 'collection', id: parseIdFromUri( tail ), tail };
+	}
+	if ( splat === PUBLISHED_DOCUMENTS_URI ) {
+		return { kind: 'published', tail: '' };
 	}
 	if ( ! splat ) {
 		return { kind: 'empty', tail: '' };
@@ -71,6 +79,8 @@ export function reducer( state, action ) {
 
 			if ( target.kind === 'empty' ) {
 				active = { kind: 'empty' };
+			} else if ( target.kind === 'published' ) {
+				active = { kind: 'published' };
 			} else if ( target.kind === 'document' ) {
 				if ( target.id === null ) {
 					active = { kind: 'document-not-found' };
@@ -189,6 +199,8 @@ export function init( target ) {
 	let active;
 	if ( target.kind === 'empty' ) {
 		active = { kind: 'empty' };
+	} else if ( target.kind === 'published' ) {
+		active = { kind: 'published' };
 	} else if ( target.kind === 'document' && target.id === null ) {
 		active = { kind: 'document-not-found' };
 	} else if ( target.kind === 'collection' && target.id === null ) {

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -195,6 +195,13 @@ export function computeCollectionUri( entity ) {
 	return `collection/${ tail }`;
 }
 
+// Singleton splat for the Published documents screen. The route reducer
+// matches the splat exactly; trailing segments fall through to the document
+// resolver and end up at "not found".
+//
+// FIXME: I don't like this constant
+export const PUBLISHED_DOCUMENTS_URI = 'published';
+
 // Strips the prefix from a splat URI and returns { prefix, tail }.
 export function parseSplatUri( uri ) {
 	const slash = ( uri ?? '' ).indexOf( '/' );

--- a/tests/js/entityRouteReducer.test.js
+++ b/tests/js/entityRouteReducer.test.js
@@ -1,4 +1,8 @@
-import { reducer, init } from '../../src/router/entityRouteReducer';
+import {
+	parseTarget,
+	reducer,
+	init,
+} from '../../src/router/entityRouteReducer';
 
 const emptyTarget = { kind: 'empty', tail: '' };
 const documentTarget = ( id ) => ( {
@@ -11,6 +15,7 @@ const collectionTarget = ( id ) => ( {
 	id,
 	tail: `${ id }`,
 } );
+const publishedTarget = { kind: 'published', tail: '' };
 
 const PAGE_TYPE = 'crtxt_page';
 
@@ -32,9 +37,28 @@ function activate( state, target, options = {} ) {
 }
 
 describe( 'EntityRoute reducer', () => {
+	describe( 'parseTarget', () => {
+		it( 'maps a bare `published` splat to the published kind', () => {
+			expect( parseTarget( 'published' ) ).toEqual( {
+				kind: 'published',
+				tail: '',
+			} );
+		} );
+
+		it( 'does not match `published/<anything>` (falls through to document)', () => {
+			expect( parseTarget( 'published/foo' ).kind ).toBe( 'document' );
+		} );
+	} );
+
 	describe( 'init', () => {
 		it( 'starts an empty target on the empty pane', () => {
 			expect( init( emptyTarget ).active ).toEqual( { kind: 'empty' } );
+		} );
+
+		it( 'starts a published target on the published pane', () => {
+			expect( init( publishedTarget ).active ).toEqual( {
+				kind: 'published',
+			} );
 		} );
 
 		it( 'starts a document target as loading', () => {
@@ -118,6 +142,18 @@ describe( 'EntityRoute reducer', () => {
 			state = activate( state, documentTarget( 1 ) );
 			// The previous collection is pruned once the document activates.
 			expect( state.mountedCollectionIds ).toEqual( [] );
+		} );
+
+		it( 'switches to published immediately', () => {
+			const state = activate(
+				init( documentTarget( 1 ) ),
+				documentTarget( 1 )
+			);
+			const next = reducer( state, {
+				type: 'TARGET_CHANGED',
+				target: publishedTarget,
+			} );
+			expect( next.active ).toEqual( { kind: 'published' } );
 		} );
 
 		it( 'switches to empty immediately', () => {


### PR DESCRIPTION
Part of: #223

~https://github.com/user-attachments/assets/8c7b757c-6c36-4434-a0d8-4d927a64d58b~

https://github.com/user-attachments/assets/01a50aff-a316-4c18-bb73-b24bf7815692


## Summary
- New full-canvas screen listing every page and collection currently published (`status=publish`), so users can see at a glance which documents are publicly accessible. Closes #223.
- Sidebar entry sits as a quick-action button immediately under Home, with a globe icon and pressed-state highlight when the route is active.
- DataViews-based table with Title (links back to the document), Type, Modified, and Public link columns; sorts by Modified desc by default.

## Implementation notes
- New `published` kind in `parseTarget` / `entityRouteReducer`, mounted as a `WorkspacePane` from `EntityRoute`.
- Pane uses `__experimentalHeading`, `__experimentalText`, `__experimentalVStack` from `@wordpress/components` for the header chrome — minimal bespoke CSS.
- Queries added: `PUBLISHED_PAGES_QUERY` (page-queries.js) and `PUBLISHED_COLLECTIONS_QUERY` (collections.js). Inline collections are included since publishing them exposes their rows via REST.
- Sidebar reuses `cortext-sidebar__quick-action` with a `--published` modifier; the existing hover/focus rule was generalised to target `__quick-actions > .components-button` so we don't duplicate per-modifier.

## Test plan
- [ ] Click "Published documents" in the sidebar — URL canonicalises to `?p=/published`, pane renders pages + collections with `status=publish`.
- [ ] Reload on `?p=/published` — paints directly without bouncing through the home-redirect.
- [ ] Publish a draft page → screen lists it. Unpublish → it disappears.
- [ ] Click a page row → opens the Canvas editor; click a collection row → opens CollectionPane. Back returns to Published documents.
- [ ] Trash a published page → it leaves the list; restore → it returns.
- [ ] Visit `?p=/published/foo` → falls through to document-not-found.
- [ ] Empty case: no published documents → muted "No documents are currently public." text.
- [ ] Sidebar entry shows `is-pressed` styling only while on the Published documents screen.
- [ ] Collapsed sidebar: button shrinks to icon-only and remains tappable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)