### PR TITLE
Refactor: Format targets through the documents service

### DIFF
--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -623,6 +623,146 @@ final class Documents {
 		return $collections[0] ?? null;
 	}
 
+	/**
+	 * Resolves a document target by id and returns the shape used by Favorites,
+	 * Recents, and Workspace Home. Those callers pass an id, and the documents
+	 * service handles kind lookup, validation, and formatting in one place.
+	 *
+	 * The kind comes from the post type. Row targets also need `context_id`
+	 * because rows are scoped to a parent collection.
+	 *
+	 * @param int   $id   Target document id.
+	 * @param array $opts {
+	 *     Optional. Validation options.
+	 *
+	 *     @type int  $context_id   Parent collection id for row targets. Defaults to 0.
+	 *     @type bool $require_edit Enforce `edit_post` capability. Defaults to true.
+	 * }
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function format_target( int $id, array $opts = array() ) {
+		$context_id   = isset( $opts['context_id'] ) ? (int) $opts['context_id'] : 0;
+		$require_edit = ! array_key_exists( 'require_edit', $opts ) || (bool) $opts['require_edit'];
+
+		if ( $id < 1 ) {
+			return $this->invalid_target_error();
+		}
+
+		$post = get_post( $id );
+		if ( ! $post instanceof WP_Post || self::STATUS_TRASH === $post->post_status ) {
+			return $this->target_not_found_error();
+		}
+
+		$kind = $this->kind_object_for_post_type( $post->post_type );
+		if ( null === $kind ) {
+			return $this->target_not_found_error();
+		}
+
+		if ( self::KIND_COLLECTION === $kind->id() && Collection::is_inline( $id ) ) {
+			return $this->inline_collection_target_error();
+		}
+
+		if ( self::KIND_ROW === $kind->id() ) {
+			$row_check = $this->validate_row_target( $post, $context_id, $require_edit );
+			if ( $row_check instanceof WP_Error ) {
+				return $row_check;
+			}
+			$document = $this->format_document( $post );
+			return $document ?? $this->target_not_found_error();
+		}
+
+		if ( $require_edit && ! current_user_can( 'edit_post', $id ) ) {
+			return $this->target_forbidden_error();
+		}
+
+		$target = array(
+			'kind'  => $kind->id(),
+			'id'    => $id,
+			'title' => $this->post_title( $post ),
+			'path'  => $kind->path_for( $post ),
+		);
+
+		if ( $kind->has_icon() ) {
+			$icon = (string) get_post_meta( $id, DocumentIdentity::META_KEY, true );
+			if ( '' !== $icon ) {
+				$target['icon'] = $icon;
+			}
+		}
+
+		return $target;
+	}
+
+	/**
+	 * Checks that a row belongs to the expected collection and that the caller
+	 * can edit both records. Rows live in dynamic CPTs, so the parent collection
+	 * is the permission anchor.
+	 *
+	 * @param WP_Post $row           Row post.
+	 * @param int     $collection_id Expected parent collection id.
+	 * @param bool    $require_edit  Enforce `edit_post` on both row and collection.
+	 */
+	private function validate_row_target( WP_Post $row, int $collection_id, bool $require_edit ): ?WP_Error {
+		if ( $collection_id < 1 ) {
+			return $this->invalid_target_error();
+		}
+
+		$collection = get_post( $collection_id );
+		if (
+			! $collection instanceof WP_Post
+			|| Collection::POST_TYPE !== $collection->post_type
+			|| self::STATUS_TRASH === $collection->post_status
+		) {
+			return $this->target_not_found_error();
+		}
+
+		$slug = get_post_meta( $collection_id, 'slug', true );
+		$slug = is_string( $slug ) ? trim( $slug ) : '';
+		if ( '' === $slug || CollectionEntries::CPT_PREFIX . $slug !== $row->post_type ) {
+			return $this->target_not_found_error();
+		}
+
+		if ( $require_edit
+			&& ( ! current_user_can( 'edit_post', $collection_id )
+				|| ! current_user_can( 'edit_post', $row->ID ) )
+		) {
+			return $this->target_forbidden_error();
+		}
+
+		return null;
+	}
+
+	private function invalid_target_error(): WP_Error {
+		return new WP_Error(
+			'cortext_document_target_invalid',
+			__( 'Target document is invalid.', 'cortext' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	private function target_not_found_error(): WP_Error {
+		return new WP_Error(
+			'cortext_document_target_not_found',
+			__( 'Target document was not found.', 'cortext' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	private function inline_collection_target_error(): WP_Error {
+		return new WP_Error(
+			'cortext_document_target_inline_collection',
+			__( 'Inline collections cannot be used as document targets.', 'cortext' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	private function target_forbidden_error(): WP_Error {
+		return new WP_Error(
+			'cortext_document_target_forbidden',
+			__( 'You are not allowed to use this document target.', 'cortext' ),
+			array( 'status' => 403 )
+		);
+	}
+
 	private function post_title( WP_Post $post ): string {
 		$title = trim( $post->post_title );
 		return '' === $title ? __( '(untitled)', 'cortext' ) : $title;

--- a/includes/Rest/FavoritesController.php
+++ b/includes/Rest/FavoritesController.php
@@ -9,11 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
-use Cortext\PostType\Collection;
-use Cortext\PostType\DocumentIdentity;
-use Cortext\PostType\Page;
+use Cortext\Documents;
 use WP_Error;
-use WP_Post;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -21,6 +18,17 @@ final class FavoritesController {
 
 	private const NAMESPACE = 'cortext/v1';
 	private const META_KEY  = 'cortext_favorites';
+
+	private const ALLOWED_KINDS = array(
+		Documents::KIND_PAGE,
+		Documents::KIND_COLLECTION,
+	);
+
+	private Documents $documents;
+
+	public function __construct( ?Documents $documents = null ) {
+		$this->documents = $documents ?? new Documents();
+	}
 
 	public function register(): void {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
@@ -49,7 +57,7 @@ final class FavoritesController {
 								'properties' => array(
 									'kind' => array(
 										'type' => 'string',
-										'enum' => array( 'page', 'collection' ),
+										'enum' => self::ALLOWED_KINDS,
 									),
 									'id'   => array(
 										'type'    => 'integer',
@@ -93,25 +101,34 @@ final class FavoritesController {
 
 		foreach ( $favorites as $favorite ) {
 			if ( ! is_array( $favorite ) ) {
-				return $this->invalid_target_error();
+				return new WP_Error(
+					'cortext_document_target_invalid',
+					__( 'Target document is invalid.', 'cortext' ),
+					array( 'status' => 400 )
+				);
 			}
 
-			$kind = isset( $favorite['kind'] ) ? (string) $favorite['kind'] : '';
-			$id   = isset( $favorite['id'] ) ? (int) $favorite['id'] : 0;
-			$key  = "{$kind}:{$id}";
-
-			if ( isset( $seen[ $key ] ) ) {
+			$id = isset( $favorite['id'] ) ? (int) $favorite['id'] : 0;
+			if ( isset( $seen[ $id ] ) ) {
 				continue;
 			}
 
-			$target = $this->format_target( $kind, $id, true );
+			$target = $this->documents->format_target( $id );
 			if ( is_wp_error( $target ) ) {
 				return $target;
 			}
 
-			$seen[ $key ] = true;
-			$stored[]     = $key;
-			$formatted[]  = $target;
+			if ( ! in_array( $target['kind'], self::ALLOWED_KINDS, true ) ) {
+				return new WP_Error(
+					'cortext_document_target_not_found',
+					__( 'Target document was not found.', 'cortext' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			$seen[ $id ] = true;
+			$stored[]    = "{$target['kind']}:{$target['id']}";
+			$formatted[] = $target;
 		}
 
 		update_user_meta( get_current_user_id(), self::META_KEY, $stored );
@@ -133,135 +150,40 @@ final class FavoritesController {
 		$out  = array();
 		$seen = array();
 		foreach ( $raw as $entry ) {
-			$parsed = $this->parse_stored_entry( $entry );
-			if ( ! $parsed ) {
+			$id = $this->stored_entry_id( $entry );
+			if ( $id < 1 || isset( $seen[ $id ] ) ) {
 				continue;
 			}
 
-			$key = "{$parsed['kind']}:{$parsed['id']}";
-			if ( isset( $seen[ $key ] ) ) {
-				continue;
-			}
-
-			$target = $this->format_target( $parsed['kind'], $parsed['id'], true );
+			$target = $this->documents->format_target( $id );
 			if ( is_wp_error( $target ) ) {
 				continue;
 			}
 
-			$seen[ $key ] = true;
-			$out[]        = $target;
+			if ( ! in_array( $target['kind'], self::ALLOWED_KINDS, true ) ) {
+				continue;
+			}
+
+			$seen[ $id ] = true;
+			$out[]       = $target;
 		}
 
 		return $out;
 	}
 
-	private function parse_stored_entry( mixed $entry ): ?array {
+	private function stored_entry_id( mixed $entry ): int {
 		if ( is_string( $entry ) ) {
 			$parts = explode( ':', $entry, 2 );
 			if ( 2 !== count( $parts ) ) {
-				return null;
+				return 0;
 			}
-			return array(
-				'kind' => $parts[0],
-				'id'   => (int) $parts[1],
-			);
+			return (int) $parts[1];
 		}
 
-		if ( is_array( $entry ) ) {
-			return array(
-				'kind' => isset( $entry['kind'] ) ? (string) $entry['kind'] : '',
-				'id'   => isset( $entry['id'] ) ? (int) $entry['id'] : 0,
-			);
+		if ( is_array( $entry ) && isset( $entry['id'] ) ) {
+			return (int) $entry['id'];
 		}
 
-		return null;
-	}
-
-	/**
-	 * Formats a page or collection target into the shell route contract.
-	 *
-	 * @param string $kind Target kind.
-	 * @param int    $id Target post ID.
-	 * @param bool   $require_edit Whether to enforce edit_post capability.
-	 * @return array<string,mixed>|WP_Error
-	 */
-	private function format_target( string $kind, int $id, bool $require_edit ) {
-		if ( ! in_array( $kind, array( 'page', 'collection' ), true ) || $id < 1 ) {
-			return $this->invalid_target_error();
-		}
-
-		$post = get_post( $id );
-		if ( ! $this->is_supported_target( $post, $kind ) ) {
-			return new WP_Error(
-				'cortext_favorites_not_found',
-				__( 'Favorite target was not found.', 'cortext' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		if ( 'collection' === $kind && Collection::is_inline( $id ) ) {
-			return new WP_Error(
-				'cortext_favorites_inline_collection',
-				__( 'Inline collections cannot be added to favorites.', 'cortext' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		if ( $require_edit && ! current_user_can( 'edit_post', $id ) ) {
-			return new WP_Error(
-				'cortext_favorites_forbidden',
-				__( 'You are not allowed to favorite this target.', 'cortext' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		$target = array(
-			'kind'  => $kind,
-			'id'    => $id,
-			'title' => $this->post_title( $post ),
-			'path'  => $this->target_path( $post, $kind ),
-		);
-		if ( 'page' === $kind ) {
-			$icon = get_post_meta( $id, DocumentIdentity::META_KEY, true );
-			if ( is_string( $icon ) && '' !== $icon ) {
-				$target['icon'] = $icon;
-			}
-		}
-
-		return $target;
-	}
-
-	private function invalid_target_error(): WP_Error {
-		return new WP_Error(
-			'cortext_favorites_invalid_target',
-			__( 'Favorite target is invalid.', 'cortext' ),
-			array( 'status' => 400 )
-		);
-	}
-
-	private function is_supported_target( ?WP_Post $post, string $kind ): bool {
-		if ( ! $post || 'trash' === $post->post_status ) {
-			return false;
-		}
-
-		$type = 'page' === $kind ? Page::POST_TYPE : Collection::POST_TYPE;
-		return $type === $post->post_type;
-	}
-
-	private function post_title( WP_Post $post ): string {
-		$title = trim( $post->post_title );
-		return '' === $title ? __( '(untitled)', 'cortext' ) : $title;
-	}
-
-	private function target_path( WP_Post $post, string $kind ): string {
-		if ( 'collection' === $kind ) {
-			$slug = get_post_meta( (int) $post->ID, 'slug', true );
-			$slug = is_string( $slug ) ? trim( $slug ) : '';
-		} else {
-			$slug = trim( $post->post_name );
-		}
-
-		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
-		return "{$kind}/{$tail}";
+		return 0;
 	}
 }

--- a/includes/Rest/RecentsController.php
+++ b/includes/Rest/RecentsController.php
@@ -10,11 +10,7 @@ declare( strict_types=1 );
 namespace Cortext\Rest;
 
 use Cortext\Documents;
-use Cortext\PostType\Collection;
-use Cortext\PostType\CollectionEntries;
-use Cortext\PostType\Page;
 use WP_Error;
-use WP_Post;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -23,6 +19,12 @@ final class RecentsController {
 	private const NAMESPACE = 'cortext/v1';
 	private const META_KEY  = 'cortext_recents';
 	private const MAX_ITEMS = 5;
+
+	private const ALLOWED_KINDS = array(
+		Documents::KIND_PAGE,
+		Documents::KIND_COLLECTION,
+		Documents::KIND_ROW,
+	);
 
 	private Documents $documents;
 
@@ -52,7 +54,7 @@ final class RecentsController {
 						'kind'         => array(
 							'type'     => 'string',
 							'required' => true,
-							'enum'     => array( 'page', 'collection', 'row' ),
+							'enum'     => self::ALLOWED_KINDS,
 						),
 						'id'           => array(
 							'type'     => 'integer',
@@ -83,21 +85,31 @@ final class RecentsController {
 	}
 
 	public function touch_recent( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$kind          = (string) $request->get_param( 'kind' );
 		$id            = (int) $request->get_param( 'id' );
 		$collection_id = (int) $request->get_param( 'collectionId' );
 
-		$target = $this->format_target( $kind, $id, $collection_id );
+		$target = $this->documents->format_target(
+			$id,
+			array( 'context_id' => $collection_id )
+		);
 		if ( is_wp_error( $target ) ) {
 			return $target;
 		}
 
+		if ( ! in_array( $target['kind'], self::ALLOWED_KINDS, true ) ) {
+			return new WP_Error(
+				'cortext_document_target_not_found',
+				__( 'Target document was not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
 		$item = array(
-			'kind'      => $kind,
-			'id'        => $id,
+			'kind'      => $target['kind'],
+			'id'        => $target['id'],
 			'updatedAt' => gmdate( DATE_RFC3339 ),
 		);
-		if ( 'row' === $kind ) {
+		if ( Documents::KIND_ROW === $target['kind'] ) {
 			$item['collectionId'] = $collection_id;
 		}
 
@@ -135,10 +147,9 @@ final class RecentsController {
 		$valid    = array();
 
 		foreach ( $items as $item ) {
-			$target = $this->format_target(
-				$item['kind'],
+			$target = $this->documents->format_target(
 				$item['id'],
-				$item['collectionId'] ?? 0
+				array( 'context_id' => $item['collectionId'] ?? 0 )
 			);
 			if ( is_wp_error( $target ) ) {
 				continue;
@@ -175,7 +186,7 @@ final class RecentsController {
 			}
 			$kind = isset( $item['kind'] ) ? (string) $item['kind'] : '';
 			$id   = isset( $item['id'] ) ? (int) $item['id'] : 0;
-			if ( ! in_array( $kind, array( 'page', 'collection', 'row' ), true ) || $id < 1 ) {
+			if ( ! in_array( $kind, self::ALLOWED_KINDS, true ) || $id < 1 ) {
 				continue;
 			}
 
@@ -186,7 +197,7 @@ final class RecentsController {
 					? $item['updatedAt']
 					: gmdate( DATE_RFC3339 ),
 			);
-			if ( 'row' === $kind ) {
+			if ( Documents::KIND_ROW === $kind ) {
 				$collection_id = isset( $item['collectionId'] ) ? (int) $item['collectionId'] : 0;
 				if ( $collection_id < 1 ) {
 					continue;
@@ -200,158 +211,13 @@ final class RecentsController {
 	}
 
 	/**
-	 * Formats a supported Cortext target for the recents response.
+	 * Dedupe key for a stored recent item. The post id is enough because a post
+	 * can only belong to one kind; older entries may carry a stale kind label,
+	 * but the id still points to the same target.
 	 *
-	 * @param string $kind Target kind.
-	 * @param int    $id Target post ID.
-	 * @param int    $collection_id Parent collection ID for row targets.
-	 * @return array<string,mixed>|WP_Error
-	 */
-	private function format_target( string $kind, int $id, int $collection_id = 0 ) {
-		if ( ! in_array( $kind, array( 'page', 'collection', 'row' ), true ) || $id < 1 ) {
-			return new WP_Error(
-				'cortext_recents_invalid_target',
-				__( 'Recent target is invalid.', 'cortext' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		if ( 'row' === $kind ) {
-			return $this->format_row_target( $id, $collection_id );
-		}
-
-		$post          = get_post( $id );
-		$expected_type = 'page' === $kind ? Page::POST_TYPE : Collection::POST_TYPE;
-		if ( ! $post instanceof WP_Post || $expected_type !== $post->post_type || 'trash' === $post->post_status ) {
-			return new WP_Error(
-				'cortext_recents_not_found',
-				__( 'Recent target was not found.', 'cortext' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		// Inline collections do not have their own workspace route, so Recents
-		// should not point at them. Rows inside them are still valid recents.
-		if ( 'collection' === $kind && Collection::is_inline( $id ) ) {
-			return new WP_Error(
-				'cortext_recents_inline_collection',
-				__( 'Inline collections cannot be added to Recents.', 'cortext' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		if ( ! current_user_can( 'edit_post', $id ) ) {
-			return new WP_Error(
-				'cortext_recents_forbidden',
-				__( 'You are not allowed to use this target as a recent item.', 'cortext' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		if ( 'page' === $kind ) {
-			return $this->documents->format_document( $post ) ?? new WP_Error(
-				'cortext_recents_not_found',
-				__( 'Recent target was not found.', 'cortext' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		return array(
-			'kind'  => $kind,
-			'id'    => $id,
-			'title' => $this->post_title( $post ),
-			'path'  => $this->target_path( $post, $kind ),
-		);
-	}
-
-	/**
-	 * Formats a collection row target.
-	 *
-	 * @param int $row_id Row post ID.
-	 * @param int $collection_id Parent collection post ID.
-	 * @return array<string,mixed>|WP_Error
-	 */
-	private function format_row_target( int $row_id, int $collection_id ) {
-		if ( $collection_id < 1 ) {
-			return new WP_Error(
-				'cortext_recents_row_collection_required',
-				__( 'Recent row target requires a collection.', 'cortext' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		$collection = get_post( $collection_id );
-		if (
-			! $collection instanceof WP_Post ||
-			Collection::POST_TYPE !== $collection->post_type ||
-			'trash' === $collection->post_status
-		) {
-			return new WP_Error(
-				'cortext_recents_collection_not_found',
-				__( 'Recent row collection was not found.', 'cortext' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		$slug = get_post_meta( $collection_id, 'slug', true );
-		$slug = is_string( $slug ) ? trim( $slug ) : '';
-		$row  = get_post( $row_id );
-		if (
-			'' === $slug ||
-			! $row instanceof WP_Post ||
-			CollectionEntries::CPT_PREFIX . $slug !== $row->post_type ||
-			'trash' === $row->post_status
-		) {
-			return new WP_Error(
-				'cortext_recents_not_found',
-				__( 'Recent target was not found.', 'cortext' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		if ( ! current_user_can( 'edit_post', $collection_id ) || ! current_user_can( 'edit_post', $row_id ) ) {
-			return new WP_Error(
-				'cortext_recents_forbidden',
-				__( 'You are not allowed to use this target as a recent item.', 'cortext' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		$document = $this->documents->format_document( $row );
-		if ( null === $document ) {
-			return new WP_Error(
-				'cortext_recents_not_found',
-				__( 'Recent target was not found.', 'cortext' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		return $document;
-	}
-
-	private function post_title( WP_Post $post ): string {
-		$title = trim( $post->post_title );
-		return '' === $title ? __( '(untitled)', 'cortext' ) : $title;
-	}
-
-	private function target_path( WP_Post $post, string $kind ): string {
-		if ( 'collection' === $kind ) {
-			$slug = get_post_meta( (int) $post->ID, 'slug', true );
-			$slug = is_string( $slug ) ? trim( $slug ) : '';
-		} else {
-			$slug = trim( $post->post_name );
-		}
-
-		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
-		return "{$kind}/{$tail}";
-	}
-
-	/**
-	 * Builds the stable dedupe key for a stored recent item.
-	 *
-	 * @param array{kind:string,id:int} $item Recent item.
+	 * @param array{id:int} $item Recent item.
 	 */
 	private function recent_key( array $item ): string {
-		return "{$item['kind']}:{$item['id']}";
+		return (string) $item['id'];
 	}
 }

--- a/includes/Rest/WorkspaceHomeController.php
+++ b/includes/Rest/WorkspaceHomeController.php
@@ -9,10 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
-use Cortext\PostType\Collection;
-use Cortext\PostType\Page;
+use Cortext\Documents;
 use WP_Error;
-use WP_Post;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -20,6 +18,17 @@ final class WorkspaceHomeController {
 
 	private const NAMESPACE = 'cortext/v1';
 	private const META_KEY  = 'cortext_workspace_home';
+
+	private const ALLOWED_KINDS = array(
+		Documents::KIND_PAGE,
+		Documents::KIND_COLLECTION,
+	);
+
+	private Documents $documents;
+
+	public function __construct( ?Documents $documents = null ) {
+		$this->documents = $documents ?? new Documents();
+	}
 
 	public function register(): void {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
@@ -43,7 +52,7 @@ final class WorkspaceHomeController {
 						'kind' => array(
 							'type'     => 'string',
 							'required' => true,
-							'enum'     => array( 'page', 'collection' ),
+							'enum'     => self::ALLOWED_KINDS,
 						),
 						'id'   => array(
 							'type'     => 'integer',
@@ -72,15 +81,14 @@ final class WorkspaceHomeController {
 	}
 
 	public function update_home( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$kind = (string) $request->get_param( 'kind' );
-		$id   = (int) $request->get_param( 'id' );
+		$id = (int) $request->get_param( 'id' );
 
-		$home = $this->format_target( $kind, $id, true );
+		$home = $this->resolve_home_target( $id );
 		if ( is_wp_error( $home ) ) {
 			return $home;
 		}
 
-		update_user_meta( get_current_user_id(), self::META_KEY, "{$kind}:{$id}" );
+		update_user_meta( get_current_user_id(), self::META_KEY, "{$home['kind']}:{$home['id']}" );
 
 		return new WP_REST_Response(
 			array(
@@ -101,77 +109,36 @@ final class WorkspaceHomeController {
 			return null;
 		}
 
-		$home = $this->format_target( $parts[0], (int) $parts[1], true );
+		$home = $this->resolve_home_target( (int) $parts[1] );
 		return is_wp_error( $home ) ? null : $home;
 	}
 
 	/**
-	 * Formats a page or collection target into the shell route contract.
+	 * Resolves a workspace home target by id and returns the small wire shape
+	 * Home needs. The response keeps `{kind, id, path}` only; callers can read
+	 * title or icon from the matching document record when they need it.
 	 *
-	 * @param string $kind Target kind.
-	 * @param int    $id Target post ID.
-	 * @param bool   $require_edit Whether to enforce edit_post capability.
+	 * @param int $id Target document id.
 	 * @return array{kind:string,id:int,path:string}|WP_Error
 	 */
-	private function format_target( string $kind, int $id, bool $require_edit ) {
-		if ( ! in_array( $kind, array( 'page', 'collection' ), true ) || $id < 1 ) {
-			return new WP_Error(
-				'cortext_workspace_home_invalid_target',
-				__( 'Workspace home target is invalid.', 'cortext' ),
-				array( 'status' => 400 )
-			);
+	private function resolve_home_target( int $id ) {
+		$target = $this->documents->format_target( $id );
+		if ( is_wp_error( $target ) ) {
+			return $target;
 		}
 
-		$post = get_post( $id );
-		if ( ! $this->is_supported_target( $post, $kind ) ) {
+		if ( ! in_array( $target['kind'], self::ALLOWED_KINDS, true ) ) {
 			return new WP_Error(
-				'cortext_workspace_home_not_found',
-				__( 'Workspace home target was not found.', 'cortext' ),
+				'cortext_document_target_not_found',
+				__( 'Target document was not found.', 'cortext' ),
 				array( 'status' => 404 )
 			);
 		}
 
-		if ( 'collection' === $kind && Collection::is_inline( $id ) ) {
-			return new WP_Error(
-				'cortext_workspace_home_inline_collection',
-				__( 'Inline collections cannot be used as the workspace home.', 'cortext' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		if ( $require_edit && ! current_user_can( 'edit_post', $id ) ) {
-			return new WP_Error(
-				'cortext_workspace_home_forbidden',
-				__( 'You are not allowed to use this target as your workspace home.', 'cortext' ),
-				array( 'status' => 403 )
-			);
-		}
-
 		return array(
-			'kind' => $kind,
-			'id'   => $id,
-			'path' => $this->target_path( $post, $kind ),
+			'kind' => $target['kind'],
+			'id'   => $target['id'],
+			'path' => $target['path'],
 		);
-	}
-
-	private function is_supported_target( ?WP_Post $post, string $kind ): bool {
-		if ( ! $post || 'trash' === $post->post_status ) {
-			return false;
-		}
-
-		$type = 'page' === $kind ? Page::POST_TYPE : Collection::POST_TYPE;
-		return $type === $post->post_type;
-	}
-
-	private function target_path( WP_Post $post, string $kind ): string {
-		if ( 'collection' === $kind ) {
-			$slug = get_post_meta( (int) $post->ID, 'slug', true );
-			$slug = is_string( $slug ) ? trim( $slug ) : '';
-		} else {
-			$slug = trim( $post->post_name );
-		}
-
-		$tail = '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
-		return "{$kind}/{$tail}";
 	}
 }

--- a/tests/php/test-rest-favorites-controller.php
+++ b/tests/php/test-rest-favorites-controller.php
@@ -196,7 +196,7 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 
 		$this->assertSame( 404, $response->get_status() );
 		$this->assertSame(
-			'cortext_favorites_not_found',
+			'cortext_document_target_not_found',
 			$response->get_data()['code']
 		);
 	}
@@ -223,7 +223,7 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 
 		$this->assertSame( 403, $response->get_status() );
 		$this->assertSame(
-			'cortext_favorites_forbidden',
+			'cortext_document_target_forbidden',
 			$response->get_data()['code']
 		);
 	}
@@ -297,7 +297,7 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 
 		$this->assertSame( 400, $response->get_status() );
 		$this->assertSame(
-			'cortext_favorites_inline_collection',
+			'cortext_document_target_inline_collection',
 			$response->get_data()['code']
 		);
 	}

--- a/tests/php/test-rest-recents-controller.php
+++ b/tests/php/test-rest-recents-controller.php
@@ -144,9 +144,11 @@ final class Test_Rest_Recents_Controller extends BaseTestCase {
 				'post_title'  => 'Regular post',
 			)
 		);
+		$this->create_collection( 'people', 'People' );
+		$row_id = $this->create_row( 'crtxt_people', 'Ada Lovelace' );
 
 		$invalid_type           = $this->touch_recent( 'page', $post_id );
-		$row_missing_collection = $this->touch_recent( 'row', 999 );
+		$row_missing_collection = $this->touch_recent( 'row', $row_id );
 
 		$owner_id = $this->create_user( 'administrator' );
 		wp_set_current_user( $owner_id );
@@ -162,6 +164,10 @@ final class Test_Rest_Recents_Controller extends BaseTestCase {
 
 		$this->assertSame( 404, $invalid_type->get_status() );
 		$this->assertSame( 400, $row_missing_collection->get_status() );
+		$this->assertSame(
+			'cortext_document_target_invalid',
+			$row_missing_collection->get_data()['code']
+		);
 		$this->assertSame( 403, $forbidden->get_status() );
 	}
 
@@ -223,7 +229,7 @@ final class Test_Rest_Recents_Controller extends BaseTestCase {
 
 		$this->assertSame( 400, $response->get_status() );
 		$this->assertSame(
-			'cortext_recents_inline_collection',
+			'cortext_document_target_inline_collection',
 			$response->get_data()['code']
 		);
 	}

--- a/tests/php/test-rest-workspace-home-controller.php
+++ b/tests/php/test-rest-workspace-home-controller.php
@@ -116,7 +116,7 @@ final class Test_Rest_Workspace_Home_Controller extends BaseTestCase {
 
 		$this->assertSame( 404, $response->get_status() );
 		$this->assertSame(
-			'cortext_workspace_home_not_found',
+			'cortext_document_target_not_found',
 			$response->get_data()['code']
 		);
 	}
@@ -136,7 +136,7 @@ final class Test_Rest_Workspace_Home_Controller extends BaseTestCase {
 
 		$this->assertSame( 403, $response->get_status() );
 		$this->assertSame(
-			'cortext_workspace_home_forbidden',
+			'cortext_document_target_forbidden',
 			$response->get_data()['code']
 		);
 	}
@@ -182,7 +182,7 @@ final class Test_Rest_Workspace_Home_Controller extends BaseTestCase {
 
 		$this->assertSame( 400, $response->get_status() );
 		$this->assertSame(
-			'cortext_workspace_home_inline_collection',
+			'cortext_document_target_inline_collection',
 			$response->get_data()['code']
 		);
 	}


### PR DESCRIPTION
## What

Part of #226.

Favorites, Recents, and Workspace Home now ask the documents service to resolve document targets. They still accept the same ids, but target validation, kind lookup, title/path formatting, and target error codes now come from one place.

Favorites also support row targets when the caller includes the parent `collectionId`, and collection icons now show up when a collection has one. Row favorites keep the same document path; `collectionId` is only stored so the row can be checked again later.

## Why

These three flows had drifted into separate copies of the same target handling. Pulling it into the documents service removes that duplication before the next #226 changes build on it.

## Testing Instructions

1. Add a page and a collection to Favorites from the sidebar. Confirm both render and survive a reload.
2. Open a page, a collection, and a collection row. Confirm each appears in Recents.
3. Set a page as Workspace Home from the inspector, reload, and confirm Home opens it.
4. Set a collection as Workspace Home, reload, and confirm Home opens it.
5. Add a row favorite through the Favorites REST endpoint with `kind`, `id`, and `collectionId`. Reload and confirm it appears in Favorites and opens the row.
6. Try favoriting an inline collection from a command-palette result, if available, and confirm it returns an error.
