### PR TITLE
Bugfix: Isolate row detail toolbars

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -524,3 +524,13 @@ The brittle bit is the sizing. The skeleton copies DataViews row heights for com
 **Where.** `HeaderPrefixToolbarGuard`, `syncHeaderBoundaryMoveUpButtons`, and the header-prefix correction in `src/components/EditorBody.js`, with coverage in `tests/e2e/specs/editor-header-blocks.spec.js`.
 
 **Solution.** Gutenberg exposes a block-list boundary policy for root lists: a minimum insertion index, a minimum move target, and mover button state derived from that policy. Then Cortext can declare "body blocks start after the title" once and drop the toolbar DOM query, the mutation observer, and the local button-state restoration.
+
+## 57. Row detail toolbars rely on local editor-surface isolation `[upstream, soft]`
+
+**What.** Row peek and modal now keep their toolbars separate from the parent page editor. The fix is local and covered by e2e: each row editor gets its own `SlotFillProvider`, the row surface says it has no block inspector, and the parent page toolbar is hidden while peek/modal owns the screen.
+
+The only reason this stays in the debt log is the plumbing. Gutenberg's toolbar path still runs through `BlockControls`, SlotFill, and portaled popovers, and there is no clean public primitive for saying "this nested editor owns its toolbar and inspector." Cortext avoids the unsafe inspector entrypoint instead of building a row-scoped inspector in this pass. Normal row block toolbar actions still work.
+
+**Where.** `src/components/RowEditor.js` (`SlotFillProvider` and `EditorSurfaceProvider`), `src/components/EditorSurfaceContext.js`, `src/blocks/data-view/edit.js` (`hasBlockInspector` around the DataView toolbar button), `src/components/RowDetailView.js` (body class while side/modal is open), and `src/index.scss` (parent canvas toolbar hiding).
+
+**Solution.** If Gutenberg grows editor-instance-scoped `BlockControls`, toolbar popovers, and `InspectorControls`, Cortext can drop the local `SlotFillProvider`, the `hasBlockInspector` context, and the parent-toolbar body class. If row peek/modal needs block settings before that exists upstream, build a row-scoped inspector deliberately rather than routing those actions to the parent inspector.

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -32,6 +32,7 @@ import { cog, plus, replace } from '@wordpress/icons';
 
 import CollectionDataViews from '../../components/CollectionDataViews';
 import AddFieldPopover from '../../components/fields/AddFieldPopover';
+import { useEditorSurface } from '../../components/EditorSurfaceContext';
 import { FULL_PAGE_COLLECTION_QUERY } from '../../collections';
 import { toDataViewId } from '../../hooks/fieldIds';
 import {
@@ -243,6 +244,7 @@ function CollectionToolbarControl( {
 	onFieldCreated,
 } ) {
 	const { collection, isResolving } = useCollectionFieldsContext();
+	const { hasBlockInspector } = useEditorSurface();
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	const isCollectionValid = ! isResolving && collectionId && collection;
@@ -297,16 +299,20 @@ function CollectionToolbarControl( {
 					) }
 				/>
 			) }
-			<ToolbarButton
-				icon={ cog }
-				label={ __( 'View settings', 'cortext' ) }
-				onClick={ () =>
-					enableComplementaryArea(
-						'cortext',
-						'cortext/block-inspector'
-					)
-				}
-			/>
+			{ /* tech-debt.md#57: peek/modal hide the parent inspector
+			     entrypoint until there is a row-scoped one. */ }
+			{ hasBlockInspector ? (
+				<ToolbarButton
+					icon={ cog }
+					label={ __( 'View settings', 'cortext' ) }
+					onClick={ () =>
+						enableComplementaryArea(
+							'cortext',
+							'cortext/block-inspector'
+						)
+					}
+				/>
+			) : null }
 		</BlockControls>
 	);
 }

--- a/src/components/EditorSurfaceContext.js
+++ b/src/components/EditorSurfaceContext.js
@@ -1,0 +1,27 @@
+import { createContext, useContext, useMemo } from '@wordpress/element';
+
+const DEFAULT_EDITOR_SURFACE = {
+	hasBlockInspector: true,
+};
+
+const EditorSurfaceContext = createContext( DEFAULT_EDITOR_SURFACE );
+
+export function EditorSurfaceProvider( {
+	children,
+	hasBlockInspector = true,
+} ) {
+	const value = useMemo(
+		() => ( { hasBlockInspector } ),
+		[ hasBlockInspector ]
+	);
+
+	return (
+		<EditorSurfaceContext.Provider value={ value }>
+			{ children }
+		</EditorSurfaceContext.Provider>
+	);
+}
+
+export function useEditorSurface() {
+	return useContext( EditorSurfaceContext );
+}

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -5,6 +5,7 @@ import {
 	Suspense,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useState,
 } from '@wordpress/element';
@@ -76,6 +77,7 @@ export const ROW_DETAIL_MODE_LABELS = {
 const ROW_DETAIL_MODAL_CLOSE_MS = 240;
 const ROW_DETAIL_SWITCH_MS = 180;
 const ROW_DETAIL_SWITCH_FALLBACK_MS = ROW_DETAIL_SWITCH_MS + 100;
+const HIDE_PARENT_BLOCK_TOOLBAR_CLASS = 'cortext-hide-parent-block-toolbar';
 
 function delay( duration ) {
 	return new Promise( ( resolve ) => {
@@ -383,6 +385,19 @@ export default function RowDetailView( {
 		if ( normalizedMode !== 'modal' ) {
 			setIsModalClosing( false );
 		}
+	}, [ normalizedMode ] );
+
+	useLayoutEffect( () => {
+		if ( normalizedMode !== 'side' && normalizedMode !== 'modal' ) {
+			return undefined;
+		}
+
+		// tech-debt.md#57: while row detail owns the surface, keep the
+		// still-selected page block toolbar out of sight.
+		document.body.classList.add( HIDE_PARENT_BLOCK_TOOLBAR_CLASS );
+		return () => {
+			document.body.classList.remove( HIDE_PARENT_BLOCK_TOOLBAR_CLASS );
+		};
 	}, [ normalizedMode ] );
 
 	const activeDetail =

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -7,6 +7,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { EditorProvider, store as editorStore } from '@wordpress/editor';
 import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
+import { SlotFillProvider } from '@wordpress/components';
 
 import useAutosave from '../hooks/useAutosave';
 // Registers core + Cortext blocks before any editor renders. Living here
@@ -15,6 +16,7 @@ import useAutosave from '../hooks/useAutosave';
 // bundle. The module is idempotent, so Canvas's copy of this import is
 // a no-op when RowEditor mounts second, or vice versa.
 import './initEditor';
+import { EditorSurfaceProvider } from './EditorSurfaceContext';
 import EditorBody from './EditorBody';
 import RowProperties from './RowProperties';
 import { titleFromRow } from './rowDetailUtils';
@@ -198,25 +200,31 @@ export default function RowEditor( {
 			settings={ window.cortextEditorSettings ?? {} }
 			useSubRegistry
 		>
-			<DetailReadySignal
-				detailKey={ detailKey }
-				onReady={ onPaneReady }
-			/>
-			<DetailPaneContent
-				collectionId={ collectionId }
-				fields={ fields }
-				isActive={ isActive }
-				isHidden={ isHidden }
-				isTitleActive={ isTitleActive }
-				onApi={ onApi }
-				onRestored={ onRestored }
-				onSaved={ onSaved }
-				onTitle={ onTitle }
-				postType={ postType }
-				propertiesVisible={ propertiesVisible }
-				row={ row }
-				rowId={ rowId }
-			/>
+			{ /* tech-debt.md#57: row detail owns these SlotFills while
+			     peek/modal are open. */ }
+			<SlotFillProvider>
+				<EditorSurfaceProvider hasBlockInspector={ false }>
+					<DetailReadySignal
+						detailKey={ detailKey }
+						onReady={ onPaneReady }
+					/>
+					<DetailPaneContent
+						collectionId={ collectionId }
+						fields={ fields }
+						isActive={ isActive }
+						isHidden={ isHidden }
+						isTitleActive={ isTitleActive }
+						onApi={ onApi }
+						onRestored={ onRestored }
+						onSaved={ onSaved }
+						onTitle={ onTitle }
+						postType={ postType }
+						propertiesVisible={ propertiesVisible }
+						row={ row }
+						rowId={ rowId }
+					/>
+				</EditorSurfaceProvider>
+			</SlotFillProvider>
 		</EditorProvider>
 	);
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -5447,6 +5447,17 @@ body.cortext-hide-block-settings-menu .block-editor-block-switcher {
 	display: none;
 }
 
+// tech-debt.md#57: while row peek/modal owns the surface, keep the page
+// canvas toolbar out of sight so only row toolbar actions are reachable.
+body.cortext-hide-parent-block-toolbar
+.cortext-shell__canvas
+.cortext-workspace__pane[data-active="true"]
+.cortext-canvas.interface-interface-skeleton
+.cortext-canvas__block-canvas
+.block-editor-block-popover {
+	display: none;
+}
+
 .cortext-icon-library {
 	display: flex;
 	flex-direction: column;

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -201,6 +201,72 @@ async function expectSidePeekShellStayedOpen( page ) {
 	).toEqual( [] );
 }
 
+async function selectParentDataViewBlock( page ) {
+	await page.evaluate( () => {
+		const dataViewBlock = window.wp.data
+			.select( 'core/block-editor' )
+			.getBlocks()
+			.find( ( block ) => block.name === 'cortext/data-view' );
+		if ( ! dataViewBlock ) {
+			throw new Error( 'Could not find the DataView block.' );
+		}
+		window.wp.data
+			.dispatch( 'core/block-editor' )
+			.selectBlock( dataViewBlock.clientId );
+	} );
+}
+
+async function getParentDataViewAttributes( page ) {
+	return page.evaluate( () => {
+		const dataViewBlock = window.wp.data
+			.select( 'core/block-editor' )
+			.getBlocks()
+			.find( ( block ) => block.name === 'cortext/data-view' );
+		if ( ! dataViewBlock ) {
+			throw new Error( 'Could not find the DataView block.' );
+		}
+		return JSON.parse( JSON.stringify( dataViewBlock.attributes ) );
+	} );
+}
+
+async function expectRowToolbarIsolated( page, detail, blockText ) {
+	const rowCanvas = detail.frameLocator( 'iframe[name="editor-canvas"]' );
+	const rowBlock = rowCanvas.getByText( blockText, { exact: true } ).first();
+	await expect( rowBlock ).toBeVisible();
+	await rowBlock.click();
+	await rowBlock.press( 'Alt+F10' );
+
+	const rowToolbar = detail.locator(
+		'.block-editor-block-contextual-toolbar'
+	);
+	await expect( rowToolbar ).toBeVisible();
+	await expect(
+		page.locator( '.cortext-shell__canvas .block-editor-block-popover' )
+	).toBeHidden();
+	await expect(
+		page.getByRole( 'button', { name: 'Change collection' } )
+	).toHaveCount( 0 );
+	await expect(
+		page.getByRole( 'button', { name: 'Add field', exact: true } )
+	).toHaveCount( 0 );
+	await expect(
+		page.getByRole( 'button', { name: 'View settings' } )
+	).toHaveCount( 0 );
+
+	const optionsButton = rowToolbar.getByRole( 'button', {
+		name: 'Options',
+	} );
+	await expect( optionsButton ).toBeVisible();
+	await optionsButton.click();
+	const copyMenuItem = page
+		.locator( '.components-popover .components-menu-item__button' )
+		.filter( { hasText: 'Copy' } )
+		.first();
+	await expect( copyMenuItem ).toBeVisible();
+	await expect( copyMenuItem ).toContainText( 'Copy' );
+	await page.keyboard.press( 'Escape' );
+}
+
 async function createCollectionFixture( requestUtils ) {
 	const suffix = Date.now().toString( 36 ).slice( -4 );
 	const slug = `e2ebooks${ suffix }`;
@@ -1591,6 +1657,117 @@ test.describe( 'Collection view block', () => {
 				.toBe( 'U. K. Le Guin' );
 
 			await expect( canvas.getByText( 'U. K. Le Guin' ) ).toBeVisible();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+
+	test( 'row detail toolbar stays separate from the parent DataView toolbar', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		const rowBodyText = 'Body text for the toolbar check';
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture( requestUtils )
+			);
+
+			fixture.entry = await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`,
+				data: {
+					content: `<!-- wp:paragraph --><p>${ rowBodyText }</p><!-- /wp:paragraph -->`,
+				},
+			} );
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Row toolbar test page',
+					status: 'private',
+					content: createDataViewBlockMarkup( fixture.collection.id ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page
+				.getByRole( 'region', { name: 'Content' } )
+				.frameLocator( 'iframe[name="editor-canvas"]' );
+			await expect(
+				canvas.getByText( 'The Left Hand of Darkness' )
+			).toBeVisible();
+
+			await selectParentDataViewBlock( page );
+			const beforeAttributes = await getParentDataViewAttributes( page );
+
+			const firstRow = canvas
+				.locator( '.cortext-data-view tbody tr' )
+				.first();
+			const titleCellOpenButton = canvas
+				.locator( '.cortext-title-cell__open' )
+				.first();
+			await firstRow.hover();
+			await titleCellOpenButton.click();
+
+			const detail = page.getByRole( 'dialog', {
+				name: 'Row detail',
+			} );
+			await expect( detail ).toBeVisible();
+			await selectParentDataViewBlock( page );
+			await expectRowToolbarIsolated( page, detail, rowBodyText );
+			const afterSideAttributes =
+				await getParentDataViewAttributes( page );
+			expect( afterSideAttributes ).toEqual( beforeAttributes );
+
+			await detail
+				.getByRole( 'button', { name: 'Center modal' } )
+				.click();
+			const modalDetail = page.locator(
+				'.components-modal__frame.cortext-row-detail-modal'
+			);
+			await expect( modalDetail ).toBeVisible();
+			await selectParentDataViewBlock( page );
+			const beforeModalAttributes =
+				await getParentDataViewAttributes( page );
+			await expectRowToolbarIsolated( page, modalDetail, rowBodyText );
+
+			const afterAttributes = await getParentDataViewAttributes( page );
+			expect( afterAttributes ).toEqual( beforeModalAttributes );
 		} finally {
 			await deleteIfCreated(
 				requestUtils,


### PR DESCRIPTION
## What

Keeps the row peek and modal toolbars from picking up controls from the parent DataView block. When a row is open, selecting its title or body no longer displays DataView actions such as “Change collection,” “Add field,” or “View settings.” The row toolbar still works for row blocks.

## Why

The parent DataView can stay selected behind the row detail. Before this, its toolbar controls would appear in the row editor and still affect the parent block, which made it too easy to change the DataView by mistake.

## How

- Scopes row detail toolbar fills to the row editor.
- Hides the parent inspector entrypoint in peek/modal until there is a row-scoped inspector.
- Hides the parent canvas toolbar while side peek or modal is open.
- Notes the remaining Gutenberg upstream gap in tech debt.

## Testing Instructions

1. Open a page with a DataView block and select the DataView.
2. Open a row in side peek.
3. Select a row title or body block.
4. Confirm the row toolbar does not show “Change collection,” “Add field,” or “View settings.”
5. Open the row toolbar options menu and confirm normal block actions are available.
6. Switch the row detail view to modal and repeat the toolbar checks.
7. Confirm the parent DataView settings do not change after using the row toolbar.

## Before / After
This is a detail of the side peek:
| Before | After |
| --- | --- |
| <img width="484" height="381" alt="image" src="https://github.com/user-attachments/assets/a4a74d03-c4db-4b37-a821-d63f3739f658" /> | <img width="530" height="414" alt="image" src="https://github.com/user-attachments/assets/7fce7380-0623-4e7d-8e64-682b2517474b" /> |