### PR TITLE
Document Unification: Support row favorites

### DIFF
--- a/includes/Rest/FavoritesController.php
+++ b/includes/Rest/FavoritesController.php
@@ -22,6 +22,7 @@ final class FavoritesController {
 	private const ALLOWED_KINDS = array(
 		Documents::KIND_PAGE,
 		Documents::KIND_COLLECTION,
+		Documents::KIND_ROW,
 	);
 
 	private Documents $documents;
@@ -55,11 +56,15 @@ final class FavoritesController {
 							'items'    => array(
 								'type'       => 'object',
 								'properties' => array(
-									'kind' => array(
+									'kind'         => array(
 										'type' => 'string',
 										'enum' => self::ALLOWED_KINDS,
 									),
-									'id'   => array(
+									'id'           => array(
+										'type'    => 'integer',
+										'minimum' => 1,
+									),
+									'collectionId' => array(
 										'type'    => 'integer',
 										'minimum' => 1,
 									),
@@ -108,12 +113,16 @@ final class FavoritesController {
 				);
 			}
 
-			$id = isset( $favorite['id'] ) ? (int) $favorite['id'] : 0;
+			$id            = isset( $favorite['id'] ) ? (int) $favorite['id'] : 0;
+			$collection_id = isset( $favorite['collectionId'] ) ? (int) $favorite['collectionId'] : 0;
 			if ( isset( $seen[ $id ] ) ) {
 				continue;
 			}
 
-			$target = $this->documents->format_target( $id );
+			$target = $this->documents->format_target(
+				$id,
+				array( 'context_id' => $collection_id )
+			);
 			if ( is_wp_error( $target ) ) {
 				return $target;
 			}
@@ -127,7 +136,7 @@ final class FavoritesController {
 			}
 
 			$seen[ $id ] = true;
-			$stored[]    = "{$target['kind']}:{$target['id']}";
+			$stored[]    = $this->stored_entry_for_target( $target );
 			$formatted[] = $target;
 		}
 
@@ -147,15 +156,19 @@ final class FavoritesController {
 			return array();
 		}
 
-		$out  = array();
-		$seen = array();
+		$out   = array();
+		$valid = array();
+		$seen  = array();
 		foreach ( $raw as $entry ) {
-			$id = $this->stored_entry_id( $entry );
-			if ( $id < 1 || isset( $seen[ $id ] ) ) {
+			$parsed = $this->parse_stored_entry( $entry );
+			if ( null === $parsed || isset( $seen[ $parsed['id'] ] ) ) {
 				continue;
 			}
 
-			$target = $this->documents->format_target( $id );
+			$target = $this->documents->format_target(
+				$parsed['id'],
+				array( 'context_id' => $parsed['collectionId'] )
+			);
 			if ( is_wp_error( $target ) ) {
 				continue;
 			}
@@ -164,26 +177,79 @@ final class FavoritesController {
 				continue;
 			}
 
-			$seen[ $id ] = true;
-			$out[]       = $target;
+			$seen[ $parsed['id'] ] = true;
+			$valid[]               = $entry;
+			$out[]                 = $target;
+		}
+
+		// Keep storage matched to what we can still resolve. Otherwise the next
+		// save may replay a stale favorite and fail the whole update.
+		if ( count( $valid ) !== count( $raw ) ) {
+			update_user_meta( $user_id, self::META_KEY, $valid );
 		}
 
 		return $out;
 	}
 
-	private function stored_entry_id( mixed $entry ): int {
+	/**
+	 * Stores a favorite in the user's saved format. Pages and collections keep
+	 * the old `"kind:id"` string; rows use an array because their id needs the
+	 * parent collection id too.
+	 *
+	 * @param array<string,mixed> $target Formatted document target.
+	 * @return string|array{kind:string,id:int,collectionId:int}
+	 */
+	private function stored_entry_for_target( array $target ): string|array {
+		$kind = (string) $target['kind'];
+		$id   = (int) $target['id'];
+		if ( Documents::KIND_ROW !== $kind ) {
+			return "{$kind}:{$id}";
+		}
+
+		return array(
+			'kind'         => $kind,
+			'id'           => $id,
+			'collectionId' => isset( $target['collection']['id'] )
+				? (int) $target['collection']['id']
+				: 0,
+		);
+	}
+
+	/**
+	 * Turns a saved favorite back into the `{id, collectionId}` pair
+	 * `format_target` expects. Bad entries are skipped when favorites are read.
+	 *
+	 * @param mixed $entry Raw stored entry: a string for pages/collections, or an
+	 *                     array for rows.
+	 * @return array{id:int,collectionId:int}|null
+	 */
+	private function parse_stored_entry( mixed $entry ): ?array {
 		if ( is_string( $entry ) ) {
 			$parts = explode( ':', $entry, 2 );
 			if ( 2 !== count( $parts ) ) {
-				return 0;
+				return null;
 			}
-			return (int) $parts[1];
+			$id = (int) $parts[1];
+			return $id > 0
+				? array(
+					'id'           => $id,
+					'collectionId' => 0,
+				)
+				: null;
 		}
 
 		if ( is_array( $entry ) && isset( $entry['id'] ) ) {
-			return (int) $entry['id'];
+			$id = (int) $entry['id'];
+			return $id > 0
+				? array(
+					'id'           => $id,
+					'collectionId' => isset( $entry['collectionId'] )
+						? (int) $entry['collectionId']
+						: 0,
+				)
+				: null;
 		}
 
-		return 0;
+		return null;
 	}
 }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -208,7 +208,7 @@ export default function Sidebar( {
 		[ favoriteKeys ]
 	);
 	const toggleFavorite = useCallback(
-		async ( kind, id ) => {
+		async ( kind, id, extra = {} ) => {
 			if ( areFavoriteActionsDisabled ) {
 				return;
 			}
@@ -223,7 +223,7 @@ export default function Sidebar( {
 						? current.filter(
 								( favorite ) => favoriteKey( favorite ) !== key
 						  )
-						: [ ...current, { kind, id } ];
+						: [ ...current, { kind, id, ...extra } ];
 				} );
 			} catch ( err ) {
 				setFavoritesError(
@@ -254,7 +254,8 @@ export default function Sidebar( {
 	const selectFavorite = useCallback(
 		( favorite ) => {
 			if (
-				( favorite.kind === 'page' && favorite.id === selectedId ) ||
+				( ( favorite.kind === 'page' || favorite.kind === 'row' ) &&
+					favorite.id === selectedId ) ||
 				( favorite.kind === 'collection' &&
 					favorite.id === selectedCollectionId )
 			) {

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -106,6 +106,13 @@ export function filterFavoritesForTrashedPage(
 		if ( favorite.kind === 'collection' ) {
 			return ! trashedCollectionIds.has( Number( favorite.id ) );
 		}
+		if ( favorite.kind === 'row' ) {
+			// A trashed page may take owned collections with it. If this row
+			// belonged to one of them, remove its favorite too.
+			return ! trashedCollectionIds.has(
+				Number( favorite.collectionId )
+			);
+		}
 		return true;
 	} );
 }
@@ -115,8 +122,10 @@ export function filterFavoritesForTrashedCollection( favorites, collectionId ) {
 	return favorites.filter(
 		( favorite ) =>
 			! (
-				favorite.kind === 'collection' &&
-				Number( favorite.id ) === target
+				( favorite.kind === 'collection' &&
+					Number( favorite.id ) === target ) ||
+				( favorite.kind === 'row' &&
+					Number( favorite.collectionId ) === target )
 			)
 	);
 }
@@ -176,6 +185,23 @@ export function resolveFavoriteItems( favorites, pages, collections ) {
 					path: collection
 						? computeCollectionUri( collection )
 						: favorite.path,
+				};
+			}
+
+			if ( favorite.kind === 'row' ) {
+				// Rows come from the server, not the sidebar tree. Use the title
+				// and path already returned with the favorite.
+				if ( ! favorite.path ) {
+					return null;
+				}
+				const key = favoriteKey( favorite );
+				return {
+					...favorite,
+					id,
+					key,
+					sortableId: key,
+					title: favoriteTitle( favorite, __( 'Row', 'cortext' ) ),
+					path: favorite.path,
 				};
 			}
 

--- a/src/hooks/useFavorites.js
+++ b/src/hooks/useFavorites.js
@@ -15,11 +15,19 @@ function normalizeFavorite( favorite ) {
 	if ( ! favorite || ! favorite.kind || ! favorite.id ) {
 		return null;
 	}
-	return {
+	const normalized = {
 		...favorite,
 		kind: favorite.kind,
 		id: Number( favorite.id ),
 	};
+	// Keep a row's collection id around for the next save. Optimistic writes send
+	// `collectionId`; reads send it inside `collection`.
+	const collectionId =
+		favorite.collectionId ?? favorite.collection?.id ?? null;
+	if ( collectionId ) {
+		normalized.collectionId = Number( collectionId );
+	}
+	return normalized;
 }
 
 function normalizeFavorites( favorites ) {
@@ -35,7 +43,9 @@ function areFavoritesEqual( a, b ) {
 	}
 	return a.every(
 		( favorite, index ) =>
-			favorite.kind === b[ index ]?.kind && favorite.id === b[ index ]?.id
+			favorite.kind === b[ index ]?.kind &&
+			favorite.id === b[ index ]?.id &&
+			( favorite.collectionId ?? 0 ) === ( b[ index ]?.collectionId ?? 0 )
 	);
 }
 

--- a/tests/php/test-rest-favorites-controller.php
+++ b/tests/php/test-rest-favorites-controller.php
@@ -10,7 +10,9 @@ declare( strict_types=1 );
 namespace Cortext\Tests;
 
 use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\DocumentIdentity;
+use Cortext\PostType\Field;
 use Cortext\PostType\Page;
 use Cortext\Rest\FavoritesController;
 use WorDBless\BaseTestCase;
@@ -19,13 +21,17 @@ use WP_REST_Server;
 
 final class Test_Rest_Favorites_Controller extends BaseTestCase {
 
+	use InMemoryPostsQuery;
+
 	private const META_KEY = 'cortext_favorites';
 
 	public function set_up(): void {
 		parent::set_up();
 
+		$this->unregister_dynamic_collection_post_types();
 		( new Page() )->register_post_type();
 		( new Collection() )->register_post_type();
+		$this->install_in_memory_posts_query();
 
 		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
 		( new FavoritesController() )->register();
@@ -33,6 +39,7 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 	}
 
 	public function tear_down(): void {
+		$this->uninstall_in_memory_posts_query();
 		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
@@ -48,7 +55,7 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 
 	public function test_sets_and_reads_page_and_collection_favorites_in_order(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$page_id       = $this->create_page(
+		$page_id   = $this->create_page(
 			array(
 				'post_name'  => 'daily-notes',
 				'post_title' => 'Daily Notes',
@@ -271,6 +278,56 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 			array( $valid_page ),
 			array_column( $response->get_data()['favorites'], 'id' )
 		);
+		// Keep storage pruned too. Otherwise the next save can replay a stale
+		// favorite and fail before it writes the valid ones.
+		$this->assertSame(
+			array( "page:{$valid_page}" ),
+			get_user_meta( $user_id, self::META_KEY, true )
+		);
+	}
+
+	public function test_get_prunes_a_row_favorite_whose_row_was_trashed(): void {
+		$user_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_id );
+		$collection_id = $this->create_collection( 'people', 'People' );
+		$kept_row      = $this->create_row( 'crtxt_people', 'Kept' );
+		$trashed_row   = $this->create_row( 'crtxt_people', 'Trashed' );
+
+		update_user_meta(
+			$user_id,
+			self::META_KEY,
+			array(
+				array(
+					'kind'         => 'row',
+					'id'           => $kept_row,
+					'collectionId' => $collection_id,
+				),
+				array(
+					'kind'         => 'row',
+					'id'           => $trashed_row,
+					'collectionId' => $collection_id,
+				),
+			)
+		);
+
+		wp_trash_post( $trashed_row );
+		$response = $this->get_favorites();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array( $kept_row ),
+			array_column( $response->get_data()['favorites'], 'id' )
+		);
+		$this->assertSame(
+			array(
+				array(
+					'kind'         => 'row',
+					'id'           => $kept_row,
+					'collectionId' => $collection_id,
+				),
+			),
+			get_user_meta( $user_id, self::META_KEY, true )
+		);
 	}
 
 	public function test_requires_edit_posts_capability(): void {
@@ -298,6 +355,69 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 		$this->assertSame( 400, $response->get_status() );
 		$this->assertSame(
 			'cortext_document_target_inline_collection',
+			$response->get_data()['code']
+		);
+	}
+
+	public function test_sets_and_reads_row_favorites(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'people', 'People' );
+		$row_id        = $this->create_row( 'crtxt_people', 'Ada Lovelace' );
+
+		$set_response = $this->set_favorites(
+			array(
+				array(
+					'kind'         => 'row',
+					'id'           => $row_id,
+					'collectionId' => $collection_id,
+				),
+			)
+		);
+		$get_response = $this->get_favorites();
+
+		$this->assertSame( 200, $set_response->get_status() );
+		$favorites = $set_response->get_data()['favorites'];
+		$this->assertCount( 1, $favorites );
+		$this->assertSame( 'row', $favorites[0]['kind'] );
+		$this->assertSame( $row_id, $favorites[0]['id'] );
+		$this->assertSame( 'Ada Lovelace', $favorites[0]['title'] );
+		$this->assertSame( $collection_id, $favorites[0]['collection']['id'] );
+		$this->assertSame( 'People', $favorites[0]['collection']['title'] );
+		$this->assertSame(
+			$favorites,
+			$get_response->get_data()['favorites']
+		);
+		// Row favorites carry their collection id. Page and collection favorites
+		// keep the old `"kind:id"` string.
+		$this->assertSame(
+			array(
+				array(
+					'kind'         => 'row',
+					'id'           => $row_id,
+					'collectionId' => $collection_id,
+				),
+			),
+			get_user_meta( get_current_user_id(), self::META_KEY, true )
+		);
+	}
+
+	public function test_rejects_a_row_favorite_without_its_collection(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$this->create_collection( 'people', 'People' );
+		$row_id = $this->create_row( 'crtxt_people', 'Ada Lovelace' );
+
+		$response = $this->set_favorites(
+			array(
+				array(
+					'kind' => 'row',
+					'id'   => $row_id,
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame(
+			'cortext_document_target_invalid',
 			$response->get_data()['code']
 		);
 	}
@@ -410,6 +530,34 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 		);
 		$this->assertIsInt( $id );
 		$this->assertGreaterThan( 0, $id );
+
+		( new CollectionEntries() )->register_for_collection( get_post( (int) $id ) );
+
 		return (int) $id;
+	}
+
+	private function create_row( string $post_type, string $title ): int {
+		$id = wp_insert_post(
+			array(
+				'post_type'   => $post_type,
+				'post_status' => 'private',
+				'post_title'  => $title,
+			)
+		);
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+
+		return (int) $id;
+	}
+
+	private function unregister_dynamic_collection_post_types(): void {
+		foreach ( get_post_types() as $post_type ) {
+			if (
+				str_starts_with( $post_type, CollectionEntries::CPT_PREFIX ) &&
+				! in_array( $post_type, array( Page::POST_TYPE, Collection::POST_TYPE, Field::POST_TYPE ), true )
+			) {
+				unregister_post_type( $post_type );
+			}
+		}
 	}
 }


### PR DESCRIPTION
## What

Part of #226.

Favorites can now point at rows, not only pages and full-page collections. Row favorites keep their parent collection context, open through the path returned by the server, and get removed when their row or parent collection is no longer valid.

Existing page and collection favorites keep the same saved format.

## Why

Rows need to be valid favorite targets even before the UI has a dedicated favorite button for them.

## Testing Instructions

1. Add a row favorite through the favorites REST endpoint and confirm it appears in Favorites.
2. Open the row from Favorites and confirm it lands on the row route.
3. Trash that row and reload Favorites; confirm the stale favorite disappears.
4. Favorite a row, then trash its parent collection; confirm the row favorite is removed too.
5. Confirm existing page and collection favorites still load and reorder normally.
