### PR TITLE
Use server trash descendants in the sidebar

### DIFF
--- a/includes/PostType/Cascade/CollectionToRowTrashCascade.php
+++ b/includes/PostType/Cascade/CollectionToRowTrashCascade.php
@@ -37,6 +37,18 @@ final class CollectionToRowTrashCascade extends BaseCascadeStrategy {
 		return Collection::POST_TYPE === get_post_type( $post_id );
 	}
 
+	/**
+	 * Rows trashed alongside their collection. The engine combines this with
+	 * page and collection descendants so the REST trash response can report
+	 * the full subtree in one list.
+	 *
+	 * @param int $root_id Collection post id.
+	 * @return int[]
+	 */
+	public function descendants_for_root( int $root_id ): array {
+		return $this->trashed_child_ids_tagged_with( $root_id );
+	}
+
 	protected function active_child_ids( int $owner_id ): array {
 		$post_type = $this->row_post_type_for( $owner_id );
 		if ( null === $post_type ) {

--- a/includes/PostType/Cascade/DocumentToCollectionTrashCascade.php
+++ b/includes/PostType/Cascade/DocumentToCollectionTrashCascade.php
@@ -40,6 +40,18 @@ final class DocumentToCollectionTrashCascade extends BaseCascadeStrategy {
 		return post_type_supports( $post_type, 'cortext-document' );
 	}
 
+	/**
+	 * Inline collections trashed alongside the owner show up here. The engine
+	 * combines this with descendant pages from the hierarchy strategy so the
+	 * REST trash response can report the full cascade in one list.
+	 *
+	 * @param int $root_id Owner document id (a page or a row).
+	 * @return int[]
+	 */
+	public function descendants_for_root( int $root_id ): array {
+		return $this->trashed_child_ids_tagged_with( $root_id );
+	}
+
 	protected function active_child_ids( int $owner_id ): array {
 		$statuses = array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft' );
 		return $this->dedupe_ids(

--- a/includes/PostType/TrashCascadeEngine.php
+++ b/includes/PostType/TrashCascadeEngine.php
@@ -17,6 +17,9 @@ declare( strict_types=1 );
 namespace Cortext\PostType;
 
 use Cortext\PostType\Cascade\CascadeStrategy;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
 
 final class TrashCascadeEngine {
 
@@ -44,9 +47,95 @@ final class TrashCascadeEngine {
 		add_action( 'wp_trash_post', array( $this, 'on_trash' ), 10, 1 );
 		add_action( 'untrashed_post', array( $this, 'on_restore' ), 10, 1 );
 		add_action( 'before_delete_post', array( $this, 'on_delete' ), 10, 1 );
+		add_action( 'rest_api_init', array( $this, 'register_rest_filters' ) );
 		foreach ( $this->strategies as $strategy ) {
 			$strategy->register_filters();
 		}
+	}
+
+	public function register_rest_filters(): void {
+		// Pages cascade into descendants and inline collections; the response
+		// to a REST trash should carry those ids so the client can drop them
+		// from favorites without re-computing the cascade locally.
+		add_filter(
+			'rest_prepare_' . Page::POST_TYPE,
+			array( $this, 'extend_trash_response' ),
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Adds the cascade list to a REST trash response. The client uses it to
+	 * filter favorites without re-walking the page tree locally.
+	 *
+	 * @param WP_REST_Response $response Prepared response.
+	 * @param WP_Post          $post     Post being responded for.
+	 * @param WP_REST_Request  $request  Incoming REST request.
+	 */
+	public function extend_trash_response( WP_REST_Response $response, WP_Post $post, WP_REST_Request $request ): WP_REST_Response {
+		if ( 'DELETE' !== $request->get_method() ) {
+			return $response;
+		}
+
+		$data = $response->get_data();
+		if ( ! is_array( $data ) ) {
+			return $response;
+		}
+
+		$data['cascade_deleted'] = $this->cascade_deleted_for_root( (int) $post->ID );
+		$response->set_data( $data );
+		return $response;
+	}
+
+	/**
+	 * Groups cascade-deleted ids by document kind. Walks across strategies so
+	 * a page subtree picks up inline collections nested in subpages and rows
+	 * nested in those collections, not just the descendants the root strategy
+	 * sees directly.
+	 *
+	 * @param int $root_id Root post id that was trashed.
+	 * @return array{pages: int[], collections: int[], rows: int[]}
+	 */
+	private function cascade_deleted_for_root( int $root_id ): array {
+		$grouped = array(
+			'pages'       => array(),
+			'collections' => array(),
+			'rows'        => array(),
+		);
+
+		$seen     = array( $root_id => true );
+		$frontier = array( $root_id );
+		while ( ! empty( $frontier ) ) {
+			$next = array();
+			foreach ( $frontier as $current ) {
+				foreach ( $this->strategies as $strategy ) {
+					if ( ! $strategy->applies_to( $current ) ) {
+						continue;
+					}
+					foreach ( $strategy->descendants_for_root( $current ) as $descendant_id ) {
+						$descendant_id = (int) $descendant_id;
+						if ( isset( $seen[ $descendant_id ] ) ) {
+							continue;
+						}
+						$seen[ $descendant_id ] = true;
+						$next[]                 = $descendant_id;
+
+						$type = get_post_type( $descendant_id );
+						if ( Page::POST_TYPE === $type ) {
+							$grouped['pages'][] = $descendant_id;
+						} elseif ( Collection::POST_TYPE === $type ) {
+							$grouped['collections'][] = $descendant_id;
+						} elseif ( is_string( $type ) && str_starts_with( $type, CollectionEntries::CPT_PREFIX ) ) {
+							$grouped['rows'][] = $descendant_id;
+						}
+					}
+				}
+			}
+			$frontier = $next;
+		}
+
+		return $grouped;
 	}
 
 	public function register_meta(): void {

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -411,11 +411,11 @@ export default function Sidebar( {
 		[ home ]
 	);
 
-	// Descriptors need the sidebar lists plus a few feedback callbacks.
+	// Feedback channel descriptors call into. The page tree and collection
+	// list stay out of here: the trash cascade now rides on the server
+	// response, so descriptors no longer need to walk them locally.
 	const documentsHandlers = useMemo(
 		() => ( {
-			pages,
-			collections,
 			selectedCollectionId,
 			expand,
 			onSelect,
@@ -424,7 +424,7 @@ export default function Sidebar( {
 			onDuplicateNotice: setDuplicateNotice,
 			onFavoritesError: setFavoritesError,
 		} ),
-		[ pages, collections, selectedCollectionId, expand, onSelect ]
+		[ selectedCollectionId, expand, onSelect ]
 	);
 
 	// Props shared by every DocumentRow. Keeping them together makes the Pages

--- a/src/documents/descriptors/page.js
+++ b/src/documents/descriptors/page.js
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 import { POST_TYPE } from '../../components/page-queries';
-import { collectDescendants } from '../../components/pages-tree';
 import { computeDocumentUri } from '../../router/useResolveEntity';
 import { notifyDocumentTrashChanged } from '../../hooks/documentTrashInvalidation';
 import { cascadeFavorites } from '../favorites';
@@ -10,8 +9,8 @@ import { afterPageTrash, applyInvalidationPack } from '../invalidation';
 
 /**
  * Page actions used by the sidebar. Pages are hierarchical, can own child
- * pages, and can have their own icon. Trash still computes the affected page
- * and collection ids locally until the server returns that list.
+ * pages, and can have their own icon. The REST trash response carries the
+ * cascade ids so the favorites cleanup does not need a local page tree walk.
  */
 const pageDescriptor = {
 	features: {
@@ -75,24 +74,23 @@ const pageDescriptor = {
 		}
 		applyInvalidationPack( ctx.invalidateResolution, afterPageTrash );
 		notifyDocumentTrashChanged();
-		// Cascade the local trash set into Favorites: the page itself, its
-		// descendants, and any inline collections owned by those pages. The
-		// server can replace this with an authoritative list later without
-		// changing the favorites filter step.
-		const trashedPageIds = new Set( [
-			Number( record.id ),
-			...collectDescendants( Number( record.id ), ctx.pages ?? [] ),
-		] );
-		const trashedCollectionIds = new Set(
-			( ctx.collections ?? [] )
-				.filter( ( collection ) =>
-					trashedPageIds.has( Number( collection.parent ?? 0 ) )
-				)
-				.map( ( collection ) => Number( collection.id ) )
-		);
+		// The server returns the cascade alongside the trashed page: child
+		// pages plus any inline collections that came with them. The favorites
+		// cleanup just consumes that list, so the page tree never has to be
+		// walked on the client.
+		const cascade = deleted?.cascade_deleted ?? {};
 		await cascadeFavorites(
 			ctx,
-			{ page: trashedPageIds, collection: trashedCollectionIds },
+			{
+				page: new Set( [
+					Number( record.id ),
+					...( cascade.pages ?? [] ).map( Number ),
+				] ),
+				collection: new Set(
+					( cascade.collections ?? [] ).map( Number )
+				),
+				row: new Set( ( cascade.rows ?? [] ).map( Number ) ),
+			},
 			__(
 				'Page moved to Trash, but Favorites could not be updated.',
 				'cortext'

--- a/src/documents/hooks.js
+++ b/src/documents/hooks.js
@@ -25,8 +25,6 @@ import { getDescriptor } from './descriptors';
 const DocumentsContext = createContext( null );
 
 export function DocumentsProvider( {
-	pages,
-	collections,
 	selectedCollectionId = null,
 	expand,
 	onSelect,
@@ -38,8 +36,6 @@ export function DocumentsProvider( {
 } ) {
 	const value = useMemo(
 		() => ( {
-			pages,
-			collections,
 			selectedCollectionId,
 			expand,
 			onSelect,
@@ -49,8 +45,6 @@ export function DocumentsProvider( {
 			onFavoritesError,
 		} ),
 		[
-			pages,
-			collections,
 			selectedCollectionId,
 			expand,
 			onSelect,

--- a/tests/php/test-rest-documents-controller-mutations.php
+++ b/tests/php/test-rest-documents-controller-mutations.php
@@ -281,6 +281,42 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 		$this->assertNull( get_post( $row_id ) );
 	}
 
+	public function test_trash_response_lists_cascade_deleted_pages_and_collections(): void {
+		// The sidebar uses this list to drop favorites without re-walking the
+		// page tree. Without it, the client carries that knowledge.
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id     = $this->create_page();
+		$child_id      = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$grandchild_id = $this->create_page( array( 'post_parent' => $child_id ) );
+
+		$inline_collection_id = wp_insert_post(
+			array(
+				'post_type'   => Collection::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Inline owned by parent',
+				'meta_input'  => array(
+					Collection::MODE_META_KEY         => Collection::MODE_INLINE,
+					Collection::INLINE_OWNER_META_KEY => $parent_id,
+				),
+			)
+		);
+
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/crtxt_pages/' . $parent_id );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'cascade_deleted', $data );
+		$this->assertContains( $child_id, $data['cascade_deleted']['pages'] );
+		$this->assertContains( $grandchild_id, $data['cascade_deleted']['pages'] );
+		$this->assertContains(
+			$inline_collection_id,
+			$data['cascade_deleted']['collections'],
+			'Inline collections owned by the trashed page belong in the cascade response.'
+		);
+	}
+
 	public function test_restores_a_trashed_full_page_collection(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
 


### PR DESCRIPTION
## What

Part of #226.

The sidebar no longer rebuilds the page trash tree on its own. When a page is trashed, the REST response includes the pages and collections that went with it, and Favorites uses that list to clean itself up.

This also keeps the shared row/descriptor work in place for pages and collections. The sidebar should look and behave the same: render, navigate, drag, rename, duplicate, favorite, and trash should all keep working.

## Why

The trash cascade already knows what it touched. The sidebar should use that answer instead of carrying a second copy of the rules.

## How

- Returning trashed descendant ids from page trash responses.
- Moving page/collection row behavior behind descriptors.
- Reusing one row component and one Favorites cleanup path.

## Testing Instructions

1. Open Cortext and confirm pages and collections render in the sidebar.
2. Rename, favorite, and duplicate a page; confirm each action still works.
3. Rename, favorite, and duplicate a collection; confirm each action still works.
4. Drag a page into another page and drag a collection above or below a page; confirm the same drop behavior as before.
5. Favorite a child page and a collection under a page, then trash the parent page; confirm those favorites disappear and the Trash panel opens.
6. Restore the trashed page tree and confirm the sidebar shows the restored items again.
