### PR TITLE
Chore: Fix performance benchmark JSON output

### DIFF
--- a/includes/Block/DataView.php
+++ b/includes/Block/DataView.php
@@ -13,13 +13,20 @@ use Cortext\PostType\Collection;
 
 final class DataView {
 
+	public const BLOCK_NAME = 'cortext/data-view';
+
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_block' ) );
 	}
 
 	public function register_block(): void {
+		$block_path = CORTEXT_PATH . 'build/blocks/data-view';
+		if ( ! is_readable( $block_path . '/block.json' ) ) {
+			$block_path = CORTEXT_PATH . 'src/blocks/data-view';
+		}
+
 		register_block_type(
-			CORTEXT_PATH . 'build/blocks/data-view',
+			$block_path,
 			array(
 				'render_callback' => array( $this, 'render' ),
 			)

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1389,7 +1389,7 @@ export default function CollectionDataViews( {
 					return false;
 				}
 			}
-			scrollToEndQuickly( wrapper );
+			scrollToEndQuickly( wrapper, { trackEnd: true } );
 			if ( localRevealFieldId === pendingRevealFieldId ) {
 				setLocalRevealFieldId( null );
 			}
@@ -1401,10 +1401,21 @@ export default function CollectionDataViews( {
 			return undefined;
 		}
 
-		const frame = window.requestAnimationFrame( reveal );
+		let frame = 0;
+		let attempts = 0;
+		const retryReveal = () => {
+			if ( reveal() || attempts >= 30 ) {
+				return;
+			}
+			attempts += 1;
+			frame = window.requestAnimationFrame( retryReveal );
+		};
+		frame = window.requestAnimationFrame( retryReveal );
 
 		return () => {
-			window.cancelAnimationFrame( frame );
+			if ( frame ) {
+				window.cancelAnimationFrame( frame );
+			}
 		};
 	}, [
 		fieldsResolved,

--- a/src/components/dataViewScroll.js
+++ b/src/components/dataViewScroll.js
@@ -11,11 +11,16 @@ function isAtScrollEnd( scrollLeft, target ) {
 
 export function scrollToEndQuickly( wrapper, options = {} ) {
 	const maxScroll = wrapper.scrollWidth - wrapper.clientWidth;
-	if ( maxScroll <= 0 ) {
+	const trackEnd = options.trackEnd === true;
+	if ( maxScroll <= 0 && ! trackEnd ) {
 		return;
 	}
 	const isRtl = window.getComputedStyle( wrapper ).direction === 'rtl';
-	const target = isRtl ? -maxScroll : maxScroll;
+	const endTarget = () => {
+		const currentMaxScroll = wrapper.scrollWidth - wrapper.clientWidth;
+		return isRtl ? -currentMaxScroll : currentMaxScroll;
+	};
+	const target = endTarget();
 	const start = wrapper.scrollLeft;
 	if ( options.snapIfAtEnd ) {
 		if ( isAtScrollEnd( start, target ) ) {
@@ -35,7 +40,7 @@ export function scrollToEndQuickly( wrapper, options = {} ) {
 	}
 
 	const distance = target - start;
-	if ( distance === 0 ) {
+	if ( distance === 0 && ! trackEnd ) {
 		return;
 	}
 
@@ -45,9 +50,13 @@ export function scrollToEndQuickly( wrapper, options = {} ) {
 
 	const animate = ( now ) => {
 		const progress = Math.min( 1, ( now - startedAt ) / duration );
-		wrapper.scrollLeft = start + distance * easeOutCubic( progress );
+		const currentTarget = endTarget();
+		wrapper.scrollLeft =
+			start + ( currentTarget - start ) * easeOutCubic( progress );
 		if ( progress < 1 ) {
 			window.requestAnimationFrame( animate );
+		} else {
+			wrapper.scrollLeft = currentTarget;
 		}
 	};
 	window.requestAnimationFrame( animate );

--- a/tests/js/components/CollectionDataViews.test.js
+++ b/tests/js/components/CollectionDataViews.test.js
@@ -1,13 +1,18 @@
 import { scrollToEndQuickly } from '../../../src/components/dataViewScroll';
 
-function makeScroller( { direction = 'ltr', scrollLeft = 0 } = {} ) {
+function makeScroller( {
+	direction = 'ltr',
+	scrollLeft = 0,
+	scrollWidth = 800,
+	clientWidth = 200,
+} = {} ) {
 	const wrapper = document.createElement( 'div' );
 	Object.defineProperty( wrapper, 'clientWidth', {
-		value: 200,
+		value: clientWidth,
 		configurable: true,
 	} );
 	Object.defineProperty( wrapper, 'scrollWidth', {
-		value: 800,
+		value: scrollWidth,
 		configurable: true,
 	} );
 	wrapper.scrollLeft = scrollLeft;
@@ -84,5 +89,28 @@ describe( 'scrollToEndQuickly', () => {
 		expect( wrapper.scrollLeft ).toBe( 800 );
 		expect( wrapper.dataset.cortextRevealAtEnd ).toBeUndefined();
 		expect( window.requestAnimationFrame ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps chasing the end while the table grows', () => {
+		window.matchMedia = jest.fn( () => ( { matches: false } ) );
+		const now = jest
+			.spyOn( window.performance, 'now' )
+			.mockReturnValue( 0 );
+		let frame;
+		window.requestAnimationFrame = jest.fn( ( callback ) => {
+			frame = callback;
+			return 1;
+		} );
+		const wrapper = makeScroller( { scrollWidth: 200 } );
+
+		scrollToEndQuickly( wrapper, { trackEnd: true } );
+		Object.defineProperty( wrapper, 'scrollWidth', {
+			value: 500,
+			configurable: true,
+		} );
+		frame( 180 );
+
+		expect( wrapper.scrollLeft ).toBe( 300 );
+		now.mockRestore();
 	} );
 } );

--- a/tests/php/test-data-view-block.php
+++ b/tests/php/test-data-view-block.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for the server-side data-view block registration.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Block\DataView;
+use WP_Block_Type_Registry;
+use WorDBless\BaseTestCase;
+
+final class Test_Data_View_Block extends BaseTestCase {
+
+	/**
+	 * Doing-it-wrong notices captured while registering the block.
+	 *
+	 * @var string[]
+	 */
+	private array $doing_it_wrong_messages = array();
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->unregister_data_view_block();
+		add_action( 'doing_it_wrong_run', array( $this, 'capture_doing_it_wrong' ), 10, 3 );
+	}
+
+	public function tear_down(): void {
+		remove_action( 'doing_it_wrong_run', array( $this, 'capture_doing_it_wrong' ), 10 );
+		$this->unregister_data_view_block();
+
+		parent::tear_down();
+	}
+
+	public function test_register_block_uses_valid_metadata_when_build_is_missing(): void {
+		( new DataView() )->register_block();
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		$block    = $registry->get_registered( DataView::BLOCK_NAME );
+
+		$this->assertSame( array(), $this->doing_it_wrong_messages );
+		$this->assertNotFalse( $block );
+		$this->assertSame( DataView::BLOCK_NAME, $block->name );
+		$this->assertIsCallable( $block->render_callback );
+	}
+
+	public function capture_doing_it_wrong( string $function_name, string $message, string $version ): void {
+		unset( $version );
+
+		$this->doing_it_wrong_messages[] = "{$function_name}: {$message}";
+	}
+
+	private function unregister_data_view_block(): void {
+		$registry = WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( DataView::BLOCK_NAME ) ) {
+			$registry->unregister( DataView::BLOCK_NAME );
+		}
+	}
+}


### PR DESCRIPTION
## What

Fixes the benchmark JSON noise visible in the first failing main benchmark run I found: [26181483432](https://github.com/Automattic/cortext/actions/runs/26181483432). The data view block now falls back to source metadata when build files are missing.