### PR TITLE
Refactor: Use Cortext colors for shell UI

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,22 +1,81 @@
 # Theming
 
-These are implementation notes for the current prototype, not a stable public API.
+These are implementation notes for the current prototype, not a stable
+public API.
 
 Cortext has two visual surfaces:
 
--   The shell: sidebar, toolbar, buttons, empty states, and collection views.
--   Content: published pages and the block editor canvas.
+- The shell: sidebar, toolbar, buttons, empty states, and collection views.
+- Content: published pages and the block editor canvas.
 
-The shell is Cortext UI. Published content belongs to the active WordPress theme. Cortext should not push shell colors into public pages or into the editor iframe.
+The shell is Cortext UI. Published content belongs to the active WordPress
+theme. Cortext should not push shell colors into public pages or into the
+editor iframe.
 
 ## Current behavior
 
-Cortext has light, dark, and system color modes for the shell. The preference is stored locally in the browser for now.
+Cortext has light, dark, and system color modes for the shell. The
+preference is stored locally in the browser for now.
 
-Collection views stay on a light surface even when the shell is dark. That is a practical choice: DataViews and several WordPress controls still assume a light admin canvas.
+Collection views stay on a light surface even when the shell is dark. That
+is a practical choice: DataViews and several WordPress controls still
+assume a light admin canvas. Row detail is treated the same way; it is a
+canvas-adjacent surface and stays light in both shell modes.
 
 ## Tokens
 
-Shell colors are controlled by CSS custom properties in `src/styles/_tokens.scss`. They are useful for local experiments, but they are not a public theme API yet.
+Shell colors are controlled by CSS custom properties:
 
-If we make shell theming public later, the contract should stay small: colors, basic radius, and maybe accent choices. Layout changes should stay out of scope.
+- `src/styles/_tokens.scss`: shell chrome tokens. Live on `:root` for the
+  accent/danger/option palette (so popovers and the editor iframe can
+  resolve them) and on `.cortext-root` for surfaces, text, borders and
+  state overlays (so dark mode can override via
+  `.cortext-root[data-theme="dark"]`).
+- `src/styles/_tokens-row-detail.scss`: row-detail tokens. Scoped to
+  `.cortext-row-detail, .cortext-row-detail-modal`. Light-only by design;
+  see "current behavior" above.
+
+The tokens are useful for local experiments, but they are not a public
+theme API yet. If shell theming becomes public later, the contract should
+stay small: colors, basic radius, and maybe accent choices. Layout
+changes should stay out of scope.
+
+## Cortext-owned vs editor-owned accents
+
+`var(--cortext-accent)` is the brand color for Cortext-rendered UI:
+sidebar primary buttons, popover focus rings, row-detail input focus
+rings, drag/drop indicators, the alpha notice icon, cell link color,
+relation chip focus, format-submenu selected tile, the canvas progress
+bar, and so on.
+
+`var(--wp-admin-theme-color)` is intentionally kept in a small set of
+places where the surface belongs to the editor or follows the editor's
+conventions:
+
+- `.cortext-cell-bar` / `.cortext-cell-ring` default color: the "default"
+  value in the number-format palette means "follow site default", which
+  is the editor's accent.
+- `cortext/document-icon` block selection outline: matches the editor's
+  block-selection convention so it does not visually diverge from other
+  blocks in the canvas.
+- `FieldFormatPopover.js` default-color swatch: same semantic as the
+  bar/ring above; "default" maps to the editor's accent.
+
+If you add a new piece of Cortext UI, default to `--cortext-accent`. Only
+fall back to `--wp-admin-theme-color` when the surface is genuinely
+editor-owned or needs to track the editor's chrome.
+
+## Destructive signal
+
+`var(--cortext-danger)` is the Cortext-owned destructive red, with
+`var(--cortext-danger-strong)` for hover/active states. Same value as
+WordPress's destructive red so the visual stays familiar. Both live on
+`:root` so popover-mounted destructive items can resolve them.
+
+## Where this leaves us
+
+The shell now reads from a coherent token contract. Light and dark
+remain the two visible modes. The door is open for named variants
+(`[data-cortext-variant="..."]`) and a font-family toggle to land later
+without touching every shell-owned selector again. Those are feature
+work, not part of this refactor.

--- a/src/components/DocumentIdentityControls.js
+++ b/src/components/DocumentIdentityControls.js
@@ -419,7 +419,6 @@ function PickerBody( {
 					<button
 						type="button"
 						className="cortext-document-identity-popover__remove"
-						style={ { color: '#d63638' } }
 						onClick={ () => persist( '' ) }
 					>
 						{ __( 'Remove', 'cortext' ) }

--- a/src/components/IconLibraryPicker.js
+++ b/src/components/IconLibraryPicker.js
@@ -3,6 +3,8 @@ import * as icons from '@wordpress/icons';
 import { Button, SearchControl } from '@wordpress/components';
 import { useMemo, useState } from '@wordpress/element';
 
+import { ICON_COLORS as NAMED_ICON_COLORS } from './iconColors';
+
 // Filter the package down to renderable icon components. `@wordpress/icons`
 // exports the `Icon` wrapper alongside the actual glyphs; the wrapper is a
 // function component while glyphs are JSX trees (object). We want only the
@@ -18,22 +20,13 @@ const ICON_NAMES = Object.entries( icons )
 	.map( ( [ name ] ) => name )
 	.sort();
 
-// Fixed named palette so the storage stays
-// validatable (PHP sanitize accepts only these names) and so the visual
-// language is consistent across the editor and frontend. `default` falls
-// back to currentColor, which means the icon picks up the surrounding
-// text color (works in both light and dark mode without extra tokens).
+// Picker palette: the shared named colors plus a `default` entry that maps
+// to `currentColor` so the icon picks up the surrounding text color (works
+// in light and dark without extra tokens). PHP sanitize accepts the named
+// values; `default` is represented as the absence of a stored color.
 const ICON_COLORS = [
 	{ name: 'default', label: __( 'Default', 'cortext' ), css: 'currentColor' },
-	{ name: 'gray', label: __( 'Gray', 'cortext' ), css: '#9ca3af' },
-	{ name: 'brown', label: __( 'Brown', 'cortext' ), css: '#92400e' },
-	{ name: 'orange', label: __( 'Orange', 'cortext' ), css: '#f97316' },
-	{ name: 'yellow', label: __( 'Yellow', 'cortext' ), css: '#eab308' },
-	{ name: 'green', label: __( 'Green', 'cortext' ), css: '#22c55e' },
-	{ name: 'blue', label: __( 'Blue', 'cortext' ), css: '#3b82f6' },
-	{ name: 'purple', label: __( 'Purple', 'cortext' ), css: '#a855f7' },
-	{ name: 'pink', label: __( 'Pink', 'cortext' ), css: '#ec4899' },
-	{ name: 'red', label: __( 'Red', 'cortext' ), css: '#ef4444' },
+	...NAMED_ICON_COLORS,
 ];
 
 const HumanizeName = ( name ) =>

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/element';
 
 import useDelayedFlag from '../hooks/useDelayedFlag';
+import { ICON_COLOR_BY_NAME } from './iconColors';
 
 // PageIconWp does `import * as icons from '@wordpress/icons'` so it can look
 // glyphs up by name at runtime. That defeats tree-shaking and would pull the
@@ -24,17 +25,6 @@ const PageIconWp = lazy( () =>
 //   { type: 'image', id: 123 }
 //   { type: 'wp', name: 'home', color?: 'red' }
 // Anything else (empty meta, parse error) falls through to the page glyph.
-const WP_ICON_COLORS = {
-	gray: '#9ca3af',
-	brown: '#92400e',
-	orange: '#f97316',
-	yellow: '#eab308',
-	green: '#22c55e',
-	blue: '#3b82f6',
-	purple: '#a855f7',
-	pink: '#ec4899',
-	red: '#ef4444',
-};
 
 export function parsePageIcon( raw ) {
 	if ( ! raw ) {
@@ -64,7 +54,7 @@ export function parsePageIcon( raw ) {
 		) {
 			const color =
 				typeof decoded.color === 'string' &&
-				WP_ICON_COLORS[ decoded.color ]
+				ICON_COLOR_BY_NAME[ decoded.color ]
 					? decoded.color
 					: null;
 			return { type: 'wp', name: decoded.name, color };
@@ -189,7 +179,7 @@ export default function PageIcon( { icon, size = 16, alt, className } ) {
 
 	if ( parsed.type === 'wp' ) {
 		const colorStyle = parsed.color
-			? { color: WP_ICON_COLORS[ parsed.color ] }
+			? { color: ICON_COLOR_BY_NAME[ parsed.color ] }
 			: undefined;
 		return (
 			<span

--- a/src/components/iconColors.js
+++ b/src/components/iconColors.js
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+
+// Named icon colors persisted in the `cortext_document_icon` meta as the
+// `color` field. PHP sanitization accepts only these names, so the JS palette
+// is the source of truth for both the picker UI and the renderer.
+export const ICON_COLORS = [
+	{ name: 'gray', label: __( 'Gray', 'cortext' ), css: '#9ca3af' },
+	{ name: 'brown', label: __( 'Brown', 'cortext' ), css: '#92400e' },
+	{ name: 'orange', label: __( 'Orange', 'cortext' ), css: '#f97316' },
+	{ name: 'yellow', label: __( 'Yellow', 'cortext' ), css: '#eab308' },
+	{ name: 'green', label: __( 'Green', 'cortext' ), css: '#22c55e' },
+	{ name: 'blue', label: __( 'Blue', 'cortext' ), css: '#3b82f6' },
+	{ name: 'purple', label: __( 'Purple', 'cortext' ), css: '#a855f7' },
+	{ name: 'pink', label: __( 'Pink', 'cortext' ), css: '#ec4899' },
+	{ name: 'red', label: __( 'Red', 'cortext' ), css: '#ef4444' },
+];
+
+// Lookup map for the renderer: name → css value. Unknown names yield
+// undefined so callers can fall back to the surrounding color.
+export const ICON_COLOR_BY_NAME = Object.fromEntries(
+	ICON_COLORS.map( ( c ) => [ c.name, c.css ] )
+);

--- a/src/index.scss
+++ b/src/index.scss
@@ -880,7 +880,7 @@ body.cortext-fullscreen {
 		margin: 0;
 		padding: 0 $grid-unit-05;
 		font-size: 11px;
-		color: #cc1818;
+		color: var(--cortext-danger);
 	}
 
 	// Modeled on `.cortext-column-resizer` so both resizers feel the same.
@@ -2110,7 +2110,7 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 // flips the row to the neutral active color above, which keeps the row
 // readable without leaking the destructive color into hover.
 .cortext-column-header-actions__destructive-item:not([data-active-item="true"]) {
-	color: var(--wp-components-color-destructive, #cc1818);
+	color: var(--cortext-danger);
 }
 
 // Marker spans live inside DataViews' header trigger button. Zero-size
@@ -2440,7 +2440,7 @@ tbody > tr > td:not(:first-child) {
 	}
 
 	&__error {
-		color: #cc1818;
+		color: var(--cortext-danger);
 		font-size: 12px;
 		margin-top: $grid-unit-05;
 	}
@@ -2808,7 +2808,7 @@ tr:has(.cortext-title-cell--is-opening)
 
 	&__error {
 		padding: $grid-unit-05 $grid-unit-10;
-		color: #cc1818;
+		color: var(--cortext-danger);
 		font-size: 12px;
 	}
 }
@@ -5700,13 +5700,13 @@ body.cortext-hide-parent-block-toolbar
 			background: transparent;
 			border: 0;
 			cursor: pointer;
-			color: #d63638 !important;
+			color: var(--cortext-danger) !important;
 			font-size: 13px;
 			font-weight: 500;
 
 			&:hover,
 			&:focus {
-				color: #b32d2e !important;
+				color: var(--cortext-danger-strong) !important;
 			}
 		}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -3282,15 +3282,6 @@ tr:has(.cortext-title-cell--is-opening)
 
 .cortext-row-detail,
 .cortext-row-detail-modal {
-	--cortext-row-detail-text: #37352f;
-	--cortext-row-detail-muted: #787774;
-	--cortext-row-detail-border: #e9e9e7;
-	--cortext-row-detail-hover-surface: #f7f6f3;
-	--cortext-row-detail-pressed-surface: #ebeae6;
-	--cortext-row-detail-field-inset: 56px;
-	--cortext-row-detail-toolbar-button-size: #{$grid-unit-40};
-	--cortext-row-detail-toolbar-button-padding: #{$grid-unit-10};
-
 	font-size: 13px;
 	line-height: 1.4;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1217,7 +1217,7 @@ body.cortext-sidebar-resizing {
 		border-radius: 2px;
 
 		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color, #3858e9);
+			outline: 2px solid var(--cortext-accent);
 			outline-offset: 1px;
 		}
 	}
@@ -1739,7 +1739,7 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline: 2px solid var(--cortext-accent);
 			outline-offset: -1px;
 		}
 
@@ -1811,7 +1811,7 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline: 2px solid var(--cortext-accent);
 			outline-offset: -1px;
 		}
 
@@ -1859,7 +1859,7 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline: 2px solid var(--cortext-accent);
 			outline-offset: -1px;
 		}
 	}
@@ -1933,13 +1933,13 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline: 2px solid var(--cortext-accent);
 			outline-offset: -1px;
 		}
 
 		&.is-selected {
-			border-color: var(--wp-admin-theme-color, $gray-700);
-			color: var(--wp-admin-theme-color, $gray-900);
+			border-color: var(--cortext-accent);
+			color: var(--cortext-accent);
 		}
 	}
 
@@ -2053,12 +2053,12 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline: 2px solid var(--cortext-accent);
 			outline-offset: -1px;
 		}
 
 		&.is-selected {
-			color: var(--wp-admin-theme-color, $gray-900);
+			color: var(--cortext-accent);
 		}
 	}
 
@@ -2564,7 +2564,7 @@ tr:has(.cortext-title-cell--is-opening)
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	vertical-align: middle;
-	color: var(--wp-admin-theme-color);
+	color: var(--cortext-accent);
 	text-decoration: underline;
 	text-underline-offset: 2px;
 
@@ -2630,7 +2630,7 @@ tr:has(.cortext-title-cell--is-opening)
 
 	&:focus-visible {
 		outline: 0;
-		box-shadow: inset 0 0 0 2px var(--wp-admin-theme-color, $gray-700);
+		box-shadow: inset 0 0 0 2px var(--cortext-accent);
 	}
 }
 
@@ -2750,7 +2750,7 @@ tr:has(.cortext-title-cell--is-opening)
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--wp-admin-theme-color, $gray-700);
+			outline: 2px solid var(--cortext-accent);
 			outline-offset: -1px;
 		}
 
@@ -3568,7 +3568,7 @@ tr:has(.cortext-title-cell--is-opening)
 		&:focus,
 		&:focus-visible {
 			background: transparent;
-			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px var(--cortext-accent);
 		}
 	}
 
@@ -3587,7 +3587,7 @@ tr:has(.cortext-title-cell--is-opening)
 	input.cortext-row-detail__title-input:focus,
 	input.cortext-row-detail__title-input:focus-visible {
 		background: transparent;
-		box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 1px var(--cortext-accent);
 	}
 
 	/* stylelint-disable no-descending-specificity */
@@ -3835,8 +3835,8 @@ tr:has(.cortext-title-cell--is-opening)
 			}
 
 			&:focus {
-				border-color: var(--wp-admin-theme-color);
-				box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+				border-color: var(--cortext-accent);
+				box-shadow: 0 0 0 1px var(--cortext-accent);
 			}
 		}
 
@@ -3855,7 +3855,7 @@ tr:has(.cortext-title-cell--is-opening)
 			position: absolute;
 			inset: 0 -6px;
 			border-radius: 4px;
-			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px var(--cortext-accent);
 			pointer-events: none;
 		}
 	}
@@ -4234,7 +4234,7 @@ tr:has(.cortext-title-cell--is-opening)
 		left: -40%;
 		width: 40%;
 		height: 100%;
-		background: var(--wp-admin-theme-color, #007cba);
+		background: var(--cortext-accent);
 		border-radius: 2px;
 		animation: cortext-canvas-progress-slide 1.4s ease-in-out infinite;
 	}
@@ -4341,7 +4341,7 @@ tr:has(.cortext-title-cell--is-opening)
 
 		&:hover::after,
 		&:focus-visible::after {
-			background: var(--wp-admin-theme-color);
+			background: var(--cortext-accent);
 		}
 
 		&:focus-visible {
@@ -4866,7 +4866,7 @@ body.cortext-row-reorder-no-transition .cortext-row-reorder-target {
 
 .cortext-row-drag-handle:focus-visible {
 	opacity: 1;
-	outline: 2px solid var(--wp-admin-theme-color);
+	outline: 2px solid var(--cortext-accent);
 	outline-offset: 1px;
 }
 
@@ -4890,7 +4890,7 @@ body.cortext-row-dragging .cortext-row-drop-indicator {
 	right: 0;
 	left: 0;
 	top: 0;
-	border-top: 2px solid var(--wp-admin-theme-color);
+	border-top: 2px solid var(--cortext-accent);
 	opacity: 0;
 }
 
@@ -4916,7 +4916,7 @@ body.cortext-row-dragging .cortext-row-drop-indicator {
 	max-width: calc(100vw - 48px);
 	background: $white;
 	box-shadow:
-		inset 3px 0 0 var(--wp-admin-theme-color),
+		inset 3px 0 0 var(--cortext-accent),
 		inset 0 0 0 $border-width $gray-200,
 		0 2px 8px rgba(0, 0, 0, 0.12);
 	border-radius: 2px;
@@ -5068,7 +5068,7 @@ div[role="row"]:not(.is-selected).is-hovered
 		right: 0;
 		width: 3px;
 		height: 100%;
-		background: var(--wp-admin-theme-color);
+		background: var(--cortext-accent);
 		opacity: 0;
 		transition: opacity 100ms ease;
 	}
@@ -5087,7 +5087,7 @@ body.cortext-column-resizing {
 .cortext-column-drop-indicator {
 	position: absolute;
 	width: 2px;
-	background: var(--wp-admin-theme-color);
+	background: var(--cortext-accent);
 	pointer-events: none;
 	z-index: 3;
 	transform: translateX(-1px);
@@ -5754,7 +5754,7 @@ body.cortext-hide-parent-block-toolbar
 		display: inline-flex;
 		flex-shrink: 0;
 		margin-top: 2px;
-		color: var(--wp-admin-theme-color, #007cba);
+		color: var(--cortext-accent);
 	}
 
 	&__repo {

--- a/src/index.scss
+++ b/src/index.scss
@@ -4234,10 +4234,18 @@ tr:has(.cortext-title-cell--is-opening)
 		left: -40%;
 		width: 40%;
 		height: 100%;
+		// Sits on the canvas frame, which goes dark with the shell.
+		// Accent-contrast keeps the bar visible against `#2a2a2a`; the
+		// override below applies inside `.cortext-root` so the cascade
+		// picks the right value automatically.
 		background: var(--cortext-accent);
 		border-radius: 2px;
 		animation: cortext-canvas-progress-slide 1.4s ease-in-out infinite;
 	}
+}
+
+.cortext-root[data-theme="dark"] .cortext-canvas-progress::before {
+	background: var(--cortext-accent-contrast);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/_tokens-row-detail.scss
+++ b/src/styles/_tokens-row-detail.scss
@@ -1,0 +1,18 @@
+@use "@wordpress/base-styles/variables" as variables;
+
+// Row-detail tokens. Live alongside the shell tokens but stay on a
+// light surface even when the shell is in dark mode: row detail is a
+// canvas-adjacent surface and the canvas itself is light-only today.
+// If the canvas ever gets a real dark variant, mirror these under the
+// dark selector at the same time.
+.cortext-row-detail,
+.cortext-row-detail-modal {
+	--cortext-row-detail-text: #37352f;
+	--cortext-row-detail-muted: #787774;
+	--cortext-row-detail-border: #e9e9e7;
+	--cortext-row-detail-hover-surface: #f7f6f3;
+	--cortext-row-detail-pressed-surface: #ebeae6;
+	--cortext-row-detail-field-inset: 56px;
+	--cortext-row-detail-toolbar-button-size: #{variables.$grid-unit-40};
+	--cortext-row-detail-toolbar-button-padding: #{variables.$grid-unit-10};
+}

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -18,6 +18,21 @@
 	--cortext-scrollbar-thumb: rgba(0, 0, 0, 0.12);
 	--cortext-scrollbar-thumb-hover: rgba(0, 0, 0, 0.28);
 
+	// Cortext-owned product accent. WordPress blue stays available through
+	// WP component variables, but shell chrome should not inherit it as the
+	// default brand color. Lives at `:root` so popovers and the editor
+	// iframe (both outside `.cortext-root`) can still resolve it; that's
+	// also why focus rings inside Cortext popovers can drop the
+	// `var(--wp-admin-theme-color, ...)` fallback they used to need.
+	--cortext-accent: #0a1530;
+	--cortext-accent-contrast: #5ad9ff;
+
+	// Destructive signal. Same value as WP's destructive red so the visual
+	// stays familiar; the `-strong` variant is for hover/active states.
+	// Lives at `:root` so popover-mounted destructive items can reach it.
+	--cortext-danger: #cc1818;
+	--cortext-danger-strong: #b32d2e;
+
 	// Option chip palette. Backgrounds are muted tints; foregrounds are a
 	// matching hue dark enough to read on the background. Names mirror
 	// `Cortext\OptionPalette::names()` and the JS `OPTION_COLOR_NAMES`
@@ -86,12 +101,6 @@
 	--cortext-text-muted: #{colors.$gray-700};
 	--cortext-text-strong: #{colors.$gray-900};
 	--cortext-shadow-color: rgba(0, 0, 0, 0.12);
-
-	// Cortext-owned product accent. WordPress blue stays available through
-	// WP component variables, but shell chrome should not inherit it as the
-	// default brand color.
-	--cortext-accent: #0a1530;
-	--cortext-accent-contrast: #5ad9ff;
 
 	// Shell buttons. These map onto @wordpress/components buttons only inside
 	// Cortext-owned chrome, not globally in wp-admin or inside the iframe.

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/base-styles/colors" as colors;
 @use "@wordpress/base-styles/variables" as variables;
+@use "tokens-row-detail";
 
 // Cortext shell tokens (v1).
 // These CSS custom properties are the Cortext shell-theme API. They describe


### PR DESCRIPTION
## What

Follow-up to #158.

Cortext shell UI now uses Cortext's existing accent and destructive colors in places that were still picking up the WordPress admin accent. This does not change the accent color value; it changes which UI owns and reads it. Focus rings, drag/drop indicators, row detail controls, the canvas loading bar, and remove/delete actions now follow Cortext tokens, so future WordPress admin accent changes won't leak into Cortext chrome.

Document icon colors now come from one shared palette, and the theming docs spell out which UI should follow Cortext colors versus WordPress editor colors.

## Why

This gives us a cleaner base for theming work. Shell-owned UI needs to read from Cortext tokens before we add named shell variants, and it also draws a clearer line for future canvas theming: canvas/editor-owned pieces can get their own rules later without inheriting WordPress admin colors by accident or mixing them with shell chrome.

## How

- Moving the existing Cortext accent and destructive tokens where popovers and iframe-adjacent UI can read them.
- Keeping row detail light until the canvas has a real dark mode.
- Sharing the document icon color list between the picker and renderer.

## Testing Instructions

1. Open Cortext and switch between light and dark shell modes.
2. Check focus rings, selected states, drag/drop indicators, row detail inputs, and the alpha notice icon.
3. Open the document icon picker, choose a WordPress icon, change its color, close and reopen the picker, and confirm the saved color is still selected.
4. Remove a document icon and confirm the remove action uses destructive red styling.
5. Check the number format default bar/ring color still follows the editor accent.
