### PR TITLE
Resolve sidebar row targets from the row CPT

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -394,14 +394,6 @@ The same selector shape affects user-visible save side effects. `didPostSaveRequ
 
 **Solution.** Build `cortext/document-properties` as a locked dynamic block, in the same family as `cortext/document-cover` and `cortext/document-icon`. Its `edit()` should reuse the row-property form inside the editor iframe. Its `render_callback` should read the row's collection schema and meta, then emit frontend HTML for public themes. The header-block insertion path should place it after cover/icon/title on row documents. The full-page hide/show control then becomes an editor visibility preference, not the source of truth for whether properties exist in the document.
 
-## 43. Row recents still target the parent collection `[internal]`
-
-**What.** Recents stores row identity (`kind: row`, row id, and parent collection id), but the response still sends the parent collection as the clickable path. Row documents now have their own document URLs, so this is only a first-pass fallback: it gets the user back to the right table, but not directly into the row document they touched. The stored identity is enough to improve the target without changing the saved meta shape.
-
-**Where.** Row handling in `includes/Rest/RecentsController.php`, row clicks in `src/components/SidebarRecents.js`, recent row commands in `src/components/CommandPalette.js`, and the row-recents e2e coverage in `tests/e2e/specs/recents.spec.js`.
-
-**Solution.** Have row recents return the row document path, or give recents a route target shape instead of a single path string. That target should use the same document URL helper as row detail and relations, so sidebar recents and palette recents open the row directly instead of stopping at the parent collection.
-
 ## 44. Recents tracking is wired at each call site `[internal]`
 
 **What.** There is no workspace activity layer. Each surface that counts as a visit or edit calls `touchRecent` itself: route resolution, page autosave, sidebar rename, row field save, row creation, and relation-created rows. That makes the behavior easy to understand right now, but future write paths can forget to update recents unless the reviewer knows to look for it.
@@ -438,7 +430,7 @@ The same selector shape affects user-visible save side effects. `didPostSaveRequ
 
 **What.** Pages and collection rows both opt into `cortext-document`, and there is now a shared reader: `Cortext\Documents`, `GET /cortext/v1/documents`, `useDocuments`, trash listing, and recents formatting all use the same document shape. That removes the old one-off trash enumerator and gives cross-type search/list code one place to start.
 
-The layer is still mostly read-only. Pages still go through the page tree and `core-data`, rows still go through `useCollectionRows`, and restore/delete still fan out into page-tree refresh, row-query invalidation, collection context refresh, and Trash refresh. Favorites, routing, URL targets, and activity tracking also still ask "page or row?" in places that should only need "document." Relation chips now open row documents, but that path still uses local row URL helpers (`rowRoute` / `rowHref`) and needs `slug` in relation responses. The document layer does not own those row targets yet. Row documents in recents still route back to their parent collection (#43), so the document shape carries a path, but not always the final document target users expect.
+The layer is still mostly read-only. Pages still go through the page tree and `core-data`, rows still go through `useCollectionRows`, and restore/delete still fan out into page-tree refresh, row-query invalidation, collection context refresh, and Trash refresh. Favorites and recents now use the document service for row paths, but routing, URL targets, and activity tracking still ask "page or row?" in places that should only need "document." Relation chips now open row documents, but that path still uses local row URL helpers (`rowRoute` / `rowHref`) and needs `slug` in relation responses. The document layer does not own those row targets yet.
 
 **Where.** `includes/Documents.php`, `includes/Rest/DocumentsController.php`, `includes/Rest/RecentsController.php`, relation slug hydration in `includes/Rest/RowsController.php`, `src/hooks/useDocuments.js`, `src/hooks/useTrashedDocuments.js`, `src/components/SidebarTrash.js`, `src/router/useResolveEntity.js`, `src/router/EntityRoute.js`, `rowRoute` / `rowHref` in `src/components/relations/relationUtils.js`, `src/hooks/documentTrashInvalidation.js`, and `src/hooks/rowInvalidation.js`.
 

--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -529,20 +529,18 @@ final class Documents {
 	 * Recents, and Workspace Home. Those callers pass an id, and the documents
 	 * service handles kind lookup, validation, and formatting in one place.
 	 *
-	 * The kind comes from the post type. Row targets also need `context_id`
-	 * because rows are scoped to a parent collection.
+	 * The kind comes from the post type. Rows resolve their parent collection
+	 * from the dynamic CPT that stores them.
 	 *
 	 * @param int   $id   Target document id.
 	 * @param array $opts {
 	 *     Optional. Validation options.
 	 *
-	 *     @type int  $context_id   Parent collection id for row targets. Defaults to 0.
 	 *     @type bool $require_edit Enforce `edit_post` capability. Defaults to true.
 	 * }
 	 * @return array<string,mixed>|WP_Error
 	 */
 	public function format_target( int $id, array $opts = array() ) {
-		$context_id   = isset( $opts['context_id'] ) ? (int) $opts['context_id'] : 0;
 		$require_edit = ! array_key_exists( 'require_edit', $opts ) || (bool) $opts['require_edit'];
 
 		if ( $id < 1 ) {
@@ -564,7 +562,7 @@ final class Documents {
 		}
 
 		if ( self::KIND_ROW === $kind->id() ) {
-			$row_check = $this->validate_row_target( $post, $context_id, $require_edit );
+			$row_check = $this->validate_row_target( $post, $require_edit );
 			if ( $row_check instanceof WP_Error ) {
 				return $row_check;
 			}
@@ -594,36 +592,25 @@ final class Documents {
 	}
 
 	/**
-	 * Checks that a row belongs to the expected collection and that the caller
-	 * can edit both records. Rows live in dynamic CPTs, so the parent collection
-	 * is the permission anchor.
+	 * Resolves a row's parent collection from its CPT and runs the permission
+	 * check. The CPT already names the collection (`crtxt_<slug>`), so callers
+	 * do not pass a separate collection id; the lookup is cached for the
+	 * service instance.
 	 *
-	 * @param WP_Post $row           Row post.
-	 * @param int     $collection_id Expected parent collection id.
-	 * @param bool    $require_edit  Enforce `edit_post` on both row and collection.
+	 * @param WP_Post $row          Row post.
+	 * @param bool    $require_edit Enforce `edit_post` on both row and collection.
 	 */
-	private function validate_row_target( WP_Post $row, int $collection_id, bool $require_edit ): ?WP_Error {
-		if ( $collection_id < 1 ) {
-			return $this->invalid_target_error();
-		}
-
-		$collection = get_post( $collection_id );
+	private function validate_row_target( WP_Post $row, bool $require_edit ): ?WP_Error {
+		$collection = $this->find_collection_by_row_post_type( $row->post_type );
 		if (
 			! $collection instanceof WP_Post
-			|| Collection::POST_TYPE !== $collection->post_type
 			|| self::STATUS_TRASH === $collection->post_status
 		) {
 			return $this->target_not_found_error();
 		}
 
-		$slug = get_post_meta( $collection_id, 'slug', true );
-		$slug = is_string( $slug ) ? trim( $slug ) : '';
-		if ( '' === $slug || CollectionEntries::CPT_PREFIX . $slug !== $row->post_type ) {
-			return $this->target_not_found_error();
-		}
-
 		if ( $require_edit
-			&& ( ! current_user_can( 'edit_post', $collection_id )
+			&& ( ! current_user_can( 'edit_post', $collection->ID )
 				|| ! current_user_can( 'edit_post', $row->ID ) )
 		) {
 			return $this->target_forbidden_error();

--- a/includes/Rest/FavoritesController.php
+++ b/includes/Rest/FavoritesController.php
@@ -56,15 +56,11 @@ final class FavoritesController {
 							'items'    => array(
 								'type'       => 'object',
 								'properties' => array(
-									'kind'         => array(
+									'kind' => array(
 										'type' => 'string',
 										'enum' => self::ALLOWED_KINDS,
 									),
-									'id'           => array(
-										'type'    => 'integer',
-										'minimum' => 1,
-									),
-									'collectionId' => array(
+									'id'   => array(
 										'type'    => 'integer',
 										'minimum' => 1,
 									),
@@ -113,16 +109,12 @@ final class FavoritesController {
 				);
 			}
 
-			$id            = isset( $favorite['id'] ) ? (int) $favorite['id'] : 0;
-			$collection_id = isset( $favorite['collectionId'] ) ? (int) $favorite['collectionId'] : 0;
+			$id = isset( $favorite['id'] ) ? (int) $favorite['id'] : 0;
 			if ( isset( $seen[ $id ] ) ) {
 				continue;
 			}
 
-			$target = $this->documents->format_target(
-				$id,
-				array( 'context_id' => $collection_id )
-			);
+			$target = $this->documents->format_target( $id );
 			if ( is_wp_error( $target ) ) {
 				return $target;
 			}
@@ -136,7 +128,7 @@ final class FavoritesController {
 			}
 
 			$seen[ $id ] = true;
-			$stored[]    = $this->stored_entry_for_target( $target );
+			$stored[]    = "{$target['kind']}:{$target['id']}";
 			$formatted[] = $target;
 		}
 
@@ -160,15 +152,12 @@ final class FavoritesController {
 		$valid = array();
 		$seen  = array();
 		foreach ( $raw as $entry ) {
-			$parsed = $this->parse_stored_entry( $entry );
-			if ( null === $parsed || isset( $seen[ $parsed['id'] ] ) ) {
+			$id = $this->stored_entry_id( $entry );
+			if ( $id < 1 || isset( $seen[ $id ] ) ) {
 				continue;
 			}
 
-			$target = $this->documents->format_target(
-				$parsed['id'],
-				array( 'context_id' => $parsed['collectionId'] )
-			);
+			$target = $this->documents->format_target( $id );
 			if ( is_wp_error( $target ) ) {
 				continue;
 			}
@@ -177,14 +166,16 @@ final class FavoritesController {
 				continue;
 			}
 
-			$seen[ $parsed['id'] ] = true;
-			$valid[]               = $entry;
-			$out[]                 = $target;
+			$seen[ $id ] = true;
+			// Re-normalise to the canonical `"kind:id"` shape on read so older
+			// row entries stored as arrays migrate forward on first access.
+			$valid[] = "{$target['kind']}:{$target['id']}";
+			$out[]   = $target;
 		}
 
 		// Keep storage matched to what we can still resolve. Otherwise the next
 		// save may replay a stale favorite and fail the whole update.
-		if ( count( $valid ) !== count( $raw ) ) {
+		if ( array_values( $raw ) !== $valid ) {
 			update_user_meta( $user_id, self::META_KEY, $valid );
 		}
 
@@ -192,64 +183,26 @@ final class FavoritesController {
 	}
 
 	/**
-	 * Stores a favorite in the user's saved format. Pages and collections keep
-	 * the old `"kind:id"` string; rows use an array because their id needs the
-	 * parent collection id too.
+	 * Reads the document id out of a stored favorite. Strings are the canonical
+	 * `"kind:id"` shape; arrays come from older storage (when row favorites
+	 * carried a `collectionId`) and are accepted for lazy migration on the
+	 * next read.
 	 *
-	 * @param array<string,mixed> $target Formatted document target.
-	 * @return string|array{kind:string,id:int,collectionId:int}
+	 * @param mixed $entry Raw stored entry.
 	 */
-	private function stored_entry_for_target( array $target ): string|array {
-		$kind = (string) $target['kind'];
-		$id   = (int) $target['id'];
-		if ( Documents::KIND_ROW !== $kind ) {
-			return "{$kind}:{$id}";
-		}
-
-		return array(
-			'kind'         => $kind,
-			'id'           => $id,
-			'collectionId' => isset( $target['collection']['id'] )
-				? (int) $target['collection']['id']
-				: 0,
-		);
-	}
-
-	/**
-	 * Turns a saved favorite back into the `{id, collectionId}` pair
-	 * `format_target` expects. Bad entries are skipped when favorites are read.
-	 *
-	 * @param mixed $entry Raw stored entry: a string for pages/collections, or an
-	 *                     array for rows.
-	 * @return array{id:int,collectionId:int}|null
-	 */
-	private function parse_stored_entry( mixed $entry ): ?array {
+	private function stored_entry_id( mixed $entry ): int {
 		if ( is_string( $entry ) ) {
 			$parts = explode( ':', $entry, 2 );
 			if ( 2 !== count( $parts ) ) {
-				return null;
+				return 0;
 			}
-			$id = (int) $parts[1];
-			return $id > 0
-				? array(
-					'id'           => $id,
-					'collectionId' => 0,
-				)
-				: null;
+			return (int) $parts[1];
 		}
 
 		if ( is_array( $entry ) && isset( $entry['id'] ) ) {
-			$id = (int) $entry['id'];
-			return $id > 0
-				? array(
-					'id'           => $id,
-					'collectionId' => isset( $entry['collectionId'] )
-						? (int) $entry['collectionId']
-						: 0,
-				)
-				: null;
+			return (int) $entry['id'];
 		}
 
-		return null;
+		return 0;
 	}
 }

--- a/includes/Rest/RecentsController.php
+++ b/includes/Rest/RecentsController.php
@@ -51,19 +51,15 @@ final class RecentsController {
 					'callback'            => array( $this, 'touch_recent' ),
 					'permission_callback' => array( $this, 'can_read' ),
 					'args'                => array(
-						'kind'         => array(
+						'kind' => array(
 							'type'     => 'string',
 							'required' => true,
 							'enum'     => self::ALLOWED_KINDS,
 						),
-						'id'           => array(
+						'id'   => array(
 							'type'     => 'integer',
 							'required' => true,
 							'minimum'  => 1,
-						),
-						'collectionId' => array(
-							'type'    => 'integer',
-							'minimum' => 1,
 						),
 					),
 				),
@@ -85,13 +81,9 @@ final class RecentsController {
 	}
 
 	public function touch_recent( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$id            = (int) $request->get_param( 'id' );
-		$collection_id = (int) $request->get_param( 'collectionId' );
+		$id = (int) $request->get_param( 'id' );
 
-		$target = $this->documents->format_target(
-			$id,
-			array( 'context_id' => $collection_id )
-		);
+		$target = $this->documents->format_target( $id );
 		if ( is_wp_error( $target ) ) {
 			return $target;
 		}
@@ -109,9 +101,6 @@ final class RecentsController {
 			'id'        => $target['id'],
 			'updatedAt' => gmdate( DATE_RFC3339 ),
 		);
-		if ( Documents::KIND_ROW === $target['kind'] ) {
-			$item['collectionId'] = $collection_id;
-		}
 
 		$items = array( $item );
 		$key   = $this->recent_key( $item );
@@ -147,10 +136,7 @@ final class RecentsController {
 		$valid    = array();
 
 		foreach ( $items as $item ) {
-			$target = $this->documents->format_target(
-				$item['id'],
-				array( 'context_id' => $item['collectionId'] ?? 0 )
-			);
+			$target = $this->documents->format_target( $item['id'] );
 			if ( is_wp_error( $target ) ) {
 				continue;
 			}
@@ -171,7 +157,7 @@ final class RecentsController {
 	 * Reads normalized stored recent items.
 	 *
 	 * @param int $user_id User ID.
-	 * @return array<int,array{kind:string,id:int,updatedAt:string,collectionId?:int}>
+	 * @return array<int,array{kind:string,id:int,updatedAt:string}>
 	 */
 	private function read_stored_items( int $user_id ): array {
 		$raw = get_user_meta( $user_id, self::META_KEY, true );
@@ -190,21 +176,13 @@ final class RecentsController {
 				continue;
 			}
 
-			$stored = array(
+			$items[] = array(
 				'kind'      => $kind,
 				'id'        => $id,
 				'updatedAt' => isset( $item['updatedAt'] ) && is_string( $item['updatedAt'] )
 					? $item['updatedAt']
 					: gmdate( DATE_RFC3339 ),
 			);
-			if ( Documents::KIND_ROW === $kind ) {
-				$collection_id = isset( $item['collectionId'] ) ? (int) $item['collectionId'] : 0;
-				if ( $collection_id < 1 ) {
-					continue;
-				}
-				$stored['collectionId'] = $collection_id;
-			}
-			$items[] = $stored;
 		}
 
 		return array_slice( $items, 0, self::MAX_ITEMS );

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -103,10 +103,10 @@ export function filterFavoritesForTrashedPage(
 			return ! trashedCollectionIds.has( Number( favorite.id ) );
 		}
 		if ( favorite.kind === 'row' ) {
-			// A trashed page may take owned collections with it. If this row
-			// belonged to one of them, remove its favorite too.
+			// Rows fall with their parent collection. The favorite carries the
+			// owner inline (`collection.id`), set by `format_target` on read.
 			return ! trashedCollectionIds.has(
-				Number( favorite.collectionId )
+				Number( favorite.collection?.id )
 			);
 		}
 		return true;
@@ -121,7 +121,7 @@ export function filterFavoritesForTrashedCollection( favorites, collectionId ) {
 				( favorite.kind === 'collection' &&
 					Number( favorite.id ) === target ) ||
 				( favorite.kind === 'row' &&
-					Number( favorite.collectionId ) === target )
+					Number( favorite.collection?.id ) === target )
 			)
 	);
 }

--- a/src/hooks/useFavorites.js
+++ b/src/hooks/useFavorites.js
@@ -15,19 +15,11 @@ function normalizeFavorite( favorite ) {
 	if ( ! favorite || ! favorite.kind || ! favorite.id ) {
 		return null;
 	}
-	const normalized = {
+	return {
 		...favorite,
 		kind: favorite.kind,
 		id: Number( favorite.id ),
 	};
-	// Keep a row's collection id around for the next save. Optimistic writes send
-	// `collectionId`; reads send it inside `collection`.
-	const collectionId =
-		favorite.collectionId ?? favorite.collection?.id ?? null;
-	if ( collectionId ) {
-		normalized.collectionId = Number( collectionId );
-	}
-	return normalized;
 }
 
 function normalizeFavorites( favorites ) {
@@ -43,9 +35,7 @@ function areFavoritesEqual( a, b ) {
 	}
 	return a.every(
 		( favorite, index ) =>
-			favorite.kind === b[ index ]?.kind &&
-			favorite.id === b[ index ]?.id &&
-			( favorite.collectionId ?? 0 ) === ( b[ index ]?.collectionId ?? 0 )
+			favorite.kind === b[ index ]?.kind && favorite.id === b[ index ]?.id
 	);
 }
 

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -98,6 +98,26 @@ describe( 'SidebarFavorites helpers', () => {
 		);
 	} );
 
+	it( 'drops row favorites whose collection fell with the trashed page', () => {
+		// Trashing page 1 cascades into collection 5 (nested under it).
+		// Row 6 lives in that collection, so its favorite must come out of the
+		// list too; otherwise the next save would replay a now-trashed row.
+		const favorites = [
+			{ kind: 'page', id: 1 },
+			{ kind: 'row', id: 6, collection: { id: 5 } },
+			{ kind: 'row', id: 7, collection: { id: 9 } },
+		];
+		const pages = [ { id: 1, parent: 0 } ];
+		const collections = [
+			{ id: 5, parent: 1 },
+			{ id: 9, parent: 0 },
+		];
+
+		expect(
+			filterFavoritesForTrashedPage( favorites, 1, pages, collections )
+		).toEqual( [ { kind: 'row', id: 7, collection: { id: 9 } } ] );
+	} );
+
 	it( 'resolves page and collection favorites from loaded records', () => {
 		const items = resolveFavoriteItems(
 			[

--- a/tests/php/test-rest-favorites-controller.php
+++ b/tests/php/test-rest-favorites-controller.php
@@ -289,25 +289,14 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 	public function test_get_prunes_a_row_favorite_whose_row_was_trashed(): void {
 		$user_id = $this->create_user( 'administrator' );
 		wp_set_current_user( $user_id );
-		$collection_id = $this->create_collection( 'people', 'People' );
-		$kept_row      = $this->create_row( 'crtxt_people', 'Kept' );
-		$trashed_row   = $this->create_row( 'crtxt_people', 'Trashed' );
+		$this->create_collection( 'people', 'People' );
+		$kept_row    = $this->create_row( 'crtxt_people', 'Kept' );
+		$trashed_row = $this->create_row( 'crtxt_people', 'Trashed' );
 
 		update_user_meta(
 			$user_id,
 			self::META_KEY,
-			array(
-				array(
-					'kind'         => 'row',
-					'id'           => $kept_row,
-					'collectionId' => $collection_id,
-				),
-				array(
-					'kind'         => 'row',
-					'id'           => $trashed_row,
-					'collectionId' => $collection_id,
-				),
-			)
+			array( "row:{$kept_row}", "row:{$trashed_row}" )
 		);
 
 		wp_trash_post( $trashed_row );
@@ -319,13 +308,41 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 			array_column( $response->get_data()['favorites'], 'id' )
 		);
 		$this->assertSame(
+			array( "row:{$kept_row}" ),
+			get_user_meta( $user_id, self::META_KEY, true )
+		);
+	}
+
+	public function test_get_migrates_legacy_row_favorite_array_shape(): void {
+		// Older builds stored row favorites as arrays carrying the parent
+		// collection id. The read should accept that shape and rewrite it as
+		// the canonical `"row:id"` string so the next save uses the new shape.
+		$user_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_id );
+		$collection_id = $this->create_collection( 'people', 'People' );
+		$row_id        = $this->create_row( 'crtxt_people', 'Ada Lovelace' );
+
+		update_user_meta(
+			$user_id,
+			self::META_KEY,
 			array(
 				array(
 					'kind'         => 'row',
-					'id'           => $kept_row,
+					'id'           => $row_id,
 					'collectionId' => $collection_id,
 				),
-			),
+			)
+		);
+
+		$response = $this->get_favorites();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array( $row_id ),
+			array_column( $response->get_data()['favorites'], 'id' )
+		);
+		$this->assertSame(
+			array( "row:{$row_id}" ),
 			get_user_meta( $user_id, self::META_KEY, true )
 		);
 	}
@@ -367,9 +384,8 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 		$set_response = $this->set_favorites(
 			array(
 				array(
-					'kind'         => 'row',
-					'id'           => $row_id,
-					'collectionId' => $collection_id,
+					'kind' => 'row',
+					'id'   => $row_id,
 				),
 			)
 		);
@@ -381,44 +397,17 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 		$this->assertSame( 'row', $favorites[0]['kind'] );
 		$this->assertSame( $row_id, $favorites[0]['id'] );
 		$this->assertSame( 'Ada Lovelace', $favorites[0]['title'] );
+		// The parent collection comes out of the response — the server resolves
+		// it from the row's CPT, so the client never has to send it.
 		$this->assertSame( $collection_id, $favorites[0]['collection']['id'] );
 		$this->assertSame( 'People', $favorites[0]['collection']['title'] );
 		$this->assertSame(
 			$favorites,
 			$get_response->get_data()['favorites']
 		);
-		// Row favorites carry their collection id. Page and collection favorites
-		// keep the old `"kind:id"` string.
 		$this->assertSame(
-			array(
-				array(
-					'kind'         => 'row',
-					'id'           => $row_id,
-					'collectionId' => $collection_id,
-				),
-			),
+			array( "row:{$row_id}" ),
 			get_user_meta( get_current_user_id(), self::META_KEY, true )
-		);
-	}
-
-	public function test_rejects_a_row_favorite_without_its_collection(): void {
-		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$this->create_collection( 'people', 'People' );
-		$row_id = $this->create_row( 'crtxt_people', 'Ada Lovelace' );
-
-		$response = $this->set_favorites(
-			array(
-				array(
-					'kind' => 'row',
-					'id'   => $row_id,
-				),
-			)
-		);
-
-		$this->assertSame( 400, $response->get_status() );
-		$this->assertSame(
-			'cortext_document_target_invalid',
-			$response->get_data()['code']
 		);
 	}
 

--- a/tests/php/test-rest-recents-controller.php
+++ b/tests/php/test-rest-recents-controller.php
@@ -144,11 +144,8 @@ final class Test_Rest_Recents_Controller extends BaseTestCase {
 				'post_title'  => 'Regular post',
 			)
 		);
-		$this->create_collection( 'people', 'People' );
-		$row_id = $this->create_row( 'crtxt_people', 'Ada Lovelace' );
 
-		$invalid_type           = $this->touch_recent( 'page', $post_id );
-		$row_missing_collection = $this->touch_recent( 'row', $row_id );
+		$invalid_type = $this->touch_recent( 'page', $post_id );
 
 		$owner_id = $this->create_user( 'administrator' );
 		wp_set_current_user( $owner_id );
@@ -163,11 +160,6 @@ final class Test_Rest_Recents_Controller extends BaseTestCase {
 		$forbidden = $this->touch_recent( 'page', $private_page );
 
 		$this->assertSame( 404, $invalid_type->get_status() );
-		$this->assertSame( 400, $row_missing_collection->get_status() );
-		$this->assertSame(
-			'cortext_document_target_invalid',
-			$row_missing_collection->get_data()['code']
-		);
 		$this->assertSame( 403, $forbidden->get_status() );
 	}
 


### PR DESCRIPTION
## What

Part of #226.

Favorites and Recents now store row targets the same way they already store pages and collections: `"kind:id"`.

The client does not need to send `collectionId` for rows anymore. When the server needs the parent collection, it reads it from the row CPT.

Older row favorites that still include `collectionId` keep loading. Once they are read, they get normalized into the new string shape.

## Why

A row already knows which collection owns it, so keeping a second copy of that id in Favorites or Recents just gives us another value to keep in sync.

## Testing Instructions

1. Open Cortext, edit a row, and confirm it appears in Recents.
2. Click that row from Recents and confirm it opens the row document.
3. Add a row favorite through the Favorites REST endpoint with only `kind: "row"` and `id`; confirm it appears in Favorites and opens the row.
4. Reload and confirm the row favorite still appears.
5. Confirm page and collection Favorites and Recents still work.
