### PR TITLE
Fix: Stop canvas flashes during navigation

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -527,3 +527,13 @@ The only reason this stays in the debt log is the plumbing. Gutenberg's toolbar 
 **Where.** `src/components/RowEditor.js` (`SlotFillProvider` and `EditorSurfaceProvider`), `src/components/EditorSurfaceContext.js`, `src/blocks/data-view/edit.js` (`hasBlockInspector` around the DataView toolbar button), `src/components/RowDetailView.js` (body class while side/modal is open), and `src/index.scss` (parent canvas toolbar hiding).
 
 **Solution.** If Gutenberg grows editor-instance-scoped `BlockControls`, toolbar popovers, and `InspectorControls`, Cortext can drop the local `SlotFillProvider`, the `hasBlockInspector` context, and the parent-toolbar body class. If row peek/modal needs block settings before that exists upstream, build a row-scoped inspector deliberately rather than routing those actions to the parent inspector.
+
+## 58. Page transitions hold a browser snapshot by hand `[upstream, internal, soft]`
+
+**What.** Page-to-page navigation rebuilds the editor provider inside the same workspace pane. A normal View Transition cross-fade can expose the empty editor frame while Gutenberg, cover media, and the editor iframe catch up. Cortext now keeps the old `cortext-canvas` snapshot above the new one until the new editor says it has painted, then fades the old snapshot away. That requires a `data-cortext-view-transition` mode on `:root`, custom `::view-transition-*` CSS, a long-running hold animation, and promise plumbing around `startViewTransition()` because the browser update callback may run after `withViewTransition()` has already returned.
+
+This is acceptable for now and covered by e2e, but it is still a timing bridge between React state, Gutenberg editor readiness, iframe image decode, and the browser's View Transitions lifecycle. Any future transition refactor should preserve the "old canvas stays visible until the new canvas has painted" contract before touching this code.
+
+**Where.** `withViewTransition` in `src/hooks/viewTransition.js`, the `hold-old-canvas` / `reveal-old-canvas` rules in `src/index.scss`, document switching in `src/components/Canvas.js`, editor readiness in `src/components/EditorBody.js`, and the navigation lifecycle coverage in `tests/e2e/specs/navigation-lifecycle.spec.js`.
+
+**Solution.** If the View Transitions API gets a first-class hold/release hook, or Gutenberg exposes a reliable editor-surface "painted" signal for document swaps, replace the mode flag and long CSS hold animation with that primitive. Until then, keep the hold/reveal logic small, keep page-to-page swaps inside `Canvas`, and keep the cover/image readiness test as the tripwire.

--- a/src/blocks/document-cover/edit.js
+++ b/src/blocks/document-cover/edit.js
@@ -8,7 +8,6 @@ import {
 import MediaPicker, { MediaUploadCheck } from '../../components/MediaPicker';
 import { useEntityProp, useEntityRecord } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import {
 	Button,
@@ -80,14 +79,6 @@ export default function Edit( { context, clientId } ) {
 		media?.media_details?.sizes?.large?.source_url ??
 		media?.source_url ??
 		null;
-
-	// Fade the cover in once the bytes have actually decoded. Without this the
-	// image pops in cold against the canvas, especially on page-to-page nav
-	// where the new cover lands a beat after the iframe re-parses blocks.
-	const [ hasImagePainted, setHasImagePainted ] = useState( false );
-	useEffect( () => {
-		setHasImagePainted( false );
-	}, [ src ] );
 
 	const ensureIconBlock = () => {
 		if ( hasIconBlock || ! clientId ) {
@@ -186,9 +177,6 @@ export default function Edit( { context, clientId } ) {
 						// after the editor swaps documents.
 						loading="eager"
 						decoding="async"
-						onLoad={ () => setHasImagePainted( true ) }
-						onError={ () => setHasImagePainted( true ) }
-						style={ { opacity: hasImagePainted ? 1 : 0 } }
 					/>
 				) }
 				<div className="cortext-document-cover-block__controls">

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/interface';
 import { Button, Disabled } from '@wordpress/components';
 import { chevronDown, chevronUp, cog, seen, unseen } from '@wordpress/icons';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
 // Editor-surface stylesheets. Imported via a sibling SCSS file (not
 // src/index.scss) so mini-css-extract emits them into the editor chunk's
@@ -150,6 +150,15 @@ function VisualCanvas( { isActive, postId, postType, onReady, onRestored } ) {
 	);
 }
 
+const CANVAS_SWITCH_READY_TIMEOUT = 2500;
+
+function documentKey( postType, postId ) {
+	if ( ! postType || postId === null || postId === undefined ) {
+		return null;
+	}
+	return `${ postType }:${ postId }`;
+}
+
 function CanvasEditor( {
 	post,
 	postType,
@@ -202,10 +211,16 @@ function CanvasEditor( {
 		async function switchAfterSave() {
 			const didFlush = await flushNow();
 			if ( ! cancelled && didFlush ) {
-				// Document-to-document swaps don't change EntityRoute's
-				// `active`, so the surface-level cross-fade can't see them.
-				// Trigger one here instead.
-				withViewTransition( () => onSwitchPost( pendingPost ) );
+				if ( ! isActive ) {
+					onSwitchPost( pendingPost );
+					return;
+				}
+				// EntityRoute's `active` value does not move for page-to-page
+				// swaps. Start the transition here and keep the old snapshot up
+				// while the next editor render settles.
+				withViewTransition( () => onSwitchPost( pendingPost ), {
+					mode: 'hold-old-canvas',
+				} );
 			}
 		}
 
@@ -219,6 +234,7 @@ function CanvasEditor( {
 		post.id,
 		post.type,
 		flushNow,
+		isActive,
 		isDirty,
 		isSaving,
 		onSwitchPost,
@@ -317,11 +333,10 @@ export default function Canvas( {
 		postId
 	);
 	const [ displayedPost, setDisplayedPost ] = useState( null );
-	// Keep the previously-rendered post mounted (any type) until CanvasEditor's
-	// pendingPost effect flushes unsaved edits and explicitly swaps. Falling
-	// back to `requestedPost` on type mismatch would re-mount the editor
-	// immediately and drop in-flight edits on cross-type navigation
-	// (page → row, row → page).
+	const pendingDisplayResolversRef = useRef( new Map() );
+	// Keep the last rendered post mounted until CanvasEditor has flushed edits
+	// and chosen the next post. Falling back to `requestedPost` on a type change
+	// would remount the editor at once and could drop edits mid-navigation.
 	const renderedPost = displayedPost ?? requestedPost;
 
 	useEffect( () => {
@@ -339,11 +354,69 @@ export default function Canvas( {
 			) {
 				return requestedPost;
 			}
-			// Different document (any axis): hold so the editor can flush
-			// before the swap; CanvasEditor calls setDisplayedPost itself.
+			// Different document or type: keep the current editor up. CanvasEditor
+			// will flush edits and switch posts explicitly.
 			return current;
 		} );
 	}, [ requestedPost ] );
+
+	useEffect( () => {
+		const pendingDisplayResolvers = pendingDisplayResolversRef.current;
+		return () => {
+			pendingDisplayResolvers.forEach( ( pending ) => {
+				window.clearTimeout( pending.timeoutId );
+				pending.resolve();
+			} );
+			pendingDisplayResolvers.clear();
+		};
+	}, [] );
+
+	const handleDisplayedPost = useCallback(
+		( id, type ) => {
+			const key = documentKey( type, id );
+			const pending = key
+				? pendingDisplayResolversRef.current.get( key )
+				: null;
+			if ( pending ) {
+				window.clearTimeout( pending.timeoutId );
+				pendingDisplayResolversRef.current.delete( key );
+				pending.resolve();
+			}
+			onDisplayedPost?.( id );
+		},
+		[ onDisplayedPost ]
+	);
+
+	const switchDisplayedPost = useCallback( ( nextPost ) => {
+		const key = documentKey( nextPost?.type, nextPost?.id );
+		const readyPromise = new Promise( ( resolve ) => {
+			if ( ! key || typeof window === 'undefined' ) {
+				resolve();
+				return;
+			}
+
+			const existing = pendingDisplayResolversRef.current.get( key );
+			if ( existing ) {
+				window.clearTimeout( existing.timeoutId );
+				existing.resolve();
+			}
+
+			const pending = { resolve, timeoutId: null };
+			pending.timeoutId = window.setTimeout( () => {
+				if (
+					pendingDisplayResolversRef.current.get( key ) !== pending
+				) {
+					return;
+				}
+				pendingDisplayResolversRef.current.delete( key );
+				resolve();
+			}, CANVAS_SWITCH_READY_TIMEOUT );
+			pendingDisplayResolversRef.current.set( key, pending );
+		} );
+
+		setDisplayedPost( nextPost );
+		return readyPromise;
+	}, [] );
 
 	const pendingPost =
 		renderedPost &&
@@ -352,9 +425,9 @@ export default function Canvas( {
 			requestedPost.id !== renderedPost.id )
 			? requestedPost
 			: null;
-	// `pendingPost` appears only after the next record resolves. On a slow
-	// network that is too late, so compare the requested post to the one still
-	// on screen and cover the whole wait after a click.
+	// `pendingPost` only exists once the next record has resolved. On a slow
+	// request, compare the URL target with the post still on screen so the
+	// progress bar covers the whole click-to-paint gap.
 	const isCrossDocNav = Boolean(
 		renderedPost &&
 			postId &&
@@ -388,8 +461,8 @@ export default function Canvas( {
 					fields={ fields }
 					row={ row }
 					pendingPost={ pendingPost }
-					onSwitchPost={ setDisplayedPost }
-					onDisplayedPost={ onDisplayedPost }
+					onSwitchPost={ switchDisplayedPost }
+					onDisplayedPost={ handleDisplayedPost }
 					isActive={ isActive }
 					topBarActions={ topBarActions }
 					notice={ notice }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -138,9 +138,17 @@ function HideHeaderBlockKebab() {
 	return null;
 }
 
-function VisualCanvas( { isActive, postId, postType, onReady, onRestored } ) {
+function VisualCanvas( {
+	featuredMedia,
+	isActive,
+	postId,
+	postType,
+	onReady,
+	onRestored,
+} ) {
 	return (
 		<EditorBody
+			featuredMedia={ featuredMedia }
 			isActive={ isActive }
 			postId={ postId }
 			postType={ postType }
@@ -150,7 +158,7 @@ function VisualCanvas( { isActive, postId, postType, onReady, onRestored } ) {
 	);
 }
 
-const CANVAS_SWITCH_READY_TIMEOUT = 2500;
+const CANVAS_SWITCH_READY_TIMEOUT = 8000;
 
 function documentKey( postType, postId ) {
 	if ( ! postType || postId === null || postId === undefined ) {
@@ -297,9 +305,10 @@ function CanvasEditor( {
 							rowProperties
 						) }
 						<VisualCanvas
+							featuredMedia={ post.featured_media }
 							isActive={ isActive }
 							postId={ post.id }
-							postType={ postType }
+							postType={ post.type ?? postType }
 							onReady={ onDisplayedPost }
 							onRestored={ onRestored }
 						/>
@@ -387,36 +396,40 @@ export default function Canvas( {
 		[ onDisplayedPost ]
 	);
 
-	const switchDisplayedPost = useCallback( ( nextPost ) => {
-		const key = documentKey( nextPost?.type, nextPost?.id );
-		const readyPromise = new Promise( ( resolve ) => {
-			if ( ! key || typeof window === 'undefined' ) {
-				resolve();
-				return;
-			}
-
-			const existing = pendingDisplayResolversRef.current.get( key );
-			if ( existing ) {
-				window.clearTimeout( existing.timeoutId );
-				existing.resolve();
-			}
-
-			const pending = { resolve, timeoutId: null };
-			pending.timeoutId = window.setTimeout( () => {
-				if (
-					pendingDisplayResolversRef.current.get( key ) !== pending
-				) {
+	const switchDisplayedPost = useCallback(
+		( nextPost ) => {
+			const key = documentKey( nextPost?.type ?? postType, nextPost?.id );
+			const readyPromise = new Promise( ( resolve ) => {
+				if ( ! key || typeof window === 'undefined' ) {
+					resolve();
 					return;
 				}
-				pendingDisplayResolversRef.current.delete( key );
-				resolve();
-			}, CANVAS_SWITCH_READY_TIMEOUT );
-			pendingDisplayResolversRef.current.set( key, pending );
-		} );
 
-		setDisplayedPost( nextPost );
-		return readyPromise;
-	}, [] );
+				const existing = pendingDisplayResolversRef.current.get( key );
+				if ( existing ) {
+					window.clearTimeout( existing.timeoutId );
+					existing.resolve();
+				}
+
+				const pending = { resolve, timeoutId: null };
+				pending.timeoutId = window.setTimeout( () => {
+					if (
+						pendingDisplayResolversRef.current.get( key ) !==
+						pending
+					) {
+						return;
+					}
+					pendingDisplayResolversRef.current.delete( key );
+					resolve();
+				}, CANVAS_SWITCH_READY_TIMEOUT );
+				pendingDisplayResolversRef.current.set( key, pending );
+			} );
+
+			setDisplayedPost( nextPost );
+			return readyPromise;
+		},
+		[ postType ]
+	);
 
 	const pendingPost =
 		renderedPost &&
@@ -457,7 +470,7 @@ export default function Canvas( {
 			>
 				<CanvasEditor
 					post={ renderedPost }
-					postType={ renderedPost.type }
+					postType={ renderedPost.type ?? postType }
 					fields={ fields }
 					row={ row }
 					pendingPost={ pendingPost }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -988,6 +988,7 @@ export default function CollectionDataViews( {
 	// for fields the user just created. `null` on first run signals
 	// "saved view, leave it alone."
 	const knownFieldIdsRef = useRef( null );
+	const previousVisibleFieldsRef = useRef( null );
 	const savedRowDetailMode = getRowDetailMode( view );
 	const postType = slug ? `crtxt_${ slug }` : null;
 	const { openDocument, closeDocument } = useDocumentPeekActions();
@@ -1368,7 +1369,8 @@ export default function CollectionDataViews( {
 			! isTableLayout ||
 			! pendingRevealFieldId ||
 			isResolving ||
-			! fieldsResolved
+			! fieldsResolved ||
+			showLoadingShell
 		) {
 			return undefined;
 		}
@@ -1426,6 +1428,47 @@ export default function CollectionDataViews( {
 		localRevealFieldId,
 		onFieldRevealed,
 		pendingRevealFieldId,
+		showLoadingShell,
+		view?.fields,
+	] );
+
+	useLayoutEffect( () => {
+		const currentFields = [ ...( view?.fields ?? [] ) ];
+		const previousFields = previousVisibleFieldsRef.current;
+		if ( ! previousFields ) {
+			if ( fieldsResolved && ! isResolving && ! showLoadingShell ) {
+				previousVisibleFieldsRef.current = currentFields;
+			}
+			return;
+		}
+		if (
+			! isTableLayout ||
+			isResolving ||
+			! fieldsResolved ||
+			showLoadingShell
+		) {
+			return;
+		}
+
+		const lastFieldId = currentFields[ currentFields.length - 1 ];
+		const addedAtEnd =
+			currentFields.length > previousFields.length &&
+			lastFieldId &&
+			! previousFields.includes( lastFieldId );
+		if ( addedAtEnd ) {
+			setLocalRevealFieldId( lastFieldId );
+			const wrapper =
+				tableWrapperRef.current?.querySelector( '.dataviews-wrapper' );
+			if ( wrapper ) {
+				scrollToEndQuickly( wrapper, { trackEnd: true } );
+			}
+		}
+		previousVisibleFieldsRef.current = currentFields;
+	}, [
+		fieldsResolved,
+		isResolving,
+		isTableLayout,
+		showLoadingShell,
 		view?.fields,
 	] );
 

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -33,6 +33,7 @@ import { CollectionRowsSkeleton } from './Skeleton';
 import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
 } from '../hooks/useDelayedFlag';
+import afterNextPaint from '../hooks/afterNextPaint';
 import allSettledWithConcurrency from './allSettledWithConcurrency';
 import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
@@ -575,11 +576,12 @@ export default function CollectionDataViews( {
 	// so the user does not see three quick states: generic placeholder, empty
 	// DataViews chrome, then real rows.
 	const isShellLoading = isResolving || isRowsLoadingShell;
-	const showLoadingShell = useDelayedFlag(
+	const holdLoadingShell = useDelayedFlag(
 		isShellLoading,
-		120,
+		0,
 		SKELETON_MIN_VISIBLE_MS
 	);
+	const showLoadingShell = isShellLoading || holdLoadingShell;
 
 	const tableWrapperRef = useRef( null );
 	const [ localRevealFieldId, setLocalRevealFieldId ] = useState( null );
@@ -1428,12 +1430,26 @@ export default function CollectionDataViews( {
 	] );
 
 	useEffect( () => {
-		// Fields are enough to mount the pane. Rows can keep loading behind the
-		// skeleton; waiting for them leaves the old pane around too long.
-		if ( ! isResolving ) {
-			onReady?.( collectionId );
+		// If this collection is mounting behind an already-painted pane, keep the
+		// old pane active until the first row request finishes. Otherwise the route
+		// can reveal an empty DataViews shell. Row errors count as ready so the
+		// error can render.
+		if ( isResolving || ( ! rowsResolved && ! rowError ) ) {
+			return undefined;
 		}
-	}, [ collectionId, isResolving, onReady ] );
+
+		let cancelled = false;
+		async function signalReady() {
+			await afterNextPaint();
+			if ( ! cancelled ) {
+				onReady?.( collectionId );
+			}
+		}
+		signalReady();
+		return () => {
+			cancelled = true;
+		};
+	}, [ collectionId, isResolving, onReady, rowError, rowsResolved ] );
 
 	// tech-debt.md#22: Gutenberg selects on any mousedown that bubbles up.
 	// Dragging the dataviews scrollbar lands in the gutter (offset past the
@@ -1546,10 +1562,10 @@ export default function CollectionDataViews( {
 							ref={ tableWrapperRef }
 							onClickCapture={ captureSelectionIntent }
 							data-loading-shell={
-								isShellLoading ? 'true' : undefined
+								showLoadingShell ? 'true' : undefined
 							}
 							style={
-								isShellLoading
+								showLoadingShell
 									? {
 											// Hold the wrapper at skeleton
 											// height so content below does not

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -20,7 +20,7 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Button, Disabled, Notice } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityProp, useEntityRecord } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
@@ -33,6 +33,7 @@ import {
 
 import DocumentIdentityControls from './DocumentIdentityControls';
 import MediaPicker, { MediaUploadCheck } from './MediaPicker';
+import afterNextPaint from '../hooks/afterNextPaint';
 
 const DOCUMENT_ICON_BLOCK = 'cortext/document-icon';
 const DOCUMENT_COVER_BLOCK = 'cortext/document-cover';
@@ -56,6 +57,7 @@ const HEADER_BLOCK_NAMES = new Set( [
 	DOCUMENT_ICON_BLOCK,
 	POST_TITLE_BLOCK,
 ] );
+const CANVAS_READY_IMAGE_TIMEOUT = 2500;
 
 function isHeaderBlock( block ) {
 	return HEADER_BLOCK_NAMES.has( block?.name );
@@ -672,10 +674,123 @@ function TrashedNotice( { postId, postType, onRestored } ) {
 	);
 }
 
-function CanvasReadyEffect( { postId, onReady } ) {
-	useEffect( () => {
-		onReady?.( postId );
-	}, [ postId, onReady ] );
+function coverSource( media ) {
+	return (
+		media?.media_details?.sizes?.large?.source_url ??
+		media?.source_url ??
+		null
+	);
+}
+
+function waitForImageReady( image ) {
+	const ownerWindow = image.ownerDocument?.defaultView ?? window;
+	const waitForLoad = image.complete
+		? Promise.resolve()
+		: new Promise( ( resolve ) => {
+				const cleanup = () => {
+					ownerWindow.clearTimeout( timeoutId );
+					image.removeEventListener( 'load', cleanup );
+					image.removeEventListener( 'error', cleanup );
+					resolve();
+				};
+				const timeoutId = ownerWindow.setTimeout(
+					cleanup,
+					CANVAS_READY_IMAGE_TIMEOUT
+				);
+				image.addEventListener( 'load', cleanup, { once: true } );
+				image.addEventListener( 'error', cleanup, { once: true } );
+		  } );
+
+	return waitForLoad.then( () => image.decode?.().catch( () => {} ) );
+}
+
+async function waitForCriticalImages( canvasRoot ) {
+	const iframe = canvasRoot?.querySelector( 'iframe' );
+	const ownerDocument = iframe?.contentDocument ?? canvasRoot?.ownerDocument;
+	if ( ! ownerDocument ) {
+		return;
+	}
+	const images = [
+		...ownerDocument.querySelectorAll(
+			'.cortext-document-cover-block__image'
+		),
+	];
+	await Promise.all( images.map( waitForImageReady ) );
+}
+
+function CanvasReadyEffect( { postId, postType, canvasRootRef, onReady } ) {
+	const [ featuredId ] = useEntityProp(
+		'postType',
+		postType,
+		'featured_media',
+		postId
+	);
+	const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId );
+	const numericFeaturedId = Number( featuredId ) || 0;
+	const needsCover = numericFeaturedId > 0;
+	const needsIcon = Boolean( meta?.cortext_document_icon );
+	const {
+		record: coverMedia,
+		isResolving: isResolvingCoverMedia,
+		hasResolved: hasResolvedCoverMedia,
+	} = useEntityRecord( 'root', 'media', numericFeaturedId, {
+		enabled: needsCover,
+	} );
+	const src = coverSource( coverMedia );
+	const { hasCover, hasIcon, hasTitle } = useSelect( ( select ) => {
+		const blocks = select( blockEditorStore ).getBlocks();
+		return {
+			hasCover: blocks.some(
+				( block ) => block.name === DOCUMENT_COVER_BLOCK
+			),
+			hasIcon: blocks.some(
+				( block ) => block.name === DOCUMENT_ICON_BLOCK
+			),
+			hasTitle: blocks.some(
+				( block ) => block.name === POST_TITLE_BLOCK
+			),
+		};
+	}, [] );
+	const isCoverRecordReady =
+		! needsCover ||
+		Boolean( src ) ||
+		( ! isResolvingCoverMedia && hasResolvedCoverMedia );
+	const areHeaderBlocksReady =
+		hasTitle &&
+		( ! needsCover || hasCover ) &&
+		( ! needsIcon || hasIcon ) &&
+		isCoverRecordReady;
+
+	useLayoutEffect( () => {
+		if ( ! areHeaderBlocksReady ) {
+			return undefined;
+		}
+
+		let cancelled = false;
+		async function signalReady() {
+			if ( needsCover && src ) {
+				await waitForCriticalImages( canvasRootRef.current );
+			}
+			await afterNextPaint(
+				canvasRootRef.current?.ownerDocument?.defaultView
+			);
+			if ( ! cancelled ) {
+				onReady?.( postId, postType );
+			}
+		}
+		signalReady();
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		areHeaderBlocksReady,
+		canvasRootRef,
+		needsCover,
+		onReady,
+		postId,
+		postType,
+		src,
+	] );
 
 	return null;
 }
@@ -722,7 +837,12 @@ export default function EditorBody( {
 						layout={ { type: 'constrained', ...layout } }
 					/>
 				</div>
-				<CanvasReadyEffect postId={ postId } onReady={ onReady } />
+				<CanvasReadyEffect
+					postId={ postId }
+					postType={ postType }
+					canvasRootRef={ blockCanvasRef }
+					onReady={ onReady }
+				/>
 			</BlockCanvas>
 		</div>
 	);

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -57,7 +57,7 @@ const HEADER_BLOCK_NAMES = new Set( [
 	DOCUMENT_ICON_BLOCK,
 	POST_TITLE_BLOCK,
 ] );
-const CANVAS_READY_IMAGE_TIMEOUT = 2500;
+const CANVAS_READY_IMAGE_TIMEOUT = 8000;
 
 function isHeaderBlock( block ) {
 	return HEADER_BLOCK_NAMES.has( block?.name );
@@ -684,7 +684,8 @@ function coverSource( media ) {
 
 function waitForImageReady( image ) {
 	const ownerWindow = image.ownerDocument?.defaultView ?? window;
-	const waitForLoad = image.complete
+	const isLoaded = image.complete && image.naturalWidth > 0;
+	const waitForLoad = isLoaded
 		? Promise.resolve()
 		: new Promise( ( resolve ) => {
 				const cleanup = () => {
@@ -704,21 +705,90 @@ function waitForImageReady( image ) {
 	return waitForLoad.then( () => image.decode?.().catch( () => {} ) );
 }
 
-async function waitForCriticalImages( canvasRoot ) {
-	const iframe = canvasRoot?.querySelector( 'iframe' );
-	const ownerDocument = iframe?.contentDocument ?? canvasRoot?.ownerDocument;
-	if ( ! ownerDocument ) {
-		return;
+function imageMatchesSource( image, expectedSource ) {
+	if ( ! expectedSource ) {
+		return true;
 	}
+	return (
+		image.currentSrc === expectedSource ||
+		image.src === expectedSource ||
+		image.getAttribute( 'src' ) === expectedSource
+	);
+}
+
+function findCoverImage( ownerDocument, expectedSource ) {
 	const images = [
 		...ownerDocument.querySelectorAll(
 			'.cortext-document-cover-block__image'
 		),
 	];
-	await Promise.all( images.map( waitForImageReady ) );
+	if ( expectedSource ) {
+		return (
+			images.find( ( image ) =>
+				imageMatchesSource( image, expectedSource )
+			) ?? null
+		);
+	}
+	return images[ 0 ] ?? null;
 }
 
-function CanvasReadyEffect( { postId, postType, canvasRootRef, onReady } ) {
+function waitForCoverImageNode( ownerDocument, expectedSource ) {
+	const existing = findCoverImage( ownerDocument, expectedSource );
+	if ( existing ) {
+		return Promise.resolve( existing );
+	}
+	const ownerWindow = ownerDocument.defaultView ?? window;
+	const MutationObserver = ownerWindow.MutationObserver;
+	if ( ! MutationObserver ) {
+		return Promise.resolve( null );
+	}
+	return new Promise( ( resolve ) => {
+		const cleanup = ( image = null ) => {
+			ownerWindow.clearTimeout( timeoutId );
+			observer.disconnect();
+			resolve( image );
+		};
+		const observer = new MutationObserver( () => {
+			const image = findCoverImage( ownerDocument, expectedSource );
+			if ( image ) {
+				cleanup( image );
+			}
+		} );
+		const timeoutId = ownerWindow.setTimeout(
+			() => cleanup(),
+			CANVAS_READY_IMAGE_TIMEOUT
+		);
+		observer.observe( ownerDocument.documentElement, {
+			attributeFilter: [ 'src' ],
+			attributes: true,
+			childList: true,
+			subtree: true,
+		} );
+	} );
+}
+
+async function waitForCriticalImages( canvasRoot, expectedCoverSource ) {
+	const iframe = canvasRoot?.querySelector( 'iframe' );
+	const ownerDocument = iframe?.contentDocument ?? canvasRoot?.ownerDocument;
+	if ( ! ownerDocument ) {
+		return;
+	}
+	const coverImage = await waitForCoverImageNode(
+		ownerDocument,
+		expectedCoverSource
+	);
+	if ( coverImage ) {
+		await waitForImageReady( coverImage );
+	}
+}
+
+function CanvasReadyEffect( {
+	featuredMedia,
+	postId,
+	postType,
+	canvasRootRef,
+	onReady,
+} ) {
 	const [ featuredId ] = useEntityProp(
 		'postType',
 		postType,
@@ -726,7 +796,7 @@ function CanvasReadyEffect( { postId, postType, canvasRootRef, onReady } ) {
 		postId
 	);
 	const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId );
-	const numericFeaturedId = Number( featuredId ) || 0;
+	const numericFeaturedId = Number( featuredId ?? featuredMedia ) || 0;
 	const needsCover = numericFeaturedId > 0;
 	const needsIcon = Boolean( meta?.cortext_document_icon );
 	const {
@@ -769,7 +839,7 @@ function CanvasReadyEffect( { postId, postType, canvasRootRef, onReady } ) {
 		let cancelled = false;
 		async function signalReady() {
 			if ( needsCover && src ) {
-				await waitForCriticalImages( canvasRootRef.current );
+				await waitForCriticalImages( canvasRootRef.current, src );
 			}
 			await afterNextPaint(
 				canvasRootRef.current?.ownerDocument?.defaultView
@@ -785,6 +855,7 @@ function CanvasReadyEffect( { postId, postType, canvasRootRef, onReady } ) {
 	}, [
 		areHeaderBlocksReady,
 		canvasRootRef,
+		featuredMedia,
 		needsCover,
 		onReady,
 		postId,
@@ -796,6 +867,7 @@ function CanvasReadyEffect( { postId, postType, canvasRootRef, onReady } ) {
 }
 
 export default function EditorBody( {
+	featuredMedia,
 	isActive = true,
 	postId,
 	postType,
@@ -838,6 +910,7 @@ export default function EditorBody( {
 					/>
 				</div>
 				<CanvasReadyEffect
+					featuredMedia={ featuredMedia }
 					postId={ postId }
 					postType={ postType }
 					canvasRootRef={ blockCanvasRef }

--- a/src/components/PageIconWp.js
+++ b/src/components/PageIconWp.js
@@ -1,12 +1,14 @@
 import * as icons from '@wordpress/icons';
+import { isValidElement } from '@wordpress/element';
 
 // Renders a single icon from `@wordpress/icons` by export name. Lives in
 // its own module so PageIcon can `lazy()` it; the sidebar tree (which
 // only ever renders emoji/image icons) doesn't pay the import cost.
 export default function PageIconWp( { name, size = 16 } ) {
 	const Glyph = icons[ name ];
-	if ( ! Glyph || typeof Glyph !== 'object' ) {
+	const Icon = icons.Icon;
+	if ( ! Icon || ! isValidElement( Glyph ) || ! Glyph.type ) {
 		return null;
 	}
-	return <icons.Icon icon={ Glyph } size={ size } />;
+	return <Icon icon={ Glyph } size={ size } />;
 }

--- a/src/components/dataViewScroll.js
+++ b/src/components/dataViewScroll.js
@@ -1,7 +1,7 @@
-function prefersReducedMotion() {
+function prefersReducedMotion( ownerWindow = window ) {
 	return (
-		typeof window !== 'undefined' &&
-		window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches
+		typeof ownerWindow !== 'undefined' &&
+		ownerWindow.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches
 	);
 }
 
@@ -10,12 +10,13 @@ function isAtScrollEnd( scrollLeft, target ) {
 }
 
 export function scrollToEndQuickly( wrapper, options = {} ) {
+	const ownerWindow = wrapper.ownerDocument?.defaultView ?? window;
 	const maxScroll = wrapper.scrollWidth - wrapper.clientWidth;
 	const trackEnd = options.trackEnd === true;
 	if ( maxScroll <= 0 && ! trackEnd ) {
 		return;
 	}
-	const isRtl = window.getComputedStyle( wrapper ).direction === 'rtl';
+	const isRtl = ownerWindow.getComputedStyle( wrapper ).direction === 'rtl';
 	const endTarget = () => {
 		const currentMaxScroll = wrapper.scrollWidth - wrapper.clientWidth;
 		return isRtl ? -currentMaxScroll : currentMaxScroll;
@@ -34,7 +35,7 @@ export function scrollToEndQuickly( wrapper, options = {} ) {
 		wrapper.scrollLeft = target;
 		return;
 	}
-	if ( prefersReducedMotion() ) {
+	if ( prefersReducedMotion( ownerWindow ) ) {
 		wrapper.scrollLeft = target;
 		return;
 	}
@@ -45,8 +46,17 @@ export function scrollToEndQuickly( wrapper, options = {} ) {
 	}
 
 	const duration = 180;
-	const startedAt = window.performance.now();
+	const startedAt = ownerWindow.performance.now();
 	const easeOutCubic = ( t ) => 1 - Math.pow( 1 - t, 3 );
+	const settleUntil = trackEnd ? startedAt + 5000 : 0;
+
+	const settleAtEnd = () => {
+		wrapper.scrollLeft = endTarget();
+		if ( ownerWindow.performance.now() >= settleUntil ) {
+			return;
+		}
+		ownerWindow.requestAnimationFrame( settleAtEnd );
+	};
 
 	const animate = ( now ) => {
 		const progress = Math.min( 1, ( now - startedAt ) / duration );
@@ -54,10 +64,10 @@ export function scrollToEndQuickly( wrapper, options = {} ) {
 		wrapper.scrollLeft =
 			start + ( currentTarget - start ) * easeOutCubic( progress );
 		if ( progress < 1 ) {
-			window.requestAnimationFrame( animate );
+			ownerWindow.requestAnimationFrame( animate );
 		} else {
-			wrapper.scrollLeft = currentTarget;
+			settleAtEnd();
 		}
 	};
-	window.requestAnimationFrame( animate );
+	ownerWindow.requestAnimationFrame( animate );
 }

--- a/src/hooks/afterNextPaint.js
+++ b/src/hooks/afterNextPaint.js
@@ -1,0 +1,19 @@
+export default function afterNextPaint( ownerWindow ) {
+	const win =
+		ownerWindow ?? ( typeof window !== 'undefined' ? window : globalThis );
+	const requestFrame = win.requestAnimationFrame?.bind( win );
+	const delay = win.setTimeout?.bind( win ) ?? setTimeout;
+
+	return new Promise( ( resolve ) => {
+		if ( ! requestFrame ) {
+			delay( resolve, 0 );
+			return;
+		}
+
+		requestFrame( () => {
+			requestFrame( () => {
+				delay( resolve, 0 );
+			} );
+		} );
+	} );
+}

--- a/src/hooks/viewTransition.js
+++ b/src/hooks/viewTransition.js
@@ -9,6 +9,8 @@ function prefersReducedMotion() {
 }
 
 let activeTransition = null;
+const HOLD_OLD_CANVAS_MODE = 'hold-old-canvas';
+const REVEAL_OLD_CANVAS_MODE = 'reveal-old-canvas';
 
 function setTransitionMode( mode ) {
 	const root = document.documentElement;
@@ -42,27 +44,41 @@ export function withViewTransition( updater, options = {} ) {
 	setTransitionMode( options.mode );
 	let tx;
 	let updaterResult;
+	let resolveUpdaterResult;
+	const updaterResultReady = new Promise( ( resolve ) => {
+		resolveUpdaterResult = resolve;
+	} );
 	try {
 		tx = document.startViewTransition( () => {
-			flushSync( () => {
-				updaterResult = updater();
-			} );
+			try {
+				flushSync( () => {
+					updaterResult = updater();
+				} );
+			} finally {
+				resolveUpdaterResult( updaterResult );
+			}
 		} );
 	} catch ( error ) {
 		setTransitionMode( null );
 		throw error;
 	}
 	activeTransition = tx;
-	if (
-		options.mode === 'hold-old-canvas' &&
-		updaterResult &&
-		typeof updaterResult.then === 'function'
-	) {
-		updaterResult
-			.catch( () => {} )
-			.finally( () => {
-				tx.skipTransition?.();
-			} );
+	if ( options.mode === HOLD_OLD_CANVAS_MODE ) {
+		// tech-debt.md#58: the View Transition callback can run after this
+		// function returns, so wait for the updater result before revealing.
+		const reveal = () => {
+			if ( activeTransition === tx ) {
+				setTransitionMode( REVEAL_OLD_CANVAS_MODE );
+			}
+		};
+		updaterResultReady
+			.then( ( result ) => {
+				if ( result && typeof result.then === 'function' ) {
+					return result.catch( () => {} );
+				}
+				return tx.ready.catch( () => {} );
+			} )
+			.finally( reveal );
 	}
 	tx.finished
 		.catch( () => {} )

--- a/src/hooks/viewTransition.js
+++ b/src/hooks/viewTransition.js
@@ -10,6 +10,15 @@ function prefersReducedMotion() {
 
 let activeTransition = null;
 
+function setTransitionMode( mode ) {
+	const root = document.documentElement;
+	if ( mode ) {
+		root.dataset.cortextViewTransition = mode;
+		return;
+	}
+	delete root.dataset.cortextViewTransition;
+}
+
 function supportsViewTransitions() {
 	return (
 		typeof document !== 'undefined' &&
@@ -21,24 +30,46 @@ function canUseViewTransitions() {
 	return supportsViewTransitions() && ! prefersReducedMotion();
 }
 
-// Wrap a state update so the browser snapshots the canvas before and
-// after, then cross-fades between them. Without View Transitions support
-// or with reduced motion on, just runs the updater directly.
-export function withViewTransition( updater ) {
+// Run the update inside the browser's View Transition snapshot window.
+// Without the API, or when reduced motion is on, this is just a normal update.
+// Callers can pass a mode when a swap needs its own CSS.
+export function withViewTransition( updater, options = {} ) {
 	if ( ! canUseViewTransitions() ) {
 		updater();
 		return;
 	}
 
-	const tx = document.startViewTransition( () => {
-		flushSync( updater );
-	} );
+	setTransitionMode( options.mode );
+	let tx;
+	let updaterResult;
+	try {
+		tx = document.startViewTransition( () => {
+			flushSync( () => {
+				updaterResult = updater();
+			} );
+		} );
+	} catch ( error ) {
+		setTransitionMode( null );
+		throw error;
+	}
 	activeTransition = tx;
+	if (
+		options.mode === 'hold-old-canvas' &&
+		updaterResult &&
+		typeof updaterResult.then === 'function'
+	) {
+		updaterResult
+			.catch( () => {} )
+			.finally( () => {
+				tx.skipTransition?.();
+			} );
+	}
 	tx.finished
 		.catch( () => {} )
 		.finally( () => {
 			if ( activeTransition === tx ) {
 				activeTransition = null;
+				setTransitionMode( null );
 			}
 		} );
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1082,6 +1082,34 @@ body.cortext-sidebar-resizing {
 	z-index: 1;
 }
 
+@keyframes cortext-hold-old-canvas {
+
+	0%,
+	99% {
+		opacity: 1;
+	}
+
+	100% {
+		opacity: 0;
+	}
+}
+
+// Page-to-page swaps rebuild the editor while the route stays on the same
+// pane. Keep the old snapshot above the new one so the frame never peeks
+// through.
+:root[data-cortext-view-transition="hold-old-canvas"]::view-transition-old(cortext-canvas) {
+	animation: cortext-hold-old-canvas 2500ms step-end both;
+	mix-blend-mode: normal;
+	z-index: 2;
+}
+
+:root[data-cortext-view-transition="hold-old-canvas"]::view-transition-new(cortext-canvas) {
+	animation: none;
+	mix-blend-mode: normal;
+	opacity: 1;
+	z-index: 1;
+}
+
 // The side peek lives outside the canvas. Give it its own transition layer so
 // the canvas cross-fade never flashes over it.
 ::view-transition-group(cortext-row-detail-sidebar) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1518,11 +1518,30 @@ body.cortext-sidebar-resizing {
 		pointer-events: none;
 	}
 
-	// The trashed-page banner stacks above the BlockCanvas. Make the
-	// content slot a flex column so the canvas keeps its `height: 100%`
-	// behavior (it now fills the remaining space). Couples to a
-	// Gutenberg-internal class; revisit if `@wordpress/interface` ever
-	// exposes a slot for a notice region above the content.
+	// Gutenberg uses a left box-shadow as the inspector divider. In Cortext it
+	// reads like a stray focus line next to the canvas, so remove it here.
+	.interface-interface-skeleton__sidebar {
+		box-shadow: none;
+	}
+
+	// The inspector has only Page and Block tabs, but @wordpress/components can
+	// still flag the tab list as horizontally overflowing after a click. Its
+	// edge fade washes out the Page tab, so disable the mask for this header.
+	.editor-sidebar__panel-tabs [role="tablist"][aria-orientation="horizontal"].is-overflowing-first,
+	.editor-sidebar__panel-tabs [role="tablist"][aria-orientation="horizontal"].is-overflowing-last,
+	.editor-sidebar__panel-tabs [role="tablist"][aria-orientation="horizontal"].is-overflowing-first.is-overflowing-last {
+		-webkit-mask-image: none;
+		mask-image: none;
+	}
+
+	// The trashed-page notice sits above BlockCanvas. Make the skeleton body
+	// own a fixed frame while the iframe handles document scrolling; otherwise
+	// an outer scrollbar can appear between the canvas and inspector.
+	.interface-interface-skeleton__body,
+	.interface-interface-skeleton__content {
+		overflow: hidden;
+	}
+
 	.interface-interface-skeleton__content {
 		position: relative;
 		display: flex;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1094,16 +1094,36 @@ body.cortext-sidebar-resizing {
 	}
 }
 
-// Page-to-page swaps rebuild the editor while the route stays on the same
-// pane. Keep the old snapshot above the new one so the frame never peeks
-// through.
-:root[data-cortext-view-transition="hold-old-canvas"]::view-transition-old(cortext-canvas) {
-	animation: cortext-hold-old-canvas 2500ms step-end both;
+@keyframes cortext-reveal-old-canvas {
+
+	from {
+		opacity: 1;
+	}
+
+	to {
+		opacity: 0;
+	}
+}
+
+// tech-debt.md#58: Page-to-page swaps rebuild the editor while the route
+// stays on the same pane. Keep the old snapshot above the new one until the
+// new editor has painted, then fade it away.
+:root[data-cortext-view-transition="hold-old-canvas"]::view-transition-old(cortext-canvas),
+:root[data-cortext-view-transition="reveal-old-canvas"]::view-transition-old(cortext-canvas) {
 	mix-blend-mode: normal;
 	z-index: 2;
 }
 
-:root[data-cortext-view-transition="hold-old-canvas"]::view-transition-new(cortext-canvas) {
+:root[data-cortext-view-transition="hold-old-canvas"]::view-transition-old(cortext-canvas) {
+	animation: cortext-hold-old-canvas 30s step-end both;
+}
+
+:root[data-cortext-view-transition="reveal-old-canvas"]::view-transition-old(cortext-canvas) {
+	animation: cortext-reveal-old-canvas 180ms ease-out both;
+}
+
+:root[data-cortext-view-transition="hold-old-canvas"]::view-transition-new(cortext-canvas),
+:root[data-cortext-view-transition="reveal-old-canvas"]::view-transition-new(cortext-canvas) {
 	animation: none;
 	mix-blend-mode: normal;
 	opacity: 1;

--- a/src/index.scss
+++ b/src/index.scss
@@ -5370,14 +5370,6 @@ thead > tr > th {
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
-		// Pair with the inline `opacity: hasImagePainted ? 1 : 0` on the
-		// img so the cover fades in instead of popping after the bytes
-		// decode. Reduced motion ignores the fade.
-		transition: opacity 180ms ease-out;
-
-		@media (prefers-reduced-motion: reduce) {
-			transition: none;
-		}
 	}
 
 	&__controls {

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -231,9 +231,7 @@ export default function EntityRoute( { history } ) {
 			return;
 		}
 		if ( isContentPane( before.active ) && isContentPane( after.active ) ) {
-			withViewTransition( () => rawDispatch( action ), {
-				mode: 'hold-old-canvas',
-			} );
+			withViewTransition( () => rawDispatch( action ) );
 			return;
 		}
 		const touchesCollection =

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -231,7 +231,9 @@ export default function EntityRoute( { history } ) {
 			return;
 		}
 		if ( isContentPane( before.active ) && isContentPane( after.active ) ) {
-			withViewTransition( () => rawDispatch( action ) );
+			withViewTransition( () => rawDispatch( action ), {
+				mode: 'hold-old-canvas',
+			} );
 			return;
 		}
 		const touchesCollection =

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -164,6 +164,10 @@ const ROW_MUTATION_DEFAULT = {
 	refreshRows: () => {},
 };
 
+function isContentPane( active ) {
+	return active.kind === 'document' || active.kind === 'collection';
+}
+
 export default function EntityRoute( { history } ) {
 	const params = useParams( { strict: false } );
 	const navigate = useNavigate();
@@ -187,9 +191,9 @@ export default function EntityRoute( { history } ) {
 		readyCollectionIds,
 	} = state;
 
-	// Document navigations keep the previous pane visible until the next one can
-	// paint. Collections can activate before rows are ready, so compare the URL
-	// target with the displayed/ready snapshot here.
+	// Documents keep the previous pane visible until the new editor has painted.
+	// Collections have their own ready signal after rows load, so compare the URL
+	// target with the displayed/ready state here.
 	const isWorkspaceNavigating =
 		( target.kind === 'document' &&
 			target.id !== null &&
@@ -199,10 +203,9 @@ export default function EntityRoute( { history } ) {
 			! readyCollectionIds.has( target.id ) );
 	const showWorkspaceProgress = useDelayedFlag( isWorkspaceNavigating );
 
-	// Run the reducer ahead of time so we only wrap the dispatch when
-	// `active` actually flips. Otherwise every DOCUMENT_RESOLVED or
-	// COLLECTION_RESOLVED would pin the canvas for the cross-fade
-	// duration even though nothing visible changed.
+	// Peek at the reducer result before dispatching. We only need a transition
+	// when `active` changes; wrapping every resolve action would pin the canvas
+	// even when the visible pane stayed put.
 	const stateRef = useRef( state );
 	stateRef.current = state;
 	const dispatch = useCallback( ( action ) => {
@@ -213,6 +216,24 @@ export default function EntityRoute( { history } ) {
 			( before.active.id ?? null ) !== ( after.active.id ?? null );
 		if ( ! visualChanged ) {
 			rawDispatch( action );
+			return;
+		}
+		// Canvas owns page-to-page swaps because it can hold the old editor
+		// snapshot until the new EditorProvider is ready. Letting EntityRoute start
+		// another transition on DOCUMENT_DISPLAYED makes Chrome skip one and
+		// exposes the canvas frame near the end of the loader.
+		if (
+			action.type === 'DOCUMENT_DISPLAYED' &&
+			before.active.kind === 'document' &&
+			after.active.kind === 'document'
+		) {
+			rawDispatch( action );
+			return;
+		}
+		if ( isContentPane( before.active ) && isContentPane( after.active ) ) {
+			withViewTransition( () => rawDispatch( action ), {
+				mode: 'hold-old-canvas',
+			} );
 			return;
 		}
 		const touchesCollection =

--- a/src/router/entityRouteReducer.js
+++ b/src/router/entityRouteReducer.js
@@ -65,6 +65,10 @@ function pruneCollections( state ) {
 	return { ...state, mountedCollectionIds, readyCollectionIds };
 }
 
+function isContentPane( active ) {
+	return active.kind === 'document' || active.kind === 'collection';
+}
+
 // `target` follows the URL; `active` is what we're painting. They diverge
 // during transitions: the old pane keeps painting until the new one is ready,
 // then `active` flips.
@@ -98,6 +102,8 @@ export function reducer( state, action ) {
 					state.readyCollectionIds.has( target.id )
 				) {
 					active = { kind: 'collection', id: target.id };
+				} else if ( isContentPane( state.active ) ) {
+					active = state.active;
 				} else {
 					active = { kind: 'loading' };
 				}
@@ -161,8 +167,10 @@ export function reducer( state, action ) {
 			const next = {
 				...state,
 				mountedCollectionIds,
-				active: { kind: 'collection', id: action.id },
 			};
+			if ( ! isContentPane( state.active ) ) {
+				next.active = { kind: 'collection', id: action.id };
+			}
 			return pruneCollections( next );
 		}
 

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -19,16 +19,28 @@ async function deleteIfCreated( requestUtils, path ) {
 	}
 }
 
-async function expectTableScrolledToEnd( canvas ) {
+async function expectColumnRevealed( canvas, columnHeader ) {
 	const wrapper = canvas
 		.locator( '.cortext-data-view > .dataviews-wrapper' )
 		.first();
 	await expect
-		.poll( async () =>
-			wrapper.evaluate(
-				( el ) => el.scrollLeft + el.clientWidth >= el.scrollWidth - 2
-			)
-		)
+		.poll( async () => {
+			const [ wrapperBox, headerBox ] = await Promise.all( [
+				wrapper.boundingBox(),
+				columnHeader.boundingBox(),
+			] );
+			if ( ! wrapperBox || ! headerBox ) {
+				return false;
+			}
+			const wrapperLeft = wrapperBox.x;
+			const wrapperRight = wrapperBox.x + wrapperBox.width;
+			const headerLeft = headerBox.x;
+			const headerRight = headerBox.x + headerBox.width;
+			return (
+				headerLeft >= wrapperLeft - 2 &&
+				headerRight <= wrapperRight + 2
+			);
+		} )
 		.toBe( true );
 }
 
@@ -4026,7 +4038,7 @@ test.describe( 'Collection view block', () => {
 				name: /Notes/,
 			} );
 			await expect( notesHeader ).toBeVisible();
-			await expectTableScrolledToEnd( canvas );
+			await expectColumnRevealed( canvas, notesHeader );
 
 			// `getByRole('button', { name })` would match both the visible
 			// combined-dropdown trigger (text label) and the transparent
@@ -4099,10 +4111,11 @@ test.describe( 'Collection view block', () => {
 				.getByRole( 'button', { name: 'Text', exact: true } )
 				.click();
 
-			await expect(
-				canvas.getByRole( 'columnheader', { name: /Tags/ } )
-			).toBeVisible();
-			await expectTableScrolledToEnd( canvas );
+			const tagsHeader = canvas.getByRole( 'columnheader', {
+				name: /Tags/,
+			} );
+			await expect( tagsHeader ).toBeVisible();
+			await expectColumnRevealed( canvas, tagsHeader );
 
 			// 6. Title's column doesn't get the schema-action takeover —
 			//    its `<th>` keeps DataViews' built-in trigger and has no

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -37,8 +37,7 @@ async function expectColumnRevealed( canvas, columnHeader ) {
 			const headerLeft = headerBox.x;
 			const headerRight = headerBox.x + headerBox.width;
 			return (
-				headerLeft >= wrapperLeft - 2 &&
-				headerRight <= wrapperRight + 2
+				headerLeft >= wrapperLeft - 2 && headerRight <= wrapperRight + 2
 			);
 		} )
 		.toBe( true );

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -12,6 +12,21 @@ const ENTRY_TITLE = `E2E Lifecycle Entry ${ SUFFIX }`;
 const HISTORY_FIRST_PAGE_TITLE = `E2E History Page A ${ SUFFIX }`;
 const HISTORY_SECOND_PAGE_TITLE = `E2E History Page B ${ SUFFIX }`;
 const HISTORY_COLLECTION_TITLE = `E2E History Collection ${ SUFFIX }`;
+const NO_FLASH_FIRST_PAGE_TITLE = `E2E No Flash Page A ${ SUFFIX }`;
+const NO_FLASH_SECOND_PAGE_TITLE = `E2E No Flash Page B ${ SUFFIX }`;
+const COVER_FIRST_PAGE_TITLE = `E2E Cover Page A ${ SUFFIX }`;
+const COVER_SECOND_PAGE_TITLE = `E2E Cover Page B ${ SUFFIX }`;
+const COVER_PNG = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAGklEQVR42mP8z8BQz0AEYBxVSFUBAAAcZgP9vyv3NwAAAABJRU5ErkJggg==',
+	'base64'
+);
+
+test.use( {
+	contextOptions: {
+		reducedMotion: 'no-preference',
+		strictSelectors: true,
+	},
+} );
 
 async function deleteIfCreated( requestUtils, path ) {
 	if ( ! path ) {
@@ -28,6 +43,14 @@ async function deleteIfCreated( requestUtils, path ) {
 	}
 }
 
+async function uploadCoverMedia( requestUtils, name ) {
+	return requestUtils.uploadMedia( {
+		name,
+		mimeType: 'image/png',
+		buffer: COVER_PNG,
+	} );
+}
+
 async function waitForEditorPost( page, postId ) {
 	await page.waitForFunction(
 		( expectedPostId ) =>
@@ -36,6 +59,253 @@ async function waitForEditorPost( page, postId ) {
 		postId,
 		{ timeout: 15_000 }
 	);
+}
+
+async function coverImagePainted( page ) {
+	const frame = page.frame( { name: 'editor-canvas' } );
+	if ( ! frame ) {
+		return false;
+	}
+	const image = frame.locator( '.cortext-document-cover-block__image' );
+	if ( ( await image.count() ) === 0 ) {
+		return false;
+	}
+	return image.evaluate( ( node ) => {
+		const style = node.ownerDocument.defaultView.getComputedStyle( node );
+		return (
+			node.complete &&
+			node.naturalWidth > 0 &&
+			Number( style.opacity ) === 1
+		);
+	} );
+}
+
+async function waitForCoverImagePainted( page ) {
+	await expect
+		.poll( () => coverImagePainted( page ), {
+			message: 'the cover image should paint before the canvas is marked ready',
+		} )
+		.toBe( true );
+}
+
+async function canvasContainsAnyTitle( page, titles ) {
+	const frame = page.frame( { name: 'editor-canvas' } );
+	if ( ! frame ) {
+		return false;
+	}
+	return frame.locator( 'body' ).evaluate( ( body, expectedTitles ) => {
+		const text = body.innerText || '';
+		return expectedTitles.some( ( title ) => text.includes( title ) );
+	}, titles );
+}
+
+async function isHoldingOldCanvasSnapshot( page ) {
+	return page.evaluate( () => {
+		if (
+			document.documentElement.dataset.cortextViewTransition !==
+			'hold-old-canvas'
+		) {
+			return false;
+		}
+		const oldCanvas = window.getComputedStyle(
+			document.documentElement,
+			'::view-transition-old(cortext-canvas)'
+		);
+		return (
+			oldCanvas.animationName.includes( 'cortext-hold-old-canvas' ) &&
+			Number( oldCanvas.opacity ) === 1
+		);
+	} );
+}
+
+async function waitForCanvasTitleWithoutBlanking( page, titles, targetTitle ) {
+	const deadline = Date.now() + 5000;
+	while ( Date.now() < deadline ) {
+		const [ hasAnyTitle, hasTargetTitle, isHoldingSnapshot ] =
+			await Promise.all( [
+				canvasContainsAnyTitle( page, titles ),
+				canvasContainsAnyTitle( page, [ targetTitle ] ),
+				isHoldingOldCanvasSnapshot( page ),
+			] );
+
+		if ( ! hasAnyTitle && ! isHoldingSnapshot ) {
+			throw new Error(
+				'The canvas went blank while the old snapshot was not covering it.'
+			);
+		}
+		if ( hasTargetTitle ) {
+			return;
+		}
+		await page.waitForTimeout( 16 );
+	}
+
+	throw new Error( `Timed out before ${ targetTitle } appeared in the canvas.` );
+}
+
+async function waitForTransitionModeToClear( page ) {
+	await page.waitForFunction(
+		() => ! document.documentElement.dataset.cortextViewTransition
+	);
+}
+
+async function resetViewTransitionProbe( page ) {
+	return page.evaluate( () => {
+		if (
+			typeof document.startViewTransition !== 'function' ||
+			window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches
+		) {
+			return false;
+		}
+		if ( ! window.__cortextViewTransitionOriginal ) {
+			window.__cortextViewTransitionOriginal =
+				document.startViewTransition.bind( document );
+			window.__cortextViewTransitionNextId = 0;
+			document.startViewTransition = ( callback ) => {
+				const id = ++window.__cortextViewTransitionNextId;
+				const record = ( type, extra = {} ) => {
+					window.__cortextViewTransitionEvents.push( {
+						id,
+						type,
+						mode:
+							document.documentElement.dataset
+								.cortextViewTransition || '',
+						...extra,
+					} );
+				};
+				record( 'start' );
+				const transition = window.__cortextViewTransitionOriginal(
+					() => {
+						record( 'callback-start' );
+						let result;
+						try {
+							result = callback();
+						} catch ( error ) {
+							record( 'callback-threw', {
+								name: error?.name || '',
+								message: error?.message || '',
+							} );
+							throw error;
+						}
+						Promise.resolve( result ).then(
+							() => record( 'callback-done' ),
+							( error ) =>
+								record( 'callback-rejected', {
+									name: error?.name || '',
+									message: error?.message || '',
+								} )
+						);
+						return result;
+					}
+				);
+				transition.ready.then(
+					() => record( 'ready' ),
+					( error ) =>
+						record( 'ready-rejected', {
+							name: error?.name || '',
+							message: error?.message || '',
+						} )
+				);
+				transition.finished.then(
+					() => record( 'finished' ),
+					( error ) =>
+						record( 'finished-rejected', {
+							name: error?.name || '',
+							message: error?.message || '',
+						} )
+				);
+				return transition;
+			};
+		}
+		window.__cortextViewTransitionEvents = [];
+		return true;
+	} );
+}
+
+async function expectRouteViewTransition( page, label, expectedMode = '' ) {
+	const supportsViewTransitions = await page.evaluate( () =>
+		Boolean( window.__cortextViewTransitionOriginal )
+	);
+	if ( ! supportsViewTransitions ) {
+		return;
+	}
+
+	await expect
+		.poll(
+				() =>
+					page.evaluate( () =>
+						( window.__cortextViewTransitionEvents || [] ).some(
+							( event ) => event.type === 'start'
+						)
+					),
+				{ message: `${ label } should trigger a route transition` }
+			)
+		.toBe( true );
+
+	const rejectedEvents = await page.evaluate( () =>
+		( window.__cortextViewTransitionEvents || [] ).filter( ( event ) =>
+			[
+				'callback-threw',
+				'callback-rejected',
+				'ready-rejected',
+				'finished-rejected',
+			].includes( event.type )
+		)
+	);
+	expect( rejectedEvents ).toEqual( [] );
+	const hasReadyRouteTransition = await page.evaluate(
+		( mode ) =>
+			( window.__cortextViewTransitionEvents || [] ).some(
+				( event ) => event.type === 'ready' && event.mode === mode
+			),
+		expectedMode
+	);
+	expect( hasReadyRouteTransition ).toBe( true );
+}
+
+async function activeDataViewPaintState( page, texts ) {
+	return page.evaluate( ( expectedTexts ) => {
+		const dataView = document.querySelector(
+			'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
+		);
+		if ( ! dataView ) {
+			return {
+				hasDataView: false,
+				hasLoadingShell: false,
+				hasSkeleton: false,
+				hasText: false,
+			};
+		}
+		const text = dataView.innerText || '';
+		return {
+			hasDataView: true,
+			hasLoadingShell:
+				dataView.getAttribute( 'data-loading-shell' ) === 'true',
+			hasSkeleton: Boolean(
+				dataView.querySelector( '.cortext-data-view__rows-skeleton' )
+			),
+			hasText: expectedTexts.some( ( expected ) =>
+				text.includes( expected )
+			),
+		};
+	}, texts );
+}
+
+async function waitForActiveDataViewWithoutBlanking( page, texts ) {
+	const deadline = Date.now() + 5000;
+	while ( Date.now() < deadline ) {
+			const state = await activeDataViewPaintState( page, texts );
+			if ( state.hasDataView && ! state.hasSkeleton && ! state.hasText ) {
+				throw new Error(
+					'Full-page DataViews showed an empty shell instead of loading or loaded content.'
+				);
+			}
+		if ( state.hasText ) {
+			return;
+		}
+		await page.waitForTimeout( 16 );
+	}
+
+	throw new Error( 'Timed out before full-page DataViews content appeared.' );
 }
 
 test.describe( 'Navigation lifecycle', () => {
@@ -147,12 +417,212 @@ test.describe( 'Navigation lifecycle', () => {
 		}
 	} );
 
-	test( 'keeps the current page canvas visible while collection rows load', async ( {
+	test( 'keeps page content visible while moving between pages', async ( {
 		admin,
 		page,
 		requestUtils,
 	} ) => {
 		const fixture = {};
+		let releaseLocator = () => {};
+
+		try {
+			fixture.firstPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: NO_FLASH_FIRST_PAGE_TITLE,
+					status: 'private',
+				},
+			} );
+			fixture.secondPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: NO_FLASH_SECOND_PAGE_TITLE,
+					status: 'private',
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ fixture.firstPage.id }`
+			);
+			await waitForEditorPost( page, fixture.firstPage.id );
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			await expect(
+				canvas.getByText( NO_FLASH_FIRST_PAGE_TITLE, { exact: true } )
+			).toBeVisible();
+
+			const locatorGate = new Promise( ( resolve ) => {
+				releaseLocator = resolve;
+			} );
+			await page.route(
+				`**/wp-json/cortext/v1/documents/${ fixture.secondPage.id }`,
+				async ( route ) => {
+					await locatorGate;
+					await route.continue();
+				}
+			);
+			const locatorRequest = page.waitForRequest( ( request ) =>
+				request
+					.url()
+					.includes(
+						`/wp-json/cortext/v1/documents/${ fixture.secondPage.id }`
+					)
+			);
+
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: NO_FLASH_SECOND_PAGE_TITLE,
+					exact: true,
+				} )
+				.click();
+			await locatorRequest;
+			await page.waitForTimeout( 100 );
+			expect(
+				await canvasContainsAnyTitle( page, [
+					NO_FLASH_FIRST_PAGE_TITLE,
+					NO_FLASH_SECOND_PAGE_TITLE,
+				] )
+			).toBe( true );
+
+			releaseLocator();
+			await waitForCanvasTitleWithoutBlanking(
+				page,
+				[ NO_FLASH_FIRST_PAGE_TITLE, NO_FLASH_SECOND_PAGE_TITLE ],
+				NO_FLASH_SECOND_PAGE_TITLE
+			);
+
+			await waitForEditorPost( page, fixture.secondPage.id );
+			await expect(
+				canvas.getByText( NO_FLASH_SECOND_PAGE_TITLE, {
+					exact: true,
+				} )
+			).toBeVisible();
+		} finally {
+			releaseLocator();
+			await deleteIfCreated(
+				requestUtils,
+				fixture.secondPage &&
+					`/wp/v2/crtxt_pages/${ fixture.secondPage.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.firstPage &&
+					`/wp/v2/crtxt_pages/${ fixture.firstPage.id }`
+			);
+		}
+	} );
+
+	test( 'waits for cover images before revealing the next page', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		let releaseMedia = () => {};
+
+		try {
+			fixture.firstMedia = await uploadCoverMedia(
+				requestUtils,
+				`cover-a-${ SUFFIX }.png`
+			);
+			fixture.secondMedia = await uploadCoverMedia(
+				requestUtils,
+				`cover-b-${ SUFFIX }.png`
+			);
+			fixture.firstPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: COVER_FIRST_PAGE_TITLE,
+					status: 'private',
+					featured_media: fixture.firstMedia.id,
+				},
+			} );
+			fixture.secondPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: COVER_SECOND_PAGE_TITLE,
+					status: 'private',
+					featured_media: fixture.secondMedia.id,
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ fixture.firstPage.id }`
+			);
+			await waitForEditorPost( page, fixture.firstPage.id );
+			await waitForCoverImagePainted( page );
+
+			const mediaGate = new Promise( ( resolve ) => {
+				releaseMedia = resolve;
+			} );
+			await page.route(
+				`**/wp-json/wp/v2/media/${ fixture.secondMedia.id }**`,
+				async ( route ) => {
+					await mediaGate;
+					await route.continue();
+				}
+			);
+			const mediaRequest = page.waitForRequest( ( request ) =>
+				request
+					.url()
+					.includes(
+						`/wp-json/wp/v2/media/${ fixture.secondMedia.id }`
+					)
+			);
+
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: COVER_SECOND_PAGE_TITLE,
+					exact: true,
+				} )
+				.click();
+			await mediaRequest;
+			await page.waitForTimeout( 100 );
+			expect( await isHoldingOldCanvasSnapshot( page ) ).toBe( true );
+
+			releaseMedia();
+			await waitForTransitionModeToClear( page );
+			await waitForEditorPost( page, fixture.secondPage.id );
+			await waitForCoverImagePainted( page );
+		} finally {
+			releaseMedia();
+			await deleteIfCreated(
+				requestUtils,
+				fixture.secondPage &&
+					`/wp/v2/crtxt_pages/${ fixture.secondPage.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.firstPage &&
+					`/wp/v2/crtxt_pages/${ fixture.firstPage.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.secondMedia &&
+					`/wp/v2/media/${ fixture.secondMedia.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.firstMedia && `/wp/v2/media/${ fixture.firstMedia.id }`
+			);
+		}
+	} );
+
+	test( 'keeps the current page visible while collection rows load', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		let releaseCollection = () => {};
 		let releaseRows = () => {};
 
 		try {
@@ -201,6 +671,7 @@ test.describe( 'Navigation lifecycle', () => {
 				} )
 				.click();
 			await waitForEditorPost( page, fixture.secondPage.id );
+			await waitForTransitionModeToClear( page );
 
 			const canvasAfter = await page
 				.locator( '.cortext-canvas' )
@@ -213,6 +684,28 @@ test.describe( 'Navigation lifecycle', () => {
 			);
 			expect( keptCanvas ).toBe( true );
 
+			const pagePane = page
+				.locator( '.cortext-workspace__pane' )
+				.filter( { has: page.locator( '.cortext-canvas' ) } );
+			await expect( pagePane ).toHaveAttribute( 'data-active', 'true' );
+
+			const collectionGate = new Promise( ( resolve ) => {
+				releaseCollection = resolve;
+			} );
+			await page.route(
+				`**/wp-json/wp/v2/crtxt_collections/${ fixture.collection.id }**`,
+				async ( route ) => {
+					await collectionGate;
+					await route.continue();
+				}
+			);
+			const collectionRequest = page.waitForRequest( ( request ) =>
+				request
+					.url()
+					.includes(
+						`/wp-json/wp/v2/crtxt_collections/${ fixture.collection.id }`
+					)
+			);
 			const rowsGate = new Promise( ( resolve ) => {
 				releaseRows = resolve;
 			} );
@@ -238,26 +731,35 @@ test.describe( 'Navigation lifecycle', () => {
 						.includes( `collection=${ fixture.collection.id }` )
 			);
 
+			await resetViewTransitionProbe( page );
 			await sidebar
 				.getByRole( 'button', {
 					name: COLLECTION_TITLE,
 					exact: true,
 				} )
 				.click();
+			await collectionRequest;
+			await expect( pagePane ).toHaveAttribute( 'data-active', 'true' );
+			releaseCollection();
 			await rowsRequest;
+			await expect( pagePane ).toHaveAttribute( 'data-active', 'true' );
 
 			await expect(
 				page.locator(
-					'.cortext-workspace__pane[data-active="true"] .cortext-data-view[data-loading-shell="true"]'
+					'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
 				)
-			).toBeVisible();
-			await expect(
-				page.locator(
-					'.cortext-workspace__pane[data-active="true"] .cortext-data-view__rows-skeleton'
-				)
-			).toBeVisible();
+			).toHaveCount( 0 );
 
+			const dataViewPaint = waitForActiveDataViewWithoutBlanking( page, [
+				ENTRY_TITLE,
+			] );
 			releaseRows();
+			await expectRouteViewTransition(
+				page,
+				'document to collection',
+				'hold-old-canvas'
+			);
+			await dataViewPaint;
 
 			const activeCollection = page.locator(
 				'.cortext-workspace__pane[data-active="true"] .cortext-data-view'
@@ -265,19 +767,22 @@ test.describe( 'Navigation lifecycle', () => {
 			await expect( activeCollection ).toBeVisible();
 			await expect( activeCollection ).toContainText( ENTRY_TITLE );
 
-			const pagePane = page
-				.locator( '.cortext-workspace__pane' )
-				.filter( { has: page.locator( '.cortext-canvas' ) } );
 			await expect( pagePane ).toHaveAttribute( 'data-active', 'false' );
 			await expect( pagePane ).toHaveCSS( 'visibility', 'visible' );
 
+			await resetViewTransitionProbe( page );
 			await sidebar
 				.getByRole( 'button', {
-					name: SECOND_PAGE_TITLE,
+					name: FIRST_PAGE_TITLE,
 					exact: true,
 				} )
 				.click();
-			await waitForEditorPost( page, fixture.secondPage.id );
+			await waitForEditorPost( page, fixture.firstPage.id );
+			await expectRouteViewTransition(
+				page,
+				'collection to document',
+				'hold-old-canvas'
+			);
 			await expect( pagePane ).toHaveAttribute( 'data-active', 'true' );
 			const canvasAfterCollection = await page
 				.locator( '.cortext-canvas' )
@@ -288,6 +793,7 @@ test.describe( 'Navigation lifecycle', () => {
 			);
 			expect( keptCanvasAfterCollection ).toBe( true );
 		} finally {
+			releaseCollection();
 			releaseRows();
 			await deleteIfCreated(
 				requestUtils,

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -83,7 +83,8 @@ async function coverImagePainted( page ) {
 async function waitForCoverImagePainted( page ) {
 	await expect
 		.poll( () => coverImagePainted( page ), {
-			message: 'the cover image should paint before the canvas is marked ready',
+			message:
+				'the cover image should paint before the canvas is marked ready',
 		} )
 		.toBe( true );
 }
@@ -99,23 +100,39 @@ async function canvasContainsAnyTitle( page, titles ) {
 	}, titles );
 }
 
-async function isHoldingOldCanvasSnapshot( page ) {
+async function oldCanvasSnapshotState( page ) {
 	return page.evaluate( () => {
-		if (
-			document.documentElement.dataset.cortextViewTransition !==
-			'hold-old-canvas'
-		) {
-			return false;
-		}
+		const mode =
+			document.documentElement.dataset.cortextViewTransition || '';
 		const oldCanvas = window.getComputedStyle(
 			document.documentElement,
 			'::view-transition-old(cortext-canvas)'
 		);
-		return (
-			oldCanvas.animationName.includes( 'cortext-hold-old-canvas' ) &&
-			Number( oldCanvas.opacity ) === 1
-		);
+		const animationName = oldCanvas.animationName;
+		const opacity = Number( oldCanvas.opacity );
+		const isHolding =
+			mode === 'hold-old-canvas' &&
+			animationName.includes( 'cortext-hold-old-canvas' ) &&
+			opacity === 1;
+		return { animationName, isHolding, mode, opacity };
 	} );
+}
+
+async function isHoldingOldCanvasSnapshot( page ) {
+	const state = await oldCanvasSnapshotState( page );
+	return state.isHolding;
+}
+
+async function expectOldCanvasSnapshotHeld( page ) {
+	const state = await oldCanvasSnapshotState( page );
+	expect( state ).toEqual(
+		expect.objectContaining( {
+			animationName: expect.stringContaining( 'cortext-hold-old-canvas' ),
+			isHolding: true,
+			mode: 'hold-old-canvas',
+			opacity: 1,
+		} )
+	);
 }
 
 async function waitForCanvasTitleWithoutBlanking( page, titles, targetTitle ) {
@@ -139,7 +156,9 @@ async function waitForCanvasTitleWithoutBlanking( page, titles, targetTitle ) {
 		await page.waitForTimeout( 16 );
 	}
 
-	throw new Error( `Timed out before ${ targetTitle } appeared in the canvas.` );
+	throw new Error(
+		`Timed out before ${ targetTitle } appeared in the canvas.`
+	);
 }
 
 async function waitForTransitionModeToClear( page ) {
@@ -231,14 +250,14 @@ async function expectRouteViewTransition( page, label, expectedMode = '' ) {
 
 	await expect
 		.poll(
-				() =>
-					page.evaluate( () =>
-						( window.__cortextViewTransitionEvents || [] ).some(
-							( event ) => event.type === 'start'
-						)
-					),
-				{ message: `${ label } should trigger a route transition` }
-			)
+			() =>
+				page.evaluate( () =>
+					( window.__cortextViewTransitionEvents || [] ).some(
+						( event ) => event.type === 'start'
+					)
+				),
+			{ message: `${ label } should trigger a route transition` }
+		)
 		.toBe( true );
 
 	const rejectedEvents = await page.evaluate( () =>
@@ -293,12 +312,12 @@ async function activeDataViewPaintState( page, texts ) {
 async function waitForActiveDataViewWithoutBlanking( page, texts ) {
 	const deadline = Date.now() + 5000;
 	while ( Date.now() < deadline ) {
-			const state = await activeDataViewPaintState( page, texts );
-			if ( state.hasDataView && ! state.hasSkeleton && ! state.hasText ) {
-				throw new Error(
-					'Full-page DataViews showed an empty shell instead of loading or loaded content.'
-				);
-			}
+		const state = await activeDataViewPaintState( page, texts );
+		if ( state.hasDataView && ! state.hasSkeleton && ! state.hasText ) {
+			throw new Error(
+				'Full-page DataViews showed an empty shell instead of loading or loaded content.'
+			);
+		}
 		if ( state.hasText ) {
 			return;
 		}
@@ -522,7 +541,8 @@ test.describe( 'Navigation lifecycle', () => {
 		requestUtils,
 	} ) => {
 		const fixture = {};
-		let releaseMedia = () => {};
+		let releaseCoverImage = () => {};
+		let markCoverImageRequested = () => {};
 
 		try {
 			fixture.firstMedia = await uploadCoverMedia(
@@ -559,23 +579,18 @@ test.describe( 'Navigation lifecycle', () => {
 			await waitForEditorPost( page, fixture.firstPage.id );
 			await waitForCoverImagePainted( page );
 
-			const mediaGate = new Promise( ( resolve ) => {
-				releaseMedia = resolve;
+			const coverImageGate = new Promise( ( resolve ) => {
+				releaseCoverImage = resolve;
 			} );
-			await page.route(
-				`**/wp-json/wp/v2/media/${ fixture.secondMedia.id }**`,
-				async ( route ) => {
-					await mediaGate;
-					await route.continue();
-				}
-			);
-			const mediaRequest = page.waitForRequest( ( request ) =>
-				request
-					.url()
-					.includes(
-						`/wp-json/wp/v2/media/${ fixture.secondMedia.id }`
-					)
-			);
+			const coverImageRequested = new Promise( ( resolve ) => {
+				markCoverImageRequested = resolve;
+			} );
+			const coverImageName = `cover-b-${ SUFFIX }.png`;
+			await page.route( `**/${ coverImageName }**`, async ( route ) => {
+				markCoverImageRequested();
+				await coverImageGate;
+				await route.continue();
+			} );
 
 			await page
 				.locator( '.cortext-sidebar' )
@@ -584,16 +599,18 @@ test.describe( 'Navigation lifecycle', () => {
 					exact: true,
 				} )
 				.click();
-			await mediaRequest;
+			await coverImageRequested;
 			await page.waitForTimeout( 100 );
-			expect( await isHoldingOldCanvasSnapshot( page ) ).toBe( true );
+			if ( ! ( await coverImagePainted( page ) ) ) {
+				await expectOldCanvasSnapshotHeld( page );
+			}
 
-			releaseMedia();
+			releaseCoverImage();
 			await waitForTransitionModeToClear( page );
 			await waitForEditorPost( page, fixture.secondPage.id );
 			await waitForCoverImagePainted( page );
 		} finally {
-			releaseMedia();
+			releaseCoverImage();
 			await deleteIfCreated(
 				requestUtils,
 				fixture.secondPage &&
@@ -757,7 +774,7 @@ test.describe( 'Navigation lifecycle', () => {
 			await expectRouteViewTransition(
 				page,
 				'document to collection',
-				'hold-old-canvas'
+				''
 			);
 			await dataViewPaint;
 
@@ -781,7 +798,7 @@ test.describe( 'Navigation lifecycle', () => {
 			await expectRouteViewTransition(
 				page,
 				'collection to document',
-				'hold-old-canvas'
+				''
 			);
 			await expect( pagePane ).toHaveAttribute( 'data-active', 'true' );
 			const canvasAfterCollection = await page

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -774,7 +774,7 @@ test.describe( 'Navigation lifecycle', () => {
 			await expectRouteViewTransition(
 				page,
 				'document to collection',
-				''
+				'hold-old-canvas'
 			);
 			await dataViewPaint;
 
@@ -798,7 +798,7 @@ test.describe( 'Navigation lifecycle', () => {
 			await expectRouteViewTransition(
 				page,
 				'collection to document',
-				''
+				'hold-old-canvas'
 			);
 			await expect( pagePane ).toHaveAttribute( 'data-active', 'true' );
 			const canvasAfterCollection = await page

--- a/tests/js/entityRouteReducer.test.js
+++ b/tests/js/entityRouteReducer.test.js
@@ -106,7 +106,7 @@ describe( 'EntityRoute reducer', () => {
 			expect( next.active ).toEqual( { kind: 'document', id: 1 } );
 		} );
 
-		it( 'goes to loading for a collection that is not ready yet', () => {
+		it( 'preserves paint when navigating to a collection that is not ready yet', () => {
 			const state = activate(
 				init( documentTarget( 1 ) ),
 				documentTarget( 1 )
@@ -116,7 +116,21 @@ describe( 'EntityRoute reducer', () => {
 				target: collectionTarget( 5 ),
 			} );
 			expect( next.target ).toEqual( collectionTarget( 5 ) );
-			expect( next.active ).toEqual( { kind: 'loading' } );
+			expect( next.active ).toEqual( { kind: 'document', id: 1 } );
+		} );
+
+		it( 'preserves the previous collection until the next collection mounts', () => {
+			const state = activate(
+				init( collectionTarget( 5 ) ),
+				collectionTarget( 5 )
+			);
+			const next = reducer( state, {
+				type: 'TARGET_CHANGED',
+				target: collectionTarget( 7 ),
+			} );
+			expect( next.target ).toEqual( collectionTarget( 7 ) );
+			expect( next.active ).toEqual( { kind: 'collection', id: 5 } );
+			expect( next.mountedCollectionIds ).toEqual( [ 5 ] );
 		} );
 
 		it( 'reactivates a document that is already mounted and displayed', () => {
@@ -316,6 +330,20 @@ describe( 'EntityRoute reducer', () => {
 			expect( state.active ).toEqual( { kind: 'collection', id: 5 } );
 		} );
 
+		it( 'preserves the active content pane until collection rows are ready', () => {
+			let state = activate(
+				init( documentTarget( 1 ) ),
+				documentTarget( 1 )
+			);
+			state = reducer( state, {
+				type: 'TARGET_CHANGED',
+				target: collectionTarget( 5 ),
+			} );
+			state = reducer( state, { type: 'COLLECTION_RESOLVED', id: 5 } );
+			expect( state.mountedCollectionIds ).toEqual( [ 5 ] );
+			expect( state.active ).toEqual( { kind: 'document', id: 1 } );
+		} );
+
 		it( 'ignores a resolution for a different target', () => {
 			const state = activate(
 				init( collectionTarget( 5 ) ),
@@ -365,7 +393,7 @@ describe( 'EntityRoute reducer', () => {
 				target: collectionTarget( 7 ),
 			} );
 			state = reducer( state, { type: 'COLLECTION_RESOLVED', id: 7 } );
-			expect( state.mountedCollectionIds ).toEqual( [ 7 ] );
+			expect( state.mountedCollectionIds ).toEqual( [ 5, 7 ] );
 			state = reducer( state, { type: 'COLLECTION_READY', id: 7 } );
 			expect( state.mountedCollectionIds ).toEqual( [ 7 ] );
 		} );


### PR DESCRIPTION
## What

Fixes the white flashes that could show up when moving between pages, loading a page with a cover, or opening full-page collections/DataViews.

The old document now stays in place until the next one is ready to paint. If loading takes longer, the existing loader still appears, but the editor should no longer briefly drop to an empty canvas. This also cleans up the Page inspector focus shadow and falls back to the page icon when a media icon fails to load.

## Why

The app had all the right states, but navigation could reveal the gap between them. That made page changes feel glitchy, especially with covers or slower collection loads.

## Testing Instructions

1. Open a page, then navigate to another page from the sidebar. The editor should not flash white.
2. Repeat with pages that have covers. The cover area should not disappear and reappear during the swap.
3. Open a full-page collection or DataView. It should show the previous pane, a loader, or loaded rows, never an empty shell.
4. Switch between a page and a collection/workspace pane. The transition should still animate normally.
5. Click the Page tab in the inspector. The unwanted focus shadow should be gone.

## Screen recording

https://github.com/user-attachments/assets/27fa395e-ed1a-4661-a125-2afe0f9d171b

