### PR TITLE
Refactor: Document Unification; move trash restore and delete into descriptors

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -411,9 +411,9 @@ export default function Sidebar( {
 		[ home ]
 	);
 
-	// Feedback channel descriptors call into. The page tree and collection
-	// list stay out of here: the trash cascade now rides on the server
-	// response, so descriptors no longer need to walk them locally.
+	// Callbacks for document descriptors. The page tree and collection list
+	// stay out of this: trash cascades now come from the server response, so
+	// descriptors do not need to walk local trees.
 	const documentsHandlers = useMemo(
 		() => ( {
 			selectedCollectionId,
@@ -688,27 +688,27 @@ export default function Sidebar( {
 							</DragOverlay>
 						</DndContext>
 					</div>
+					{ isTrashPanelOpen && (
+						<section
+							id="cortext-sidebar-trash-panel"
+							className="cortext-sidebar__trash-panel"
+							aria-label={ __( 'Trash', 'cortext' ) }
+						>
+							<div className="cortext-sidebar__trash-panel-header">
+								<h2 className="cortext-sidebar__section-title">
+									{ __( 'Trash', 'cortext' ) }
+								</h2>
+							</div>
+							<SidebarTrash
+								activePages={ pages }
+								selectedId={ selectedId }
+								selectedCollectionId={ selectedCollectionId }
+								onSelect={ onSelect }
+								trashedDocumentsState={ trashedDocumentsState }
+							/>
+						</section>
+					) }
 				</DocumentsProvider>
-			) }
-			{ ! collapsed && isTrashPanelOpen && (
-				<section
-					id="cortext-sidebar-trash-panel"
-					className="cortext-sidebar__trash-panel"
-					aria-label={ __( 'Trash', 'cortext' ) }
-				>
-					<div className="cortext-sidebar__trash-panel-header">
-						<h2 className="cortext-sidebar__section-title">
-							{ __( 'Trash', 'cortext' ) }
-						</h2>
-					</div>
-					<SidebarTrash
-						activePages={ pages }
-						selectedId={ selectedId }
-						selectedCollectionId={ selectedCollectionId }
-						onSelect={ onSelect }
-						trashedDocumentsState={ trashedDocumentsState }
-					/>
-				</section>
 			) }
 			<div className="cortext-sidebar__footer">
 				<div className="cortext-sidebar__footer-group cortext-sidebar__footer-group--navigation">

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -1,4 +1,4 @@
-import { __, sprintf, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import {
@@ -6,23 +6,17 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
-import apiFetch from '@wordpress/api-fetch';
 import { rotateLeft, trash } from '@wordpress/icons';
 import { useNavigate } from '@tanstack/react-router';
 
 import PageIcon from './PageIcon';
 import { SidebarListSkeleton } from './Skeleton';
 import TypeToConfirmDialog from './TypeToConfirmDialog';
-import {
-	ACTIVE_PAGES_QUERY,
-	POST_TYPE,
-	TRASHED_PAGES_QUERY,
-} from './page-queries';
+import { POST_TYPE, TRASHED_PAGES_QUERY } from './page-queries';
 import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
 } from '../hooks/useDelayedFlag';
-import { FULL_PAGE_COLLECTION_QUERY } from '../collections';
-import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
+import { useDocumentActions, useDocumentRecord } from '../documents';
 
 const EMPTY_TRASHED_DOCUMENTS_STATE = {
 	documents: [],
@@ -33,9 +27,9 @@ const EMPTY_TRASHED_DOCUMENTS_STATE = {
 	refresh: () => {},
 };
 
-// Keep these in sync with the PHP cascade marker meta keys. Trash entries
-// carry a marker pointing at the cascade root (page → subpage, page → owned
-// inline collection) so the sidebar can fold descendants under their root.
+// These mirror the PHP cascade marker meta keys. Trash entries point back to
+// the cascade root (page → subpage, page → owned inline collection), which lets
+// the sidebar show one row for the whole trashed group.
 const PARENT_MARKER_META = '_cortext_trashed_by_parent';
 const OWNER_PAGE_MARKER_META = '_cortext_trashed_by_owner_page';
 
@@ -48,9 +42,8 @@ export function computeSidebarTrashRoots( trashedDocuments = [] ) {
 
 	const markerOf = ( document ) => {
 		const meta = document.meta ?? {};
-		// Pages → subpages share the original marker. Pages → owned inline
-		// collections use a different key, but both point at a parent page
-		// that's the cascade root.
+		// Pages → subpages and pages → owned inline collections use different
+		// marker keys, but both point at the same kind of root: a parent page.
 		const parent = Number( meta[ PARENT_MARKER_META ] ?? 0 );
 		if ( parent > 0 ) {
 			return parent;
@@ -106,62 +99,230 @@ function titleText( title, fallback ) {
 	return title?.rendered?.trim() || title?.raw?.trim() || fallback;
 }
 
-function documentKind( document ) {
-	if ( document?.kind ) {
-		return document.kind;
+function buildBreadcrumb( record, ancestorById ) {
+	const ancestors = [];
+	let current = record.parent ? ancestorById.get( record.parent ) : null;
+	const seen = new Set( [ record.id ] );
+	while ( current && ! seen.has( current.id ) ) {
+		seen.add( current.id );
+		ancestors.unshift( {
+			id: current.id,
+			title:
+				current.title?.rendered?.trim() ||
+				__( '(untitled)', 'cortext' ),
+			icon: current.meta?.cortext_document_icon ?? '',
+		} );
+		current = current.parent ? ancestorById.get( current.parent ) : null;
 	}
-	if ( document?.type === POST_TYPE ) {
-		return 'page';
-	}
-	if ( document?.type === 'crtxt_collection' ) {
-		return 'collection';
-	}
-	return 'document';
+	return ancestors;
 }
 
-function descendantLabel( rootKind, counts ) {
-	// Mixed subtrees (page → subpage + page → owned inline collection) read
-	// as "%d nested items" so the wording stays honest. Pure subtrees keep
-	// the more specific noun.
-	if ( rootKind === 'page' ) {
-		if ( counts.pages > 0 && counts.collections === 0 ) {
-			return sprintf(
-				/* translators: %d: number of subpages */
-				_n( '%d subpage', '%d subpages', counts.pages, 'cortext' ),
-				counts.pages
-			);
-		}
-		if ( counts.collections > 0 && counts.pages === 0 ) {
-			return sprintf(
-				/* translators: %d: number of nested inline collections */
-				_n(
-					'%d collection',
-					'%d collections',
-					counts.collections,
-					'cortext'
-				),
-				counts.collections
-			);
-		}
+const EMPTY_COUNTS = Object.freeze( { pages: 0, collections: 0, total: 0 } );
+
+/**
+ * One row in the trash list. Display copy comes from `useDocumentRecord`, so
+ * the parent component does not need kind checks.
+ *
+ * @param {Object}                         props
+ * @param {Object}                         props.record           Trashed document record.
+ * @param {Object}                         props.descendantCounts Cascade counts for this root.
+ * @param {Map<number, Object>}            props.ancestorById     Lookup map for breadcrumb walking.
+ * @param {boolean}                        props.isSelected       Whether the canvas is currently showing this document.
+ * @param {boolean}                        props.isBusy           Restore or delete in flight for this row.
+ * @param {?{id: number, message: string}} props.error            Per-row error to display under the row.
+ * @param {Function}                       props.onRestore        Parent callback `(record, restoreErrorMessage)`.
+ * @param {Function}                       props.onRequestDelete  Parent callback `(record)` to open the confirm dialog.
+ */
+function SidebarTrashRow( {
+	record,
+	descendantCounts,
+	ancestorById,
+	isSelected,
+	isBusy,
+	error,
+	onRestore,
+	onRequestDelete,
+} ) {
+	const navigate = useNavigate();
+	const { title, features, descendantLabel, restoreErrorMessage } =
+		useDocumentRecord( record );
+
+	const breadcrumb = features.hierarchy
+		? buildBreadcrumb( record, ancestorById )
+		: [];
+	const documentIcon = record.meta?.cortext_document_icon ?? '';
+	const collectionTitle = record.collection?.id
+		? titleText( record.collection?.title, __( 'Collection', 'cortext' ) )
+		: '';
+	// Inline collections are the only trash items with an owner. If that page
+	// is still active, show its title so similar inline tables are easier to
+	// tell apart.
+	const ownerTitle = record.owner
+		? titleText( record.owner?.title, __( 'Page', 'cortext' ) )
+		: '';
+	const meta = descendantCounts.total
+		? descendantLabel( descendantCounts )
+		: '';
+
+	const handleRestore = useCallback( () => {
+		onRestore( record, restoreErrorMessage );
+	}, [ onRestore, record, restoreErrorMessage ] );
+
+	const handleRequestDelete = useCallback( () => {
+		onRequestDelete( record );
+	}, [ onRequestDelete, record ] );
+
+	const rowClasses = [ 'cortext-sidebar__row' ];
+	if ( isSelected ) {
+		rowClasses.push( 'is-selected' );
 	}
 
-	return sprintf(
-		/* translators: %d: number of nested trashed documents */
-		_n( '%d nested item', '%d nested items', counts.total, 'cortext' ),
-		counts.total
+	return (
+		<li className="cortext-sidebar__node cortext-sidebar__trash-row">
+			<div className={ rowClasses.join( ' ' ) }>
+				<Button
+					className="cortext-sidebar__title cortext-sidebar__trash-text"
+					variant="tertiary"
+					onClick={ () =>
+						navigate( {
+							to: '/$',
+							params: { _splat: record.path },
+						} )
+					}
+				>
+					<span className="cortext-sidebar__trash-title">
+						<PageIcon
+							icon={ documentIcon }
+							size={ 14 }
+							className="cortext-sidebar__trash-title-icon"
+						/>
+						<span className="cortext-sidebar__trash-title-text">
+							{ title }
+						</span>
+					</span>
+					{ ( breadcrumb.length > 0 ||
+						collectionTitle ||
+						ownerTitle ||
+						meta ) && (
+						<span className="cortext-sidebar__breadcrumb">
+							{ breadcrumb.map( ( crumb, index ) => (
+								<span
+									key={ crumb.id }
+									className="cortext-sidebar__breadcrumb-crumb"
+								>
+									<PageIcon icon={ crumb.icon } size={ 12 } />
+									<span>{ crumb.title }</span>
+									{ index < breadcrumb.length - 1 && (
+										<span
+											className="cortext-sidebar__breadcrumb-sep"
+											aria-hidden="true"
+										>
+											{ ' / ' }
+										</span>
+									) }
+								</span>
+							) ) }
+							{ ownerTitle && <span>{ ownerTitle }</span> }
+							{ collectionTitle && (
+								<span>{ collectionTitle }</span>
+							) }
+							{ meta && (
+								<>
+									{ ( breadcrumb.length > 0 ||
+										collectionTitle ||
+										ownerTitle ) && (
+										<span aria-hidden="true">
+											{ ' · ' }
+										</span>
+									) }
+									<span>{ meta }</span>
+								</>
+							) }
+						</span>
+					) }
+				</Button>
+				<div className="cortext-sidebar__trash-actions">
+					<Button
+						size="small"
+						icon={ rotateLeft }
+						label={ __( 'Restore', 'cortext' ) }
+						disabled={ isBusy }
+						onClick={ handleRestore }
+					/>
+					<Button
+						size="small"
+						icon={ trash }
+						isDestructive
+						label={ __( 'Delete permanently', 'cortext' ) }
+						disabled={ isBusy }
+						onClick={ handleRequestDelete }
+					/>
+				</div>
+			</div>
+			{ error && (
+				<p className="cortext-sidebar__row-error" role="alert">
+					{ error.message }
+				</p>
+			) }
+		</li>
+	);
+}
+
+/**
+ * Confirmation for permanent delete. The descriptor decides whether this can
+ * use a plain confirm dialog or needs the typed-name flow.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.record    Trashed record pending delete.
+ * @param {Object}   props.counts    Cascade counts for the pending root.
+ * @param {Function} props.onConfirm Parent callback `(record, permanentDeleteErrorMessage)`.
+ * @param {Function} props.onCancel  Closes the dialog without deleting.
+ */
+function SidebarTrashConfirmDialog( { record, counts, onConfirm, onCancel } ) {
+	const { title, permanentDeleteConfirmation, permanentDeleteErrorMessage } =
+		useDocumentRecord( record );
+	const dialogConfig = permanentDeleteConfirmation( counts ) ?? {
+		title: '',
+		message: '',
+	};
+
+	const handleConfirm = useCallback( () => {
+		onConfirm( record, permanentDeleteErrorMessage );
+	}, [ onConfirm, record, permanentDeleteErrorMessage ] );
+
+	if ( dialogConfig.requireTypeToConfirm ) {
+		return (
+			<TypeToConfirmDialog
+				title={ dialogConfig.title }
+				message={ dialogConfig.message }
+				confirmPhrase={ title }
+				confirmLabel={ __( 'Delete permanently', 'cortext' ) }
+				onConfirm={ handleConfirm }
+				onCancel={ onCancel }
+			/>
+		);
+	}
+
+	return (
+		<ConfirmDialog
+			onConfirm={ handleConfirm }
+			onCancel={ onCancel }
+			confirmButtonText={ __( 'Delete permanently', 'cortext' ) }
+		>
+			{ dialogConfig.message }
+		</ConfirmDialog>
 	);
 }
 
 /**
  * Sidebar Trash for Cortext documents.
  *
- * Trash shows cascade roots. Children that were trashed with a parent are
- * restored or deleted with that parent. If a marker points to a parent that is
- * no longer in Trash, the orphan still appears so it can be recovered.
+ * Trash shows cascade roots. Children trashed with a parent are restored or
+ * deleted with that parent. If a marker points to a parent that is no longer
+ * in Trash, the orphan still appears so it can be recovered.
  *
- * Mutations use the document Trash endpoints. Pages also refresh the page tree;
- * rows notify collection queries because relation chips and rollups can change
- * outside the row's own collection.
+ * Restore and permanent delete go through the descriptors, keeping per-kind
+ * refreshes and error copy out of this component.
  *
  * @param {Object}      props
  * @param {Array}       props.activePages           Active page records for
@@ -184,7 +345,6 @@ export default function SidebarTrash( {
 	onSelect,
 	trashedDocumentsState = EMPTY_TRASHED_DOCUMENTS_STATE,
 } ) {
-	const navigate = useNavigate();
 	const {
 		documents: trashedDocuments,
 		isLoading: isResolvingTrash,
@@ -193,6 +353,7 @@ export default function SidebarTrash( {
 	} = trashedDocumentsState;
 
 	const { invalidateResolution } = useDispatch( 'core' );
+	const { restore, permanentDelete } = useDocumentActions();
 
 	const [ pendingDelete, setPendingDelete ] = useState( null );
 	const [ rowError, setRowError ] = useState( null );
@@ -236,145 +397,52 @@ export default function SidebarTrash( {
 		[ visibleTrashed ]
 	);
 
-	const buildBreadcrumb = useCallback(
-		( document ) => {
-			const ancestors = [];
-			let current = document.parent
-				? ancestorById.get( document.parent )
-				: null;
-			const seen = new Set( [ document.id ] );
-			while ( current && ! seen.has( current.id ) ) {
-				seen.add( current.id );
-				ancestors.unshift( {
-					id: current.id,
-					title:
-						current.title?.rendered?.trim() ||
-						__( '(untitled)', 'cortext' ),
-					icon: current.meta?.cortext_document_icon ?? '',
-				} );
-				current = current.parent
-					? ancestorById.get( current.parent )
-					: null;
-			}
-			return ancestors;
-		},
-		[ ancestorById ]
-	);
-
-	const refreshQueries = useCallback( () => {
-		invalidateResolution( 'getEntityRecords', [
-			'postType',
-			POST_TYPE,
-			ACTIVE_PAGES_QUERY,
-		] );
-		invalidateResolution( 'getEntityRecords', [
-			'postType',
-			POST_TYPE,
-			TRASHED_PAGES_QUERY,
-		] );
-		// Restoring a page can also restore collections. Refresh the full-page
-		// list so they return to the sidebar.
-		invalidateResolution( 'getEntityRecords', [
-			'postType',
-			'crtxt_collection',
-			FULL_PAGE_COLLECTION_QUERY,
-		] );
-	}, [ invalidateResolution ] );
-
-	const refreshTrash = useCallback( () => {
-		trashedDocumentsState.refresh?.();
-	}, [ trashedDocumentsState ] );
-
-	const refreshRows = useCallback( () => {
-		notifyCollectionRowsChanged();
-		refreshTrash();
-	}, [ refreshTrash ] );
-
-	const restore = useCallback(
-		async ( item ) => {
-			const { id } = item;
-			const kind = documentKind( item );
+	const handleRestore = useCallback(
+		async ( record, restoreErrorMessage ) => {
 			setRowError( null );
-			setBusyId( id );
+			setBusyId( record.id );
 			try {
-				await apiFetch( {
-					path: `/cortext/v1/documents/${ id }/restore`,
-					method: 'POST',
-				} );
-				if ( kind === 'row' ) {
-					refreshRows( item );
-				} else {
-					refreshQueries();
-					refreshTrash();
-				}
+				await restore( record );
 			} catch ( error ) {
 				setRowError( {
-					id,
-					message:
-						error?.message ??
-						( kind === 'row'
-							? __( 'Could not restore row.', 'cortext' )
-							: __( 'Could not restore page.', 'cortext' ) ),
+					id: record.id,
+					message: error?.message ?? restoreErrorMessage,
 				} );
 			} finally {
 				setBusyId( null );
 			}
 		},
-		[ refreshQueries, refreshRows, refreshTrash ]
+		[ restore ]
 	);
 
-	const confirmPermanentDelete = useCallback( async () => {
-		const item = pendingDelete;
-		setPendingDelete( null );
-		if ( ! item?.id ) {
-			return;
-		}
-		const { id } = item;
-		const kind = documentKind( item );
-		setRowError( null );
-		setBusyId( id );
-		try {
-			const response = await apiFetch( {
-				path: `/cortext/v1/documents/${ id }/permanent-delete`,
-				method: 'POST',
-			} );
-			// If the canvas was showing one of the deleted documents,
-			// navigate away. Without this `useEntityRecord` would return
-			// undefined and the canvas would spin forever (the document is
-			// genuinely gone now, not just trashed). Collections track via
-			// `selectedCollectionId`, so check both.
-			const deletedIds = response?.deleted ?? [];
-			const openId = selectedId ?? selectedCollectionId;
-			if ( openId && deletedIds.includes( openId ) ) {
-				onSelect( null );
+	const handlePermanentDelete = useCallback(
+		async ( record, permanentDeleteErrorMessage ) => {
+			setPendingDelete( null );
+			setRowError( null );
+			setBusyId( record.id );
+			try {
+				const response = await permanentDelete( record );
+				const deletedIds = response?.deleted ?? [];
+				// If the canvas was showing one of the deleted documents, move
+				// away from it. Otherwise `useEntityRecord` returns undefined
+				// and the canvas keeps spinning because the document is gone,
+				// not just trashed. Collections track via `selectedCollectionId`,
+				// so check both ids.
+				const openId = selectedId ?? selectedCollectionId;
+				if ( openId && deletedIds.includes( openId ) ) {
+					onSelect( null );
+				}
+			} catch ( error ) {
+				setRowError( {
+					id: record.id,
+					message: error?.message ?? permanentDeleteErrorMessage,
+				} );
+			} finally {
+				setBusyId( null );
 			}
-			if ( kind === 'row' ) {
-				refreshRows( item );
-			} else {
-				refreshQueries();
-				refreshTrash();
-			}
-		} catch ( error ) {
-			setRowError( {
-				id,
-				message:
-					error?.message ??
-					( kind === 'row'
-						? __( 'Could not delete row.', 'cortext' )
-						: __( 'Could not delete page.', 'cortext' ) ),
-			} );
-		} finally {
-			setBusyId( null );
-		}
-	}, [
-		pendingDelete,
-		refreshQueries,
-		refreshRows,
-		refreshTrash,
-		selectedId,
-		selectedCollectionId,
-		onSelect,
-	] );
+		},
+		[ permanentDelete, selectedId, selectedCollectionId, onSelect ]
+	);
 
 	const isLoading = isResolvingTrash && ! hasTrashCache;
 	const showSkeleton = useDelayedFlag(
@@ -384,97 +452,15 @@ export default function SidebarTrash( {
 	);
 	const hasError = Boolean( trashError && ! hasTrashCache );
 	const hasItems = roots.length > 0;
-	const pendingKind = pendingDelete ? documentKind( pendingDelete ) : null;
-	const pendingDescendantCounts = pendingDelete
-		? descendantCountById.get( pendingDelete.id ) ?? {
-				pages: 0,
-				collections: 0,
-				total: 0,
-		  }
-		: { pages: 0, collections: 0, total: 0 };
-	const pendingDescendantCount = pendingDescendantCounts.total;
+
 	const retryTrashFetch = useCallback( () => {
 		invalidateResolution( 'getEntityRecords', [
 			'postType',
 			POST_TYPE,
 			TRASHED_PAGES_QUERY,
 		] );
-		refreshTrash();
-	}, [ invalidateResolution, refreshTrash ] );
-
-	let pendingDeleteMessage = __(
-		"Permanently delete this page? You can't undo this.",
-		'cortext'
-	);
-	if ( pendingKind === 'row' ) {
-		pendingDeleteMessage = __(
-			"Permanently delete this row? You can't undo this.",
-			'cortext'
-		);
-	} else if ( pendingKind === 'collection' ) {
-		pendingDeleteMessage = __(
-			"Permanently delete this collection and all its rows? You can't undo this.",
-			'cortext'
-		);
-	} else if ( pendingKind === 'document' ) {
-		pendingDeleteMessage = __(
-			"Permanently delete this document? You can't undo this.",
-			'cortext'
-		);
-	} else if ( pendingDescendantCount > 0 ) {
-		// Mixed subtrees (subpages + inline collections) use the generic
-		// "nested items" wording so the count stays correct without
-		// pretending an inline collection is a subpage.
-		if (
-			pendingDescendantCounts.pages > 0 &&
-			pendingDescendantCounts.collections === 0
-		) {
-			pendingDeleteMessage = sprintf(
-				/* translators: %d: number of subpages that will be deleted along with the page. */
-				_n(
-					"Permanently delete this page and %d subpage? You can't undo this.",
-					"Permanently delete this page and %d subpages? You can't undo this.",
-					pendingDescendantCounts.pages,
-					'cortext'
-				),
-				pendingDescendantCounts.pages
-			);
-		} else {
-			pendingDeleteMessage = sprintf(
-				/* translators: %d: number of nested trashed items deleted along with the page. */
-				_n(
-					"Permanently delete this page and %d nested item? You can't undo this.",
-					"Permanently delete this page and %d nested items? You can't undo this.",
-					pendingDescendantCount,
-					'cortext'
-				),
-				pendingDescendantCount
-			);
-		}
-	}
-	if ( pendingDescendantCount > 0 && pendingKind === 'row' ) {
-		pendingDeleteMessage = sprintf(
-			/* translators: %d: number of nested items that will be deleted along with the row. */
-			_n(
-				"Permanently delete this row and %d nested item? You can't undo this.",
-				"Permanently delete this row and %d nested items? You can't undo this.",
-				pendingDescendantCount,
-				'cortext'
-			),
-			pendingDescendantCount
-		);
-	} else if ( pendingDescendantCount > 0 && pendingKind === 'document' ) {
-		pendingDeleteMessage = sprintf(
-			/* translators: %d: number of nested items that will be deleted along with the document. */
-			_n(
-				"Permanently delete this document and %d nested item? You can't undo this.",
-				"Permanently delete this document and %d nested items? You can't undo this.",
-				pendingDescendantCount,
-				'cortext'
-			),
-			pendingDescendantCount
-		);
-	}
+		trashedDocumentsState.refresh?.();
+	}, [ invalidateResolution, trashedDocumentsState ] );
 
 	return (
 		<>
@@ -499,210 +485,38 @@ export default function SidebarTrash( {
 
 			{ ! isLoading && ! hasError && hasItems && (
 				<ul className="cortext-sidebar__list cortext-sidebar__trash-list">
-					{ roots.map( ( document ) => {
-						const kind = documentKind( document );
-						const title = titleText(
-							document.title,
-							__( '(untitled)', 'cortext' )
-						);
-						const breadcrumb =
-							kind === 'page' ? buildBreadcrumb( document ) : [];
-						const documentIcon =
-							document.meta?.cortext_document_icon ?? '';
-						const isBusy = busyId === document.id;
-						const isSelected = selectedId === document.id;
-						const error =
-							rowError?.id === document.id ? rowError : null;
-						const descendantCounts = descendantCountById.get(
-							document.id
-						) ?? {
-							pages: 0,
-							collections: 0,
-							total: 0,
-						};
-						const meta = descendantCounts.total
-							? descendantLabel( kind, descendantCounts )
-							: '';
-						const collectionTitle =
-							kind === 'row'
-								? titleText(
-										document.collection?.title,
-										__( 'Collection', 'cortext' )
-								  )
-								: '';
-						// Inline collections are the only trash items with an
-						// owner. Show that page title when the owner is still
-						// active so similar inline tables are easier to tell
-						// apart.
-						const ownerTitle = document.owner
-							? titleText(
-									document.owner?.title,
-									__( 'Page', 'cortext' )
-							  )
-							: '';
-						const rowClasses = [ 'cortext-sidebar__row' ];
-						if ( isSelected ) {
-							rowClasses.push( 'is-selected' );
-						}
-
-						return (
-							<li
-								key={ document.id }
-								className="cortext-sidebar__node cortext-sidebar__trash-row"
-							>
-								<div className={ rowClasses.join( ' ' ) }>
-									<Button
-										className="cortext-sidebar__title cortext-sidebar__trash-text"
-										variant="tertiary"
-										onClick={ () =>
-											navigate( {
-												to: '/$',
-												params: {
-													_splat: document.path,
-												},
-											} )
-										}
-									>
-										<span className="cortext-sidebar__trash-title">
-											<PageIcon
-												icon={ documentIcon }
-												size={ 14 }
-												className="cortext-sidebar__trash-title-icon"
-											/>
-											<span className="cortext-sidebar__trash-title-text">
-												{ title }
-											</span>
-										</span>
-										{ ( breadcrumb.length > 0 ||
-											collectionTitle ||
-											ownerTitle ||
-											meta ) && (
-											<span className="cortext-sidebar__breadcrumb">
-												{ breadcrumb.map(
-													( crumb, index ) => (
-														<span
-															key={ crumb.id }
-															className="cortext-sidebar__breadcrumb-crumb"
-														>
-															<PageIcon
-																icon={
-																	crumb.icon
-																}
-																size={ 12 }
-															/>
-															<span>
-																{ crumb.title }
-															</span>
-															{ index <
-																breadcrumb.length -
-																	1 && (
-																<span
-																	className="cortext-sidebar__breadcrumb-sep"
-																	aria-hidden="true"
-																>
-																	{ ' / ' }
-																</span>
-															) }
-														</span>
-													)
-												) }
-												{ ownerTitle && (
-													<span>{ ownerTitle }</span>
-												) }
-												{ collectionTitle && (
-													<span>
-														{ collectionTitle }
-													</span>
-												) }
-												{ meta && (
-													<>
-														{ ( breadcrumb.length >
-															0 ||
-															collectionTitle ||
-															ownerTitle ) && (
-															<span aria-hidden="true">
-																{ ' · ' }
-															</span>
-														) }
-														<span>{ meta }</span>
-													</>
-												) }
-											</span>
-										) }
-									</Button>
-									<div className="cortext-sidebar__trash-actions">
-										<Button
-											size="small"
-											icon={ rotateLeft }
-											label={ __( 'Restore', 'cortext' ) }
-											disabled={ isBusy }
-											onClick={ () =>
-												restore( {
-													...document,
-													kind,
-												} )
-											}
-										/>
-										<Button
-											size="small"
-											icon={ trash }
-											isDestructive
-											label={ __(
-												'Delete permanently',
-												'cortext'
-											) }
-											disabled={ isBusy }
-											onClick={ () =>
-												setPendingDelete( {
-													...document,
-													kind,
-												} )
-											}
-										/>
-									</div>
-								</div>
-								{ error && (
-									<p
-										className="cortext-sidebar__row-error"
-										role="alert"
-									>
-										{ error.message }
-									</p>
-								) }
-							</li>
-						);
-					} ) }
+					{ roots.map( ( record ) => (
+						<SidebarTrashRow
+							key={ record.id }
+							record={ record }
+							descendantCounts={
+								descendantCountById.get( record.id ) ??
+								EMPTY_COUNTS
+							}
+							ancestorById={ ancestorById }
+							isSelected={ selectedId === record.id }
+							isBusy={ busyId === record.id }
+							error={
+								rowError?.id === record.id ? rowError : null
+							}
+							onRestore={ handleRestore }
+							onRequestDelete={ setPendingDelete }
+						/>
+					) ) }
 				</ul>
 			) }
 
-			{ pendingDelete !== null &&
-				( pendingKind === 'collection' ? (
-					<TypeToConfirmDialog
-						title={ __(
-							'Delete collection permanently?',
-							'cortext'
-						) }
-						message={ pendingDeleteMessage }
-						confirmPhrase={ titleText(
-							pendingDelete.title,
-							__( '(untitled)', 'cortext' )
-						) }
-						confirmLabel={ __( 'Delete permanently', 'cortext' ) }
-						onConfirm={ confirmPermanentDelete }
-						onCancel={ () => setPendingDelete( null ) }
-					/>
-				) : (
-					<ConfirmDialog
-						onConfirm={ confirmPermanentDelete }
-						onCancel={ () => setPendingDelete( null ) }
-						confirmButtonText={ __(
-							'Delete permanently',
-							'cortext'
-						) }
-					>
-						{ pendingDeleteMessage }
-					</ConfirmDialog>
-				) ) }
+			{ pendingDelete !== null && (
+				<SidebarTrashConfirmDialog
+					record={ pendingDelete }
+					counts={
+						descendantCountById.get( pendingDelete.id ) ??
+						EMPTY_COUNTS
+					}
+					onConfirm={ handlePermanentDelete }
+					onCancel={ () => setPendingDelete( null ) }
+				/>
+			) }
 		</>
 	);
 }

--- a/src/documents/descriptors/collection.js
+++ b/src/documents/descriptors/collection.js
@@ -12,8 +12,8 @@ import {
 
 /**
  * Collection actions used by the sidebar. Collections are leaves in the tree,
- * so their rows expose before/after drops only. Duplication stays on the
- * documents endpoint because the server copies the schema and rows together.
+ * so their rows only expose before/after drops. Duplication stays on the
+ * documents endpoint because the server copies both schema and rows.
  */
 const collectionDescriptor = {
 	features: {
@@ -81,7 +81,7 @@ const collectionDescriptor = {
 		applyInvalidationPack( ctx.invalidateResolution, afterCollectionTrash );
 		notifyDocumentTrashChanged();
 		// For now, Favorites only needs to drop the collection itself. Keep the
-		// same data shape as page trash so server-provided ids can replace this
+		// same shape as page trash so server-provided ids can replace this
 		// local set later.
 		await cascadeFavorites(
 			ctx,
@@ -95,6 +95,45 @@ const collectionDescriptor = {
 			ctx.navigate?.( { to: '/' } );
 		}
 		ctx.onAfterTrash?.( { kind: 'collection', record } );
+	},
+
+	async restore( record, ctx ) {
+		await apiFetch( {
+			path: `/cortext/v1/documents/${ record.id }/restore`,
+			method: 'POST',
+		} );
+		applyInvalidationPack( ctx.invalidateResolution, afterCollectionTrash );
+		notifyDocumentTrashChanged();
+	},
+
+	async permanentDelete( record, ctx ) {
+		const response = await apiFetch( {
+			path: `/cortext/v1/documents/${ record.id }/permanent-delete`,
+			method: 'POST',
+		} );
+		applyInvalidationPack( ctx.invalidateResolution, afterCollectionTrash );
+		notifyDocumentTrashChanged();
+		return response;
+	},
+
+	restoreErrorMessage: __( 'Could not restore collection.', 'cortext' ),
+
+	permanentDeleteErrorMessage: __(
+		'Could not delete collection.',
+		'cortext'
+	),
+
+	// Collections may contain rows that are not shown in Trash, so say so and
+	// ask for the title before final delete.
+	permanentDeleteConfirmation() {
+		return {
+			title: __( 'Permanently delete collection?', 'cortext' ),
+			message: __(
+				"Permanently delete this collection and all its rows? You can't undo this.",
+				'cortext'
+			),
+			requireTypeToConfirm: true,
+		};
 	},
 };
 

--- a/src/documents/descriptors/page.js
+++ b/src/documents/descriptors/page.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 import { POST_TYPE } from '../../components/page-queries';
@@ -8,9 +8,9 @@ import { cascadeFavorites } from '../favorites';
 import { afterPageTrash, applyInvalidationPack } from '../invalidation';
 
 /**
- * Page actions used by the sidebar. Pages are hierarchical, can own child
- * pages, and can have their own icon. The REST trash response carries the
- * cascade ids so the favorites cleanup does not need a local page tree walk.
+ * Page actions used by the sidebar. Pages can have child pages and their own
+ * icon. The REST trash response includes the cascade ids, so Favorites can be
+ * cleaned up without walking the page tree in the client.
  */
 const pageDescriptor = {
 	features: {
@@ -74,10 +74,9 @@ const pageDescriptor = {
 		}
 		applyInvalidationPack( ctx.invalidateResolution, afterPageTrash );
 		notifyDocumentTrashChanged();
-		// The server returns the cascade alongside the trashed page: child
-		// pages plus any inline collections that came with them. The favorites
-		// cleanup just consumes that list, so the page tree never has to be
-		// walked on the client.
+		// The server returns the cascade with the trashed page: child pages plus
+		// any inline collections that came with them. Favorites can use that
+		// list directly instead of walking the page tree in the client.
 		const cascade = deleted?.cascade_deleted ?? {};
 		await cascadeFavorites(
 			ctx,
@@ -97,6 +96,103 @@ const pageDescriptor = {
 			)
 		);
 		ctx.onAfterTrash?.( { kind: 'page', record } );
+	},
+
+	async restore( record, ctx ) {
+		await apiFetch( {
+			path: `/cortext/v1/documents/${ record.id }/restore`,
+			method: 'POST',
+		} );
+		applyInvalidationPack( ctx.invalidateResolution, afterPageTrash );
+		notifyDocumentTrashChanged();
+	},
+
+	// Return the REST response so the caller can navigate away if the open page
+	// is in `deleted`. The server prunes favorites that still point at deleted
+	// pages on the next read, so there is no client cleanup here.
+	async permanentDelete( record, ctx ) {
+		const response = await apiFetch( {
+			path: `/cortext/v1/documents/${ record.id }/permanent-delete`,
+			method: 'POST',
+		} );
+		applyInvalidationPack( ctx.invalidateResolution, afterPageTrash );
+		notifyDocumentTrashChanged();
+		return response;
+	},
+
+	restoreErrorMessage: __( 'Could not restore page.', 'cortext' ),
+
+	permanentDeleteErrorMessage: __( 'Could not delete page.', 'cortext' ),
+
+	descendantLabel( counts ) {
+		// Mixed subtrees (subpages + owned inline collections) use
+		// "%d nested items". Pure subtrees keep the more specific noun.
+		if ( counts.pages > 0 && counts.collections === 0 ) {
+			return sprintf(
+				/* translators: %d: number of subpages */
+				_n( '%d subpage', '%d subpages', counts.pages, 'cortext' ),
+				counts.pages
+			);
+		}
+		if ( counts.collections > 0 && counts.pages === 0 ) {
+			return sprintf(
+				/* translators: %d: number of nested inline collections */
+				_n(
+					'%d collection',
+					'%d collections',
+					counts.collections,
+					'cortext'
+				),
+				counts.collections
+			);
+		}
+		return sprintf(
+			/* translators: %d: number of nested trashed documents */
+			_n( '%d nested item', '%d nested items', counts.total, 'cortext' ),
+			counts.total
+		);
+	},
+
+	permanentDeleteConfirmation( counts ) {
+		const total = counts?.total ?? 0;
+		const title = __( 'Permanently delete page?', 'cortext' );
+		if ( total === 0 ) {
+			return {
+				title,
+				message: __(
+					"Permanently delete this page? You can't undo this.",
+					'cortext'
+				),
+			};
+		}
+		if ( counts.pages > 0 && counts.collections === 0 ) {
+			return {
+				title,
+				message: sprintf(
+					/* translators: %d: number of subpages that will be deleted along with the page. */
+					_n(
+						"Permanently delete this page and %d subpage? You can't undo this.",
+						"Permanently delete this page and %d subpages? You can't undo this.",
+						counts.pages,
+						'cortext'
+					),
+					counts.pages
+				),
+			};
+		}
+		return {
+			title,
+			message: sprintf(
+				/* translators: %d: number of nested trashed items deleted along with the page. */
+				_n(
+					"Permanently delete this page and %d nested item? You can't undo this.",
+					"Permanently delete this page and %d nested items? You can't undo this.",
+					total,
+					'cortext'
+				),
+				total
+			),
+		};
 	},
 };
 

--- a/src/documents/descriptors/row.js
+++ b/src/documents/descriptors/row.js
@@ -1,7 +1,16 @@
+import { __, _n, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+import { notifyCollectionRowsChanged } from '../../hooks/rowInvalidation';
+import { notifyDocumentTrashChanged } from '../../hooks/documentTrashInvalidation';
+
 /**
- * Row defaults for shared document hooks. Rows are leaves and do not have a
- * normal sidebar row yet. Restore and permanent delete still live in
- * `SidebarTrash` for now.
+ * Row actions used by the trash list. Rows do not have their own sidebar row
+ * yet, so rename, duplicate, and the initial trash action still live in the
+ * DataView. SidebarTrash handles restore and permanent delete.
+ *
+ * Rows are not in core-data, so refresh runs through
+ * `notifyCollectionRowsChanged` instead of `invalidateResolution`.
  */
 const rowDescriptor = {
 	features: {
@@ -10,8 +19,66 @@ const rowDescriptor = {
 		hasOwnIcon: false,
 	},
 
-	// Row rename lives in the row editor. Duplicate and trash come from the
-	// DataView, so the sidebar does not expose those actions here.
+	async restore( record ) {
+		await apiFetch( {
+			path: `/cortext/v1/documents/${ record.id }/restore`,
+			method: 'POST',
+		} );
+		notifyCollectionRowsChanged( record.collection?.id ?? null );
+		notifyDocumentTrashChanged();
+	},
+
+	async permanentDelete( record ) {
+		const response = await apiFetch( {
+			path: `/cortext/v1/documents/${ record.id }/permanent-delete`,
+			method: 'POST',
+		} );
+		notifyCollectionRowsChanged( record.collection?.id ?? null );
+		notifyDocumentTrashChanged();
+		return response;
+	},
+
+	restoreErrorMessage: __( 'Could not restore row.', 'cortext' ),
+
+	permanentDeleteErrorMessage: __( 'Could not delete row.', 'cortext' ),
+
+	// A row that owns an inline collection drags it down via
+	// `_cortext_trashed_by_owner_page`, so the trash list folds the collection
+	// under the row. The generic "nested item" phrasing covers that.
+	descendantLabel( counts ) {
+		return sprintf(
+			/* translators: %d: number of nested trashed items under the row. */
+			_n( '%d nested item', '%d nested items', counts.total, 'cortext' ),
+			counts.total
+		);
+	},
+
+	permanentDeleteConfirmation( counts ) {
+		const total = counts?.total ?? 0;
+		const title = __( 'Permanently delete row?', 'cortext' );
+		if ( total === 0 ) {
+			return {
+				title,
+				message: __(
+					"Permanently delete this row? You can't undo this.",
+					'cortext'
+				),
+			};
+		}
+		return {
+			title,
+			message: sprintf(
+				/* translators: %d: number of nested trashed items deleted along with the row. */
+				_n(
+					"Permanently delete this row and %d nested item? You can't undo this.",
+					"Permanently delete this row and %d nested items? You can't undo this.",
+					total,
+					'cortext'
+				),
+				total
+			),
+		};
+	},
 };
 
 export default rowDescriptor;

--- a/src/documents/hooks.js
+++ b/src/documents/hooks.js
@@ -73,11 +73,13 @@ function useDocumentsContext() {
 }
 
 /**
- * Bind descriptor actions to the current dispatcher, navigation, and UI
- * callbacks. Returns async `rename`, `duplicate`, and `trash` functions.
+ * Bind descriptor actions to the current dispatcher, router, and UI callbacks.
+ * Returns async `rename`, `duplicate`, `trash`, `restore`, and
+ * `permanentDelete` functions.
  *
- * `duplicate` resolves to the created record; descriptors handle the usual
- * post-create selection or notice work themselves.
+ * `duplicate` resolves to the created record and `permanentDelete` resolves
+ * to the REST response (with the deleted ids) so callers can react to it.
+ * Descriptors own the per-kind refresh logic.
  */
 export function useDocumentActions() {
 	const docCtx = useDocumentsContext();
@@ -141,18 +143,44 @@ export function useDocumentActions() {
 		[ ctx ]
 	);
 
+	const restore = useCallback(
+		async ( record ) => {
+			const descriptor = descriptorFor( record );
+			if ( ! descriptor.restore ) {
+				return;
+			}
+			return descriptor.restore( record, ctx );
+		},
+		[ ctx ]
+	);
+
+	const permanentDelete = useCallback(
+		async ( record ) => {
+			const descriptor = descriptorFor( record );
+			if ( ! descriptor.permanentDelete ) {
+				return undefined;
+			}
+			return descriptor.permanentDelete( record, ctx );
+		},
+		[ ctx ]
+	);
+
 	return useMemo(
-		() => ( { rename, duplicate, trash } ),
-		[ rename, duplicate, trash ]
+		() => ( { rename, duplicate, trash, restore, permanentDelete } ),
+		[ rename, duplicate, trash, restore, permanentDelete ]
 	);
 }
 
 /**
- * Resolve the display bits for a record: kind, title, icon, and feature flags.
- * Components should prefer the feature flags over their own kind checks.
+ * Resolve the display data for a record: kind, title, icon, feature flags, and
+ * trash-list copy such as descendant labels, confirmation text, and error
+ * messages. Components should prefer this over their own kind checks.
+ *
+ * `descendantLabel` and `permanentDeleteConfirmation` take the cascade counts
+ * (`{ pages, collections, total }`) and return localized copy for that subtree.
  *
  * @param {Object} record Document record (page, collection, or row).
- * @return {Object} `{ kind, title, icon, features }` display attributes.
+ * @return {Object} Display attributes.
  */
 export function useDocumentRecord( record ) {
 	const kind = kindFromRecord( record );
@@ -164,6 +192,13 @@ export function useDocumentRecord( record ) {
 		title,
 		icon,
 		features: descriptor.features,
+		descendantLabel: ( counts ) =>
+			descriptor.descendantLabel?.( counts ) ?? '',
+		permanentDeleteConfirmation: ( counts ) =>
+			descriptor.permanentDeleteConfirmation?.( counts ) ?? null,
+		restoreErrorMessage: descriptor.restoreErrorMessage ?? '',
+		permanentDeleteErrorMessage:
+			descriptor.permanentDeleteErrorMessage ?? '',
 	};
 }
 

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -1,9 +1,9 @@
 /**
- * Render and behavior tests for `src/components/SidebarTrash.js`.
+ * Tests for `src/components/SidebarTrash.js`.
  *
  * Mocks `@wordpress/core-data`, `@wordpress/data`, and `@wordpress/api-fetch`
  * so each case can drive the trash query state, capture dispatched actions,
- * and assert the REST calls SidebarTrash makes.
+ * and check the REST calls SidebarTrash makes.
  */
 
 import {
@@ -14,9 +14,8 @@ import {
 	waitFor,
 } from '@testing-library/react';
 
-// Stub @wordpress/components so the test does not transitively pull in
-// rich-text → block-editor → parsel-js (an ESM-only package the jest CJS
-// transformer chokes on).
+// Stub @wordpress/components so Jest does not pull in rich-text →
+// block-editor → parsel-js, an ESM-only package the CJS transformer chokes on.
 jest.mock( '@wordpress/components', () => {
 	const ReactLib = require( 'react' );
 	const Button = ( {
@@ -96,6 +95,19 @@ jest.mock( '@tanstack/react-router', () => ( {
 	useNavigate: jest.fn(),
 } ) );
 
+// useDocumentActions builds its context through useFavorites and useRecents.
+// SidebarTrash does not call either one directly, so stub them instead of
+// mounting the real providers.
+jest.mock( '../../../src/hooks/useFavorites', () => ( {
+	__esModule: true,
+	useFavorites: () => ( { setFavorites: jest.fn() } ),
+} ) );
+
+jest.mock( '../../../src/hooks/useRecents', () => ( {
+	__esModule: true,
+	useRecents: () => ( { touchRecent: jest.fn() } ),
+} ) );
+
 jest.mock( '../../../src/components/TypeToConfirmDialog', () => {
 	const ReactLib = require( 'react' );
 	return {
@@ -140,11 +152,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { useNavigate } from '@tanstack/react-router';
 
 import SidebarTrash from '../../../src/components/SidebarTrash';
+import { DocumentsProvider } from '../../../src/documents';
 import {
 	ACTIVE_PAGES_QUERY,
 	POST_TYPE,
 	TRASHED_PAGES_QUERY,
 } from '../../../src/components/page-queries';
+import { DOCUMENT_TRASH_CHANGED_EVENT } from '../../../src/hooks/documentTrashInvalidation';
 
 const dispatchMocks = {
 	deleteEntityRecord: jest.fn(),
@@ -152,6 +166,8 @@ const dispatchMocks = {
 };
 
 const navigateMock = jest.fn();
+
+let trashRefreshListener;
 
 beforeEach( () => {
 	useDispatch.mockReset();
@@ -163,6 +179,21 @@ beforeEach( () => {
 	useDispatch.mockReturnValue( dispatchMocks );
 	useNavigate.mockReturnValue( navigateMock );
 	trashState = makeDocumentsState();
+	// In production, `useTrashedDocuments` listens for this event and refreshes.
+	// Tests inject `trashState` directly, so wire the listener by hand for
+	// descriptors that emit it.
+	trashRefreshListener = () => trashState.refresh?.();
+	window.addEventListener(
+		DOCUMENT_TRASH_CHANGED_EVENT,
+		trashRefreshListener
+	);
+} );
+
+afterEach( () => {
+	window.removeEventListener(
+		DOCUMENT_TRASH_CHANGED_EVENT,
+		trashRefreshListener
+	);
 } );
 
 let trashState;
@@ -182,11 +213,13 @@ function setTrashRecords( {
 
 function renderSidebarTrash( props = {} ) {
 	return render(
-		<SidebarTrash
-			activePages={ [] }
-			trashedDocumentsState={ trashState }
-			{ ...props }
-		/>
+		<DocumentsProvider>
+			<SidebarTrash
+				activePages={ [] }
+				trashedDocumentsState={ trashState }
+				{ ...props }
+			/>
+		</DocumentsProvider>
 	);
 }
 
@@ -311,10 +344,12 @@ describe( 'SidebarTrash', () => {
 			status: 'RESOLVING',
 		} );
 		rerender(
-			<SidebarTrash
-				activePages={ [] }
-				trashedDocumentsState={ trashState }
-			/>
+			<DocumentsProvider>
+				<SidebarTrash
+					activePages={ [] }
+					trashedDocumentsState={ trashState }
+				/>
+			</DocumentsProvider>
 		);
 
 		expect( screen.queryByTestId( 'spinner' ) ).not.toBeInTheDocument();
@@ -675,6 +710,30 @@ describe( 'SidebarTrash', () => {
 		).toHaveTextContent( '2 nested items' );
 	} );
 
+	it( 'shows the cascade count beside a row that owns a trashed collection', () => {
+		// `DocumentToCollectionTrashCascade` applies to any document that owns
+		// a collection, rows included. The owned collection points back at the
+		// row via `_cortext_trashed_by_owner_page`, so the row should surface
+		// the nested-item badge.
+		const row = makeRow( {
+			id: 17,
+			title: { rendered: 'Sprint 12', raw: 'Sprint 12' },
+		} );
+		const ownedCollection = makeCollection( {
+			id: 22,
+			title: { rendered: 'Tasks', raw: 'Tasks' },
+			meta: { _cortext_trashed_by_owner_page: 17 },
+		} );
+
+		setTrashRecords( { records: [ row, ownedCollection ] } );
+
+		const { container } = renderSidebarTrash();
+
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toHaveTextContent( '1 nested item' );
+	} );
+
 	it( 'promotes orphaned descendants (stale marker) back to roots', () => {
 		// Marker points at a parent no longer in Trash. It may have been
 		// permanently deleted by an older build or a different path; either
@@ -799,7 +858,7 @@ describe( 'SidebarTrash', () => {
 		expect( screen.queryByText( 'Action items' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'announces collection rows in the permanent-delete confirmation', () => {
+	it( 'mentions collection rows in the permanent-delete confirmation', () => {
 		setTrashRecords( {
 			records: [
 				makeCollection( {
@@ -822,7 +881,7 @@ describe( 'SidebarTrash', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'announces subtree size in the permanent-delete confirmation', () => {
+	it( 'mentions subtree size in the permanent-delete confirmation', () => {
 		const root = makePage( {
 			id: 1,
 			title: { rendered: 'Workspace', raw: 'Workspace' },
@@ -850,7 +909,7 @@ describe( 'SidebarTrash', () => {
 
 	it( 'uses the typed-name dialog when permanently deleting a collection', () => {
 		// Collections can contain rows, so they ask for the title before the
-		// final delete. Pages and rows keep the lighter confirm dialog.
+		// final delete. Pages and rows use the lighter confirm dialog.
 		setTrashRecords( {
 			records: [
 				makeCollection( {


### PR DESCRIPTION
## What

Part of #226.

Trash restore and permanent delete now go through the descriptor for the item being acted on. Pages, collections, and rows each keep their own refresh behavior, error text, confirmation text, and descendant labels. SidebarTrash just renders the list and calls the right action.

No user-facing change intended. Trash should still group children under the root item, show the same breadcrumbs and counts, and require typed confirmation for collections.

## Why

This removes another chunk of kind-specific Trash logic from the sidebar before the rest of the descriptor work lands.

## Testing Instructions

1. Trash a page with a child page and confirm Trash shows the root with the child count.
2. Restore that page and confirm the page tree comes back.
3. Permanently delete a trashed page tree and confirm the canvas navigates away if the open item was deleted.
4. Trash a collection and confirm typed confirmation still appears before permanent delete.
5. Trash, restore, and permanently delete a row from a collection and confirm the row still shows its collection context in Trash.
