### PR TITLE
Fix: Stop row detail transition jitter

### DIFF
--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -353,7 +353,7 @@ export default function RowDetailView( {
 					{
 						key: activeDetailKey,
 						detail: activeDetail,
-						state: 'active',
+						state: 'preparing',
 					},
 			  ]
 			: []
@@ -403,7 +403,7 @@ export default function RowDetailView( {
 				{
 					key: activeDetailKey,
 					detail: activeDetail,
-					state: visiblePanes.length ? 'preparing' : 'active',
+					state: 'preparing',
 				},
 			];
 		} );
@@ -494,6 +494,9 @@ export default function RowDetailView( {
 			activePane.state !== 'covered' &&
 			String( activeDetail.rowId ) === String( rowId )
 	);
+	const isWaitingForFirstPane =
+		detailPanes.length > 0 &&
+		! detailPanes.some( ( pane ) => pane.state !== 'preparing' );
 
 	const content =
 		! activeDetail && detailPanes.length === 0 ? (
@@ -517,11 +520,18 @@ export default function RowDetailView( {
 				setArePropertiesVisible={ setArePropertiesVisible }
 			>
 				<div className="cortext-row-detail__pane-stack">
+					{ isWaitingForFirstPane ? (
+						<div className="cortext-row-detail__pane cortext-row-detail__pane--loading">
+							<Spinner />
+						</div>
+					) : null }
 					<Suspense
 						fallback={
-							<div className="cortext-row-detail__pane cortext-row-detail__pane--loading">
-								<Spinner />
-							</div>
+							isWaitingForFirstPane ? null : (
+								<div className="cortext-row-detail__pane cortext-row-detail__pane--loading">
+									<Spinner />
+								</div>
+							)
 						}
 					>
 						{ detailPanes.map( ( pane ) => {

--- a/src/components/RowDetailView.scss
+++ b/src/components/RowDetailView.scss
@@ -174,6 +174,26 @@
 		}
 	}
 
+	&__pane--loading {
+		position: absolute;
+		inset: 0;
+		z-index: 2;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 100%;
+		color: var(--cortext-row-detail-muted);
+		pointer-events: none;
+	}
+
+	&--side .cortext-row-detail__pane--loading,
+	&--modal .cortext-row-detail__pane--loading {
+		position: absolute;
+		inset: 0;
+		height: 100%;
+		min-height: 100%;
+	}
+
 	&__properties-shell {
 		position: relative;
 		min-width: 0;

--- a/src/components/RowDetailView.scss
+++ b/src/components/RowDetailView.scss
@@ -850,12 +850,10 @@
 
 	from {
 		opacity: 0;
-		transform: translateY(4px);
 	}
 
 	to {
 		opacity: 1;
-		transform: translateY(0);
 	}
 }
 

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -47,14 +47,6 @@ const ROW_DETAIL_EDITOR_CSS = `
 
 const ROW_DETAIL_EXTRA_STYLES = [ { css: ROW_DETAIL_EDITOR_CSS } ];
 
-function DetailReadySignal( { detailKey, onReady } ) {
-	useEffect( () => {
-		onReady( detailKey );
-	}, [ detailKey, onReady ] );
-
-	return null;
-}
-
 function RowAutosaveBridge( {
 	isActive = true,
 	onApi,
@@ -104,10 +96,12 @@ function RowAutosaveBridge( {
 
 function DetailPaneContent( {
 	collectionId,
+	detailKey,
 	fields,
 	isActive,
 	isHidden,
 	onApi,
+	onPaneReady,
 	onRestored,
 	onSaved,
 	onTogglePropertiesVisible,
@@ -116,6 +110,11 @@ function DetailPaneContent( {
 	row,
 	rowId,
 } ) {
+	const handleReady = useCallback(
+		() => onPaneReady( detailKey ),
+		[ detailKey, onPaneReady ]
+	);
+
 	return (
 		<>
 			<RowAutosaveBridge
@@ -140,6 +139,7 @@ function DetailPaneContent( {
 					postId={ row?.id }
 					postType={ postType }
 					extraStyles={ ROW_DETAIL_EXTRA_STYLES }
+					onReady={ handleReady }
 					onRestored={ onRestored }
 				/>
 			</DocumentPropertiesProvider>
@@ -178,16 +178,14 @@ export default function RowEditor( {
 			     peek/modal are open. */ }
 			<SlotFillProvider>
 				<EditorSurfaceProvider hasBlockInspector={ false }>
-					<DetailReadySignal
-						detailKey={ detailKey }
-						onReady={ onPaneReady }
-					/>
 					<DetailPaneContent
 						collectionId={ collectionId }
+						detailKey={ detailKey }
 						fields={ fields }
 						isActive={ isActive }
 						isHidden={ isHidden }
 						onApi={ onApi }
+						onPaneReady={ onPaneReady }
 						onRestored={ onRestored }
 						onSaved={ onSaved }
 						onTogglePropertiesVisible={ onTogglePropertiesVisible }

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -240,8 +240,14 @@ async function getParentDataViewAttributes( page ) {
 	} );
 }
 
+function activeRowDetailCanvas( detail ) {
+	return detail
+		.locator( '.cortext-row-detail__pane[data-interactive="true"]' )
+		.frameLocator( 'iframe[name="editor-canvas"]' );
+}
+
 async function expectRowToolbarIsolated( page, detail, blockText ) {
-	const rowCanvas = detail.frameLocator( 'iframe[name="editor-canvas"]' );
+	const rowCanvas = activeRowDetailCanvas( detail );
 	const rowBlock = rowCanvas.getByText( blockText, { exact: true } ).first();
 	await expect( rowBlock ).toBeVisible();
 	await rowBlock.click();
@@ -1965,9 +1971,7 @@ test.describe( 'Collection view block', () => {
 			// The row title now lives in the locked `core/post-title` block
 			// inside the editor iframe. Properties sit next to it in the
 			// `cortext/document-properties` block.
-			const detailCanvas = detail.frameLocator(
-				'[name="editor-canvas"]'
-			);
+			const detailCanvas = activeRowDetailCanvas( detail );
 			const detailTitle = detailCanvas
 				.locator( '[data-type="core/post-title"]' )
 				.first();

--- a/tests/js/components/RowEditor.test.js
+++ b/tests/js/components/RowEditor.test.js
@@ -1,0 +1,81 @@
+import { act, render } from '@testing-library/react';
+
+import RowEditor from '../../../src/components/RowEditor';
+import EditorBody from '../../../src/components/EditorBody';
+
+jest.mock( '@wordpress/components', () => ( {
+	SlotFillProvider: ( { children } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { resetPost: jest.fn() } ),
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	EditorProvider: ( { children } ) => <>{ children }</>,
+	store: {},
+} ) );
+
+jest.mock( '../../../src/components/DocumentPropertiesContext', () => ( {
+	DocumentPropertiesProvider: ( { children } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '../../../src/components/EditorSurfaceContext', () => ( {
+	EditorSurfaceProvider: ( { children } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '../../../src/components/EditorBody', () =>
+	jest.fn( () => <div data-testid="editor-body" /> )
+);
+
+jest.mock( '../../../src/components/initEditor', () => ( {} ) );
+
+jest.mock( '../../../src/hooks/useAutosave', () =>
+	jest.fn( () => ( {
+		discard: jest.fn(),
+		flushNow: jest.fn(),
+		isDirty: false,
+		isSaving: false,
+		lastSavedAt: null,
+		status: 'idle',
+	} ) )
+);
+
+describe( 'RowEditor', () => {
+	beforeEach( () => {
+		EditorBody.mockClear();
+		window.cortextEditorSettings = {};
+	} );
+
+	it( 'waits for the editor body paint signal before marking the pane ready', () => {
+		const onPaneReady = jest.fn();
+
+		render(
+			<RowEditor
+				collectionId={ 10 }
+				detailKey="crtxt_tasks:20"
+				fields={ [] }
+				isActive
+				isHidden={ false }
+				onApi={ jest.fn() }
+				onPaneReady={ onPaneReady }
+				onRestored={ jest.fn() }
+				onSaved={ jest.fn() }
+				onTogglePropertiesVisible={ jest.fn() }
+				post={ { id: 20, type: 'crtxt_tasks' } }
+				postType="crtxt_tasks"
+				propertiesVisible
+				row={ { id: 20 } }
+				rowId={ 20 }
+			/>
+		);
+
+		expect( onPaneReady ).not.toHaveBeenCalled();
+
+		act( () => {
+			EditorBody.mock.calls[ 0 ][ 0 ].onReady();
+		} );
+
+		expect( onPaneReady ).toHaveBeenCalledWith( 'crtxt_tasks:20' );
+	} );
+} );


### PR DESCRIPTION
## What

Opening one row while another row detail is already visible now keeps the side peek in place. The pane still fades in, but it no longer nudges vertically during the transition.

## Why

That small vertical movement made the row detail feel like it was jumping, especially when switching between an empty row and a row with content.

## Testing Instructions

1. Open a collection with at least two rows.
2. Open one row in the side peek.
3. Switch directly to another row, including one with different property content.
4. Confirm the detail pane fades in without the canvas shifting up or down.

##Screen recording
Before:

https://github.com/user-attachments/assets/af14db96-b72b-4856-84e7-567b12356bb8


After:

https://github.com/user-attachments/assets/64f8f4d6-a8d0-4eb5-af0a-14364cae277f


