### PR TITLE
Refactor: Document Unification; Move Recents icons and labels into descriptors

### DIFF
--- a/includes/Documents/RowKind.php
+++ b/includes/Documents/RowKind.php
@@ -47,7 +47,11 @@ final class RowKind implements DocumentKind {
 	}
 
 	public function has_icon(): bool {
-		return false;
+		// Rows carry the same `cortext_document_icon` meta as pages (registered
+		// via `DocumentTypeRegistrar` on every document CPT). The DataView
+		// title cell already renders that glyph; favorites and recents pick
+		// it up through `Documents::format_target`.
+		return true;
 	}
 
 	public function owner_context( WP_Post $post ): ?KindOwnerContext {

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -1,15 +1,14 @@
 import { useNavigate } from '@tanstack/react-router';
-import { Button, Icon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useCallback, useLayoutEffect, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { listItem, table } from '@wordpress/icons';
 
-import PageIcon from './PageIcon';
 import { SidebarListSkeleton } from './Skeleton';
 import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
 } from '../hooks/useDelayedFlag';
 import { useRecents } from '../hooks/useRecents';
+import { useDocumentRecord } from '../documents';
 
 const RECENT_REPOSITION_OPTIONS = {
 	duration: 180,
@@ -47,53 +46,72 @@ function runNodeAnimation( node, keyframes, options ) {
 	node.animate( keyframes, options );
 }
 
-function kindLabel( kind ) {
-	if ( kind === 'collection' ) {
-		return __( 'Collection', 'cortext' );
-	}
-	if ( kind === 'row' ) {
-		return __( 'Row', 'cortext' );
-	}
-	return __( 'Page', 'cortext' );
-}
-
-function recentTitle( recent ) {
+/**
+ * Single row in the recents list. Pulls display copy through
+ * `useDocumentRecord` so this component stays kind-blind: the descriptor
+ * decides the icon and the type label, and the row formats the title with
+ * the collection context when the record carries one (i.e. rows).
+ *
+ * @param {Object}   props
+ * @param {Object}   props.recent     Recent activity record from the server.
+ * @param {Function} props.setNodeRef Ref setter used by the FLIP animation.
+ * @param {Function} props.onSelect   Navigate to the recent's path.
+ */
+function SidebarRecentsRow( { recent, setNodeRef, onSelect } ) {
+	const { listIcon, kindLabel } = useDocumentRecord( recent );
 	const title = recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
-	if ( recent?.kind === 'row' && recent?.collection?.title ) {
-		return sprintf(
-			/* translators: 1: row title, 2: collection title */
-			__( '%1$s in %2$s', 'cortext' ),
-			title,
-			recent.collection.title
-		);
-	}
-	return title;
-}
+	const contextTitle = recent?.collection?.title?.trim?.() ?? '';
 
-function recentAriaLabel( recent ) {
-	const title = recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
-	if ( recent?.kind === 'row' && recent?.collection?.title ) {
-		return sprintf(
-			/* translators: 1: row title, 2: collection title */
-			__( 'Recent row: %1$s in %2$s', 'cortext' ),
-			title,
-			recent.collection.title
-		);
-	}
-	return sprintf(
-		/* translators: 1: recent item type, 2: recent item title */
-		__( 'Recent %1$s: %2$s', 'cortext' ),
-		kindLabel( recent?.kind ).toLowerCase(),
-		title
+	const displayTitle = contextTitle
+		? sprintf(
+				/* translators: 1: row title, 2: collection title */
+				__( '%1$s in %2$s', 'cortext' ),
+				title,
+				contextTitle
+		  )
+		: title;
+
+	const ariaLabel = contextTitle
+		? sprintf(
+				/* translators: 1: row title, 2: collection title */
+				__( 'Recent row: %1$s in %2$s', 'cortext' ),
+				title,
+				contextTitle
+		  )
+		: sprintf(
+				/* translators: 1: recent item type, 2: recent item title */
+				__( 'Recent %1$s: %2$s', 'cortext' ),
+				kindLabel.toLowerCase(),
+				title
+		  );
+
+	return (
+		<li
+			ref={ setNodeRef }
+			className="cortext-sidebar__node cortext-sidebar__recent-node"
+		>
+			<div className="cortext-sidebar__row">
+				<span
+					className="cortext-sidebar__recent-icon"
+					aria-hidden="true"
+				>
+					{ listIcon?.() }
+				</span>
+				<Button
+					className="cortext-sidebar__title cortext-sidebar__recent-title"
+					size="compact"
+					variant="tertiary"
+					onClick={ ( event ) => {
+						event.currentTarget.blur();
+						onSelect( recent );
+					} }
+					aria-label={ ariaLabel }
+				>
+					{ displayTitle }
+				</Button>
+			</div>
+		</li>
 	);
-}
-
-function RecentIcon( { recent } ) {
-	if ( recent?.kind === 'page' ) {
-		return <PageIcon icon={ recent.icon ?? '' } size={ 16 } />;
-	}
-	const icon = recent?.kind === 'row' ? listItem : table;
-	return <Icon icon={ icon } size={ 16 } />;
 }
 
 export default function SidebarRecents() {
@@ -111,6 +129,19 @@ export default function SidebarRecents() {
 			}
 		},
 		[]
+	);
+
+	const onSelectRecent = useCallback(
+		( recent ) => {
+			if ( ! recent.path ) {
+				return;
+			}
+			navigate( {
+				to: '/$',
+				params: { _splat: recent.path },
+			} );
+		},
+		[ navigate ]
 	);
 
 	useLayoutEffect( () => {
@@ -177,40 +208,12 @@ export default function SidebarRecents() {
 					{ recents.map( ( recent ) => {
 						const key = recentKey( recent );
 						return (
-							<li
+							<SidebarRecentsRow
 								key={ key }
-								ref={ setRecentNodeRef( key ) }
-								className="cortext-sidebar__node cortext-sidebar__recent-node"
-							>
-								<div className="cortext-sidebar__row">
-									<span
-										className="cortext-sidebar__recent-icon"
-										aria-hidden="true"
-									>
-										<RecentIcon recent={ recent } />
-									</span>
-									<Button
-										className="cortext-sidebar__title cortext-sidebar__recent-title"
-										size="compact"
-										variant="tertiary"
-										onClick={ ( event ) => {
-											event.currentTarget.blur();
-											if ( ! recent.path ) {
-												return;
-											}
-											navigate( {
-												to: '/$',
-												params: {
-													_splat: recent.path,
-												},
-											} );
-										} }
-										aria-label={ recentAriaLabel( recent ) }
-									>
-										{ recentTitle( recent ) }
-									</Button>
-								</div>
-							</li>
+								recent={ recent }
+								setNodeRef={ setRecentNodeRef( key ) }
+								onSelect={ onSelectRecent }
+							/>
 						);
 					} ) }
 				</ul>

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -47,10 +47,8 @@ function runNodeAnimation( node, keyframes, options ) {
 }
 
 /**
- * Single row in the recents list. Pulls display copy through
- * `useDocumentRecord` so this component stays kind-blind: the descriptor
- * decides the icon and the type label, and the row formats the title with
- * the collection context when the record carries one (i.e. rows).
+ * One item in Recents. The descriptor supplies the icon and type label, while
+ * this row only adds collection context when the recent item is a row.
  *
  * @param {Object}   props
  * @param {Object}   props.recent     Recent activity record from the server.

--- a/src/documents/descriptors/collection.js
+++ b/src/documents/descriptors/collection.js
@@ -1,6 +1,5 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Icon } from '@wordpress/components';
-import { table } from '@wordpress/icons';
+import { Icon, table } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
 import { computeCollectionUri } from '../../router/useResolveEntity';
@@ -26,7 +25,7 @@ const collectionDescriptor = {
 
 	kindLabel: __( 'Collection', 'cortext' ),
 
-	listIcon( record, size = 16 ) {
+	fallbackListIcon( size = 16 ) {
 		return <Icon icon={ table } size={ size } />;
 	},
 

--- a/src/documents/descriptors/collection.js
+++ b/src/documents/descriptors/collection.js
@@ -1,4 +1,6 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import { table } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
 import { computeCollectionUri } from '../../router/useResolveEntity';
@@ -20,6 +22,12 @@ const collectionDescriptor = {
 		hierarchy: false,
 		canCreateChild: false,
 		hasOwnIcon: false,
+	},
+
+	kindLabel: __( 'Collection', 'cortext' ),
+
+	listIcon( record, size = 16 ) {
+		return <Icon icon={ table } size={ size } />;
 	},
 
 	uri( record ) {

--- a/src/documents/descriptors/page.js
+++ b/src/documents/descriptors/page.js
@@ -22,12 +22,10 @@ const pageDescriptor = {
 
 	kindLabel: __( 'Page', 'cortext' ),
 
-	// Compact-list icon used in Recents and similar surfaces. Pages keep
-	// their own glyph; falling back to the default PageIcon shape when
-	// nothing is set.
-	listIcon( record, size = 16 ) {
-		const icon = record?.icon ?? record?.meta?.cortext_document_icon ?? '';
-		return <PageIcon icon={ icon } size={ size } />;
+	// Compact-list fallback glyph for pages with no custom icon. Custom icons
+	// take precedence and are rendered by `useDocumentRecord` directly.
+	fallbackListIcon( size = 16 ) {
+		return <PageIcon icon="" size={ size } />;
 	},
 
 	uri( record ) {

--- a/src/documents/descriptors/page.js
+++ b/src/documents/descriptors/page.js
@@ -1,6 +1,7 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
+import PageIcon from '../../components/PageIcon';
 import { POST_TYPE } from '../../components/page-queries';
 import { computeDocumentUri } from '../../router/useResolveEntity';
 import { notifyDocumentTrashChanged } from '../../hooks/documentTrashInvalidation';
@@ -17,6 +18,16 @@ const pageDescriptor = {
 		hierarchy: true,
 		canCreateChild: true,
 		hasOwnIcon: true,
+	},
+
+	kindLabel: __( 'Page', 'cortext' ),
+
+	// Compact-list icon used in Recents and similar surfaces. Pages keep
+	// their own glyph; falling back to the default PageIcon shape when
+	// nothing is set.
+	listIcon( record, size = 16 ) {
+		const icon = record?.icon ?? record?.meta?.cortext_document_icon ?? '';
+		return <PageIcon icon={ icon } size={ size } />;
 	},
 
 	uri( record ) {

--- a/src/documents/descriptors/row.js
+++ b/src/documents/descriptors/row.js
@@ -1,6 +1,5 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Icon } from '@wordpress/components';
-import { listItem } from '@wordpress/icons';
+import { Icon, listItem } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
 import { notifyCollectionRowsChanged } from '../../hooks/rowInvalidation';
@@ -23,7 +22,7 @@ const rowDescriptor = {
 
 	kindLabel: __( 'Row', 'cortext' ),
 
-	listIcon( record, size = 16 ) {
+	fallbackListIcon( size = 16 ) {
 		return <Icon icon={ listItem } size={ size } />;
 	},
 

--- a/src/documents/descriptors/row.js
+++ b/src/documents/descriptors/row.js
@@ -1,4 +1,6 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import { listItem } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
 import { notifyCollectionRowsChanged } from '../../hooks/rowInvalidation';
@@ -17,6 +19,12 @@ const rowDescriptor = {
 		hierarchy: false,
 		canCreateChild: false,
 		hasOwnIcon: false,
+	},
+
+	kindLabel: __( 'Row', 'cortext' ),
+
+	listIcon( record, size = 16 ) {
+		return <Icon icon={ listItem } size={ size } />;
 	},
 
 	async restore( record ) {

--- a/src/documents/hooks.js
+++ b/src/documents/hooks.js
@@ -179,12 +179,17 @@ export function useDocumentActions() {
 }
 
 /**
- * Resolve the display data for a record: kind, title, icon, feature flags, and
- * trash-list copy such as descendant labels, confirmation text, and error
- * messages. Components should prefer this over their own kind checks.
+ * Resolve the display data for a record: kind, title, icons, feature flags,
+ * the localized kind label, and the trash-list copy (descendant labels,
+ * confirmation text, error messages). Components should prefer these over
+ * their own kind checks.
  *
+ * `listIcon` is the compact-list glyph (Recents, Favorites, Palette); the
+ * sidebar tree's identity icon stays on `icon`. `kindLabel` is the localized
+ * noun ("Page", "Collection", "Row") for aria labels and similar copy.
  * `descendantLabel` and `permanentDeleteConfirmation` take the cascade counts
- * (`{ pages, collections, total }`) and return localized copy for that subtree.
+ * (`{ pages, collections, total }`) and return the localized copy for that
+ * subtree.
  *
  * @param {Object} record Document record (page, collection, or row).
  * @return {Object} Display attributes.
@@ -194,10 +199,15 @@ export function useDocumentRecord( record ) {
 	const descriptor = getDescriptor( kind );
 	const title = documentTitle( record );
 	const icon = iconForRecord( record, kind );
+	const listIcon = descriptor.listIcon
+		? ( size ) => descriptor.listIcon( record, size )
+		: null;
 	return {
 		kind,
 		title,
 		icon,
+		listIcon,
+		kindLabel: descriptor.kindLabel ?? '',
 		features: descriptor.features,
 		descendantLabel: ( counts ) =>
 			descriptor.descendantLabel?.( counts ) ?? '',

--- a/src/documents/hooks.js
+++ b/src/documents/hooks.js
@@ -17,7 +17,7 @@ import {
 	favoriteIdentForRecord,
 	favoriteKeyForRecord,
 } from './favorites';
-import { iconForRecord } from './icons';
+import { iconForRecord, listIconForRecord } from './icons';
 import { kindFromRecord } from './kinds';
 import { getDescriptor } from './descriptors';
 
@@ -199,9 +199,7 @@ export function useDocumentRecord( record ) {
 	const descriptor = getDescriptor( kind );
 	const title = documentTitle( record );
 	const icon = iconForRecord( record, kind );
-	const listIcon = descriptor.listIcon
-		? ( size ) => descriptor.listIcon( record, size )
-		: null;
+	const listIcon = ( size ) => listIconForRecord( record, size );
 	return {
 		kind,
 		title,

--- a/src/documents/icons.js
+++ b/src/documents/icons.js
@@ -1,6 +1,8 @@
 import { Icon, customPostType } from '@wordpress/icons';
 
 import PageIcon from '../components/PageIcon';
+import { getDescriptor } from './descriptors';
+import { kindFromRecord } from './kinds';
 
 /**
  * Resolve the sidebar icon for a document record. Pages use their
@@ -17,4 +19,22 @@ export function iconForRecord( record, kind, size = 16 ) {
 		return <PageIcon icon={ iconMeta } size={ size } />;
 	}
 	return <Icon icon={ customPostType } size={ size } />;
+}
+
+/**
+ * Compact-list icon for any document record (Recents, Favorites, Palette).
+ * Custom icons on the record win regardless of kind; otherwise the descriptor
+ * supplies its own fallback glyph.
+ *
+ * @param {?Object} record Document record.
+ * @param {number}  [size] Icon size in pixels.
+ * @return {?Object} Rendered React node for the icon, or `null`.
+ */
+export function listIconForRecord( record, size = 16 ) {
+	const icon = record?.icon ?? record?.meta?.cortext_document_icon ?? '';
+	if ( icon ) {
+		return <PageIcon icon={ icon } size={ size } />;
+	}
+	const descriptor = getDescriptor( kindFromRecord( record ) );
+	return descriptor.fallbackListIcon?.( size ) ?? null;
 }

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -19,8 +19,10 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 
 jest.mock( '@wordpress/icons', () => ( {
+	customPostType: 'custom-post-type',
 	listItem: 'list-item',
 	table: 'table',
+	Icon: ( { icon } ) => <span data-testid={ `icon-${ icon }` } />,
 } ) );
 
 jest.mock( '../../../src/components/PageIcon', () => () => (
@@ -42,6 +44,25 @@ function pageRecent( id, title ) {
 		id,
 		title,
 		path: `page/${ title.toLowerCase() }-${ id }`,
+	};
+}
+
+function rowRecent( id, title, collectionTitle ) {
+	return {
+		kind: 'row',
+		id,
+		title,
+		path: `collection/books/${ title.toLowerCase() }-${ id }`,
+		collection: { id: 12, title: collectionTitle, slug: 'books' },
+	};
+}
+
+function collectionRecent( id, title ) {
+	return {
+		kind: 'collection',
+		id,
+		title,
+		path: `collection/${ title.toLowerCase() }-${ id }`,
 	};
 }
 
@@ -120,5 +141,33 @@ describe( 'SidebarRecents animation', () => {
 			params: { _splat: 'page/alpha-1' },
 		} );
 		blurSpy.mockRestore();
+	} );
+
+	it( 'shows a row recent with its collection in the title', () => {
+		mockRecents = [ rowRecent( 7, 'War and Peace', 'Books' ) ];
+
+		render( <SidebarRecents /> );
+
+		expect(
+			screen.getByText( 'War and Peace in Books' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Recent row: War and Peace in Books',
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows a collection recent with the table glyph', () => {
+		mockRecents = [ collectionRecent( 33, 'Library' ) ];
+
+		const { container } = render( <SidebarRecents /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Recent collection: Library' } )
+		).toBeInTheDocument();
+		expect(
+			container.querySelector( '[data-testid="icon-table"]' )
+		).toBeInTheDocument();
 	} );
 } );

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -158,7 +158,7 @@ describe( 'SidebarRecents animation', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'shows a collection recent with the table glyph', () => {
+	it( 'shows a collection recent with the table icon', () => {
 		mockRecents = [ collectionRecent( 33, 'Library' ) ];
 
 		const { container } = render( <SidebarRecents /> );
@@ -169,5 +169,22 @@ describe( 'SidebarRecents animation', () => {
 		expect(
 			container.querySelector( '[data-testid="icon-table"]' )
 		).toBeInTheDocument();
+	} );
+
+	it( 'shows a row recent with its custom icon when set', () => {
+		// A row that has a `cortext_document_icon` stored renders that glyph
+		// instead of the generic list-item fallback.
+		const row = rowRecent( 11, 'Ada Lovelace', 'People' );
+		row.icon = JSON.stringify( { type: 'wp', name: 'people' } );
+		mockRecents = [ row ];
+
+		const { container } = render( <SidebarRecents /> );
+
+		expect(
+			container.querySelector( '[data-testid="page-icon"]' )
+		).toBeInTheDocument();
+		expect(
+			container.querySelector( '[data-testid="icon-list-item"]' )
+		).toBeNull();
 	} );
 } );

--- a/tests/php/test-documents.php
+++ b/tests/php/test-documents.php
@@ -107,6 +107,23 @@ final class Test_Documents extends BaseTestCase {
 		$this->assertArrayNotHasKey( 'icon', $document );
 	}
 
+	public function test_find_returns_row_icon_when_set(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$icon = wp_json_encode(
+			array(
+				'type' => 'wp',
+				'name' => 'people',
+			)
+		);
+		$this->create_collection( 'projects', 'Projects' );
+		$row_id = $this->create_row( 'crtxt_projects', 'Ada Lovelace' );
+		update_post_meta( $row_id, DocumentIdentity::META_KEY, $icon );
+
+		$document = $this->documents->find( $row_id );
+
+		$this->assertSame( $icon, $document['icon'] );
+	}
+
 	public function test_find_returns_full_page_collection_document(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
 		$collection_id = $this->create_collection( 'tasks', 'Tasks' );


### PR DESCRIPTION
## What

Part of #226.

Sidebar Recents now asks the document descriptor for each item's icon and type label instead of keeping its own page/collection/row switch. Existing recents should look the same, and row recents can now show a saved custom icon when one is set.

## Why

Recents is another sidebar surface that should not need to know the details of every document kind.

## How

Rows now include their document icon in the document target payload. Compact lists use a saved icon first, then fall back to the default icon for that document kind.

## Testing Instructions

1. Open Cortext and visit a page, a collection, and a row.
2. Confirm all three appear in sidebar Recents.
3. Confirm the page keeps its page icon.
4. Confirm the collection uses the table icon.
5. Confirm the row title includes its parent collection.
6. Set a custom icon on a row, visit it, and confirm Recents shows that icon.
7. Click each recent item and confirm it opens the right document.
