### PR TITLE
Add field icons to collection tables and row details

### DIFF
--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -30,13 +30,16 @@
 // `.cortext-data-view > .dataviews-wrapper` declares `overflow: auto`
 // itself, so horizontal scroll kicks in once columns exceed the wrapper.
 .dataviews-view-table {
+	--cortext-table-column-default-width: 200px;
+	--cortext-table-field-header-icon-chrome: calc(var(--cortext-field-type-icon-size, 16px) + #{$grid-unit-05});
+
 	table-layout: fixed;
 	width: max-content;
 }
 
 .dataviews-view-table th,
 .dataviews-view-table td {
-	width: 200px;
+	width: var(--cortext-table-column-default-width);
 }
 
 // Keep the actions column only as wide as its kebab/`+` icon. Otherwise it
@@ -69,6 +72,14 @@
 .dataviews-view-table th:first-child:not(.dataviews-view-table__checkbox-column),
 .dataviews-view-table td:first-child:not(.dataviews-view-table__checkbox-column) {
 	width: 280px;
+}
+
+// Field headers include the type icon before the label. Add that chrome to
+// the default field width so the text column does not feel squeezed.
+.cortext-data-view
+.dataviews-view-table
+:where(th:has(.cortext-column-header-marker):not(:first-child):not(.dataviews-view-table__checkbox-column + th)) {
+	width: calc(var(--cortext-table-column-default-width) + var(--cortext-table-field-header-icon-chrome));
 }
 
 // WordPress admin can load DataViews 6.0.0 alongside our bundled version. The

--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -78,7 +78,10 @@
 // the default field width so the text column does not feel squeezed.
 .cortext-data-view
 .dataviews-view-table
-:where(th:has(.cortext-column-header-marker):not(:first-child):not(.dataviews-view-table__checkbox-column + th)) {
+:where(
+	th:has(.cortext-column-header-marker):not(:first-child):not(.dataviews-view-table__checkbox-column + th),
+	th:has(.cortext-column-header-system-icon):not(:first-child):not(.dataviews-view-table__checkbox-column + th)
+) {
 	width: calc(var(--cortext-table-column-default-width) + var(--cortext-table-field-header-icon-chrome));
 }
 

--- a/src/components/DataViewColumnInteractions.js
+++ b/src/components/DataViewColumnInteractions.js
@@ -220,12 +220,16 @@ function measureCellNaturalWidth( cell ) {
 	return Math.max( 0, bbox.width - chrome );
 }
 
-function getAutoFitColumnWidth( headerEl, fieldType ) {
+function getAutoFitColumnWidth( headerEl, fieldType, fieldId ) {
 	const cells = [ headerEl, ...getColumnBodyCells( headerEl ) ];
 	const naturalWidth = Math.max(
 		...cells.map( ( cell ) => measureCellNaturalWidth( cell ) )
 	);
-	return clampWidth( naturalWidth + AUTOFIT_PADDING_BUFFER, fieldType );
+	return clampWidth(
+		naturalWidth + AUTOFIT_PADDING_BUFFER,
+		fieldType,
+		fieldId
+	);
 }
 
 function applyColumnWidth( headerEl, width ) {
@@ -480,7 +484,7 @@ function ColumnResizer( { fieldId, fieldType, headerEl, view, onChangeView } ) {
 	}, [] );
 
 	const autoFitColumn = useCallback( () => {
-		const nextWidth = getAutoFitColumnWidth( headerEl, fieldType );
+		const nextWidth = getAutoFitColumnWidth( headerEl, fieldType, fieldId );
 		applyColumnWidth( headerEl, nextWidth );
 		onChangeView( withColumnWidth( view, fieldId, nextWidth, fieldType ) );
 	}, [ fieldId, fieldType, headerEl, onChangeView, view ] );
@@ -510,7 +514,7 @@ function ColumnResizer( { fieldId, fieldType, headerEl, view, onChangeView } ) {
 			const startX = event.clientX;
 			const startWidth = getColumnStyleWidth( headerEl );
 			const handle = event.currentTarget;
-			const minWidth = getMinWidth( fieldType );
+			const minWidth = getMinWidth( fieldType, fieldId );
 			// Pointer capture re-targets pointermove/pointerup for this
 			// pointerId to the handle, even if the pointer leaves the iframe
 			// or the viewport. Without it, dragging past the editor canvas

--- a/src/components/RowDetailView.scss
+++ b/src/components/RowDetailView.scss
@@ -513,6 +513,9 @@
 	}
 
 	&__property-label {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
 		overflow: hidden;
 		padding-top: 8px;
 		color: var(--cortext-row-detail-muted);
@@ -520,6 +523,17 @@
 		font-size: 12px;
 		font-weight: 400;
 		line-height: 1.3;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__property-type-icon {
+		--cortext-field-type-icon-size: 14px;
+	}
+
+	&__property-label-text {
+		min-width: 0;
+		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -35,6 +35,7 @@ import {
 } from './EditableCell';
 import { TITLE_FIELD_ID } from './dataViewColumns';
 import EditOptionsPopover from './fields/EditOptionsPopover';
+import { FieldTypeIcon } from './fields/fieldTypes';
 import { toRecordId } from '../hooks/fieldIds';
 import {
 	isRowDetailFieldEditable,
@@ -65,6 +66,13 @@ function ReadOnlyProperty( { value, type, elements, format } ) {
 function OptionPropertyValue( { value, type, elements } ) {
 	const display = formatDisplay( value, type, { elements } );
 	return display === '' ? emptyLabel() : display;
+}
+
+function isCollectionField( field ) {
+	return (
+		field?.id?.startsWith?.( 'field-' ) &&
+		Boolean( field.cortextRecordId ?? field.recordId )
+	);
 }
 
 function SelectPropertyControl( {
@@ -515,7 +523,15 @@ export default function RowProperties( { fields, row } ) {
 						}
 					>
 						<div className="cortext-row-detail__property-label">
-							{ field.label }
+							{ isCollectionField( field ) ? (
+								<FieldTypeIcon
+									type={ type }
+									className="cortext-row-detail__property-type-icon"
+								/>
+							) : null }
+							<span className="cortext-row-detail__property-label-text">
+								{ field.label }
+							</span>
 						</div>
 						<div className="cortext-row-detail__property-value">
 							{ isEditable ? (

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -35,7 +35,8 @@ import {
 } from './EditableCell';
 import { TITLE_FIELD_ID } from './dataViewColumns';
 import EditOptionsPopover from './fields/EditOptionsPopover';
-import { FieldTypeIcon } from './fields/fieldTypes';
+import { FieldTypeIcon, SystemFieldIcon } from './fields/fieldTypes';
+import { hasSystemFieldIcon } from './fields/systemFieldIconIds';
 import { toRecordId } from '../hooks/fieldIds';
 import {
 	isRowDetailFieldEditable,
@@ -73,6 +74,10 @@ function isCollectionField( field ) {
 		field?.id?.startsWith?.( 'field-' ) &&
 		Boolean( field.cortextRecordId ?? field.recordId )
 	);
+}
+
+function hasInternalFieldIcon( field ) {
+	return hasSystemFieldIcon( field?.id );
 }
 
 function SelectPropertyControl( {
@@ -511,6 +516,22 @@ export default function RowProperties( { fields, row } ) {
 					field.cortextElements ??
 					field.elements ??
 					[];
+				let propertyIcon = null;
+				if ( isCollectionField( field ) ) {
+					propertyIcon = (
+						<FieldTypeIcon
+							type={ type }
+							className="cortext-row-detail__property-type-icon"
+						/>
+					);
+				} else if ( hasInternalFieldIcon( field ) ) {
+					propertyIcon = (
+						<SystemFieldIcon
+							fieldId={ field.id }
+							className="cortext-row-detail__property-type-icon"
+						/>
+					);
+				}
 
 				return (
 					<div
@@ -523,12 +544,7 @@ export default function RowProperties( { fields, row } ) {
 						}
 					>
 						<div className="cortext-row-detail__property-label">
-							{ isCollectionField( field ) ? (
-								<FieldTypeIcon
-									type={ type }
-									className="cortext-row-detail__property-type-icon"
-								/>
-							) : null }
+							{ propertyIcon }
 							<span className="cortext-row-detail__property-label-text">
 								{ field.label }
 							</span>

--- a/src/components/dataViewColumns.js
+++ b/src/components/dataViewColumns.js
@@ -7,6 +7,7 @@
  */
 
 import { sanitizeCalculations } from './tableCalculations';
+import { hasSystemFieldIcon } from './fields/systemFieldIconIds';
 
 export const TITLE_FIELD_ID = 'title';
 export const GHOST_FIELD_ID = '__add_field';
@@ -35,13 +36,16 @@ export function isDefaultVisibleField( field ) {
 	return Boolean( field?.editable || field?.recordId );
 }
 
-export function hasFieldTypeHeaderIcon( fieldId ) {
-	return typeof fieldId === 'string' && fieldId.startsWith( 'field-' );
+export function hasFieldHeaderIcon( fieldId ) {
+	return (
+		( typeof fieldId === 'string' && fieldId.startsWith( 'field-' ) ) ||
+		hasSystemFieldIcon( fieldId )
+	);
 }
 
 export function getMinWidth( fieldType, fieldId ) {
 	const baseMinWidth = MIN_WIDTHS[ fieldType ] ?? DEFAULT_MIN_WIDTH;
-	return hasFieldTypeHeaderIcon( fieldId )
+	return hasFieldHeaderIcon( fieldId )
 		? baseMinWidth + FIELD_HEADER_ICON_CHROME
 		: baseMinWidth;
 }

--- a/src/components/dataViewColumns.js
+++ b/src/components/dataViewColumns.js
@@ -23,6 +23,10 @@ export const MIN_WIDTHS = {
 	datetime: 64,
 };
 export const DEFAULT_MIN_WIDTH = 32;
+export const FIELD_HEADER_ICON_WIDTH = 16;
+export const FIELD_HEADER_ICON_GAP = 4;
+export const FIELD_HEADER_ICON_CHROME =
+	FIELD_HEADER_ICON_WIDTH + FIELD_HEADER_ICON_GAP;
 
 // Default view seeding should show user-created collection fields even
 // when a field is read-only, as with rollups. System fields stay hidden
@@ -31,14 +35,21 @@ export function isDefaultVisibleField( field ) {
 	return Boolean( field?.editable || field?.recordId );
 }
 
-export function getMinWidth( fieldType ) {
-	return MIN_WIDTHS[ fieldType ] ?? DEFAULT_MIN_WIDTH;
+export function hasFieldTypeHeaderIcon( fieldId ) {
+	return typeof fieldId === 'string' && fieldId.startsWith( 'field-' );
+}
+
+export function getMinWidth( fieldType, fieldId ) {
+	const baseMinWidth = MIN_WIDTHS[ fieldType ] ?? DEFAULT_MIN_WIDTH;
+	return hasFieldTypeHeaderIcon( fieldId )
+		? baseMinWidth + FIELD_HEADER_ICON_CHROME
+		: baseMinWidth;
 }
 
 // Clamp a width into the per-type [min, max] range used at write time
 // (resize drag). Falls back to the per-type min for non-finite input.
-export function clampWidth( width, fieldType ) {
-	const min = getMinWidth( fieldType );
+export function clampWidth( width, fieldType, fieldId ) {
+	const min = getMinWidth( fieldType, fieldId );
 	const value = Number( width );
 	if ( ! Number.isFinite( value ) ) {
 		return min;
@@ -261,14 +272,14 @@ export function withNewlyVisibleFields(
 // the library reads. We pin `maxWidth` to the user's chosen width too, so the
 // saved shape remains defensive if DataViews changes its table sizing again.
 export function withColumnWidth( view, fieldId, width, fieldType ) {
-	const clamped = clampWidth( width, fieldType );
+	const clamped = clampWidth( width, fieldType, fieldId );
 	const layout = view?.layout ?? {};
 	const styles = layout.styles ?? {};
 	const previous = styles[ fieldId ] ?? {};
 	const nextEntry = {
 		...previous,
 		width: clamped,
-		minWidth: getMinWidth( fieldType ),
+		minWidth: getMinWidth( fieldType, fieldId ),
 		maxWidth: clamped,
 	};
 	return {

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -1,7 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
-	Icon,
 	Notice,
 	SelectControl,
 	TextControl,
@@ -9,17 +8,6 @@ import {
 } from '@wordpress/components';
 import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 import { useEffect, useMemo, useState } from '@wordpress/element';
-import {
-	atSymbol,
-	backup,
-	calendar,
-	check,
-	formatListBullets,
-	globe,
-	link,
-	tag,
-	typography,
-} from '@wordpress/icons';
 
 import './AddFieldPopover.scss';
 
@@ -27,73 +15,7 @@ import { COLLECTION_QUERY } from '../../collections';
 import { buildFieldListQuery } from '../../hooks/useCollectionFields';
 import { useCollectionFieldsContext } from '../CollectionFieldsContext';
 import { useCreateField } from '../../hooks/useFieldMutations';
-
-// Inline SVG for the "number" type. `@wordpress/icons` doesn't ship a
-// numeric glyph that reads as "single number" (formatListNumbered looks
-// like an ordered list), so we draw a `#` at the same stroke weight.
-const numberIcon = (
-	<svg
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 24 24"
-		width="24"
-		height="24"
-	>
-		<path
-			d="M9.5 5l-1 5H5v1.5h3.2l-.7 3.5H4v1.5h3.2L6.5 19h1.5l.7-3.5h3.5L11.5 19h1.5l.7-3.5h3v-1.5h-2.7l.7-3.5H17V9h-3.2l.7-4h-1.5l-.7 4h-3.5l.7-4h-1.5z"
-			fill="currentColor"
-		/>
-	</svg>
-);
-
-// Inline SVG for "date and time": a calendar with a clock face. Mirrors
-// Keep Date and Date & time as separate field choices.
-const datetimeIcon = (
-	<svg
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 24 24"
-		width="24"
-		height="24"
-	>
-		<path
-			d="M19 4h-2V3a1 1 0 1 0-2 0v1H9V3a1 1 0 1 0-2 0v1H5a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h7.1a5.5 5.5 0 1 1 8.4-7H21V6a2 2 0 0 0-2-2zm0 6H5V6h2v1a1 1 0 1 0 2 0V6h6v1a1 1 0 1 0 2 0V6h2v4zm-2 4v3h-3v1.5h4.5V14H17z"
-			fill="currentColor"
-		/>
-		<circle
-			cx="17"
-			cy="17"
-			r="4.5"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-		/>
-	</svg>
-);
-
-export const FIELD_TYPES = [
-	{ value: 'text', label: __( 'Text', 'cortext' ), icon: typography },
-	{ value: 'number', label: __( 'Number', 'cortext' ), icon: numberIcon },
-	{
-		value: 'select',
-		label: __( 'Select', 'cortext' ),
-		icon: formatListBullets,
-	},
-	{
-		value: 'multiselect',
-		label: __( 'Multi-select', 'cortext' ),
-		icon: tag,
-	},
-	{ value: 'date', label: __( 'Date', 'cortext' ), icon: calendar },
-	{
-		value: 'datetime',
-		label: __( 'Date & time', 'cortext' ),
-		icon: datetimeIcon,
-	},
-	{ value: 'checkbox', label: __( 'Checkbox', 'cortext' ), icon: check },
-	{ value: 'relation', label: __( 'Relation', 'cortext' ), icon: link },
-	{ value: 'rollup', label: __( 'Rollup', 'cortext' ), icon: backup },
-	{ value: 'url', label: __( 'URL', 'cortext' ), icon: globe },
-	{ value: 'email', label: __( 'Email', 'cortext' ), icon: atSymbol },
-];
+import { FIELD_TYPES, FieldTypeIcon, fieldTypeLabel } from './fieldTypes';
 
 const RELATION_LIMIT_OPTIONS = [
 	{ value: 'many', label: __( 'No limit', 'cortext' ) },
@@ -129,10 +51,6 @@ const ROLLUP_DATE_AGGREGATORS = [
 
 function titleOf( record ) {
 	return record?.title?.raw || record?.title?.rendered || `#${ record?.id }`;
-}
-
-function fieldTypeLabel( type ) {
-	return FIELD_TYPES.find( ( fieldType ) => fieldType.value === type )?.label;
 }
 
 function rollupAggregatorLabel( aggregator ) {
@@ -647,8 +565,8 @@ export default function AddFieldPopover( { collectionId, onCreate } ) {
 								onClick={ () => submit( option.value ) }
 								disabled={ isBusy }
 							>
-								<Icon
-									icon={ option.icon }
+								<FieldTypeIcon
+									type={ option.value }
 									className="cortext-add-field-popover__type-icon"
 								/>
 								<span>{ option.label }</span>

--- a/src/components/fields/ChangeFieldTypePopover.js
+++ b/src/components/fields/ChangeFieldTypePopover.js
@@ -1,10 +1,10 @@
 import { __ } from '@wordpress/i18n';
-import { Icon, Notice, Popover } from '@wordpress/components';
+import { Notice, Popover } from '@wordpress/components';
 import { useMemo, useState } from '@wordpress/element';
 
 import './ChangeFieldTypePopover.scss';
 
-import { FIELD_TYPES } from './AddFieldPopover';
+import { FIELD_TYPES, FieldTypeIcon } from './fieldTypes';
 import { useChangeFieldType } from '../../hooks/useFieldMutations';
 
 // These types depend on other fields or collections, so we do not offer them
@@ -69,8 +69,8 @@ export default function ChangeFieldTypePopover( {
 							disabled={ commit.isBusy }
 							aria-busy={ pending === option.value }
 						>
-							<Icon
-								icon={ option.icon }
+							<FieldTypeIcon
+								type={ option.value }
 								className="cortext-change-field-type-popover__type-icon"
 							/>
 							<span>{ option.label }</span>

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -35,6 +35,7 @@ import AddFieldPopover from './AddFieldPopover';
 import ChangeFieldTypePopover from './ChangeFieldTypePopover';
 import EditOptionsPopover from './EditOptionsPopover';
 import FieldFormatPopover from './FieldFormatPopover';
+import { FieldTypeIcon } from './fieldTypes';
 import RenameFieldInline from './RenameFieldInline';
 import {
 	useCollectionFieldsContext,
@@ -514,14 +515,23 @@ function FieldActions( {
 						/>
 					}
 				>
-					<span className="cortext-column-header-label">
-						{ label }
-					</span>
-					{ isSorted ? (
-						<span aria-hidden="true">
-							{ sortDirection === 'asc' ? ' ↑' : ' ↓' }
+					<span className="cortext-column-header-content">
+						<FieldTypeIcon
+							type={ fieldType }
+							className="cortext-column-header-type-icon"
+						/>
+						<span className="cortext-column-header-label">
+							{ label }
 						</span>
-					) : null }
+						{ isSorted ? (
+							<span
+								className="cortext-column-header-sort-indicator"
+								aria-hidden="true"
+							>
+								{ sortDirection === 'asc' ? '↑' : '↓' }
+							</span>
+						) : null }
+					</span>
 				</Menu.TriggerButton>
 				<Menu.Popover
 					className="cortext-field-actions-popover"

--- a/src/components/fields/ColumnHeaderActions.scss
+++ b/src/components/fields/ColumnHeaderActions.scss
@@ -23,3 +23,27 @@
 	display: inline-flex;
 	align-items: center;
 }
+
+.cortext-data-view .dataviews-view-table thead > tr > th {
+
+	.dataviews-view-table-header-button {
+
+		.cortext-column-header-content {
+			display: flex;
+			align-items: center;
+			gap: $grid-unit-05;
+			min-width: 0;
+			max-width: 100%;
+		}
+
+		.cortext-column-header-type-icon {
+			color: $gray-700;
+			transform: translateY(1px);
+		}
+
+		.cortext-column-header-sort-indicator {
+			flex: 0 0 auto;
+			color: $gray-700;
+		}
+	}
+}

--- a/src/components/fields/fieldTypes.js
+++ b/src/components/fields/fieldTypes.js
@@ -8,11 +8,15 @@ import {
 	formatListBullets,
 	globe,
 	link,
+	pencil,
+	postAuthor,
 	tag,
 	typography,
 } from '@wordpress/icons';
 
 import './fieldTypes.scss';
+
+import { hasSystemFieldIcon } from './systemFieldIconIds';
 
 // Inline SVG for the "number" type. `@wordpress/icons` doesn't ship a
 // numeric glyph that reads as "single number" (formatListNumbered looks
@@ -102,6 +106,33 @@ export function FieldTypeIcon( { type, className = '' } ) {
 			aria-hidden="true"
 		>
 			<Icon icon={ definition.icon } />
+		</span>
+	);
+}
+
+const SYSTEM_FIELD_ICONS = {
+	created_at: calendar,
+	created_by: postAuthor,
+	modified_at: pencil,
+	modified_by: postAuthor,
+};
+
+export function SystemFieldIcon( { fieldId, className = '' } ) {
+	if ( ! hasSystemFieldIcon( fieldId ) ) {
+		return null;
+	}
+	const icon = SYSTEM_FIELD_ICONS[ fieldId ];
+	if ( ! icon ) {
+		return null;
+	}
+
+	return (
+		<span
+			className={ `cortext-field-type-icon ${ className }`.trim() }
+			data-cortext-system-field={ fieldId }
+			aria-hidden="true"
+		>
+			<Icon icon={ icon } />
 		</span>
 	);
 }

--- a/src/components/fields/fieldTypes.js
+++ b/src/components/fields/fieldTypes.js
@@ -12,6 +12,8 @@ import {
 	typography,
 } from '@wordpress/icons';
 
+import './fieldTypes.scss';
+
 // Inline SVG for the "number" type. `@wordpress/icons` doesn't ship a
 // numeric glyph that reads as "single number" (formatListNumbered looks
 // like an ordered list), so we draw a `#` at the same stroke weight.

--- a/src/components/fields/fieldTypes.js
+++ b/src/components/fields/fieldTypes.js
@@ -1,0 +1,105 @@
+import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import {
+	atSymbol,
+	backup,
+	calendar,
+	check,
+	formatListBullets,
+	globe,
+	link,
+	tag,
+	typography,
+} from '@wordpress/icons';
+
+// Inline SVG for the "number" type. `@wordpress/icons` doesn't ship a
+// numeric glyph that reads as "single number" (formatListNumbered looks
+// like an ordered list), so we draw a `#` at the same stroke weight.
+const numberIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+	>
+		<path
+			d="M9.5 5l-1 5H5v1.5h3.2l-.7 3.5H4v1.5h3.2L6.5 19h1.5l.7-3.5h3.5L11.5 19h1.5l.7-3.5h3v-1.5h-2.7l.7-3.5H17V9h-3.2l.7-4h-1.5l-.7 4h-3.5l.7-4h-1.5z"
+			fill="currentColor"
+		/>
+	</svg>
+);
+
+// Inline SVG for "date and time": a calendar with a clock face. Mirrors
+// Keep Date and Date & time as separate field choices.
+const datetimeIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+	>
+		<path
+			d="M19 4h-2V3a1 1 0 1 0-2 0v1H9V3a1 1 0 1 0-2 0v1H5a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h7.1a5.5 5.5 0 1 1 8.4-7H21V6a2 2 0 0 0-2-2zm0 6H5V6h2v1a1 1 0 1 0 2 0V6h6v1a1 1 0 1 0 2 0V6h2v4zm-2 4v3h-3v1.5h4.5V14H17z"
+			fill="currentColor"
+		/>
+		<circle
+			cx="17"
+			cy="17"
+			r="4.5"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+	</svg>
+);
+
+export const FIELD_TYPES = [
+	{ value: 'text', label: __( 'Text', 'cortext' ), icon: typography },
+	{ value: 'number', label: __( 'Number', 'cortext' ), icon: numberIcon },
+	{
+		value: 'select',
+		label: __( 'Select', 'cortext' ),
+		icon: formatListBullets,
+	},
+	{
+		value: 'multiselect',
+		label: __( 'Multi-select', 'cortext' ),
+		icon: tag,
+	},
+	{ value: 'date', label: __( 'Date', 'cortext' ), icon: calendar },
+	{
+		value: 'datetime',
+		label: __( 'Date & time', 'cortext' ),
+		icon: datetimeIcon,
+	},
+	{ value: 'checkbox', label: __( 'Checkbox', 'cortext' ), icon: check },
+	{ value: 'relation', label: __( 'Relation', 'cortext' ), icon: link },
+	{ value: 'rollup', label: __( 'Rollup', 'cortext' ), icon: backup },
+	{ value: 'url', label: __( 'URL', 'cortext' ), icon: globe },
+	{ value: 'email', label: __( 'Email', 'cortext' ), icon: atSymbol },
+];
+
+export function fieldTypeDefinition( type ) {
+	return FIELD_TYPES.find( ( fieldType ) => fieldType.value === type );
+}
+
+export function fieldTypeLabel( type ) {
+	return fieldTypeDefinition( type )?.label;
+}
+
+export function FieldTypeIcon( { type, className = '' } ) {
+	const definition = fieldTypeDefinition( type );
+	if ( ! definition?.icon ) {
+		return null;
+	}
+
+	return (
+		<span
+			className={ `cortext-field-type-icon ${ className }`.trim() }
+			data-cortext-field-type={ type }
+			aria-hidden="true"
+		>
+			<Icon icon={ definition.icon } />
+		</span>
+	);
+}

--- a/src/components/fields/fieldTypes.scss
+++ b/src/components/fields/fieldTypes.scss
@@ -1,0 +1,18 @@
+/* stylelint-disable no-descending-specificity */
+.cortext-field-type-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--cortext-field-type-icon-size, 16px);
+	height: var(--cortext-field-type-icon-size, 16px);
+	flex: 0 0 auto;
+	color: currentcolor;
+
+	svg {
+		display: block;
+		width: var(--cortext-field-type-icon-size, 16px);
+		height: var(--cortext-field-type-icon-size, 16px);
+		fill: currentcolor;
+	}
+}
+/* stylelint-enable no-descending-specificity */

--- a/src/components/fields/systemFieldIconIds.js
+++ b/src/components/fields/systemFieldIconIds.js
@@ -1,0 +1,10 @@
+export const SYSTEM_FIELD_ICON_IDS = new Set( [
+	'created_at',
+	'created_by',
+	'modified_at',
+	'modified_by',
+] );
+
+export function hasSystemFieldIcon( fieldId ) {
+	return SYSTEM_FIELD_ICON_IDS.has( fieldId );
+}

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/components';
 
 import EditableCell from '../components/EditableCell';
+import { SystemFieldIcon } from '../components/fields/fieldTypes';
 import { elementsFromOptions } from './optionElements';
 
 // Re-export for existing call sites. The implementation lives in
@@ -147,6 +148,18 @@ function buildRender( id, type, label, elements, format, relation ) {
 
 function HeaderLabel( { children } ) {
 	return <span className="cortext-column-header-label">{ children }</span>;
+}
+
+function SystemHeaderLabel( { fieldId, children } ) {
+	return (
+		<span className="cortext-column-header-content">
+			<SystemFieldIcon
+				fieldId={ fieldId }
+				className="cortext-column-header-type-icon cortext-column-header-system-icon"
+			/>
+			<span className="cortext-column-header-label">{ children }</span>
+		</span>
+	);
 }
 
 function rollupTargetFormat( meta ) {
@@ -359,6 +372,11 @@ export function systemFields() {
 		{
 			id: 'created_at',
 			label: __( 'Created', 'cortext' ),
+			header: (
+				<SystemHeaderLabel fieldId="created_at">
+					{ __( 'Created', 'cortext' ) }
+				</SystemHeaderLabel>
+			),
 			type: 'datetime',
 			cortextType: 'datetime',
 			...SERVER_SORT_ONLY,
@@ -374,6 +392,11 @@ export function systemFields() {
 		{
 			id: 'created_by',
 			label: __( 'Created by', 'cortext' ),
+			header: (
+				<SystemHeaderLabel fieldId="created_by">
+					{ __( 'Created by', 'cortext' ) }
+				</SystemHeaderLabel>
+			),
 			type: 'text',
 			cortextType: 'text',
 			...NOT_SERVER_QUERYABLE,
@@ -389,6 +412,11 @@ export function systemFields() {
 		{
 			id: 'modified_at',
 			label: __( 'Last edited', 'cortext' ),
+			header: (
+				<SystemHeaderLabel fieldId="modified_at">
+					{ __( 'Last edited', 'cortext' ) }
+				</SystemHeaderLabel>
+			),
 			type: 'datetime',
 			cortextType: 'datetime',
 			...SERVER_SORT_ONLY,
@@ -404,6 +432,11 @@ export function systemFields() {
 		{
 			id: 'modified_by',
 			label: __( 'Last edited by', 'cortext' ),
+			header: (
+				<SystemHeaderLabel fieldId="modified_by">
+					{ __( 'Last edited by', 'cortext' ) }
+				</SystemHeaderLabel>
+			),
 			type: 'text',
 			cortextType: 'text',
 			...NOT_SERVER_QUERYABLE,

--- a/tests/js/components/RowProperties.test.js
+++ b/tests/js/components/RowProperties.test.js
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock( '@wordpress/components', () => {
+	const { createElement, forwardRef } = require( '@wordpress/element' );
+
+	const Button = forwardRef( ( { children, ...props }, ref ) =>
+		createElement( 'button', { ...props, ref, type: 'button' }, children )
+	);
+	Button.displayName = 'Button';
+
+	return {
+		__esModule: true,
+		Button,
+		CheckboxControl: () => createElement( 'input', { type: 'checkbox' } ),
+		DateTimePicker: () => createElement( 'div', null ),
+		Dropdown: () => createElement( 'div', null ),
+		Icon: () => createElement( 'span', { 'data-testid': 'wp-icon' } ),
+		Popover: ( { children } ) => createElement( 'div', null, children ),
+	};
+} );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	store: 'editor-store',
+} ) );
+
+jest.mock( '../../../src/components/EditableCell', () => {
+	const { createContext } = require( '@wordpress/element' );
+
+	return {
+		__esModule: true,
+		default: () => null,
+		RowMutationContext: createContext( {} ),
+		dateOnlyValue: ( value ) => value,
+		formatDisplay: ( value ) => ( value ? String( value ) : '' ),
+	};
+} );
+
+import { useDispatch, useSelect } from '@wordpress/data';
+import RowProperties from '../../../src/components/RowProperties';
+
+describe( 'RowProperties', () => {
+	beforeEach( () => {
+		useDispatch.mockReturnValue( { editPost: jest.fn() } );
+		useSelect.mockReturnValue( {
+			title: 'Current title',
+			meta: { 'field-7': 'Open' },
+			hydratedMeta: {},
+		} );
+	} );
+
+	it( 'shows field type icons for collection fields only', () => {
+		render(
+			<RowProperties
+				fields={ [
+					{
+						id: 'title',
+						label: 'Title',
+						cortextFieldType: 'title',
+						editable: true,
+					},
+					{
+						id: 'field-7',
+						label: 'Status',
+						cortextFieldType: 'text',
+						cortextRecordId: 7,
+						editable: true,
+					},
+					{
+						id: 'created_at',
+						label: 'Created',
+						cortextFieldType: 'datetime',
+						editable: false,
+						getValue: () => '2026-05-23T10:00:00',
+					},
+				] }
+				row={ {} }
+			/>
+		);
+
+		const statusLabel = screen
+			.getByText( 'Status' )
+			.closest( '.cortext-row-detail__property-label' );
+		expect(
+			statusLabel.querySelector(
+				'.cortext-row-detail__property-type-icon[data-cortext-field-type="text"]'
+			)
+		).toBeInTheDocument();
+
+		const createdLabel = screen
+			.getByText( 'Created' )
+			.closest( '.cortext-row-detail__property-label' );
+		expect(
+			createdLabel.querySelector( '.cortext-field-type-icon' )
+		).toBeNull();
+		expect( screen.queryByText( 'Title' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/tests/js/components/RowProperties.test.js
+++ b/tests/js/components/RowProperties.test.js
@@ -53,7 +53,7 @@ describe( 'RowProperties', () => {
 		} );
 	} );
 
-	it( 'shows field type icons for collection fields only', () => {
+	it( 'shows icons for collection and internal fields, but not title', () => {
 		render(
 			<RowProperties
 				fields={ [
@@ -95,8 +95,10 @@ describe( 'RowProperties', () => {
 			.getByText( 'Created' )
 			.closest( '.cortext-row-detail__property-label' );
 		expect(
-			createdLabel.querySelector( '.cortext-field-type-icon' )
-		).toBeNull();
+			createdLabel.querySelector(
+				'.cortext-row-detail__property-type-icon[data-cortext-system-field="created_at"]'
+			)
+		).toBeInTheDocument();
 		expect( screen.queryByText( 'Title' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/tests/js/components/dataViewColumns.test.js
+++ b/tests/js/components/dataViewColumns.test.js
@@ -1,10 +1,12 @@
 import {
 	DEFAULT_MIN_WIDTH,
+	FIELD_HEADER_ICON_CHROME,
 	MAX_COLUMN_WIDTH,
 	MIN_WIDTHS,
 	TITLE_FIELD_ID,
 	clampWidth,
 	getMinWidth,
+	hasFieldTypeHeaderIcon,
 	isDefaultVisibleField,
 	normalizeView,
 	pruneFiltersForFields,
@@ -31,6 +33,30 @@ describe( 'getMinWidth', () => {
 	it( 'uses a compact default floor', () => {
 		expect( DEFAULT_MIN_WIDTH ).toBe( 32 );
 	} );
+
+	it( 'adds icon chrome only for custom field headers', () => {
+		expect( getMinWidth( 'text', 'field-10' ) ).toBe(
+			DEFAULT_MIN_WIDTH + FIELD_HEADER_ICON_CHROME
+		);
+		expect( getMinWidth( 'date', 'field-10' ) ).toBe(
+			MIN_WIDTHS.date + FIELD_HEADER_ICON_CHROME
+		);
+		expect( getMinWidth( 'date', 'created_at' ) ).toBe(
+			MIN_WIDTHS.date
+		);
+		expect( getMinWidth( 'title', TITLE_FIELD_ID ) ).toBe(
+			MIN_WIDTHS.title
+		);
+	} );
+} );
+
+describe( 'hasFieldTypeHeaderIcon', () => {
+	it( 'matches only user-created collection field ids', () => {
+		expect( hasFieldTypeHeaderIcon( 'field-10' ) ).toBe( true );
+		expect( hasFieldTypeHeaderIcon( TITLE_FIELD_ID ) ).toBe( false );
+		expect( hasFieldTypeHeaderIcon( 'created_at' ) ).toBe( false );
+		expect( hasFieldTypeHeaderIcon( undefined ) ).toBe( false );
+	} );
 } );
 
 describe( 'clampWidth', () => {
@@ -54,6 +80,15 @@ describe( 'clampWidth', () => {
 
 	it( 'uses the default floor when no type is provided', () => {
 		expect( clampWidth( 10 ) ).toBe( DEFAULT_MIN_WIDTH );
+	} );
+
+	it( 'includes header icon chrome in the floor for custom fields', () => {
+		expect( clampWidth( 10, 'text', 'field-10' ) ).toBe(
+			DEFAULT_MIN_WIDTH + FIELD_HEADER_ICON_CHROME
+		);
+		expect( clampWidth( 10, 'datetime', 'created_at' ) ).toBe(
+			MIN_WIDTHS.datetime
+		);
 	} );
 } );
 
@@ -382,7 +417,7 @@ describe( 'withColumnWidth', () => {
 		const next = withColumnWidth( view, 'field-1', 220, 'text' );
 		expect( next.layout.styles[ 'field-1' ] ).toEqual( {
 			width: 220,
-			minWidth: DEFAULT_MIN_WIDTH,
+			minWidth: DEFAULT_MIN_WIDTH + FIELD_HEADER_ICON_CHROME,
 			maxWidth: 220,
 		} );
 	} );
@@ -390,12 +425,12 @@ describe( 'withColumnWidth', () => {
 	it( 'lets short-content columns commit a smaller width than the title', () => {
 		const view = { layout: { density: 'compact' } };
 		const text = withColumnWidth( view, 'field-t', 10, 'text' );
-		const title = withColumnWidth( view, 'field-title', 10, 'title' );
+		const title = withColumnWidth( view, TITLE_FIELD_ID, 10, 'title' );
 		expect( text.layout.styles[ 'field-t' ].width ).toBeLessThan(
-			title.layout.styles[ 'field-title' ].width
+			title.layout.styles[ TITLE_FIELD_ID ].width
 		);
 		expect( text.layout.styles[ 'field-t' ].width ).toBe(
-			DEFAULT_MIN_WIDTH
+			DEFAULT_MIN_WIDTH + FIELD_HEADER_ICON_CHROME
 		);
 	} );
 

--- a/tests/js/components/dataViewColumns.test.js
+++ b/tests/js/components/dataViewColumns.test.js
@@ -6,7 +6,7 @@ import {
 	TITLE_FIELD_ID,
 	clampWidth,
 	getMinWidth,
-	hasFieldTypeHeaderIcon,
+	hasFieldHeaderIcon,
 	isDefaultVisibleField,
 	normalizeView,
 	pruneFiltersForFields,
@@ -34,7 +34,7 @@ describe( 'getMinWidth', () => {
 		expect( DEFAULT_MIN_WIDTH ).toBe( 32 );
 	} );
 
-	it( 'adds icon chrome only for custom field headers', () => {
+	it( 'adds icon chrome for field headers with icons', () => {
 		expect( getMinWidth( 'text', 'field-10' ) ).toBe(
 			DEFAULT_MIN_WIDTH + FIELD_HEADER_ICON_CHROME
 		);
@@ -42,7 +42,7 @@ describe( 'getMinWidth', () => {
 			MIN_WIDTHS.date + FIELD_HEADER_ICON_CHROME
 		);
 		expect( getMinWidth( 'date', 'created_at' ) ).toBe(
-			MIN_WIDTHS.date
+			MIN_WIDTHS.date + FIELD_HEADER_ICON_CHROME
 		);
 		expect( getMinWidth( 'title', TITLE_FIELD_ID ) ).toBe(
 			MIN_WIDTHS.title
@@ -50,12 +50,13 @@ describe( 'getMinWidth', () => {
 	} );
 } );
 
-describe( 'hasFieldTypeHeaderIcon', () => {
-	it( 'matches only user-created collection field ids', () => {
-		expect( hasFieldTypeHeaderIcon( 'field-10' ) ).toBe( true );
-		expect( hasFieldTypeHeaderIcon( TITLE_FIELD_ID ) ).toBe( false );
-		expect( hasFieldTypeHeaderIcon( 'created_at' ) ).toBe( false );
-		expect( hasFieldTypeHeaderIcon( undefined ) ).toBe( false );
+describe( 'hasFieldHeaderIcon', () => {
+	it( 'matches custom fields and icon-bearing system fields', () => {
+		expect( hasFieldHeaderIcon( 'field-10' ) ).toBe( true );
+		expect( hasFieldHeaderIcon( 'created_at' ) ).toBe( true );
+		expect( hasFieldHeaderIcon( 'modified_by' ) ).toBe( true );
+		expect( hasFieldHeaderIcon( TITLE_FIELD_ID ) ).toBe( false );
+		expect( hasFieldHeaderIcon( undefined ) ).toBe( false );
 	} );
 } );
 
@@ -82,12 +83,12 @@ describe( 'clampWidth', () => {
 		expect( clampWidth( 10 ) ).toBe( DEFAULT_MIN_WIDTH );
 	} );
 
-	it( 'includes header icon chrome in the floor for custom fields', () => {
+	it( 'includes header icon chrome in the floor for icon-bearing fields', () => {
 		expect( clampWidth( 10, 'text', 'field-10' ) ).toBe(
 			DEFAULT_MIN_WIDTH + FIELD_HEADER_ICON_CHROME
 		);
 		expect( clampWidth( 10, 'datetime', 'created_at' ) ).toBe(
-			MIN_WIDTHS.datetime
+			MIN_WIDTHS.datetime + FIELD_HEADER_ICON_CHROME
 		);
 	} );
 } );

--- a/tests/js/components/fields/AddFieldPopover.test.js
+++ b/tests/js/components/fields/AddFieldPopover.test.js
@@ -73,6 +73,17 @@ beforeEach( () => {
 } );
 
 describe( 'AddFieldPopover rollup config', () => {
+	it( 'shows type icons in the picker', () => {
+		render( <AddFieldPopover collectionId={ 5 } /> );
+
+		const numberButton = screen.getByRole( 'button', { name: 'Number' } );
+		expect(
+			numberButton.querySelector(
+				'.cortext-add-field-popover__type-icon[data-cortext-field-type="number"]'
+			)
+		).toBeInTheDocument();
+	} );
+
 	it( 'orders rollup controls as relation, target property, then calculate', async () => {
 		render( <AddFieldPopover collectionId={ 5 } /> );
 

--- a/tests/js/components/fields/ChangeFieldTypePopover.test.js
+++ b/tests/js/components/fields/ChangeFieldTypePopover.test.js
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock( '@wordpress/components', () => {
+	const { createElement } = require( '@wordpress/element' );
+
+	return {
+		__esModule: true,
+		Icon: () => createElement( 'span', { 'data-testid': 'wp-icon' } ),
+		Notice: ( { children } ) => createElement( 'div', null, children ),
+		Popover: ( { children } ) => createElement( 'div', null, children ),
+	};
+} );
+
+jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
+	useChangeFieldType: jest.fn(),
+} ) );
+
+import ChangeFieldTypePopover from '../../../../src/components/fields/ChangeFieldTypePopover';
+import { useChangeFieldType } from '../../../../src/hooks/useFieldMutations';
+
+describe( 'ChangeFieldTypePopover', () => {
+	it( 'shows type icons and commits the selected type', () => {
+		const run = jest.fn().mockResolvedValue( {} );
+		useChangeFieldType.mockReturnValue( {
+			run,
+			isBusy: false,
+			error: null,
+		} );
+
+		render(
+			<ChangeFieldTypePopover
+				anchor={ document.body }
+				collectionId={ 5 }
+				recordId={ 77 }
+				currentType="text"
+			/>
+		);
+
+		const numberButton = screen.getByRole( 'button', { name: 'Number' } );
+		expect(
+			numberButton.querySelector(
+				'.cortext-change-field-type-popover__type-icon[data-cortext-field-type="number"]'
+			)
+		).toBeInTheDocument();
+
+		fireEvent.click( numberButton );
+
+		expect( run ).toHaveBeenCalledWith( 77, 'number' );
+	} );
+} );

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -241,6 +241,36 @@ describe( 'ColumnHeaderActions', () => {
 		).toHaveAttribute( 'aria-checked', 'false' );
 	} );
 
+	it( 'shows the field type icon in custom column headers', async () => {
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Amount',
+					cortextType: 'number',
+				},
+			],
+		} );
+
+		const { container } = render(
+			<Harness
+				collectionId={ 5 }
+				recordId={ 77 }
+				view={ { fields: [ 'field-77' ] } }
+			/>
+		);
+
+		expect(
+			await screen.findByRole( 'button', { name: 'Amount' } )
+		).toBeInTheDocument();
+		expect(
+			container.querySelector(
+				'.cortext-column-header-type-icon[data-cortext-field-type="number"]'
+			)
+		).toBeInTheDocument();
+	} );
+
 	it( 'passes the created field out of the add-field dropdown', async () => {
 		const onFieldCreated = jest.fn();
 		render(

--- a/tests/js/hooks/fieldMapping.test.js
+++ b/tests/js/hooks/fieldMapping.test.js
@@ -523,6 +523,16 @@ describe( 'systemFields', () => {
 		expect( byId( 'modified_by' ).type ).toBe( 'text' );
 	} );
 
+	it( 'renders system icons in their table headers', () => {
+		const { container } = render( byId( 'modified_at' ).header );
+		expect(
+			container.querySelector(
+				'.cortext-column-header-system-icon[data-cortext-system-field="modified_at"]'
+			)
+		).toBeInTheDocument();
+		expect( container.textContent ).toContain( 'Last edited' );
+	} );
+
 	it( 'reads each value from the row payload', () => {
 		const item = {
 			created_at: '2026-04-30T09:48:54+00:00',


### PR DESCRIPTION
## What

Add type icons next to field names in the editable collection table and row detail properties. Custom fields use the same icons as the add/change type popovers, and the internal fields get simple matching icons too: Created, Created by, Last edited, and Last edited by.

Title stays text-only.

## Why

Once a collection has a few fields, names alone are slower to scan. The icons make the table and row detail panel easier to read without changing the field labels or adding anything to the accessible name.

## How

- Share the field type icon list across the add field, change type, table header, and row detail surfaces.
- Keep the icons decorative.
- Give icon-bearing columns a little extra width so the label, sort arrow, and menu still fit.

## Testing Instructions

1. Open a collection table with custom fields and check that each field header shows the right type icon.
2. Sort a custom field and open its column menu.
3. Add a field and change an existing field type; both popovers should still show the same icons as before.
4. Open a row detail view and check the icons beside custom and internal fields.
5. Confirm Title still has no icon.

## Before / After
| Before | After |
| - | - |
| <img width="1739" height="1337" alt="image" src="https://github.com/user-attachments/assets/e7af06e8-6d3b-4d04-beaa-1ace3a9e47aa" /> | <img width="1742" height="1343" alt="image" src="https://github.com/user-attachments/assets/331d360e-5f73-4573-aac7-4758a84c40ac" /> |