### PR TITLE
Refactor: Document Unification; Use document helpers in the command palette

### DIFF
--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/data';
 import { useNavigate } from '@tanstack/react-router';
 import { __, sprintf } from '@wordpress/i18n';
-import { home as homeIcon, listItem, table } from '@wordpress/icons';
+import { home as homeIcon } from '@wordpress/icons';
 import {
 	useCallback,
 	useEffect,
@@ -25,11 +25,11 @@ import {
 import CortextCommandMenu, {
 	CommandDescriptionContext,
 } from './CortextCommandMenu';
-import PageIcon from './PageIcon';
 import useDebouncedValue from '../hooks/useDebouncedValue';
 import useDocuments from '../hooks/useDocuments';
 import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHomePath } from '../hooks/useWorkspaceHomePath';
+import { listIconForRecord } from '../documents';
 
 const OPEN_COMMAND_PALETTE_EVENT = 'cortext:open-command-palette';
 const DEFAULT_COMMAND_CONTEXT = 'root';
@@ -64,37 +64,29 @@ function focusCanvasAfterPaletteCloses( canvasRef ) {
 	}, 0 );
 }
 
-function documentCommandIcon( doc ) {
-	if ( doc?.kind === 'collection' ) {
-		return table;
-	}
-	if ( doc?.kind === 'row' ) {
-		return listItem;
-	}
-	return <PageIcon icon={ doc?.icon ?? '' } size={ 16 } />;
-}
-
 function documentTitle( doc ) {
 	const title = doc?.title?.trim?.() || __( '(untitled)', 'cortext' );
-	if ( doc?.kind === 'row' && doc?.collection?.title ) {
-		return sprintf(
-			/* translators: 1: row title, 2: collection title */
-			__( '%1$s in %2$s', 'cortext' ),
-			title,
-			doc.collection.title
-		);
+	const collectionTitle = doc?.collection?.title?.trim?.();
+	if ( ! collectionTitle ) {
+		return title;
 	}
-	return title;
+	return sprintf(
+		/* translators: 1: row title, 2: collection title */
+		__( '%1$s in %2$s', 'cortext' ),
+		title,
+		collectionTitle
+	);
 }
 
-function rowCollectionHint( doc ) {
-	if ( doc?.kind !== 'row' || ! doc?.collection?.title ) {
+function collectionHint( doc ) {
+	const collectionTitle = doc?.collection?.title?.trim?.();
+	if ( ! collectionTitle ) {
 		return '';
 	}
 	return sprintf(
 		/* translators: %s: parent collection title */
 		__( 'in %s', 'cortext' ),
-		doc.collection.title
+		collectionTitle
 	);
 }
 
@@ -157,7 +149,7 @@ function RecentCommandRegistration( { canvasRef, recent } ) {
 			documentTitle( recent )
 		),
 		context: DEFAULT_COMMAND_CONTEXT,
-		icon: documentCommandIcon( recent ),
+		icon: listIconForRecord( recent ),
 		keywords: [ __( 'recent', 'cortext' ), recent.kind ],
 		disabled: ! recent.path,
 		callback: goToRecent,
@@ -166,10 +158,9 @@ function RecentCommandRegistration( { canvasRef, recent } ) {
 }
 
 function documentDescription( doc ) {
-	if ( doc.kind === 'page' ) {
-		return doc.excerpt ?? '';
-	}
-	return rowCollectionHint( doc );
+	// Excerpt wins when present (today only pages carry one). Otherwise show
+	// the parent collection for records that have one (rows).
+	return doc?.excerpt?.trim?.() || collectionHint( doc );
 }
 
 function DocumentCommandRegistration( { canvasRef, document } ) {
@@ -192,7 +183,7 @@ function DocumentCommandRegistration( { canvasRef, document } ) {
 		name: `cortext/document/${ document.kind }-${ document.id }`,
 		label: document.title?.trim?.() || __( '(untitled)', 'cortext' ),
 		context: DEFAULT_COMMAND_CONTEXT,
-		icon: documentCommandIcon( document ),
+		icon: listIconForRecord( document ),
 		keywords: [ document.kind ],
 		disabled: ! document.path,
 		callback: goToDocument,

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -158,8 +158,7 @@ function RecentCommandRegistration( { canvasRef, recent } ) {
 }
 
 function documentDescription( doc ) {
-	// Excerpt wins when present (today only pages carry one). Otherwise show
-	// the parent collection for records that have one (rows).
+	// Pages can provide an excerpt. Rows use their parent collection as the hint.
 	return doc?.excerpt?.trim?.() || collectionHint( doc );
 }
 

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -158,8 +158,10 @@ function RecentCommandRegistration( { canvasRef, recent } ) {
 }
 
 function documentDescription( doc ) {
-	// Pages can provide an excerpt. Rows use their parent collection as the hint.
-	return doc?.excerpt?.trim?.() || collectionHint( doc );
+	// Rows ship their parent collection on `doc.collection` so identical row
+	// titles in the search results stay disambiguated. Pages and collections
+	// have no parent on the wire and fall back to the search excerpt.
+	return collectionHint( doc ) || doc?.excerpt?.trim?.() || '';
 }
 
 function DocumentCommandRegistration( { canvasRef, document } ) {

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -157,6 +157,8 @@ export default function Sidebar( {
 		onSelect,
 		goHome,
 	} = useSidebarNavigation( { pages, homePath } );
+	const { isSelected: isRowSelected, selectRecord: onRowSelect } =
+		useDocumentSelection( { selectedId, selectedCollectionId } );
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
 	const userName = window.cortextSettings?.userDisplayName ?? '';
 	const commandPaletteShortcut = displayShortcut.primary( 'k' );
@@ -211,12 +213,9 @@ export default function Sidebar( {
 	);
 	const selectFavorite = useCallback(
 		( favorite ) => {
-			if (
-				( ( favorite.kind === 'page' || favorite.kind === 'row' ) &&
-					favorite.id === selectedId ) ||
-				( favorite.kind === 'collection' &&
-					favorite.id === selectedCollectionId )
-			) {
+			// Use `isRowSelected` as the shared selected-state check. Post IDs
+			// are globally unique, so the same id cannot point at two documents.
+			if ( isRowSelected( favorite ) ) {
 				return false;
 			}
 			navigate( {
@@ -225,7 +224,7 @@ export default function Sidebar( {
 			} );
 			return true;
 		},
-		[ navigate, selectedCollectionId, selectedId ]
+		[ isRowSelected, navigate ]
 	);
 
 	const { topLevelCollections, tree, expandedIds, toggleExpand, expand } =
@@ -343,9 +342,6 @@ export default function Sidebar( {
 	);
 
 	// --- Per-row selection helpers --------------------------------------
-
-	const { isSelected: isRowSelected, selectRecord: onRowSelect } =
-		useDocumentSelection( { selectedId, selectedCollectionId } );
 
 	const onSetRowHome = useCallback(
 		async ( record ) => {

--- a/src/documents/index.js
+++ b/src/documents/index.js
@@ -13,6 +13,7 @@ export {
 	useFavoriteToggle,
 } from './hooks';
 export { documentTitle } from './title';
+export { listIconForRecord } from './icons';
 export { documentUri } from './uri';
 export {
 	favoriteKey,


### PR DESCRIPTION
## What

Part of #226.

The command palette now uses the shared document helpers for result icons and collection context instead of carrying its own page, collection, and row checks. Favorites also use the same selected-state check as document rows.

No user-facing change intended. Command palette results, icons, row labels, and favorite navigation should keep working as before.

## Testing Instructions

1. Open the command palette and search for a page, a collection, and a row; confirm each one opens the right document.
2. Search for a row and confirm the result still shows its parent collection context.
3. Click the favorite for the currently open page, collection, or row and confirm it stays put.
4. Click a different favorite and confirm it navigates there.