### PR TITLE
Fix: Stop field schema changes from reloading the table

### DIFF
--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -536,9 +536,9 @@ export default function CollectionDataViews( {
 	const { fields, collection, slug, isResolving, fieldsResolved } =
 		useCollectionFieldsContext();
 	const { touchRecent } = useRecents();
-	// Field IDs known on the previous sync. Drives the auto-show path
-	// for fields the user just created. `null` on first run signals
-	// "saved view, leave it alone."
+	// Field IDs from the last schema sync. We use this to auto-show fields
+	// the user just created. `null` on first run means the saved view should
+	// stay untouched.
 	const knownFieldIdsRef = useRef( null );
 
 	const availableFields = useMemo(

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -536,6 +536,10 @@ export default function CollectionDataViews( {
 	const { fields, collection, slug, isResolving, fieldsResolved } =
 		useCollectionFieldsContext();
 	const { touchRecent } = useRecents();
+	// Field IDs known on the previous sync. Drives the auto-show path
+	// for fields the user just created. `null` on first run signals
+	// "saved view, leave it alone."
+	const knownFieldIdsRef = useRef( null );
 
 	const availableFields = useMemo(
 		() => [ TITLE_FIELD, ...fields ],
@@ -552,8 +556,27 @@ export default function CollectionDataViews( {
 		const validIds = new Set( availableFields.map( ( f ) => f.id ) );
 		const currentFilters = view?.filters ?? [];
 		const nextFilters = pruneFiltersForFields( currentFilters, validIds );
-		if ( nextFilters !== currentFilters ) {
-			return { ...view, filters: nextFilters };
+		const currentFields = Array.isArray( view?.fields ) ? view.fields : [];
+		const previouslyKnown = knownFieldIdsRef.current;
+		const newlyVisibleFields =
+			previouslyKnown && currentFields.length > 0
+				? availableFields
+						.filter(
+							( field ) =>
+								isDefaultVisibleField( field ) &&
+								! previouslyKnown.has( field.id ) &&
+								! currentFields.includes( field.id )
+						)
+						.map( ( field ) => field.id )
+				: [];
+		if ( nextFilters !== currentFilters || newlyVisibleFields.length > 0 ) {
+			return {
+				...view,
+				filters: nextFilters,
+				...( newlyVisibleFields.length > 0
+					? { fields: [ ...currentFields, ...newlyVisibleFields ] }
+					: {} ),
+			};
 		}
 		return view;
 	}, [ view, availableFields, isResolving ] );
@@ -994,10 +1017,6 @@ export default function CollectionDataViews( {
 	viewRef.current = view;
 	const onChangeViewRef = useRef( onChangeView );
 	onChangeViewRef.current = onChangeView;
-	// Field IDs known on the previous sync. Drives the auto-show path
-	// for fields the user just created. `null` on first run signals
-	// "saved view, leave it alone."
-	const knownFieldIdsRef = useRef( null );
 	const previousVisibleFieldsRef = useRef( null );
 	const savedRowDetailMode = getRowDetailMode( view );
 	const postType = slug ? `crtxt_${ slug }` : null;

--- a/src/components/fields/ChangeFieldTypePopover.js
+++ b/src/components/fields/ChangeFieldTypePopover.js
@@ -24,6 +24,7 @@ export default function ChangeFieldTypePopover( {
 	recordId,
 	currentType,
 	onClose,
+	onTypeChanged,
 } ) {
 	const [ pending, setPending ] = useState( null );
 	const commit = useChangeFieldType( collectionId );
@@ -40,6 +41,7 @@ export default function ChangeFieldTypePopover( {
 		setPending( targetType );
 		try {
 			await commit.run( recordId, targetType );
+			onTypeChanged?.( targetType );
 			onClose?.();
 		} catch {
 			// Keep the popover open so the inline error stays visible.

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -786,6 +786,7 @@ function FieldActions( {
 					recordId={ recordId }
 					currentType={ fieldType }
 					onClose={ () => setIsChangingType( false ) }
+					onTypeChanged={ onRowsChanged }
 				/>
 			) : null }
 		</span>

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -174,6 +174,7 @@ export default function ColumnHeaderActions( {
 					<AddFieldTrigger
 						collectionId={ collectionId }
 						onFieldCreated={ onFieldCreated }
+						onRowsChanged={ onRowsChanged }
 					/>,
 					target.th,
 					`${ target.key }-${ collectionId }`
@@ -664,7 +665,11 @@ function FieldActions( {
 							prefix={ <Icon icon={ copy } /> }
 							onClick={ async () => {
 								try {
-									await duplicate.run( recordId );
+									const duplicated =
+										await duplicate.run( recordId );
+									if ( duplicated?.type === 'rollup' ) {
+										onRowsChanged?.();
+									}
 								} catch {
 									// surfaced via duplicate.error.
 								}
@@ -780,17 +785,14 @@ function FieldActions( {
 					collectionId={ collectionId }
 					recordId={ recordId }
 					currentType={ fieldType }
-					onClose={ () => {
-						setIsChangingType( false );
-						onRowsChanged?.();
-					} }
+					onClose={ () => setIsChangingType( false ) }
 				/>
 			) : null }
 		</span>
 	);
 }
 
-function AddFieldTrigger( { collectionId, onFieldCreated } ) {
+function AddFieldTrigger( { collectionId, onFieldCreated, onRowsChanged } ) {
 	return (
 		<span className="cortext-column-header-actions cortext-column-header-actions--add">
 			<Dropdown
@@ -811,6 +813,9 @@ function AddFieldTrigger( { collectionId, onFieldCreated } ) {
 							collectionId={ collectionId }
 							onCreate={ ( created ) => {
 								onFieldCreated?.( created );
+								if ( created?.type === 'rollup' ) {
+									onRowsChanged?.();
+								}
 								onClose();
 							} }
 						/>

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -122,16 +122,16 @@ export default function useCollectionFields( collectionId ) {
 		collection: collection ?? null,
 		slug: collection?.meta?.slug ?? null,
 		// True while either the collection or the field list is still on
-		// its first resolution for this collection. Once we've latched
-		// fields for the current collection (`hasStableFieldsForCollection`),
+		// its first resolution for this collection. Once we have a cached
+		// collection record and have latched fields for this collection,
 		// subsequent refetches (after a mutation that changes the field
 		// list) keep this false so the table doesn't unmount and remount.
 		// Collection 404s still work: `hasResolved` flips to true on failure too,
 		// so the invalid-collection notice can render.
 		isResolving:
 			Boolean( collectionId ) &&
-			( ! collectionHasResolved ||
-				( ! collection && collectionResolving ) ||
+			( ( ! collection &&
+				( collectionResolving || ! collectionHasResolved ) ) ||
 				( !! collection &&
 					fieldIds.length > 0 &&
 					! hasStableFieldsForCollection ) ),

--- a/src/hooks/useCollectionFields.js
+++ b/src/hooks/useCollectionFields.js
@@ -121,13 +121,11 @@ export default function useCollectionFields( collectionId ) {
 		fields,
 		collection: collection ?? null,
 		slug: collection?.meta?.slug ?? null,
-		// True while either the collection or the field list is still on
-		// its first resolution for this collection. Once we have a cached
-		// collection record and have latched fields for this collection,
-		// subsequent refetches (after a mutation that changes the field
-		// list) keep this false so the table doesn't unmount and remount.
-		// Collection 404s still work: `hasResolved` flips to true on failure too,
-		// so the invalid-collection notice can render.
+		// True only for the first load of this collection or its field list.
+		// After we have the collection and a latched field list, schema
+		// refetches stay quiet so the table doesn't unmount and remount.
+		// Collection 404s still work because `hasResolved` flips true on
+		// failure too.
 		isResolving:
 			Boolean( collectionId ) &&
 			( ( ! collection &&

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -338,6 +338,73 @@ function buildServerQueryArgs( collectionId, view, filters = [], fields = [] ) {
 	return args;
 }
 
+function customSchemaFieldIds( fields = [] ) {
+	return fields
+		.map( ( field ) => field?.id )
+		.filter( ( id ) => typeof id === 'string' && /^field-/.test( id ) );
+}
+
+function projectionValues( args = {} ) {
+	return Object.keys( args )
+		.filter( ( key ) => /^fields\[\d+\]$/.test( key ) )
+		.sort(
+			( a, b ) =>
+				Number( a.match( /\d+/ )?.[ 0 ] ?? 0 ) -
+				Number( b.match( /\d+/ )?.[ 0 ] ?? 0 )
+		)
+		.map( ( key ) => args[ key ] );
+}
+
+function argsWithoutProjection( args = {} ) {
+	return Object.fromEntries(
+		Object.entries( args ).filter(
+			( [ key ] ) => ! /^fields\[\d+\]$/.test( key )
+		)
+	);
+}
+
+function sameArgsExceptProjection( a, b ) {
+	return (
+		JSON.stringify( argsWithoutProjection( a ) ) ===
+		JSON.stringify( argsWithoutProjection( b ) )
+	);
+}
+
+function isNewFieldProjectionExpansion( previous, next ) {
+	if (
+		! previous ||
+		previous.collectionId !== next.collectionId ||
+		previous.mode !== next.mode ||
+		previous.refreshKey !== next.refreshKey ||
+		! sameArgsExceptProjection( previous.args, next.args )
+	) {
+		return false;
+	}
+
+	const previousProjection = projectionValues( previous.args );
+	const nextProjection = projectionValues( next.args );
+	if (
+		previousProjection.length === 0 ||
+		nextProjection.length <= previousProjection.length
+	) {
+		return false;
+	}
+
+	const previousProjected = new Set( previousProjection );
+	const nextProjected = new Set( nextProjection );
+	if ( previousProjection.some( ( id ) => ! nextProjected.has( id ) ) ) {
+		return false;
+	}
+
+	const previousFieldIds = new Set( previous.fieldIds );
+	const addedProjectionIds = nextProjection.filter(
+		( id ) => ! previousProjected.has( id )
+	);
+	return addedProjectionIds.every(
+		( id ) => /^field-/.test( id ) && ! previousFieldIds.has( id )
+	);
+}
+
 export function buildQueryPlan(
 	collectionId,
 	view,
@@ -370,23 +437,6 @@ export function buildQueryPlan(
 	};
 }
 
-function schemaSignature( fields = [] ) {
-	return fields
-		.map(
-			( field ) =>
-				`${ field.id }:${ field.recordId ?? '' }:${
-					field.cortextType ?? ''
-				}:${ field.sortable === true ? '1' : '0' }:${
-					field.filterable === true ? '1' : '0'
-				}:${
-					Array.isArray( field.operators )
-						? field.operators.join( ',' )
-						: '?'
-				}`
-		)
-		.join( '|' );
-}
-
 function totalPagesNumber( value ) {
 	const number = Number( value );
 	return Number.isFinite( number ) && number >= 1 ? Math.floor( number ) : 1;
@@ -414,14 +464,16 @@ export default function useCollectionRows(
 	} );
 	const [ refreshKey, setRefreshKey ] = useState( 0 );
 
+	const stateRef = useRef( state );
+	stateRef.current = state;
 	const requestIdRef = useRef( 0 );
+	const querySnapshotRef = useRef( null );
 	const queryPlan = collectionId
 		? buildQueryPlan( collectionId, view, fields, options )
 		: null;
 	const queryKey = collectionId
 		? JSON.stringify( {
 				args: queryPlan.args,
-				schema: schemaSignature( fields ),
 				mode: queryPlan.mode,
 		  } )
 		: null;
@@ -451,6 +503,7 @@ export default function useCollectionRows(
 
 	useEffect( () => {
 		if ( ! collectionId ) {
+			querySnapshotRef.current = null;
 			setState( {
 				data: [],
 				collection: null,
@@ -462,8 +515,34 @@ export default function useCollectionRows(
 			return undefined;
 		}
 
-		const requestId = ++requestIdRef.current;
 		const activeQueryPlan = queryPlan;
+		const nextSnapshot = {
+			collectionId,
+			mode: activeQueryPlan.mode,
+			args: activeQueryPlan.args,
+			fieldIds: customSchemaFieldIds( fields ),
+			refreshKey,
+		};
+		const canReuseRows =
+			stateRef.current.hasResolved &&
+			isNewFieldProjectionExpansion(
+				querySnapshotRef.current,
+				nextSnapshot
+			);
+		querySnapshotRef.current = nextSnapshot;
+
+		if ( canReuseRows ) {
+			requestIdRef.current += 1;
+			setState( ( prev ) => ( {
+				...prev,
+				isLoading: false,
+				hasResolved: true,
+				error: null,
+			} ) );
+			return undefined;
+		}
+
+		const requestId = ++requestIdRef.current;
 
 		setState( ( prev ) => ( {
 			...prev,

--- a/tests/js/components/fields/ChangeFieldTypePopover.test.js
+++ b/tests/js/components/fields/ChangeFieldTypePopover.test.js
@@ -1,4 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockRun = jest.fn();
 
 jest.mock( '@wordpress/components', () => {
 	const { createElement } = require( '@wordpress/element' );
@@ -6,27 +8,29 @@ jest.mock( '@wordpress/components', () => {
 	return {
 		__esModule: true,
 		Icon: () => createElement( 'span', { 'data-testid': 'wp-icon' } ),
-		Notice: ( { children } ) => createElement( 'div', null, children ),
+		Notice: ( { children } ) =>
+			createElement( 'div', { role: 'alert' }, children ),
 		Popover: ( { children } ) => createElement( 'div', null, children ),
 	};
 } );
 
 jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
-	useChangeFieldType: jest.fn(),
+	useChangeFieldType: () => ( {
+		run: mockRun,
+		isBusy: false,
+		error: null,
+	} ),
 } ) );
 
 import ChangeFieldTypePopover from '../../../../src/components/fields/ChangeFieldTypePopover';
-import { useChangeFieldType } from '../../../../src/hooks/useFieldMutations';
 
 describe( 'ChangeFieldTypePopover', () => {
-	it( 'shows type icons and commits the selected type', () => {
-		const run = jest.fn().mockResolvedValue( {} );
-		useChangeFieldType.mockReturnValue( {
-			run,
-			isBusy: false,
-			error: null,
-		} );
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockRun.mockResolvedValue( { id: 77, type: 'checkbox' } );
+	} );
 
+	it( 'shows type icons and commits the selected type', async () => {
 		render(
 			<ChangeFieldTypePopover
 				anchor={ document.body }
@@ -45,6 +49,54 @@ describe( 'ChangeFieldTypePopover', () => {
 
 		fireEvent.click( numberButton );
 
-		expect( run ).toHaveBeenCalledWith( 77, 'number' );
+		await waitFor( () =>
+			expect( mockRun ).toHaveBeenCalledWith( 77, 'number' )
+		);
+	} );
+
+	it( 'notifies after a successful type conversion', async () => {
+		const onClose = jest.fn();
+		const onTypeChanged = jest.fn();
+
+		render(
+			<ChangeFieldTypePopover
+				collectionId={ 5 }
+				recordId={ 77 }
+				currentType="text"
+				onClose={ onClose }
+				onTypeChanged={ onTypeChanged }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Checkbox' } )
+		);
+
+		await waitFor( () =>
+			expect( mockRun ).toHaveBeenCalledWith( 77, 'checkbox' )
+		);
+		expect( onTypeChanged ).toHaveBeenCalledWith( 'checkbox' );
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not notify when type conversion fails', async () => {
+		mockRun.mockRejectedValue( new Error( 'nope' ) );
+		const onTypeChanged = jest.fn();
+
+		render(
+			<ChangeFieldTypePopover
+				collectionId={ 5 }
+				recordId={ 77 }
+				currentType="text"
+				onTypeChanged={ onTypeChanged }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Checkbox' } )
+		);
+
+		await waitFor( () => expect( mockRun ).toHaveBeenCalled() );
+		expect( onTypeChanged ).not.toHaveBeenCalled();
 	} );
 } );

--- a/tests/js/components/fields/ChangeFieldTypePopover.test.js
+++ b/tests/js/components/fields/ChangeFieldTypePopover.test.js
@@ -68,9 +68,7 @@ describe( 'ChangeFieldTypePopover', () => {
 			/>
 		);
 
-		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Checkbox' } )
-		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Checkbox' } ) );
 
 		await waitFor( () =>
 			expect( mockRun ).toHaveBeenCalledWith( 77, 'checkbox' )
@@ -92,9 +90,7 @@ describe( 'ChangeFieldTypePopover', () => {
 			/>
 		);
 
-		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Checkbox' } )
-		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Checkbox' } ) );
 
 		await waitFor( () => expect( mockRun ).toHaveBeenCalled() );
 		expect( onTypeChanged ).not.toHaveBeenCalled();

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -1,5 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+const mockDeleteRun = jest.fn();
+const mockDuplicateRun = jest.fn();
+
 jest.mock( '@wordpress/components', () => {
 	const {
 		createElement,
@@ -104,8 +107,8 @@ jest.mock( '../../../../src/lock-unlock', () => {
 } );
 
 jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
-	useDeleteField: () => ( { run: jest.fn() } ),
-	useDuplicateField: () => ( { run: jest.fn() } ),
+	useDeleteField: () => ( { run: mockDeleteRun } ),
+	useDuplicateField: () => ( { run: mockDuplicateRun } ),
 } ) );
 
 jest.mock( '../../../../src/components/CollectionFieldsContext', () => {
@@ -131,6 +134,12 @@ jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
 			<button type="button" onClick={ () => onCreate?.( { id: 123 } ) }>
 				Create mock field
 			</button>
+			<button
+				type="button"
+				onClick={ () => onCreate?.( { id: 124, type: 'rollup' } ) }
+			>
+				Create mock rollup
+			</button>
 		</div>
 	),
 } ) );
@@ -145,6 +154,7 @@ function Harness( {
 	recordId,
 	view,
 	onFieldCreated = jest.fn(),
+	onRowsChanged = jest.fn(),
 } ) {
 	return (
 		<div className="cortext-data-view">
@@ -165,6 +175,7 @@ function Harness( {
 				view={ view ?? { fields: [] } }
 				onChangeView={ onChangeView }
 				onFieldCreated={ onFieldCreated }
+				onRowsChanged={ onRowsChanged }
 			/>
 		</div>
 	);
@@ -172,6 +183,8 @@ function Harness( {
 
 describe( 'ColumnHeaderActions', () => {
 	beforeEach( () => {
+		jest.clearAllMocks();
+		mockDuplicateRun.mockResolvedValue( { id: 88, type: 'text' } );
 		useCollectionFieldsContext.mockReturnValue( { fields: [] } );
 		useEntityRecord.mockReturnValue( {
 			record: {
@@ -290,6 +303,54 @@ describe( 'ColumnHeaderActions', () => {
 		await waitFor( () =>
 			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument()
 		);
+	} );
+
+	it( 'refreshes rows when a created field is a rollup', async () => {
+		const onRowsChanged = jest.fn();
+		render(
+			<Harness collectionId={ 5 } onRowsChanged={ onRowsChanged } />
+		);
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Add field' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'button', {
+				name: 'Create mock rollup',
+			} )
+		);
+
+		expect( onRowsChanged ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'refreshes rows when duplicating a rollup field', async () => {
+		mockDuplicateRun.mockResolvedValue( { id: 88, type: 'rollup' } );
+		const onRowsChanged = jest.fn();
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Invoice total',
+					cortextType: 'rollup',
+				},
+			],
+		} );
+
+		render(
+			<Harness
+				collectionId={ 5 }
+				recordId={ 77 }
+				onRowsChanged={ onRowsChanged }
+			/>
+		);
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Duplicate' } )
+		);
+
+		await waitFor( () => expect( onRowsChanged ).toHaveBeenCalled() );
+		expect( mockDuplicateRun ).toHaveBeenCalledWith( 77 );
 	} );
 
 	it( 'warns when deleting a field will also delete dependent rollups', async () => {

--- a/tests/js/hooks/useCollectionFields.test.js
+++ b/tests/js/hooks/useCollectionFields.test.js
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react';
+
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityRecord: jest.fn(),
+	useEntityRecords: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/hooks/fieldMapping', () => ( {
+	mapField: ( field ) => ( {
+		id: `field-${ field.id }`,
+		recordId: field.id,
+		label: field.title?.raw ?? String( field.id ),
+		cortextType: field.meta?.type ?? 'text',
+		editable: true,
+	} ),
+	systemFields: () => [
+		{
+			id: 'created_at',
+			label: 'Created',
+			cortextType: 'datetime',
+			editable: false,
+		},
+	],
+} ) );
+
+import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import useCollectionFields from '../../../src/hooks/useCollectionFields';
+
+const collectionRecord = {
+	id: 5,
+	meta: { fields: [ 10 ], slug: 'projects' },
+};
+const fieldRecords = [
+	{
+		id: 10,
+		title: { raw: 'Status', rendered: 'Status' },
+		meta: { type: 'text' },
+	},
+];
+
+describe( 'useCollectionFields', () => {
+	let collectionState;
+	let fieldsState;
+
+	beforeEach( () => {
+		collectionState = {
+			record: collectionRecord,
+			isResolving: false,
+			hasResolved: true,
+		};
+		fieldsState = {
+			records: fieldRecords,
+			isResolving: false,
+			hasResolved: true,
+		};
+		useEntityRecord.mockImplementation( () => collectionState );
+		useEntityRecords.mockImplementation( () => fieldsState );
+	} );
+
+	it( 'keeps stable fields visible while the collection record refetches', () => {
+		const { result, rerender } = renderHook( () =>
+			useCollectionFields( 5 )
+		);
+
+		expect( result.current.isResolving ).toBe( false );
+		expect( result.current.fields.map( ( field ) => field.id ) ).toEqual( [
+			'field-10',
+			'created_at',
+		] );
+
+		collectionState = {
+			record: collectionRecord,
+			isResolving: true,
+			hasResolved: false,
+		};
+		rerender();
+
+		expect( result.current.isResolving ).toBe( false );
+		expect( result.current.fields.map( ( field ) => field.id ) ).toEqual( [
+			'field-10',
+			'created_at',
+		] );
+	} );
+
+	it( 'still reports resolving before the first collection record arrives', () => {
+		collectionState = {
+			record: null,
+			isResolving: true,
+			hasResolved: false,
+		};
+		fieldsState = {
+			records: [],
+			isResolving: false,
+			hasResolved: false,
+		};
+
+		const { result } = renderHook( () => useCollectionFields( 5 ) );
+
+		expect( result.current.isResolving ).toBe( true );
+	} );
+} );

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -1028,7 +1028,9 @@ describe( 'useCollectionRows', () => {
 			{ initialProps: { view: initialView, fields: baseFields } }
 		);
 
-		await waitFor( () => expect( result.current.hasResolved ).toBe( true ) );
+		await waitFor( () =>
+			expect( result.current.hasResolved ).toBe( true )
+		);
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 		expect( lastRequestPath() ).toContain( 'fields[0]=field-10' );
 		expect( lastRequestPath() ).toContain( 'fields[1]=title' );
@@ -1069,7 +1071,9 @@ describe( 'useCollectionRows', () => {
 			{ initialProps: { view: initialView, fields: baseFields } }
 		);
 
-		await waitFor( () => expect( result.current.hasResolved ).toBe( true ) );
+		await waitFor( () =>
+			expect( result.current.hasResolved ).toBe( true )
+		);
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 
 		rerender( { view: nextView, fields: nextFields } );

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -828,15 +828,15 @@ describe( 'useCollectionRows', () => {
 		expect( lastRequestPath() ).toContain( 'per_page=100' );
 	} );
 
-	it( 'refetches rows when the visible schema gains a rollup field', async () => {
+	it( 'does not refetch rows when the schema gains a scalar field', async () => {
 		const view = { type: 'table', filters: [], page: 1, perPage: 25 };
 		const initialFields = [
 			{ id: 'title', cortextType: 'title' },
-			{ id: 'field-10', recordId: 10, cortextType: 'relation' },
+			{ id: 'field-10', recordId: 10, cortextType: 'text' },
 		];
 		const nextFields = [
 			...initialFields,
-			{ id: 'field-20', recordId: 20, cortextType: 'rollup' },
+			{ id: 'field-20', recordId: 20, cortextType: 'number' },
 		];
 
 		const { rerender } = renderHook(
@@ -848,12 +848,52 @@ describe( 'useCollectionRows', () => {
 
 		rerender( { fields: nextFields } );
 
-		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
-		expect( apiFetch ).toHaveBeenLastCalledWith(
-			expect.objectContaining( {
-				path: expect.stringContaining( 'collection=7' ),
-			} )
+		await new Promise( ( r ) => setTimeout( r, 30 ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'refetches when schema capabilities change the query plan', async () => {
+		const view = {
+			type: 'table',
+			filters: [],
+			sort: { field: 'field-10', direction: 'asc' },
+			page: 1,
+			perPage: 25,
+		};
+		const unsupportedSortFields = [
+			{
+				id: 'field-10',
+				recordId: 10,
+				cortextType: 'relation',
+				sortable: false,
+				filterable: false,
+				operators: [],
+			},
+		];
+		const supportedSortFields = [
+			{
+				id: 'field-10',
+				recordId: 10,
+				cortextType: 'text',
+				sortable: true,
+				filterable: true,
+				operators: textOperators,
+			},
+		];
+
+		const { rerender, result } = renderHook(
+			( { fields } ) => useCollectionRows( 7, view, fields ),
+			{ initialProps: { fields: unsupportedSortFields } }
 		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current.queryMode ).toBe( 'client' );
+
+		rerender( { fields: supportedSortFields } );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		expect( result.current.queryMode ).toBe( 'server' );
+		expect( lastRequestPath() ).toContain( 'sort[field]=field-10' );
 	} );
 
 	it( 'refetches rows when a global row invalidation event fires', async () => {
@@ -958,6 +998,93 @@ describe( 'useCollectionRows', () => {
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
 		expect( lastRequestPath() ).toContain( 'fields[0]=field-10' );
 		expect( lastRequestPath() ).toContain( 'fields[1]=title' );
+	} );
+
+	it( 'reuses rows when adding a newly-created field to the projection', async () => {
+		const initialView = {
+			type: 'table',
+			fields: [ 'title', 'field-10' ],
+			page: 1,
+			perPage: 25,
+		};
+		const nextView = {
+			...initialView,
+			fields: [ 'title', 'field-10', 'field-70' ],
+		};
+		const nextFields = [
+			...baseFields,
+			{
+				id: 'field-70',
+				recordId: 70,
+				cortextType: 'text',
+				sortable: true,
+				filterable: true,
+				operators: textOperators,
+			},
+		];
+
+		const { result, rerender } = renderHook(
+			( { view, fields } ) => useCollectionRows( 7, view, fields ),
+			{ initialProps: { view: initialView, fields: baseFields } }
+		);
+
+		await waitFor( () => expect( result.current.hasResolved ).toBe( true ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( lastRequestPath() ).toContain( 'fields[0]=field-10' );
+		expect( lastRequestPath() ).toContain( 'fields[1]=title' );
+
+		rerender( { view: nextView, fields: nextFields } );
+
+		await new Promise( ( r ) => setTimeout( r, 30 ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.hasResolved ).toBe( true );
+	} );
+
+	it( 'includes a newly-created projected field on the next explicit refresh', async () => {
+		const initialView = {
+			type: 'table',
+			fields: [ 'title', 'field-10' ],
+			page: 1,
+			perPage: 25,
+		};
+		const nextView = {
+			...initialView,
+			fields: [ 'title', 'field-10', 'field-70' ],
+		};
+		const nextFields = [
+			...baseFields,
+			{
+				id: 'field-70',
+				recordId: 70,
+				cortextType: 'text',
+				sortable: true,
+				filterable: true,
+				operators: textOperators,
+			},
+		];
+
+		const { result, rerender } = renderHook(
+			( { view, fields } ) => useCollectionRows( 7, view, fields ),
+			{ initialProps: { view: initialView, fields: baseFields } }
+		);
+
+		await waitFor( () => expect( result.current.hasResolved ).toBe( true ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		rerender( { view: nextView, fields: nextFields } );
+
+		await new Promise( ( r ) => setTimeout( r, 30 ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			result.current.refresh();
+		} );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		expect( lastRequestPath() ).toContain( 'fields[0]=field-10' );
+		expect( lastRequestPath() ).toContain( 'fields[1]=field-70' );
+		expect( lastRequestPath() ).toContain( 'fields[2]=title' );
 	} );
 
 	it( 'does not refetch for a column reorder', async () => {


### PR DESCRIPTION
## What

Creating or editing collection fields no longer makes the whole table disappear and reload. Adding a normal field keeps the rows already on screen and shows the new empty column in place.

Field changes that can change existing row values still refresh rows. That includes rollups and type conversions, where the table needs server-normalized or recalculated values.

## Why

Adding a field is a small edit, but the full table reload made it feel heavy and jumpy. This keeps the table steady for simple schema changes without hiding the cases where row data really does need to be fetched again.

## How

- Keep the current field list visible while the schema refetches.
- Reuse existing row data when a new scalar field only adds blank values.
- Refresh rows for rollups and field type changes, where existing values can change shape.

## Testing Instructions

1. Open a collection table with a few existing rows.
2. Add a new text field and confirm the table stays in place.
3. Rename or edit a simple field and confirm the table does not fully reload.
4. Add or duplicate a rollup field and confirm row values refresh.
5. Change a populated field to another type and confirm the visible values update correctly.

## Screen recording
Before:

https://github.com/user-attachments/assets/cb3d79fa-95a1-4835-8aa7-db22d6b909dc

After:

https://github.com/user-attachments/assets/b1f4a60d-8c57-40b3-b469-f4ce446efe56

