### PR TITLE
Open field settings from row property labels

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -26,13 +26,13 @@ Full-page collection creation hit the same schema-cache edge. A new collection r
 
 **Where.** `src/hooks/useCollectionRows.js`, `src/hooks/useCollectionRowsByIds.js`, `src/hooks/rowInvalidation.js`, `src/hooks/documentTrashInvalidation.js`, and `src/hooks/useTrashedDocuments.js`, with call sites in `src/components/CollectionDataViews.js` (`saveRowField`, `onCreated`, row trash), `src/components/SidebarTrash.js`, `src/router/EntityRoute.js`, `src/blocks/data-view/edit.js`, `src/components/Sidebar.js` (post-type entity-config invalidation after collection creation), and `src/components/relations/RelationEditor.js` (paged target-row search and selected-row label lookup).
 
-**Solution.** Switch to `useEntityRecords('postType', \`crtxt_${slug}\`, query)` plus `saveEntityRecord` for writes once the remaining query shapes can be expressed there. `core-data` would then own caching, race protection, and post-mutation invalidation. Knock-on workarounds it deletes:
+**Solution.** Switch to `useEntityRecords('postType', \`crtxt\_${slug}\`, query)`plus`saveEntityRecord`for writes once the remaining query shapes can be expressed there.`core-data` would then own caching, race protection, and post-mutation invalidation. Knock-on workarounds it deletes:
 
-- The `refresh()` handles and invalidation events exist only because rows aren't reactive.
-- Half of `RowMutationContext` (also driven by #1) exists because cells can't reach a `core-data` store that isn't there.
-- `onCreated` runs optimistic `lastPage = ceil((totalItems+1)/perPage)` arithmetic against possibly stale `paginationInfo`. With reactive pagination we'd watch `totalPages` in an effect.
-- The server/client planner becomes normal resolver queries instead of a local fetch policy.
-- Relation label lookup becomes a normal entity-record resolver instead of a one-off include query.
+-   The `refresh()` handles and invalidation events exist only because rows aren't reactive.
+-   Half of `RowMutationContext` (also driven by #1) exists because cells can't reach a `core-data` store that isn't there.
+-   `onCreated` runs optimistic `lastPage = ceil((totalItems+1)/perPage)` arithmetic against possibly stale `paginationInfo`. With reactive pagination we'd watch `totalPages` in an effect.
+-   The server/client planner becomes normal resolver queries instead of a local fetch policy.
+-   Relation label lookup becomes a normal entity-record resolver instead of a one-off include query.
 
 Worth a small spike before committing. Dynamic post-type discovery also needs a real answer: either `core-data` learns about new row CPTs after collection creation, or each collection-creation path keeps the post-type entity-config invalidation nearby.
 
@@ -68,9 +68,9 @@ The cost is another split support matrix. The client checks field type, operator
 
 **What.** Three small but real internal mechanisms exist because DataViews doesn't have an inline-edit contract (#1):
 
-- **Column anchoring via overlay.** DataViews renders an actual `<table>`; Cortext switches it to `table-layout: fixed` so resize widths behave as real column constraints instead of intrinsic-size hints. Mounting an editor inline would still change the column's content sizing and row geometry. We always render the display shell and overlay the editor on top via `position: absolute`, so the table only sees the display state while the editor is open.
-- **Row height pin.** The shell's `min-height` is hardcoded to 40px to match `__next40pxDefaultSize`, the height of TextControl/NumberControl/SelectControl with the modern WP size flag. If WP changes the default control height, the pin desyncs and rows jitter again.
-- **Density mirror.** DataViews paints row height via the td's `padding-block`, varied per density (`has-compact-density` / `has-comfortable-density`). The shell's hover/edit highlight lives on the shell itself, so the gray floated inside the larger row instead of covering it. We zero the td's `padding-block` so the shell becomes the row, then replicate DataViews's per-density row heights via `min-height` overrides on the shell (and `.cortext-cell-checkbox`, which shares the shell's dimensions). Balanced and comfortable mirror DataViews v6 exactly (12 / 16); compact is intentionally tighter than the upstream default (4 -> 0) so the row matches the 40px editor floor, and that's the density we set as the project default in `createDefaultView` and `DEFAULT_LAYOUTS`. If upstream bumps the balanced/comfortable paddings, those two row heights silently desync until we update the numbers.
+-   **Column anchoring via overlay.** DataViews renders an actual `<table>`; Cortext switches it to `table-layout: fixed` so resize widths behave as real column constraints instead of intrinsic-size hints. Mounting an editor inline would still change the column's content sizing and row geometry. We always render the display shell and overlay the editor on top via `position: absolute`, so the table only sees the display state while the editor is open.
+-   **Row height pin.** The shell's `min-height` is hardcoded to 40px to match `__next40pxDefaultSize`, the height of TextControl/NumberControl/SelectControl with the modern WP size flag. If WP changes the default control height, the pin desyncs and rows jitter again.
+-   **Density mirror.** DataViews paints row height via the td's `padding-block`, varied per density (`has-compact-density` / `has-comfortable-density`). The shell's hover/edit highlight lives on the shell itself, so the gray floated inside the larger row instead of covering it. We zero the td's `padding-block` so the shell becomes the row, then replicate DataViews's per-density row heights via `min-height` overrides on the shell (and `.cortext-cell-checkbox`, which shares the shell's dimensions). Balanced and comfortable mirror DataViews v6 exactly (12 / 16); compact is intentionally tighter than the upstream default (4 -> 0) so the row matches the 40px editor floor, and that's the density we set as the project default in `createDefaultView` and `DEFAULT_LAYOUTS`. If upstream bumps the balanced/comfortable paddings, those two row heights silently desync until we update the numbers.
 
 **Where.** `src/components/EditableCell.js` and the `.cortext-editable-cell`, `.cortext-cell-checkbox`, and `.cortext-data-view .dataviews-view-table` rules in `src/components/CollectionDataViews.scss`.
 
@@ -164,9 +164,9 @@ Double-click autofit is the trickiest piece. With no measurement hook upstream, 
 
 ## 16. DataViews has no per-column menu-item slot `[upstream, soft]`
 
-**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete or Calculate. To keep a single dropdown per column, we hide DataViews' built-in trigger on custom-field `<th>`s via CSS and portal our own combined trigger in (Sort / Move / Hide *plus* field management and table calculations). Title and system fields keep the built-in trigger. Main's drag-handle click-forward (`DataViewColumnInteractions`) iterates header buttons and skips `display: none` ones via `offsetParent`, so it lands on whichever trigger is visible. Filter is intentionally absent — Cortext doesn't surface column-level filters in the header.
+**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list — there's no `field.menuItems` to inject Rename / Duplicate / Delete or Calculate. To keep a single dropdown per column, we hide DataViews' built-in trigger on custom-field `<th>`s via CSS and portal our own combined trigger in (Sort / Move / Hide _plus_ field management and table calculations). Title and system fields keep the built-in trigger. Main's drag-handle click-forward (`DataViewColumnInteractions`) iterates header buttons and skips `display: none` ones via `offsetParent`, so it lands on whichever trigger is visible. Filter is intentionally absent — Cortext doesn't surface column-level filters in the header.
 
-**Where.** `src/components/fields/ColumnHeaderActions.js` (combined dropdown), `src/components/CollectionDataViews.scss` (`.dataviews-view-table th:has(.cortext-column-header-marker) > .dataviews-view-table-header-button { display: none }`), `src/components/DataViewColumnInteractions.js` (visible-button click forward).
+**Where.** `src/components/fields/ColumnHeaderActions.js` (table-only items and the header portal), `src/components/fields/FieldActionsMenu.js` (the shared field actions), `src/components/CollectionDataViews.scss` (`.dataviews-view-table th:has(.cortext-column-header-marker) > .dataviews-view-table-header-button { display: none }`), and `src/components/DataViewColumnInteractions.js` (visible-button click forward).
 
 **Risk.** Re-implementing Sort / Move / Hide ourselves means new DataViews items in those menus won't show up here automatically. Calculation controls add one more reason this custom menu has to stay in lockstep with DataViews. If main's drag handle stops calling `.click()` on the header trigger, the column-name click-to-open behavior would need a different forward.
 
@@ -182,21 +182,21 @@ The create-field flow also has to reveal the new trailing column itself. It carr
 
 **Solution.** DataViews exposes a trailing table-header slot, an add-column slot, or a header action area separate from per-row actions, plus refs for the table scroll wrapper and rendered headers. Then the portal targets a real extension point, the reveal code stops querying DataViews DOM, the sticky/header-label CSS disappears, and `__add_field` stays only as migration cleanup for old saved views.
 
-## 18. Field management is table-layout only `[internal]`
+## 18. Field management still needs a panel outside the table `[internal]`
 
-**What.** Rename / Duplicate / Delete only show up in the table-layout column-header kebab. Grid and list layouts have no schema actions. Users there can still create fields via the toolbar Add field button, but they have to switch to table to manage existing fields.
+**What.** Field actions now live in one shared menu, but there is still no collection-level field manager. Table users get the menu from column headers. Row-detail users get it from clickable property labels. Grid and list users can manage fields only after opening a row; those layouts still have no direct "Manage fields" entry point.
 
-**Where.** `ColumnHeaderActions` mounts only when `view.type === 'table'` (`src/components/CollectionDataViews.js`).
+**Where.** `src/components/fields/FieldActionsMenu.js` (shared field actions), `src/components/fields/ColumnHeaderActions.js` (table-header trigger), `src/components/RowProperties.js` and `src/blocks/document-properties/edit.js` (row-property labels and field snapshot context). `ColumnHeaderActions` still mounts only when `view.type === 'table'` (`src/components/CollectionDataViews.js`).
 
 **Solution.** A toolbar "Manage fields" panel listing every custom field with per-row rename / duplicate / delete, available in every layout.
 
 ## 19. Select / multi-select fields ship with no options `[internal]`
 
-**What.** Add field creates the field immediately when you click a type — there's no second step for type-specific config. For select / multi-select that means the column starts empty; users have to add options via wp-admin or by re-saving through REST.
+**What.** Add field creates the field as soon as you click a type; there is no second step for type-specific setup. For select / multi-select, the column starts with no options. Users can add options from the shared field menu, but the create flow still leaves them with an empty property first.
 
-**Where.** `src/components/fields/AddFieldPopover.js` (no options input). The REST route already accepts an `options` array; the UI just doesn't surface it.
+**Where.** `src/components/fields/AddFieldPopover.js` (no options input), plus the after-creation path in `src/components/fields/FieldActionsMenu.js` and `src/components/fields/EditOptionsPopover.js`. The REST route already accepts an `options` array; the create UI just doesn't expose it.
 
-**Solution.** A field-edit dialog from the column kebab (next to Rename / Duplicate / Delete) with an options editor — one-per-line textarea, or a chip list with colors. Until then, options live in wp-admin or REST.
+**Solution.** Add a setup step during field creation, or open the options editor immediately after creating a select / multi-select field. Until then, users fix empty select fields through the shared field menu.
 
 ## 20. Table layout overrides couple to DataViews internals `[upstream, soft]`
 
@@ -256,35 +256,35 @@ The create-field flow also has to reveal the new trailing column itself. It carr
 
 ## 27. `Menu` outside-click only watches one document `[upstream]`
 
-**What.** WP's `Menu` (privateApis, Ariakit underneath) only sees clicks on the document the popover renders in. The `cortext/data-view` block renders inside Gutenberg's editor iframe, so clicks on the editor sidebar or top toolbar never reach Ariakit and the column dropdown stays open until the user clicks back into the canvas. We add a `mousedown` listener on `window.parent.document` while the menu is open and short-circuit when there isn't a parent (the Cortext admin isn't in an iframe).
+**What.** WP's `Menu` (privateApis, Ariakit underneath) only sees clicks on the document where the popover renders. The `cortext/data-view` block and row properties render inside Gutenberg's editor iframe, so clicks on the editor sidebar or top toolbar never reach Ariakit. Without a fallback, the field menu stays open until the user clicks back into the canvas. We add a `mousedown` listener on `window.parent.document` while the menu is open and skip it when there is no parent document (the Cortext admin is not in an iframe).
 
-**Where.** The `useEffect` block in `FieldActions` in `src/components/fields/ColumnHeaderActions.js`.
+**Where.** The `useEffect` block in `src/components/fields/FieldActionsMenu.js`, used by table column headers and row-property label menus.
 
 **Solution.** Either Ariakit grows a way to register extra documents for outside-click detection, or WP's wrapper does it for us. We drop the listener once that ships.
 
 ## 28. `Menu.Item` has no destructive variant `[upstream]`
 
-**What.** The legacy `MenuItem` from `@wordpress/components` accepted `isDestructive` and rendered the row in red. The new privateApis `Menu.Item` dropped that prop without a replacement (verified in `node_modules/@wordpress/components/build-types/menu/types.d.ts` against `ItemProps`). For the Delete column action we paint the red ourselves with a className and one CSS rule, scoped to inactive rows so the focus/hover highlight overrides it.
+**What.** The legacy `MenuItem` from `@wordpress/components` accepted `isDestructive` and rendered the row in red. The new privateApis `Menu.Item` dropped that prop without a replacement (verified in `node_modules/@wordpress/components/build-types/menu/types.d.ts` against `ItemProps`). For the Delete field action we paint the red ourselves with a className and one CSS rule, scoped to inactive rows so the focus/hover highlight overrides it.
 
-**Where.** The Delete `Menu.Item` in `src/components/fields/ColumnHeaderActions.js` and `.cortext-column-header-actions__destructive-item` in `src/components/fields/ColumnHeaderActions.scss`.
+**Where.** The Delete `Menu.Item` in `src/components/fields/FieldActionsMenu.js` and `.cortext-column-header-actions__destructive-item` in `src/components/fields/ColumnHeaderActions.scss`.
 
 **Solution.** Add `isDestructive` (or a `variant: 'destructive'`) to `Menu.Item` upstream. One-line change here once it ships.
 
 ## 29. `Menu.Popover` doesn't portal by default `[upstream]`
 
-**What.** Without `portal` set, `Menu.Popover` renders inline at its mount point. Our column trigger lives inside a `<th>` whose `text-transform: uppercase` cascades into the menu items and turns every label into ALL CAPS. We pass `portal` explicitly. Most popovers in the system portal by default; this one doesn't.
+**What.** Without `portal`, `Menu.Popover` renders inline at its mount point. The table-header trigger lives inside a `<th>` whose `text-transform: uppercase` cascades into the menu items and turns every label into ALL CAPS. The shared field menu passes `portal` explicitly, so table headers and row-property labels use the same code. Most popovers in the system portal by default; this one doesn't.
 
-**Where.** The `<Menu.Popover portal …>` in `src/components/fields/ColumnHeaderActions.js`.
+**Where.** The `<Menu.Popover portal …>` in `src/components/fields/FieldActionsMenu.js`.
 
 **Solution.** Flip the default upstream. Trivial PR.
 
 ## 30. `Menu` submenus only accept menu primitives `[upstream]`
 
-**What.** `Menu.SubmenuTriggerItem` opens a nested `Menu.Popover`, but the popover's children have to be `Menu.Item` / `Menu.Group` / `Menu.Separator`. Our "Edit field" submenu has tile previews (Number / Bar / Ring), labelled rows with right-anchored values, and three more popovers for format, color, and time choices. The Calculate submenu is simpler, but it still needs the same hover bridge so it feels like the adjacent Edit field menu. None of that fits the menu-primitive contract cleanly, so these panels stay as sibling popovers, we run the hover-with-grace bridge ourselves, and the parent menu's `hideOnInteractOutside` filter ignores clicks landing in `.cortext-format-submenu`, `.cortext-format-submenu__flyout`, or `.cortext-table-calculation-submenu`.
+**What.** `Menu.SubmenuTriggerItem` opens a nested `Menu.Popover`, but that popover only accepts `Menu.Item` / `Menu.Group` / `Menu.Separator` children. Our "Edit field" submenu has tile previews (Number / Bar / Ring), labelled rows with right-anchored values, and three more popovers for format, color, and time choices. The Calculate submenu is simpler, but it still needs the same hover bridge so it feels like the adjacent Edit field menu. These panels do not fit the menu primitive cleanly, so they stay as sibling popovers. We run the hover bridge ourselves, and the parent menu ignores outside-clicks that land in `.cortext-format-submenu`, `.cortext-format-submenu__flyout`, or `.cortext-table-calculation-submenu`.
 
-**Where.** `openFormat` / `openCalculation` / `scheduleClose` and `hideMenuOnInteractOutside` in `src/components/fields/ColumnHeaderActions.js`. `FieldFormatPopover` and its flyouts in `src/components/fields/FieldFormatPopover.js`. `TableCalculationMenu` and its flyouts in `src/components/TableCalculationMenu.js`.
+**Where.** `openFormat`, `scheduleClose`, and `hideMenuOnInteractOutside` in `src/components/fields/FieldActionsMenu.js`; `openCalculation` / `scheduleClose` in `src/components/fields/ColumnHeaderActions.js`; `FieldFormatPopover` and its flyouts in `src/components/fields/FieldFormatPopover.js`; `TableCalculationMenu` and its flyouts in `src/components/TableCalculationMenu.js`.
 
-**Solution.** An arbitrary-content submenu variant in WP's `Menu` (or upstream Ariakit) would let these panels mount as real submenus, with outside-click and focus management owned by the library. Until then the manual bridge stays.
+**Solution.** A WP `Menu` submenu that accepts arbitrary content would let these panels mount as real submenus, with outside-click and focus management owned by the library. Until then the manual bridge stays.
 
 ## 31. Block editor has no non-serialized before/after block chrome slot `[upstream]`
 

--- a/src/blocks/document-properties/edit.js
+++ b/src/blocks/document-properties/edit.js
@@ -18,6 +18,7 @@ import { check, closeSmall, pencil, seen, unseen } from '@wordpress/icons';
 import DetailLayoutEditor from '../../components/DetailLayoutEditor';
 import DocumentPropertiesActions from '../../components/DocumentPropertiesActions';
 import RowProperties from '../../components/RowProperties';
+import { CollectionFieldsSnapshotProvider } from '../../components/CollectionFieldsContext';
 import { TITLE_FIELD_ID } from '../../components/dataViewColumns';
 import { useDocumentPropertiesContext } from '../../components/DocumentPropertiesContext';
 import {
@@ -302,15 +303,32 @@ export default function Edit() {
 					/>
 				) : (
 					<>
-						<RowProperties
-							fields={ inlineLayoutFields }
-							onLayoutReorder={
-								canEditLayout && ! isSavingLayout
-									? handleInlineLayoutReorder
-									: undefined
-							}
-							row={ fallbackRecord }
-						/>
+						{ collectionId ? (
+							<CollectionFieldsSnapshotProvider
+								fields={ layoutFields }
+							>
+								<RowProperties
+									collectionId={ collectionId }
+									fields={ inlineLayoutFields }
+									onLayoutReorder={
+										canEditLayout && ! isSavingLayout
+											? handleInlineLayoutReorder
+											: undefined
+									}
+									row={ fallbackRecord }
+								/>
+							</CollectionFieldsSnapshotProvider>
+						) : (
+							<RowProperties
+								fields={ inlineLayoutFields }
+								onLayoutReorder={
+									canEditLayout && ! isSavingLayout
+										? handleInlineLayoutReorder
+										: undefined
+								}
+								row={ fallbackRecord }
+							/>
+						) }
 						{ visiblePropertyFields.length === 0 ? (
 							<p className="cortext-document-properties__empty">
 								{ __( 'No visible properties.', 'cortext' ) }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -646,6 +646,14 @@ export default function CollectionDataViews( {
 			[ fieldId ]: elements,
 		} ) );
 	}, [] );
+	const [ formatOverrides, setFormatOverrides ] = useState( {} );
+	const updateFieldFormat = useCallback( ( recordId, nextFormat ) => {
+		const fieldId = `field-${ recordId }`;
+		setFormatOverrides( ( current ) => ( {
+			...current,
+			[ fieldId ]: nextFormat ?? null,
+		} ) );
+	}, [] );
 
 	// Editable, currently-visible columns in the order DataViews renders
 	// them. Drives Tab/Shift+Tab cell-to-cell navigation. See
@@ -954,6 +962,8 @@ export default function CollectionDataViews( {
 			requestNext,
 			optionOverrides,
 			updateFieldOptions,
+			formatOverrides,
+			updateFieldFormat,
 			refreshRows: refresh,
 		} ),
 		[
@@ -963,6 +973,8 @@ export default function CollectionDataViews( {
 			requestNext,
 			optionOverrides,
 			updateFieldOptions,
+			formatOverrides,
+			updateFieldFormat,
 			refresh,
 		]
 	);
@@ -1036,13 +1048,15 @@ export default function CollectionDataViews( {
 			collectionId,
 			getRowList: () => rowsRef.current ?? [],
 			refresh,
+			updateFieldOptions,
+			updateFieldFormat,
 			onModeChange: ( mode ) => {
 				onChangeViewRef.current(
 					withRowDetailMode( viewRef.current, mode )
 				);
 			},
 		} ),
-		[ collectionId, refresh ]
+		[ collectionId, refresh, updateFieldFormat, updateFieldOptions ]
 	);
 
 	const requestOpenRow = useCallback(
@@ -1794,6 +1808,9 @@ export default function CollectionDataViews( {
 											onChangeView={ onChangeView }
 											onFieldOptionsSaved={
 												updateFieldOptions
+											}
+											onFieldFormatSaved={
+												updateFieldFormat
 											}
 											onFieldCreated={
 												requestRevealCreatedField

--- a/src/components/CollectionFieldsContext.js
+++ b/src/components/CollectionFieldsContext.js
@@ -1,15 +1,26 @@
 import { createContext, useContext, useMemo } from '@wordpress/element';
 
 import useCollectionFields from '../hooks/useCollectionFields';
+import { toRecordId } from '../hooks/fieldIds';
 
-// Field menus should use this context for reads. The field list is already
-// loaded for the collection, and `useEntityRecord` would still kick off a
-// separate per-id request in core-data. See docs/architecture/shell.md.
+// Field menus read from this context. The collection's field list is already
+// loaded, and `useEntityRecord` would start a separate per-id core-data request.
+// See docs/architecture/shell.md.
 
 // Keep one field-schema read per collection. `useCollectionFields` latches the
 // last good field list, so sharing it here keeps the toolbar, inspector, table,
 // and field menus in sync after field changes.
 const CollectionFieldsContext = createContext( null );
+
+function fieldsByRecordIdFor( fields ) {
+	const entries = ( fields ?? [] )
+		.map( ( field ) => [
+			field.recordId ?? field.cortextRecordId ?? toRecordId( field.id ),
+			field,
+		] )
+		.filter( ( [ recordId ] ) => recordId );
+	return new Map( entries );
+}
 
 export function CollectionFieldsProvider( { collectionId, children } ) {
 	const {
@@ -25,7 +36,7 @@ export function CollectionFieldsProvider( { collectionId, children } ) {
 	// Index fields by record id once per update so `useMappedField` resolves
 	// in constant time regardless of column count.
 	const fieldsByRecordId = useMemo(
-		() => new Map( ( fields ?? [] ).map( ( f ) => [ f.recordId, f ] ) ),
+		() => fieldsByRecordIdFor( fields ),
 		[ fields ]
 	);
 	// `useCollectionFields` returns a fresh object each render. Memoize the
@@ -53,6 +64,29 @@ export function CollectionFieldsProvider( { collectionId, children } ) {
 			isResolving,
 			fieldsResolved,
 		]
+	);
+	return (
+		<CollectionFieldsContext.Provider value={ value }>
+			{ children }
+		</CollectionFieldsContext.Provider>
+	);
+}
+
+export function CollectionFieldsSnapshotProvider( { fields, children } ) {
+	const fieldsByRecordId = useMemo(
+		() => fieldsByRecordIdFor( fields ),
+		[ fields ]
+	);
+	const value = useMemo(
+		() => ( {
+			fields,
+			fieldsByRecordId,
+			collection: null,
+			slug: null,
+			isResolving: false,
+			fieldsResolved: true,
+		} ),
+		[ fields, fieldsByRecordId ]
 	);
 	return (
 		<CollectionFieldsContext.Provider value={ value }>

--- a/src/components/DocumentPeekHost.js
+++ b/src/components/DocumentPeekHost.js
@@ -1,5 +1,11 @@
 import { __ } from '@wordpress/i18n';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { useParams } from '@tanstack/react-router';
 
 import RowDetailView from './RowDetailView';
@@ -10,6 +16,7 @@ import {
 	useDocumentPeekState,
 	useDocumentPeekSurface,
 } from './DocumentPeekProvider';
+import { elementsFromOptions } from '../hooks/optionElements';
 import useCollectionFields from '../hooks/useCollectionFields';
 import { adjacentRowId } from './rowDetailUtils';
 
@@ -52,6 +59,56 @@ export default function DocumentPeekHost() {
 	const prevSplatRef = useRef( splat );
 	const peekStateRef = useRef( { peek, isPinned } );
 	peekStateRef.current = { peek, isPinned };
+	const [ optionOverrides, setOptionOverrides ] = useState( {} );
+	const [ formatOverrides, setFormatOverrides ] = useState( {} );
+
+	useEffect( () => {
+		setOptionOverrides( {} );
+		setFormatOverrides( {} );
+	}, [ peek?.collectionId ] );
+
+	const updateFieldOptions = useCallback( ( recordId, nextOptions ) => {
+		const fieldId = `field-${ recordId }`;
+		const elements = elementsFromOptions( nextOptions ) || [];
+		setOptionOverrides( ( current ) => ( {
+			...current,
+			[ fieldId ]: elements,
+		} ) );
+		peekStateRef.current.peek?.source?.updateFieldOptions?.(
+			recordId,
+			nextOptions
+		);
+	}, [] );
+	const updateFieldFormat = useCallback( ( recordId, nextFormat ) => {
+		const fieldId = `field-${ recordId }`;
+		setFormatOverrides( ( current ) => ( {
+			...current,
+			[ fieldId ]: nextFormat ?? null,
+		} ) );
+		peekStateRef.current.peek?.source?.updateFieldFormat?.(
+			recordId,
+			nextFormat
+		);
+	}, [] );
+	const refreshRows = useCallback( () => {
+		peekStateRef.current.peek?.source?.refresh?.();
+	}, [] );
+	const mutationContext = useMemo(
+		() => ( {
+			optionOverrides,
+			updateFieldOptions,
+			formatOverrides,
+			updateFieldFormat,
+			refreshRows,
+		} ),
+		[
+			optionOverrides,
+			updateFieldOptions,
+			formatOverrides,
+			updateFieldFormat,
+			refreshRows,
+		]
+	);
 	useEffect( () => {
 		const prev = prevSplatRef.current;
 		prevSplatRef.current = splat;
@@ -120,6 +177,7 @@ export default function DocumentPeekHost() {
 				fields={ peekFields }
 				isPinned={ isPinned }
 				mode={ renderedMode }
+				mutationContext={ mutationContext }
 				onApi={ setDetailApi }
 				onClose={ closeDocument }
 				onDiscardPending={ discardPendingTransition }

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -60,6 +60,8 @@ export const RowMutationContext = createContext( {
 	requestNext: () => {},
 	optionOverrides: {},
 	updateFieldOptions: () => {},
+	formatOverrides: {},
+	updateFieldFormat: () => {},
 	refreshRows: () => {},
 } );
 
@@ -746,6 +748,7 @@ export default function EditableCell( {
 		requestNext,
 		optionOverrides,
 		updateFieldOptions,
+		formatOverrides,
 		refreshRows,
 	} = useContext( RowMutationContext );
 	const [ isEditing, setIsEditing ] = useState( false );
@@ -758,9 +761,13 @@ export default function EditableCell( {
 		? getValue( { item } )
 		: item?.meta?.[ fieldId ] ?? null;
 	const effectiveElements = optionOverrides?.[ fieldId ] ?? elements;
+	const effectiveFormat =
+		formatOverrides?.[ fieldId ] !== undefined
+			? formatOverrides[ fieldId ]
+			: format;
 	const display = formatDisplay( value, fieldType, {
 		elements: effectiveElements,
-		format,
+		format: effectiveFormat,
 		relation,
 	} );
 
@@ -932,7 +939,7 @@ export default function EditableCell( {
 				<DateEditor
 					value={ value }
 					type={ fieldType }
-					format={ format }
+					format={ effectiveFormat }
 					onCommit={ commit }
 					onCancel={ closeEditor }
 					label={ label }

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -282,6 +282,7 @@ export default function RowDetailView( {
 	fields,
 	isPinned,
 	mode,
+	mutationContext,
 	onApi,
 	onClose,
 	onDiscardPending,
@@ -584,6 +585,7 @@ export default function RowDetailView( {
 										}
 										isActive={ isApiActive }
 										isHidden={ isHiddenPane }
+										mutationContext={ mutationContext }
 										onApi={ onApi }
 										onPaneReady={ onPaneReady }
 										onRestored={ onRestored }

--- a/src/components/RowDetailView.scss
+++ b/src/components/RowDetailView.scss
@@ -57,7 +57,9 @@
 		color: $gray-900;
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
 		opacity: 0;
-		transition: opacity 0.12s ease, background-color 0.12s ease;
+		transition:
+			opacity 0.12s ease,
+			background-color 0.12s ease;
 
 		&:hover,
 		&:focus-visible {
@@ -131,15 +133,13 @@
 
 		&[data-state="entering"] {
 			z-index: 3;
-			animation:
-				cortext-row-detail-pane-enter 180ms
+			animation: cortext-row-detail-pane-enter 180ms
 				cubic-bezier(0.6, 0, 0.4, 1) both;
 		}
 	}
 
 	&--side,
 	&--modal {
-
 		.cortext-row-detail__pane-stack {
 			flex: 1 1 auto;
 			height: 100%;
@@ -238,8 +238,7 @@
 
 		&[data-state="entering"] {
 			z-index: 3;
-			animation:
-				cortext-row-detail-pane-enter 180ms
+			animation: cortext-row-detail-pane-enter 180ms
 				cubic-bezier(0.6, 0, 0.4, 1) both;
 		}
 	}
@@ -250,8 +249,7 @@
 		flex-direction: column;
 		align-items: stretch;
 		gap: $grid-unit-10;
-		padding:
-			$grid-unit-15 var(--cortext-row-detail-field-inset)
+		padding: $grid-unit-15 var(--cortext-row-detail-field-inset)
 			$grid-unit-10;
 		border-bottom: $border-width solid $gray-200;
 		background: $white;
@@ -470,7 +468,8 @@
 		flex: 0 0 auto;
 		flex-direction: column;
 		gap: 2px;
-		padding: $grid-unit-20 var(--cortext-row-detail-field-inset) $grid-unit-10;
+		padding: $grid-unit-20 var(--cortext-row-detail-field-inset)
+			$grid-unit-10;
 	}
 
 	&__properties[data-visible="false"] {
@@ -481,7 +480,8 @@
 		display: flex;
 		flex-direction: column;
 		gap: 2px;
-		padding: $grid-unit-20 var(--cortext-row-detail-field-inset) $grid-unit-10;
+		padding: $grid-unit-20 var(--cortext-row-detail-field-inset)
+			$grid-unit-10;
 	}
 
 	.cortext-detail-layout-editor__row {
@@ -527,7 +527,6 @@
 		&:active {
 			cursor: grabbing;
 		}
-
 	}
 
 	.cortext-detail-layout-editor__handle:hover,
@@ -551,7 +550,8 @@
 	.cortext-detail-layout-editor__empty,
 	.cortext-document-properties__empty {
 		margin: 0;
-		padding: $grid-unit-20 var(--cortext-row-detail-field-inset) $grid-unit-10;
+		padding: $grid-unit-20 var(--cortext-row-detail-field-inset)
+			$grid-unit-10;
 		color: var(--cortext-row-detail-muted);
 		font-size: 12px;
 	}
@@ -639,6 +639,49 @@
 		flex: 0 0 16px;
 		width: 16px;
 		height: 16px;
+	}
+
+	&__property-label-actions {
+		display: inline-flex;
+		align-items: center;
+		min-width: 0;
+		max-width: 100%;
+	}
+
+	&__property-label-button.components-button {
+		justify-content: flex-start;
+		width: 100%;
+		min-width: 0;
+		height: auto;
+		min-height: 0;
+		padding: 0;
+		border-radius: 3px;
+		background: transparent;
+		box-shadow: none;
+		color: inherit;
+		cursor: pointer;
+		font: inherit;
+		text-align: start;
+		text-decoration: none;
+
+		&:focus-visible {
+			outline: 2px solid var(--cortext-accent);
+			outline-offset: 1px;
+		}
+
+		&:hover:not(:disabled) {
+			background: transparent;
+			box-shadow: none;
+			color: var(--cortext-row-detail-text);
+		}
+	}
+
+	&__property-label-content {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-05;
+		min-width: 0;
+		max-width: 100%;
 	}
 
 	&__property-type-icon {
@@ -940,8 +983,7 @@
 
 		.cortext-row-detail__header {
 			gap: $grid-unit-10;
-			padding:
-				$grid-unit-15 var(--cortext-row-detail-field-inset)
+			padding: $grid-unit-15 var(--cortext-row-detail-field-inset)
 				$grid-unit-10;
 		}
 
@@ -990,7 +1032,6 @@
 	// Loading frame for row detail. The title and icon come from the table row,
 	// so the panel does not open blank while useEntityRecord catches up.
 	&__frame--loading {
-
 		.cortext-row-detail__title {
 			display: flex;
 			align-items: center;
@@ -1028,7 +1069,6 @@
 }
 
 @keyframes cortext-row-detail-pane-enter {
-
 	from {
 		opacity: 0;
 	}
@@ -1048,15 +1088,18 @@
 	height: 100%;
 	min-width: 0;
 	min-height: 0;
-	max-width: min(840px, 66vw, calc(100% - var(--cortext-shell-sidebar-track-width)));
+	max-width: min(
+		840px,
+		66vw,
+		calc(100% - var(--cortext-shell-sidebar-track-width))
+	);
 	background: $white;
 	border-left: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
 	box-shadow: -18px 0 36px rgba(0, 0, 0, 0.12);
 	overflow: hidden;
 	will-change: width;
 	view-transition-name: cortext-row-detail-sidebar;
-	animation:
-		cortext-row-detail-sidebar-open 300ms
+	animation: cortext-row-detail-sidebar-open 300ms
 		cubic-bezier(0.6, 0, 0.4, 1) both;
 
 	&--closing {
@@ -1114,7 +1157,6 @@ body.cortext-row-detail-sidebar-resizing {
 }
 
 @keyframes cortext-row-detail-sidebar-open {
-
 	from {
 		flex-basis: 0;
 		width: 0;
@@ -1127,7 +1169,6 @@ body.cortext-row-detail-sidebar-resizing {
 }
 
 @keyframes cortext-row-detail-sidebar-close {
-
 	from {
 		flex-basis: var(--cortext-row-detail-sidebar-width, 560px);
 		width: var(--cortext-row-detail-sidebar-width, 560px);
@@ -1140,7 +1181,6 @@ body.cortext-row-detail-sidebar-resizing {
 }
 
 @media (prefers-reduced-motion: reduce) {
-
 	.cortext-row-detail__pane[data-state="entering"],
 	.cortext-row-detail__pane[data-state="covered"],
 	.cortext-row-detail__property-value-pane[data-state="entering"],
@@ -1182,8 +1222,7 @@ body.cortext-row-detail-sidebar-resizing {
 
 	.cortext-row-detail__header {
 		gap: $grid-unit-15;
-		padding:
-			$grid-unit-20 var(--cortext-row-detail-field-inset)
+		padding: $grid-unit-20 var(--cortext-row-detail-field-inset)
 			$grid-unit-15;
 	}
 }

--- a/src/components/RowDetailView.scss
+++ b/src/components/RowDetailView.scss
@@ -133,13 +133,15 @@
 
 		&[data-state="entering"] {
 			z-index: 3;
-			animation: cortext-row-detail-pane-enter 180ms
+			animation:
+				cortext-row-detail-pane-enter 180ms
 				cubic-bezier(0.6, 0, 0.4, 1) both;
 		}
 	}
 
 	&--side,
 	&--modal {
+
 		.cortext-row-detail__pane-stack {
 			flex: 1 1 auto;
 			height: 100%;
@@ -238,7 +240,8 @@
 
 		&[data-state="entering"] {
 			z-index: 3;
-			animation: cortext-row-detail-pane-enter 180ms
+			animation:
+				cortext-row-detail-pane-enter 180ms
 				cubic-bezier(0.6, 0, 0.4, 1) both;
 		}
 	}
@@ -249,7 +252,8 @@
 		flex-direction: column;
 		align-items: stretch;
 		gap: $grid-unit-10;
-		padding: $grid-unit-15 var(--cortext-row-detail-field-inset)
+		padding:
+			$grid-unit-15 var(--cortext-row-detail-field-inset)
 			$grid-unit-10;
 		border-bottom: $border-width solid $gray-200;
 		background: $white;
@@ -468,7 +472,8 @@
 		flex: 0 0 auto;
 		flex-direction: column;
 		gap: 2px;
-		padding: $grid-unit-20 var(--cortext-row-detail-field-inset)
+		padding:
+			$grid-unit-20 var(--cortext-row-detail-field-inset)
 			$grid-unit-10;
 	}
 
@@ -480,7 +485,8 @@
 		display: flex;
 		flex-direction: column;
 		gap: 2px;
-		padding: $grid-unit-20 var(--cortext-row-detail-field-inset)
+		padding:
+			$grid-unit-20 var(--cortext-row-detail-field-inset)
 			$grid-unit-10;
 	}
 
@@ -550,7 +556,8 @@
 	.cortext-detail-layout-editor__empty,
 	.cortext-document-properties__empty {
 		margin: 0;
-		padding: $grid-unit-20 var(--cortext-row-detail-field-inset)
+		padding:
+			$grid-unit-20 var(--cortext-row-detail-field-inset)
 			$grid-unit-10;
 		color: var(--cortext-row-detail-muted);
 		font-size: 12px;
@@ -1027,7 +1034,8 @@
 
 		.cortext-row-detail__header {
 			gap: $grid-unit-10;
-			padding: $grid-unit-15 var(--cortext-row-detail-field-inset)
+			padding:
+				$grid-unit-15 var(--cortext-row-detail-field-inset)
 				$grid-unit-10;
 		}
 
@@ -1076,6 +1084,7 @@
 	// Loading frame for row detail. The title and icon come from the table row,
 	// so the panel does not open blank while useEntityRecord catches up.
 	&__frame--loading {
+
 		.cortext-row-detail__title {
 			display: flex;
 			align-items: center;
@@ -1113,6 +1122,7 @@
 }
 
 @keyframes cortext-row-detail-pane-enter {
+
 	from {
 		opacity: 0;
 	}
@@ -1132,18 +1142,15 @@
 	height: 100%;
 	min-width: 0;
 	min-height: 0;
-	max-width: min(
-		840px,
-		66vw,
-		calc(100% - var(--cortext-shell-sidebar-track-width))
-	);
+	max-width: min(840px, 66vw, calc(100% - var(--cortext-shell-sidebar-track-width)));
 	background: $white;
 	border-left: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
 	box-shadow: -18px 0 36px rgba(0, 0, 0, 0.12);
 	overflow: hidden;
 	will-change: width;
 	view-transition-name: cortext-row-detail-sidebar;
-	animation: cortext-row-detail-sidebar-open 300ms
+	animation:
+		cortext-row-detail-sidebar-open 300ms
 		cubic-bezier(0.6, 0, 0.4, 1) both;
 
 	&--closing {
@@ -1201,6 +1208,7 @@ body.cortext-row-detail-sidebar-resizing {
 }
 
 @keyframes cortext-row-detail-sidebar-open {
+
 	from {
 		flex-basis: 0;
 		width: 0;
@@ -1213,6 +1221,7 @@ body.cortext-row-detail-sidebar-resizing {
 }
 
 @keyframes cortext-row-detail-sidebar-close {
+
 	from {
 		flex-basis: var(--cortext-row-detail-sidebar-width, 560px);
 		width: var(--cortext-row-detail-sidebar-width, 560px);
@@ -1225,6 +1234,7 @@ body.cortext-row-detail-sidebar-resizing {
 }
 
 @media (prefers-reduced-motion: reduce) {
+
 	.cortext-row-detail__pane[data-state="entering"],
 	.cortext-row-detail__pane[data-state="covered"],
 	.cortext-row-detail__property-value-pane[data-state="entering"],
@@ -1266,7 +1276,8 @@ body.cortext-row-detail-sidebar-resizing {
 
 	.cortext-row-detail__header {
 		gap: $grid-unit-15;
-		padding: $grid-unit-20 var(--cortext-row-detail-field-inset)
+		padding:
+			$grid-unit-20 var(--cortext-row-detail-field-inset)
 			$grid-unit-15;
 	}
 }

--- a/src/components/RowDetailView.scss
+++ b/src/components/RowDetailView.scss
@@ -644,8 +644,23 @@
 	&__property-label-actions {
 		display: inline-flex;
 		align-items: center;
+		gap: $grid-unit-05;
+		width: 100%;
 		min-width: 0;
 		max-width: 100%;
+
+		.cortext-field-actions__renaming-prefix {
+			display: inline-flex;
+			flex: 0 0 auto;
+			align-items: center;
+			color: var(--cortext-row-detail-muted);
+		}
+
+		.cortext-rename-field-inline {
+			display: block;
+			flex: 1 1 auto;
+			min-width: 0;
+		}
 	}
 
 	&__property-label-button.components-button {
@@ -802,6 +817,35 @@
 			border-radius: 4px;
 			box-shadow: inset 0 0 0 1px var(--cortext-accent);
 			pointer-events: none;
+		}
+	}
+
+	&__property-label-actions .cortext-rename-field-inline .components-base-control,
+	&__property-label-actions .cortext-rename-field-inline .components-base-control__field {
+		width: 100%;
+		min-width: 0;
+		margin-bottom: 0;
+	}
+
+	&__property-label-actions
+	.cortext-rename-field-inline
+	input.components-text-control__input[type="text"] {
+		width: 100%;
+		height: 22px;
+		min-height: 22px;
+		padding: 0 2px;
+		border-color: transparent;
+		border-radius: 3px;
+		background: transparent;
+		box-shadow: none;
+		color: var(--cortext-row-detail-text);
+		font: inherit;
+		line-height: 1.3;
+
+		&:focus {
+			border-color: transparent;
+			background: $white;
+			box-shadow: inset 0 0 0 1px var(--cortext-accent);
 		}
 	}
 

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -19,6 +19,7 @@ import './initEditor';
 import { DocumentPropertiesProvider } from './DocumentPropertiesContext';
 import { EditorSurfaceProvider } from './EditorSurfaceContext';
 import EditorBody from './EditorBody';
+import { RowMutationContext } from './EditableCell';
 
 const ROW_DETAIL_EDITOR_CSS = `
 	body {
@@ -102,6 +103,7 @@ function DetailPaneContent( {
 	detailLayoutEntries,
 	isActive,
 	isHidden,
+	mutationContext,
 	onApi,
 	onPaneReady,
 	onRestored,
@@ -117,6 +119,27 @@ function DetailPaneContent( {
 		[ detailKey, onPaneReady ]
 	);
 
+	const content = (
+		<DocumentPropertiesProvider
+			collectionId={ collectionId }
+			fields={ fields }
+			allFields={ allFields }
+			detailLayoutEntries={ detailLayoutEntries }
+			fallbackRecord={ row }
+			isVisible={ propertiesVisible }
+			onToggleVisible={ onTogglePropertiesVisible }
+		>
+			<EditorBody
+				isActive={ isActive && ! isHidden }
+				postId={ row?.id }
+				postType={ postType }
+				extraStyles={ ROW_DETAIL_EXTRA_STYLES }
+				onReady={ handleReady }
+				onRestored={ onRestored }
+			/>
+		</DocumentPropertiesProvider>
+	);
+
 	return (
 		<>
 			<RowAutosaveBridge
@@ -129,24 +152,13 @@ function DetailPaneContent( {
 						: null
 				}
 			/>
-			<DocumentPropertiesProvider
-				collectionId={ collectionId }
-				fields={ fields }
-				allFields={ allFields }
-				detailLayoutEntries={ detailLayoutEntries }
-				fallbackRecord={ row }
-				isVisible={ propertiesVisible }
-				onToggleVisible={ onTogglePropertiesVisible }
-			>
-				<EditorBody
-					isActive={ isActive && ! isHidden }
-					postId={ row?.id }
-					postType={ postType }
-					extraStyles={ ROW_DETAIL_EXTRA_STYLES }
-					onReady={ handleReady }
-					onRestored={ onRestored }
-				/>
-			</DocumentPropertiesProvider>
+			{ mutationContext ? (
+				<RowMutationContext.Provider value={ mutationContext }>
+					{ content }
+				</RowMutationContext.Provider>
+			) : (
+				content
+			) }
 			<div
 				aria-hidden={ isHidden ? true : undefined }
 				{ ...( isHidden ? { inert: '' } : {} ) }
@@ -163,6 +175,7 @@ export default function RowEditor( {
 	detailLayoutEntries,
 	isActive,
 	isHidden,
+	mutationContext,
 	onApi,
 	onPaneReady,
 	onRestored,
@@ -192,6 +205,7 @@ export default function RowEditor( {
 						detailLayoutEntries={ detailLayoutEntries }
 						isActive={ isActive }
 						isHidden={ isHidden }
+						mutationContext={ mutationContext }
 						onApi={ onApi }
 						onPaneReady={ onPaneReady }
 						onRestored={ onRestored }

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -54,6 +54,7 @@ import EditOptionsPopover from './fields/EditOptionsPopover';
 import { FieldTypeIcon, SystemFieldIcon } from './fields/fieldTypes';
 import { hasSystemFieldIcon } from './fields/systemFieldIconIds';
 import { toRecordId } from '../hooks/fieldIds';
+import { elementsFromOptions } from '../hooks/optionElements';
 import {
 	isRowDetailFieldEditable,
 	isValidNumberDraft,
@@ -284,13 +285,20 @@ function EditablePropertyText( { label, inputMode, value, onChange } ) {
 	);
 }
 
-function EditableNumberPropertyText( { label, value, onChange } ) {
+function EditableNumberPropertyText( { label, value, format, onChange } ) {
 	const textValue =
 		value === null || value === undefined ? '' : String( value );
 	const committedTextRef = useRef( textValue );
 	const committedValueRef = useRef( value ?? null );
 	const [ draft, setDraft ] = useState( textValue );
 	const [ isFocused, setIsFocused ] = useState( false );
+	const formattedValue = useMemo( () => {
+		if ( textValue === '' || ! format ) {
+			return textValue;
+		}
+		const display = formatDisplay( value, 'number', { format } );
+		return typeof display === 'string' ? display : textValue;
+	}, [ format, textValue, value ] );
 
 	useEffect( () => {
 		committedTextRef.current = textValue;
@@ -330,7 +338,7 @@ function EditableNumberPropertyText( { label, value, onChange } ) {
 			inputMode="decimal"
 			placeholder={ isFocused ? '' : __( 'Empty', 'cortext' ) }
 			type="text"
-			value={ draft }
+			value={ isFocused ? draft : formattedValue }
 			onBlur={ () => {
 				setIsFocused( false );
 				const parsed = parseNumberPropertyValue( draft );
@@ -345,7 +353,10 @@ function EditableNumberPropertyText( { label, value, onChange } ) {
 				setDraft( committedTextRef.current );
 			} }
 			onChange={ ( event ) => commitDraft( event.currentTarget.value ) }
-			onFocus={ () => setIsFocused( true ) }
+			onFocus={ () => {
+				setDraft( textValue );
+				setIsFocused( true );
+			} }
 		/>
 	);
 }
@@ -378,6 +389,7 @@ function PropertyControl( {
 			<EditableNumberPropertyText
 				label={ label }
 				value={ value }
+				format={ field.cortextFormat }
 				onChange={ onChange }
 			/>
 		);
@@ -441,6 +453,7 @@ function PropertyLabel( {
 	collectionId,
 	field,
 	onFieldOptionsSaved,
+	onFieldFormatSaved,
 	onRowsChanged,
 } ) {
 	const recordId = field.cortextRecordId ?? toRecordId( field.id );
@@ -479,6 +492,7 @@ function PropertyLabel( {
 				</span>
 			}
 			onFieldOptionsSaved={ onFieldOptionsSaved }
+			onFieldFormatSaved={ onFieldFormatSaved }
 			onRowsChanged={ onRowsChanged }
 		/>
 	);
@@ -497,7 +511,12 @@ function RowProperty( {
 	collectionId,
 	data,
 	field,
+	formatOverrides,
+	handleFieldFormatSaved,
+	handleFieldOptionsSaved,
 	isDragging,
+	localFormatOverrides,
+	localOptionOverrides,
 	optionOverrides,
 	refreshRows,
 	reorderAttributes,
@@ -505,16 +524,31 @@ function RowProperty( {
 	rowRef,
 	rowStyle,
 	update,
-	updateFieldOptions,
 } ) {
 	const isEditable = isRowDetailFieldEditable( field );
 	const value = valueForField( field, data );
 	const type = fieldType( field );
 	const elements =
+		localOptionOverrides?.[ field.id ] ??
 		optionOverrides?.[ field.id ] ??
 		field.cortextElements ??
 		field.elements ??
 		[];
+	let format = field.cortextFormat;
+	if ( formatOverrides?.[ field.id ] !== undefined ) {
+		format = formatOverrides[ field.id ];
+	}
+	if ( localFormatOverrides?.[ field.id ] !== undefined ) {
+		format = localFormatOverrides[ field.id ];
+	}
+	const displayField =
+		elements !== field.cortextElements || format !== field.cortextFormat
+			? {
+					...field,
+					cortextElements: elements,
+					cortextFormat: format,
+			  }
+			: field;
 	let propertyIcon = null;
 	if ( isCollectionField( field ) ) {
 		propertyIcon = (
@@ -562,24 +596,23 @@ function RowProperty( {
 				</span>
 				<PropertyLabel
 					collectionId={ collectionId }
-					field={ field }
-					onFieldOptionsSaved={ ( targetRecordId, nextOptions ) =>
-						updateFieldOptions?.( targetRecordId, nextOptions )
-					}
+					field={ displayField }
+					onFieldOptionsSaved={ handleFieldOptionsSaved }
+					onFieldFormatSaved={ handleFieldFormatSaved }
 					onRowsChanged={ refreshRows }
 				/>
 			</div>
 			<div className="cortext-row-detail__property-value">
 				{ isEditable ? (
 					<PropertyControl
-						field={ field }
+						field={ displayField }
 						value={ value }
 						elements={ elements }
 						onChange={ ( next ) =>
 							update( { [ field.id ]: next } )
 						}
 						onOptionsSaved={ ( nextOptions ) =>
-							updateFieldOptions?.(
+							handleFieldOptionsSaved(
 								field.cortextRecordId ?? toRecordId( field.id ),
 								nextOptions
 							)
@@ -591,7 +624,7 @@ function RowProperty( {
 						value={ value }
 						type={ type }
 						elements={ elements }
-						format={ field.cortextFormat }
+						format={ format }
 					/>
 				) }
 			</div>
@@ -638,8 +671,38 @@ export default function RowProperties( {
 	row,
 } ) {
 	const { editPost } = useDispatch( editorStore );
-	const { optionOverrides, updateFieldOptions, refreshRows } =
-		useContext( RowMutationContext );
+	const {
+		optionOverrides,
+		updateFieldOptions,
+		formatOverrides,
+		updateFieldFormat,
+		refreshRows,
+	} = useContext( RowMutationContext );
+	const [ localOptionOverrides, setLocalOptionOverrides ] = useState( {} );
+	const [ localFormatOverrides, setLocalFormatOverrides ] = useState( {} );
+	const handleFieldOptionsSaved = useCallback(
+		( recordId, nextOptions ) => {
+			const fieldId = `field-${ recordId }`;
+			const elements = elementsFromOptions( nextOptions ) || [];
+			setLocalOptionOverrides( ( current ) => ( {
+				...current,
+				[ fieldId ]: elements,
+			} ) );
+			updateFieldOptions?.( recordId, nextOptions );
+		},
+		[ updateFieldOptions ]
+	);
+	const handleFieldFormatSaved = useCallback(
+		( recordId, nextFormat ) => {
+			const fieldId = `field-${ recordId }`;
+			setLocalFormatOverrides( ( current ) => ( {
+				...current,
+				[ fieldId ]: nextFormat ?? null,
+			} ) );
+			updateFieldFormat?.( recordId, nextFormat );
+		},
+		[ updateFieldFormat ]
+	);
 	const sensors = useSensors(
 		useSensor( PointerSensor, { activationConstraint: { distance: 4 } } ),
 		useSensor( KeyboardSensor, {
@@ -740,10 +803,14 @@ export default function RowProperties( {
 						collectionId={ collectionId }
 						data={ data }
 						field={ field }
+						formatOverrides={ formatOverrides }
+						handleFieldFormatSaved={ handleFieldFormatSaved }
+						handleFieldOptionsSaved={ handleFieldOptionsSaved }
+						localFormatOverrides={ localFormatOverrides }
+						localOptionOverrides={ localOptionOverrides }
 						optionOverrides={ optionOverrides }
 						refreshRows={ refreshRows }
 						update={ update }
-						updateFieldOptions={ updateFieldOptions }
 					/>
 				) : (
 					<RowProperty
@@ -752,10 +819,14 @@ export default function RowProperties( {
 						collectionId={ collectionId }
 						data={ data }
 						field={ field }
+						formatOverrides={ formatOverrides }
+						handleFieldFormatSaved={ handleFieldFormatSaved }
+						handleFieldOptionsSaved={ handleFieldOptionsSaved }
+						localFormatOverrides={ localFormatOverrides }
+						localOptionOverrides={ localOptionOverrides }
 						optionOverrides={ optionOverrides }
 						refreshRows={ refreshRows }
 						update={ update }
-						updateFieldOptions={ updateFieldOptions }
 					/>
 				)
 			) }

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -49,6 +49,7 @@ import {
 	formatDisplay,
 } from './EditableCell';
 import { TITLE_FIELD_ID } from './dataViewColumns';
+import FieldActionsMenu from './fields/FieldActionsMenu';
 import EditOptionsPopover from './fields/EditOptionsPopover';
 import { FieldTypeIcon, SystemFieldIcon } from './fields/fieldTypes';
 import { hasSystemFieldIcon } from './fields/systemFieldIconIds';
@@ -436,6 +437,53 @@ function PropertyControl( {
 	);
 }
 
+function PropertyLabel( {
+	collectionId,
+	field,
+	onFieldOptionsSaved,
+	onRowsChanged,
+} ) {
+	const recordId = field.cortextRecordId ?? toRecordId( field.id );
+	if ( ! collectionId || ! recordId ) {
+		return (
+			<span className="cortext-row-detail__property-label-text">
+				{ field.label }
+			</span>
+		);
+	}
+
+	const configureLabel = sprintf(
+		/* translators: %s: Field label. */
+		__( 'Configure %s field', 'cortext' ),
+		field.label
+	);
+
+	return (
+		<FieldActionsMenu
+			recordId={ recordId }
+			collectionId={ collectionId }
+			field={ field }
+			className="cortext-row-detail__property-label-actions"
+			triggerButton={
+				<Button
+					className="cortext-row-detail__property-label-button"
+					variant="tertiary"
+					label={ configureLabel }
+				/>
+			}
+			triggerContent={
+				<span className="cortext-row-detail__property-label-content">
+					<span className="cortext-row-detail__property-label-text">
+						{ field.label }
+					</span>
+				</span>
+			}
+			onFieldOptionsSaved={ onFieldOptionsSaved }
+			onRowsChanged={ onRowsChanged }
+		/>
+	);
+}
+
 function transformToString( transform ) {
 	if ( ! transform ) {
 		return undefined;
@@ -446,6 +494,7 @@ function transformToString( transform ) {
 
 function RowProperty( {
 	canReorderLayout,
+	collectionId,
 	data,
 	field,
 	isDragging,
@@ -511,9 +560,14 @@ function RowProperty( {
 						/>
 					) : null }
 				</span>
-				<span className="cortext-row-detail__property-label-text">
-					{ field.label }
-				</span>
+				<PropertyLabel
+					collectionId={ collectionId }
+					field={ field }
+					onFieldOptionsSaved={ ( targetRecordId, nextOptions ) =>
+						updateFieldOptions?.( targetRecordId, nextOptions )
+					}
+					onRowsChanged={ refreshRows }
+				/>
 			</div>
 			<div className="cortext-row-detail__property-value">
 				{ isEditable ? (
@@ -577,7 +631,12 @@ function SortableRowProperty( props ) {
  * block editor. This is intentionally not serialized yet; see
  * tech-debt.md#42 for the block-backed version needed for frontend rendering.
  */
-export default function RowProperties( { fields, onLayoutReorder, row } ) {
+export default function RowProperties( {
+	collectionId,
+	fields,
+	onLayoutReorder,
+	row,
+} ) {
 	const { editPost } = useDispatch( editorStore );
 	const { optionOverrides, updateFieldOptions, refreshRows } =
 		useContext( RowMutationContext );
@@ -678,6 +737,7 @@ export default function RowProperties( { fields, onLayoutReorder, row } ) {
 				canReorderLayout ? (
 					<SortableRowProperty
 						key={ field.id }
+						collectionId={ collectionId }
 						data={ data }
 						field={ field }
 						optionOverrides={ optionOverrides }
@@ -689,6 +749,7 @@ export default function RowProperties( { fields, onLayoutReorder, row } ) {
 					<RowProperty
 						key={ field.id }
 						canReorderLayout={ false }
+						collectionId={ collectionId }
 						data={ data }
 						field={ field }
 						optionOverrides={ optionOverrides }

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -304,6 +304,38 @@ function EditableNumberPropertyText( { label, value, format, onChange } ) {
 		typeof formattedDisplay === 'string' ? formattedDisplay : textValue;
 	const hasRichDisplay =
 		formattedDisplay !== '' && typeof formattedDisplay !== 'string';
+	const showRawInputValue = useCallback(
+		( input ) => {
+			input.value = textValue;
+			setDraft( textValue );
+			setIsFocused( true );
+		},
+		[ textValue ]
+	);
+	const focusRawInputValue = useCallback(
+		( input ) => {
+			showRawInputValue( input );
+			input.focus();
+			input.select();
+		},
+		[ showRawInputValue ]
+	);
+	const handleInputInteractionStart = useCallback(
+		( event ) => {
+			event.stopPropagation();
+			if (
+				! isFocused ||
+				event.currentTarget.ownerDocument.activeElement !==
+					event.currentTarget
+			) {
+				focusRawInputValue( event.currentTarget );
+			}
+		},
+		[ focusRawInputValue, isFocused ]
+	);
+	const stopInputPropagation = useCallback( ( event ) => {
+		event.stopPropagation();
+	}, [] );
 
 	useEffect( () => {
 		committedTextRef.current = textValue;
@@ -348,7 +380,10 @@ function EditableNumberPropertyText( { label, value, format, onChange } ) {
 			<Button
 				className="cortext-row-detail__property-trigger"
 				variant="tertiary"
-				onClick={ () => {
+				onMouseDown={ stopInputPropagation }
+				onPointerDown={ stopInputPropagation }
+				onClick={ ( event ) => {
+					event.stopPropagation();
 					setDraft( textValue );
 					setIsFocused( true );
 				} }
@@ -368,6 +403,7 @@ function EditableNumberPropertyText( { label, value, format, onChange } ) {
 			placeholder={ isFocused ? '' : __( 'Empty', 'cortext' ) }
 			type="text"
 			value={ isFocused ? draft : formattedValue }
+			onClick={ stopInputPropagation }
 			onBlur={ () => {
 				setIsFocused( false );
 				const parsed = parseNumberPropertyValue( draft );
@@ -382,13 +418,13 @@ function EditableNumberPropertyText( { label, value, format, onChange } ) {
 				setDraft( committedTextRef.current );
 			} }
 			onChange={ ( event ) => commitDraft( event.currentTarget.value ) }
+			onMouseDown={ handleInputInteractionStart }
+			onPointerDown={ handleInputInteractionStart }
 			onFocus={ ( event ) => {
 				// The resting value may include formatting (for example
 				// thousands separators). Swap the DOM value immediately so
 				// keyboard input after focus edits the raw number.
-				event.currentTarget.value = textValue;
-				setDraft( textValue );
-				setIsFocused( true );
+				showRawInputValue( event.currentTarget );
 			} }
 		/>
 	);

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -22,6 +22,7 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -313,7 +314,7 @@ function EditableNumberPropertyText( { label, value, format, onChange } ) {
 		}
 	}, [ isFocused, textValue, value ] );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( isFocused ) {
 			inputRef.current?.focus();
 			inputRef.current?.select();
@@ -381,7 +382,11 @@ function EditableNumberPropertyText( { label, value, format, onChange } ) {
 				setDraft( committedTextRef.current );
 			} }
 			onChange={ ( event ) => commitDraft( event.currentTarget.value ) }
-			onFocus={ () => {
+			onFocus={ ( event ) => {
+				// The resting value may include formatting (for example
+				// thousands separators). Swap the DOM value immediately so
+				// keyboard input after focus edits the raw number.
+				event.currentTarget.value = textValue;
 				setDraft( textValue );
 				setIsFocused( true );
 			} }

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -288,17 +288,21 @@ function EditablePropertyText( { label, inputMode, value, onChange } ) {
 function EditableNumberPropertyText( { label, value, format, onChange } ) {
 	const textValue =
 		value === null || value === undefined ? '' : String( value );
+	const inputRef = useRef( null );
 	const committedTextRef = useRef( textValue );
 	const committedValueRef = useRef( value ?? null );
 	const [ draft, setDraft ] = useState( textValue );
 	const [ isFocused, setIsFocused ] = useState( false );
-	const formattedValue = useMemo( () => {
+	const formattedDisplay = useMemo( () => {
 		if ( textValue === '' || ! format ) {
 			return textValue;
 		}
-		const display = formatDisplay( value, 'number', { format } );
-		return typeof display === 'string' ? display : textValue;
+		return formatDisplay( value, 'number', { format } );
 	}, [ format, textValue, value ] );
+	const formattedValue =
+		typeof formattedDisplay === 'string' ? formattedDisplay : textValue;
+	const hasRichDisplay =
+		formattedDisplay !== '' && typeof formattedDisplay !== 'string';
 
 	useEffect( () => {
 		committedTextRef.current = textValue;
@@ -308,6 +312,13 @@ function EditableNumberPropertyText( { label, value, format, onChange } ) {
 			setDraft( textValue );
 		}
 	}, [ isFocused, textValue, value ] );
+
+	useEffect( () => {
+		if ( isFocused ) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [ isFocused ] );
 
 	const commitDraft = useCallback(
 		( nextDraft ) => {
@@ -331,8 +342,25 @@ function EditableNumberPropertyText( { label, value, format, onChange } ) {
 		[ onChange ]
 	);
 
+	if ( hasRichDisplay && ! isFocused ) {
+		return (
+			<Button
+				className="cortext-row-detail__property-trigger"
+				variant="tertiary"
+				onClick={ () => {
+					setDraft( textValue );
+					setIsFocused( true );
+				} }
+				aria-label={ label }
+			>
+				{ formattedDisplay }
+			</Button>
+		);
+	}
+
 	return (
 		<input
+			ref={ inputRef }
 			aria-label={ label }
 			className="cortext-row-detail__property-editable-text"
 			inputMode="decimal"

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -491,6 +491,7 @@ function PropertyLabel( {
 					</span>
 				</span>
 			}
+			renamingPrefix={ icon }
 			onFieldOptionsSaved={ onFieldOptionsSaved }
 			onFieldFormatSaved={ onFieldFormatSaved }
 			onRowsChanged={ onRowsChanged }

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -491,7 +491,6 @@ function PropertyLabel( {
 					</span>
 				</span>
 			}
-			renamingPrefix={ icon }
 			onFieldOptionsSaved={ onFieldOptionsSaved }
 			onFieldFormatSaved={ onFieldFormatSaved }
 			onRowsChanged={ onRowsChanged }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -167,6 +167,7 @@ function FieldActions( {
 	const [ shouldFocusCalculation, setShouldFocusCalculation ] =
 		useState( false );
 	const calculationItemRef = useRef( null );
+	const closeFieldMenuRef = useRef( null );
 	const closeTimerRef = useRef( null );
 	// `useCollectionFields` already fetched these records with `context: 'edit'`
 	// and ran them through `mapField`. Read label/type/options from the cached
@@ -238,6 +239,13 @@ function FieldActions( {
 		window.requestAnimationFrame( () => {
 			calculationItemRef.current?.focus();
 		} );
+	}, [ closeCalculation ] );
+	const closeFieldMenu = useCallback( () => {
+		if ( closeFieldMenuRef.current ) {
+			closeFieldMenuRef.current();
+			return;
+		}
+		closeCalculation();
 	}, [ closeCalculation ] );
 
 	const label = effectiveField?.label || `#${ recordId }`;
@@ -449,6 +457,7 @@ function FieldActions( {
 						) : null }
 					</span>
 				}
+				closeMenuRef={ closeFieldMenuRef }
 				onFieldOptionsSaved={ onFieldOptionsSaved }
 				onFieldFormatSaved={ onFieldFormatSaved }
 				onOpenFormat={ closeCalculation }
@@ -473,7 +482,7 @@ function FieldActions( {
 								calculation
 							)
 						);
-						closeCalculation();
+						closeFieldMenu();
 					} }
 					onClose={ closeCalculationAndFocusTrigger }
 					onMouseEnter={ () => openCalculation() }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -4,6 +4,7 @@ import { Button, Dropdown, Icon } from '@wordpress/components';
 import {
 	createPortal,
 	useCallback,
+	useContext,
 	useEffect,
 	useMemo,
 	useRef,
@@ -22,6 +23,7 @@ import './ColumnHeaderActions.scss';
 import AddFieldPopover from './AddFieldPopover';
 import FieldActionsMenu from './FieldActionsMenu';
 import { FieldTypeIcon } from './fieldTypes';
+import { RowMutationContext } from '../EditableCell';
 import { useMappedField } from '../CollectionFieldsContext';
 import { TableCalculationPopover } from '../TableCalculationMenu';
 import { GHOST_FIELD_ID, TITLE_FIELD_ID } from '../dataViewColumns';
@@ -45,6 +47,7 @@ export default function ColumnHeaderActions( {
 	view,
 	onChangeView,
 	onFieldOptionsSaved,
+	onFieldFormatSaved,
 	onFieldCreated,
 	onRowsChanged,
 } ) {
@@ -130,6 +133,7 @@ export default function ColumnHeaderActions( {
 							view={ view }
 							onChangeView={ onChangeView }
 							onFieldOptionsSaved={ onFieldOptionsSaved }
+							onFieldFormatSaved={ onFieldFormatSaved }
 							onRowsChanged={ onRowsChanged }
 						/>,
 						target.th,
@@ -156,6 +160,7 @@ function FieldActions( {
 	view,
 	onChangeView,
 	onFieldOptionsSaved,
+	onFieldFormatSaved,
 	onRowsChanged,
 } ) {
 	const [ isCalculating, setIsCalculating ] = useState( false );
@@ -169,7 +174,16 @@ function FieldActions( {
 	// trip, which would otherwise flash `#${ recordId }` before the title
 	// arrives. See the tech-debt note in `useCollectionFields`.
 	const mappedField = useMappedField( recordId );
-	const fieldType = mappedField?.cortextType;
+	const { formatOverrides } = useContext( RowMutationContext );
+	const dataViewId = `field-${ recordId }`;
+	const formatOverride = formatOverrides?.[ dataViewId ];
+	const effectiveField = useMemo( () => {
+		if ( ! mappedField || formatOverride === undefined ) {
+			return mappedField;
+		}
+		return { ...mappedField, cortextFormat: formatOverride };
+	}, [ formatOverride, mappedField ] );
+	const fieldType = effectiveField?.cortextType;
 
 	// Match the field-format submenu: leave a small grace window while the
 	// pointer crosses the gap between the row and the flyout.
@@ -225,8 +239,7 @@ function FieldActions( {
 		} );
 	}, [ closeCalculation ] );
 
-	const dataViewId = `field-${ recordId }`;
-	const label = mappedField?.label || `#${ recordId }`;
+	const label = effectiveField?.label || `#${ recordId }`;
 	const calculationField = useMemo(
 		() => ( {
 			id: dataViewId,
@@ -399,7 +412,7 @@ function FieldActions( {
 			<FieldActionsMenu
 				recordId={ recordId }
 				collectionId={ collectionId }
-				field={ mappedField }
+				field={ effectiveField }
 				className="cortext-column-header-actions"
 				menuKey={ `menu-${ dataViewId }-${ sortMenuKey }` }
 				triggerButton={
@@ -428,6 +441,7 @@ function FieldActions( {
 					</span>
 				}
 				onFieldOptionsSaved={ onFieldOptionsSaved }
+				onFieldFormatSaved={ onFieldFormatSaved }
 				onRowsChanged={ onRowsChanged }
 				onCloseMenu={ closeCalculation }
 				renderBetweenConfigAndLifecycle={ renderViewGroup }

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -1,14 +1,6 @@
 /* global MutationObserver */
-import { __, sprintf } from '@wordpress/i18n';
-import {
-	Button,
-	Dropdown,
-	Icon,
-	Popover,
-	privateApis as componentsPrivateApis,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalConfirmDialog as ConfirmDialog,
-} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Button, Dropdown, Icon } from '@wordpress/components';
 import {
 	createPortal,
 	useCallback,
@@ -21,45 +13,19 @@ import {
 	arrowLeft,
 	arrowRight,
 	chevronRight,
-	copy,
-	pencil,
 	plus,
-	trash,
 	unseen,
 } from '@wordpress/icons';
 
 import './ColumnHeaderActions.scss';
 
-import { unlock } from '../../lock-unlock';
 import AddFieldPopover from './AddFieldPopover';
-import ChangeFieldTypePopover from './ChangeFieldTypePopover';
-import EditOptionsPopover from './EditOptionsPopover';
-import FieldFormatPopover from './FieldFormatPopover';
+import FieldActionsMenu from './FieldActionsMenu';
 import { FieldTypeIcon } from './fieldTypes';
-import RenameFieldInline from './RenameFieldInline';
-import {
-	useCollectionFieldsContext,
-	useMappedField,
-} from '../CollectionFieldsContext';
+import { useMappedField } from '../CollectionFieldsContext';
 import { TableCalculationPopover } from '../TableCalculationMenu';
-import {
-	useDeleteField,
-	useDuplicateField,
-} from '../../hooks/useFieldMutations';
 import { GHOST_FIELD_ID, TITLE_FIELD_ID } from '../dataViewColumns';
 import { withColumnCalculation } from '../tableCalculations';
-
-const TYPES_WITH_OPTIONS = new Set( [ 'select', 'multiselect' ] );
-const { Menu } = unlock( componentsPrivateApis );
-
-const FORMATTABLE_TYPES = new Set( [ 'number', 'date', 'datetime' ] );
-
-// The server rejects conversions for these types, so hide the action up front.
-const UNCONVERTIBLE_SOURCE_TYPES = new Set( [
-	'relation',
-	'rollup',
-	'formula',
-] );
 
 // Projects Cortext controls into DataViews' table header:
 //
@@ -192,23 +158,11 @@ function FieldActions( {
 	onFieldOptionsSaved,
 	onRowsChanged,
 } ) {
-	const [ isRenaming, setIsRenaming ] = useState( false );
-	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
-	const [ isFormatting, setIsFormatting ] = useState( false );
-	const [ isEditingOptions, setIsEditingOptions ] = useState( false );
-	const [ isChangingType, setIsChangingType ] = useState( false );
 	const [ isCalculating, setIsCalculating ] = useState( false );
-	const [ shouldFocusFormat, setShouldFocusFormat ] = useState( false );
 	const [ shouldFocusCalculation, setShouldFocusCalculation ] =
 		useState( false );
-	const [ confirmDelete, setConfirmDelete ] = useState( false );
-	const formatItemRef = useRef( null );
 	const calculationItemRef = useRef( null );
 	const closeTimerRef = useRef( null );
-	const optionsAnchorRef = useRef( null );
-	const duplicate = useDuplicateField( collectionId );
-	const remove = useDeleteField( collectionId );
-	const { fields } = useCollectionFieldsContext();
 	// `useCollectionFields` already fetched these records with `context: 'edit'`
 	// and ran them through `mapField`. Read label/type/options from the cached
 	// field so the header skips `useEntityRecord`'s `default`-context resolver
@@ -216,19 +170,9 @@ function FieldActions( {
 	// arrives. See the tech-debt note in `useCollectionFields`.
 	const mappedField = useMappedField( recordId );
 	const fieldType = mappedField?.cortextType;
-	const canFormat = FORMATTABLE_TYPES.has( fieldType );
-	const supportsOptions = TYPES_WITH_OPTIONS.has( fieldType );
-	const canChangeType =
-		Boolean( fieldType ) && ! UNCONVERTIBLE_SOURCE_TYPES.has( fieldType );
-	const initialOptions = useMemo(
-		() => ( supportsOptions ? mappedField?.cortextElements ?? [] : [] ),
-		[ supportsOptions, mappedField ]
-	);
 
-	// Format submenu uses a hover-with-grace pattern: the panel stays
-	// visible while the cursor is over either the trigger row or the
-	// panel itself. The grace timer absorbs the dead pixels between them
-	// so the user doesn't lose the panel by overshooting on the way over.
+	// Match the field-format submenu: leave a small grace window while the
+	// pointer crosses the gap between the row and the flyout.
 	const cancelClose = useCallback( () => {
 		if ( closeTimerRef.current ) {
 			clearTimeout( closeTimerRef.current );
@@ -238,56 +182,25 @@ function FieldActions( {
 	const scheduleClose = useCallback( () => {
 		cancelClose();
 		closeTimerRef.current = setTimeout( () => {
-			setIsFormatting( false );
 			setIsCalculating( false );
-			setShouldFocusFormat( false );
 			setShouldFocusCalculation( false );
 			closeTimerRef.current = null;
 		}, 180 );
 	}, [ cancelClose ] );
-	const openFormat = useCallback(
-		( focus = false ) => {
-			cancelClose();
-			setIsCalculating( false );
-			setShouldFocusFormat( focus );
-			setShouldFocusCalculation( false );
-			setIsFormatting( true );
-		},
-		[ cancelClose ]
-	);
-	useEffect( () => () => cancelClose(), [ cancelClose ] );
-
-	const closeMenu = useCallback( () => {
-		cancelClose();
-		setIsFormatting( false );
-		setIsCalculating( false );
-		setShouldFocusFormat( false );
-		setShouldFocusCalculation( false );
-		setIsMenuOpen( false );
-	}, [ cancelClose ] );
-
-	const closeFormat = useCallback( () => {
-		cancelClose();
-		setIsFormatting( false );
-		setShouldFocusFormat( false );
-	}, [ cancelClose ] );
-
 	const closeCalculation = useCallback( () => {
-		cancelClose();
 		setIsCalculating( false );
 		setShouldFocusCalculation( false );
+		cancelClose();
 	}, [ cancelClose ] );
-
 	const openCalculation = useCallback(
 		( focus = false ) => {
 			cancelClose();
-			setIsFormatting( false );
-			setShouldFocusFormat( false );
 			setShouldFocusCalculation( focus );
 			setIsCalculating( true );
 		},
 		[ cancelClose ]
 	);
+	useEffect( () => () => cancelClose(), [ cancelClose ] );
 
 	const openCalculationFromKeyboard = useCallback(
 		( event ) => {
@@ -305,92 +218,12 @@ function FieldActions( {
 		[ openCalculation ]
 	);
 
-	const closeFormatAndFocusTrigger = useCallback( () => {
-		closeFormat();
-		window.requestAnimationFrame( () => {
-			formatItemRef.current?.focus();
-		} );
-	}, [ closeFormat ] );
-
 	const closeCalculationAndFocusTrigger = useCallback( () => {
 		closeCalculation();
 		window.requestAnimationFrame( () => {
 			calculationItemRef.current?.focus();
 		} );
 	}, [ closeCalculation ] );
-
-	const openFormatFromKeyboard = useCallback(
-		( event ) => {
-			if (
-				! [ 'ArrowRight', 'Enter', ' ', 'Spacebar' ].includes(
-					event.key
-				)
-			) {
-				return;
-			}
-			event.preventDefault();
-			event.stopPropagation();
-			openFormat( true );
-		},
-		[ openFormat ]
-	);
-
-	const onMenuOpenChange = useCallback(
-		( nextOpen ) => {
-			if ( nextOpen ) {
-				setIsMenuOpen( true );
-			} else {
-				closeMenu();
-			}
-		},
-		[ closeMenu ]
-	);
-
-	// Keep Ariakit from auto-hiding the menu when the user interacts
-	// with the format popover or one of its third-level flyouts.
-	const hideMenuOnInteractOutside = useCallback( ( event ) => {
-		const target = event.target;
-		if ( target && typeof target.closest === 'function' ) {
-			if (
-				target.closest( '.cortext-format-submenu' ) ||
-				target.closest( '.cortext-format-submenu__flyout' ) ||
-				target.closest( '.cortext-table-calculation-submenu' )
-			) {
-				return false;
-			}
-		}
-		return true;
-	}, [] );
-
-	// When this component renders inside an iframe (e.g. the Gutenberg
-	// canvas), Ariakit's outside-click listener only fires for events in
-	// the iframe document. Clicks on the editor chrome (sidebar, header)
-	// happen on the parent document, so without an extra listener there
-	// the menu stays open until the user clicks back into the canvas.
-	useEffect( () => {
-		if ( ! isMenuOpen ) {
-			return undefined;
-		}
-		let parentDoc;
-		try {
-			if ( window.parent && window.parent !== window ) {
-				parentDoc = window.parent.document;
-			}
-		} catch {
-			parentDoc = undefined;
-		}
-		if ( ! parentDoc || parentDoc === document ) {
-			return undefined;
-		}
-		const onParentMouseDown = ( event ) => {
-			if ( hideMenuOnInteractOutside( event ) ) {
-				closeMenu();
-			}
-		};
-		parentDoc.addEventListener( 'mousedown', onParentMouseDown );
-		return () =>
-			parentDoc.removeEventListener( 'mousedown', onParentMouseDown );
-	}, [ isMenuOpen, closeMenu, hideMenuOnInteractOutside ] );
 
 	const dataViewId = `field-${ recordId }`;
 	const label = mappedField?.label || `#${ recordId }`;
@@ -411,16 +244,6 @@ function FieldActions( {
 	const isSorted = sortField === dataViewId;
 	const sortMenuKey = isSorted ? sortDirection : 'none';
 	const sortRadioGroupName = `cortext-column-sort-${ recordId }-${ sortMenuKey }`;
-	const dependentRollups = useMemo(
-		() =>
-			fields.filter(
-				( field ) =>
-					field.cortextType === 'rollup' &&
-					( field.rollupRelationFieldId === recordId ||
-						field.rollupTargetFieldId === recordId )
-			),
-		[ fields, recordId ]
-	);
 
 	// Move only touches data fields. Title stays pinned, and the legacy
 	// ghost id is ignored if an older saved view still has it.
@@ -479,43 +302,113 @@ function FieldActions( {
 		onChangeView( { ...view, fields: next } );
 	}, [ onChangeView, view, dataViewId, visibleFields ] );
 
-	const onConfirmDelete = useCallback( async () => {
-		try {
-			await remove.run( recordId );
-		} finally {
-			setConfirmDelete( false );
-		}
-	}, [ remove, recordId ] );
+	const renderViewGroup = useCallback(
+		( { Menu, closeMenu } ) => (
+			<Menu.Group key={ `sort-${ dataViewId }-${ sortMenuKey }` }>
+				<Menu.Item
+					ref={ calculationItemRef }
+					className="cortext-column-header-actions__submenu-item"
+					hideOnClick={ false }
+					suffix={ <Icon icon={ chevronRight } size={ 18 } /> }
+					onClick={ () => openCalculation() }
+					onKeyDown={ openCalculationFromKeyboard }
+					onMouseEnter={ () => openCalculation() }
+					onMouseLeave={ scheduleClose }
+				>
+					<Menu.ItemLabel>
+						{ __( 'Calculate', 'cortext' ) }
+					</Menu.ItemLabel>
+				</Menu.Item>
+				<Menu.RadioItem
+					name={ sortRadioGroupName }
+					value="asc"
+					checked={ isSorted && sortDirection === 'asc' }
+					hideOnClick
+					onChange={ () => dispatchSort( 'asc' ) }
+				>
+					<Menu.ItemLabel>
+						{ __( 'Sort ascending', 'cortext' ) }
+					</Menu.ItemLabel>
+				</Menu.RadioItem>
+				<Menu.RadioItem
+					name={ sortRadioGroupName }
+					value="desc"
+					checked={ isSorted && sortDirection === 'desc' }
+					hideOnClick
+					onChange={ () => dispatchSort( 'desc' ) }
+				>
+					<Menu.ItemLabel>
+						{ __( 'Sort descending', 'cortext' ) }
+					</Menu.ItemLabel>
+				</Menu.RadioItem>
+				<Menu.Item
+					prefix={ <Icon icon={ unseen } /> }
+					onClick={ () => {
+						dispatchHide();
+						closeMenu();
+					} }
+				>
+					<Menu.ItemLabel>
+						{ __( 'Hide column', 'cortext' ) }
+					</Menu.ItemLabel>
+				</Menu.Item>
+			</Menu.Group>
+		),
+		[
+			dataViewId,
+			dispatchHide,
+			dispatchSort,
+			isSorted,
+			openCalculation,
+			openCalculationFromKeyboard,
+			scheduleClose,
+			sortDirection,
+			sortMenuKey,
+			sortRadioGroupName,
+		]
+	);
 
-	if ( isRenaming ) {
-		return (
-			<span className="cortext-column-header-actions">
-				<RenameFieldInline
-					recordId={ recordId }
-					onDone={ () => setIsRenaming( false ) }
-				/>
-			</span>
-		);
-	}
+	const renderLifecyclePrefix = useCallback(
+		( { Menu } ) => (
+			<>
+				<Menu.Item
+					prefix={ <Icon icon={ arrowLeft } /> }
+					disabled={ ! canMoveLeft }
+					onClick={ () => dispatchMove( -1 ) }
+				>
+					<Menu.ItemLabel>
+						{ __( 'Move left', 'cortext' ) }
+					</Menu.ItemLabel>
+				</Menu.Item>
+				<Menu.Item
+					prefix={ <Icon icon={ arrowRight } /> }
+					disabled={ ! canMoveRight }
+					onClick={ () => dispatchMove( 1 ) }
+				>
+					<Menu.ItemLabel>
+						{ __( 'Move right', 'cortext' ) }
+					</Menu.ItemLabel>
+				</Menu.Item>
+			</>
+		),
+		[ canMoveLeft, canMoveRight, dispatchMove ]
+	);
 
 	return (
-		<span
-			className="cortext-column-header-actions"
-			ref={ optionsAnchorRef }
-		>
-			<Menu
-				key={ `menu-${ dataViewId }-${ sortMenuKey }` }
-				open={ isMenuOpen }
-				onOpenChange={ onMenuOpenChange }
-			>
-				<Menu.TriggerButton
-					render={
-						<Button
-							className="dataviews-view-table-header-button cortext-column-header-trigger"
-							variant="tertiary"
-						/>
-					}
-				>
+		<>
+			<FieldActionsMenu
+				recordId={ recordId }
+				collectionId={ collectionId }
+				field={ mappedField }
+				className="cortext-column-header-actions"
+				menuKey={ `menu-${ dataViewId }-${ sortMenuKey }` }
+				triggerButton={
+					<Button
+						className="dataviews-view-table-header-button cortext-column-header-trigger"
+						variant="tertiary"
+					/>
+				}
+				triggerContent={
 					<span className="cortext-column-header-content">
 						<FieldTypeIcon
 							type={ fieldType }
@@ -533,175 +426,13 @@ function FieldActions( {
 							</span>
 						) : null }
 					</span>
-				</Menu.TriggerButton>
-				<Menu.Popover
-					className="cortext-field-actions-popover"
-					modal={ false }
-					portal
-					hideOnInteractOutside={ hideMenuOnInteractOutside }
-					style={ { minWidth: '240px' } }
-				>
-					{ /* Property-config group: edit how the column
-					     itself is defined. Keeps field actions grouped by
-					     section (Edit property / Change type). */ }
-					<Menu.Group>
-						<Menu.Item
-							prefix={ <Icon icon={ pencil } /> }
-							onClick={ () => setIsRenaming( true ) }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Rename', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-						{ canFormat ? (
-							<Menu.Item
-								ref={ formatItemRef }
-								className="cortext-column-header-actions__submenu-item"
-								hideOnClick={ false }
-								suffix={
-									<Icon icon={ chevronRight } size={ 18 } />
-								}
-								onClick={ () => openFormat() }
-								onKeyDown={ openFormatFromKeyboard }
-								onMouseEnter={ () => openFormat() }
-								onMouseLeave={ scheduleClose }
-							>
-								<Menu.ItemLabel>
-									{ __( 'Edit field', 'cortext' ) }
-								</Menu.ItemLabel>
-							</Menu.Item>
-						) : null }
-						{ supportsOptions ? (
-							<Menu.Item
-								onClick={ () => setIsEditingOptions( true ) }
-							>
-								<Menu.ItemLabel>
-									{ __( 'Edit options', 'cortext' ) }
-								</Menu.ItemLabel>
-							</Menu.Item>
-						) : null }
-						{ canChangeType ? (
-							<Menu.Item
-								onClick={ () => setIsChangingType( true ) }
-							>
-								<Menu.ItemLabel>
-									{ __( 'Change type…', 'cortext' ) }
-								</Menu.ItemLabel>
-							</Menu.Item>
-						) : null }
-					</Menu.Group>
-					<Menu.Separator />
-					{ /* View group: keep sort/hide actions together. */ }
-					<Menu.Group key={ `sort-${ dataViewId }-${ sortMenuKey }` }>
-						<Menu.Item
-							ref={ calculationItemRef }
-							className="cortext-column-header-actions__submenu-item"
-							hideOnClick={ false }
-							suffix={
-								<Icon icon={ chevronRight } size={ 18 } />
-							}
-							onClick={ () => openCalculation() }
-							onKeyDown={ openCalculationFromKeyboard }
-							onMouseEnter={ () => openCalculation() }
-							onMouseLeave={ scheduleClose }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Calculate', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.RadioItem
-							name={ sortRadioGroupName }
-							value="asc"
-							checked={ isSorted && sortDirection === 'asc' }
-							hideOnClick
-							onChange={ () => dispatchSort( 'asc' ) }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Sort ascending', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.RadioItem>
-						<Menu.RadioItem
-							name={ sortRadioGroupName }
-							value="desc"
-							checked={ isSorted && sortDirection === 'desc' }
-							hideOnClick
-							onChange={ () => dispatchSort( 'desc' ) }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Sort descending', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.RadioItem>
-						<Menu.Item
-							prefix={ <Icon icon={ unseen } /> }
-							onClick={ dispatchHide }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Hide column', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-					</Menu.Group>
-					<Menu.Separator />
-					{ /* Column-lifecycle group: move, duplicate, delete. */ }
-					<Menu.Group>
-						<Menu.Item
-							prefix={ <Icon icon={ arrowLeft } /> }
-							disabled={ ! canMoveLeft }
-							onClick={ () => dispatchMove( -1 ) }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Move left', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Item
-							prefix={ <Icon icon={ arrowRight } /> }
-							disabled={ ! canMoveRight }
-							onClick={ () => dispatchMove( 1 ) }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Move right', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Item
-							prefix={ <Icon icon={ copy } /> }
-							onClick={ async () => {
-								try {
-									const duplicated =
-										await duplicate.run( recordId );
-									if ( duplicated?.type === 'rollup' ) {
-										onRowsChanged?.();
-									}
-								} catch {
-									// surfaced via duplicate.error.
-								}
-							} }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Duplicate', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Item
-							className="cortext-column-header-actions__destructive-item"
-							prefix={ <Icon icon={ trash } /> }
-							onClick={ () => setConfirmDelete( true ) }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Delete', 'cortext' ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-					</Menu.Group>
-				</Menu.Popover>
-			</Menu>
-			{ isFormatting && canFormat ? (
-				<FieldFormatPopover
-					recordId={ recordId }
-					anchor={ formatItemRef.current }
-					focusOnMount={ shouldFocusFormat ? 'firstElement' : false }
-					onClose={ closeFormat }
-					onCloseWithFocus={ closeFormatAndFocusTrigger }
-					onMouseEnter={ () => openFormat() }
-					onMouseLeave={ scheduleClose }
-				/>
-			) : null }
+				}
+				onFieldOptionsSaved={ onFieldOptionsSaved }
+				onRowsChanged={ onRowsChanged }
+				onCloseMenu={ closeCalculation }
+				renderBetweenConfigAndLifecycle={ renderViewGroup }
+				renderLifecyclePrefix={ renderLifecyclePrefix }
+			/>
 			{ isCalculating ? (
 				<TableCalculationPopover
 					anchor={ calculationItemRef.current }
@@ -718,78 +449,14 @@ function FieldActions( {
 								calculation
 							)
 						);
-						closeMenu();
+						closeCalculation();
 					} }
 					onClose={ closeCalculationAndFocusTrigger }
 					onMouseEnter={ () => openCalculation() }
 					onMouseLeave={ scheduleClose }
 				/>
 			) : null }
-			{ confirmDelete ? (
-				<ConfirmDialog
-					onConfirm={ onConfirmDelete }
-					onCancel={ () => setConfirmDelete( false ) }
-					confirmButtonText={ __( 'Delete', 'cortext' ) }
-				>
-					<p>
-						{ __(
-							'Delete this field? Existing values for this field will be removed from every entry.',
-							'cortext'
-						) }
-					</p>
-					{ dependentRollups.length > 0 ? (
-						<p>
-							{ dependentRollups.length === 1
-								? __(
-										'This will also delete 1 rollup that depends on it:',
-										'cortext'
-								  )
-								: sprintf(
-										/* translators: %d: number of dependent rollup fields */
-										__(
-											'This will also delete %d rollups that depend on it:',
-											'cortext'
-										),
-										dependentRollups.length
-								  ) }{ ' ' }
-							{ dependentRollups
-								.map( ( field ) => field.label )
-								.join( ', ' ) }
-						</p>
-					) : null }
-				</ConfirmDialog>
-			) : null }
-			{ isEditingOptions && supportsOptions ? (
-				<Popover
-					anchor={ optionsAnchorRef.current }
-					placement="bottom-start"
-					onClose={ () => setIsEditingOptions( false ) }
-					focusOnMount="firstElement"
-					className="cortext-edit-options-popover-host"
-				>
-					<EditOptionsPopover
-						recordId={ recordId }
-						fieldType={ fieldType }
-						initialOptions={ initialOptions }
-						onOptionsSaved={ ( nextOptions ) =>
-							onFieldOptionsSaved?.( recordId, nextOptions )
-						}
-						onRowsChanged={ onRowsChanged }
-						onRequestClose={ () => setIsEditingOptions( false ) }
-					/>
-				</Popover>
-			) : null }
-			{ isChangingType && canChangeType ? (
-				<ChangeFieldTypePopover
-					anchor={ optionsAnchorRef.current }
-					collectionId={ collectionId }
-					recordId={ recordId }
-					currentType={ fieldType }
-					onClose={ () => setIsChangingType( false ) }
-					onTypeChanged={ onRowsChanged }
-				/>
-			) : null }
-		</span>
+		</>
 	);
 }
 

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -217,7 +217,7 @@ function FieldActions( {
 	useEffect( () => () => cancelClose(), [ cancelClose ] );
 
 	const openCalculationFromKeyboard = useCallback(
-		( event ) => {
+		( event, beforeOpen ) => {
 			if (
 				! [ 'ArrowRight', 'Enter', ' ', 'Spacebar' ].includes(
 					event.key
@@ -227,6 +227,7 @@ function FieldActions( {
 			}
 			event.preventDefault();
 			event.stopPropagation();
+			beforeOpen?.();
 			openCalculation( true );
 		},
 		[ openCalculation ]
@@ -316,16 +317,24 @@ function FieldActions( {
 	}, [ onChangeView, view, dataViewId, visibleFields ] );
 
 	const renderViewGroup = useCallback(
-		( { Menu, closeMenu } ) => (
+		( { Menu, closeMenu, closeFormat } ) => (
 			<Menu.Group key={ `sort-${ dataViewId }-${ sortMenuKey }` }>
 				<Menu.Item
 					ref={ calculationItemRef }
 					className="cortext-column-header-actions__submenu-item"
 					hideOnClick={ false }
 					suffix={ <Icon icon={ chevronRight } size={ 18 } /> }
-					onClick={ () => openCalculation() }
-					onKeyDown={ openCalculationFromKeyboard }
-					onMouseEnter={ () => openCalculation() }
+					onClick={ () => {
+						closeFormat?.();
+						openCalculation();
+					} }
+					onKeyDown={ ( event ) =>
+						openCalculationFromKeyboard( event, closeFormat )
+					}
+					onMouseEnter={ () => {
+						closeFormat?.();
+						openCalculation();
+					} }
 					onMouseLeave={ scheduleClose }
 				>
 					<Menu.ItemLabel>
@@ -442,6 +451,7 @@ function FieldActions( {
 				}
 				onFieldOptionsSaved={ onFieldOptionsSaved }
 				onFieldFormatSaved={ onFieldFormatSaved }
+				onOpenFormat={ closeCalculation }
 				onRowsChanged={ onRowsChanged }
 				onCloseMenu={ closeCalculation }
 				renderBetweenConfigAndLifecycle={ renderViewGroup }

--- a/src/components/fields/FieldActionsMenu.js
+++ b/src/components/fields/FieldActionsMenu.js
@@ -50,6 +50,7 @@ export default function FieldActionsMenu( {
 	menuKey,
 	triggerButton,
 	triggerContent,
+	renamingPrefix,
 	onFieldOptionsSaved,
 	onFieldFormatSaved,
 	onOpenFormat,
@@ -258,6 +259,11 @@ export default function FieldActionsMenu( {
 	if ( isRenaming ) {
 		return (
 			<span className={ className }>
+				{ renamingPrefix ? (
+					<span className="cortext-field-actions__renaming-prefix">
+						{ renamingPrefix }
+					</span>
+				) : null }
 				<RenameFieldInline
 					recordId={ recordId }
 					initialTitle={ label }

--- a/src/components/fields/FieldActionsMenu.js
+++ b/src/components/fields/FieldActionsMenu.js
@@ -52,6 +52,7 @@ export default function FieldActionsMenu( {
 	triggerContent,
 	onFieldOptionsSaved,
 	onFieldFormatSaved,
+	onOpenFormat,
 	onRowsChanged,
 	onCloseMenu,
 	renderBetweenConfigAndLifecycle,
@@ -126,10 +127,11 @@ export default function FieldActionsMenu( {
 	const openFormat = useCallback(
 		( focus = false ) => {
 			cancelClose();
+			onOpenFormat?.();
 			setShouldFocusFormat( focus );
 			setIsFormatting( true );
 		},
-		[ cancelClose ]
+		[ cancelClose, onOpenFormat ]
 	);
 	useEffect( () => () => cancelClose(), [ cancelClose ] );
 
@@ -245,6 +247,7 @@ export default function FieldActionsMenu( {
 	const menuContext = {
 		Menu,
 		closeMenu,
+		closeFormat,
 		label,
 		fieldType,
 		scheduleClose,

--- a/src/components/fields/FieldActionsMenu.js
+++ b/src/components/fields/FieldActionsMenu.js
@@ -1,0 +1,434 @@
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	Button,
+	Icon,
+	Popover,
+	privateApis as componentsPrivateApis,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import { unlock } from '../../lock-unlock';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { chevronRight, copy, pencil, trash } from '@wordpress/icons';
+
+import ChangeFieldTypePopover from './ChangeFieldTypePopover';
+import EditOptionsPopover from './EditOptionsPopover';
+import FieldFormatPopover from './FieldFormatPopover';
+import RenameFieldInline from './RenameFieldInline';
+import {
+	useCollectionFieldsContext,
+	useMappedField,
+} from '../CollectionFieldsContext';
+import {
+	useDeleteField,
+	useDuplicateField,
+} from '../../hooks/useFieldMutations';
+
+const { Menu } = unlock( componentsPrivateApis );
+
+const TYPES_WITH_OPTIONS = new Set( [ 'select', 'multiselect' ] );
+const FORMATTABLE_TYPES = new Set( [ 'number', 'date', 'datetime' ] );
+
+// The server rejects these conversions, so do not offer them.
+const UNCONVERTIBLE_SOURCE_TYPES = new Set( [
+	'relation',
+	'rollup',
+	'formula',
+] );
+
+export default function FieldActionsMenu( {
+	recordId,
+	collectionId,
+	field,
+	className = 'cortext-field-actions',
+	menuKey,
+	triggerButton,
+	triggerContent,
+	onFieldOptionsSaved,
+	onRowsChanged,
+	onCloseMenu,
+	renderBetweenConfigAndLifecycle,
+	renderLifecyclePrefix,
+} ) {
+	const [ isRenaming, setIsRenaming ] = useState( false );
+	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
+	const [ isFormatting, setIsFormatting ] = useState( false );
+	const [ isEditingOptions, setIsEditingOptions ] = useState( false );
+	const [ isChangingType, setIsChangingType ] = useState( false );
+	const [ shouldFocusFormat, setShouldFocusFormat ] = useState( false );
+	const [ confirmDelete, setConfirmDelete ] = useState( false );
+	const formatItemRef = useRef( null );
+	const closeTimerRef = useRef( null );
+	const optionsAnchorRef = useRef( null );
+	const duplicate = useDuplicateField( collectionId );
+	const remove = useDeleteField( collectionId );
+	const { fields } = useCollectionFieldsContext();
+	const mappedField = useMappedField( recordId );
+	const activeField = mappedField ?? field ?? null;
+	const label = activeField?.label || `#${ recordId }`;
+	const fieldType =
+		activeField?.cortextType ??
+		activeField?.cortextFieldType ??
+		activeField?.type;
+	const canFormat = FORMATTABLE_TYPES.has( fieldType );
+	const supportsOptions = TYPES_WITH_OPTIONS.has( fieldType );
+	const canChangeType =
+		Boolean( fieldType ) && ! UNCONVERTIBLE_SOURCE_TYPES.has( fieldType );
+	const initialOptions = useMemo(
+		() => ( supportsOptions ? activeField?.cortextElements ?? [] : [] ),
+		[ supportsOptions, activeField ]
+	);
+	const dependentRollups = useMemo( () => {
+		const fieldList = Array.isArray( fields ) ? fields : [];
+		return fieldList.filter(
+			( candidate ) =>
+				candidate.cortextType === 'rollup' &&
+				( candidate.rollupRelationFieldId === recordId ||
+					candidate.rollupTargetFieldId === recordId )
+		);
+	}, [ fields, recordId ] );
+
+	const cancelClose = useCallback( () => {
+		if ( closeTimerRef.current ) {
+			clearTimeout( closeTimerRef.current );
+			closeTimerRef.current = null;
+		}
+	}, [] );
+	const scheduleClose = useCallback( () => {
+		cancelClose();
+		closeTimerRef.current = setTimeout( () => {
+			setIsFormatting( false );
+			setShouldFocusFormat( false );
+			closeTimerRef.current = null;
+		}, 180 );
+	}, [ cancelClose ] );
+	const openFormat = useCallback(
+		( focus = false ) => {
+			cancelClose();
+			setShouldFocusFormat( focus );
+			setIsFormatting( true );
+		},
+		[ cancelClose ]
+	);
+	useEffect( () => () => cancelClose(), [ cancelClose ] );
+
+	const closeFormat = useCallback( () => {
+		cancelClose();
+		setIsFormatting( false );
+		setShouldFocusFormat( false );
+	}, [ cancelClose ] );
+
+	const closeMenu = useCallback( () => {
+		cancelClose();
+		setIsFormatting( false );
+		setShouldFocusFormat( false );
+		setIsMenuOpen( false );
+		onCloseMenu?.();
+	}, [ cancelClose, onCloseMenu ] );
+
+	const closeFormatAndFocusTrigger = useCallback( () => {
+		closeFormat();
+		window.requestAnimationFrame( () => {
+			formatItemRef.current?.focus();
+		} );
+	}, [ closeFormat ] );
+
+	const openFormatFromKeyboard = useCallback(
+		( event ) => {
+			if (
+				! [ 'ArrowRight', 'Enter', ' ', 'Spacebar' ].includes(
+					event.key
+				)
+			) {
+				return;
+			}
+			event.preventDefault();
+			event.stopPropagation();
+			openFormat( true );
+		},
+		[ openFormat ]
+	);
+
+	const onMenuOpenChange = useCallback(
+		( nextOpen ) => {
+			if ( nextOpen ) {
+				setIsMenuOpen( true );
+			} else {
+				closeMenu();
+			}
+		},
+		[ closeMenu ]
+	);
+
+	// tech-debt.md#30: Format lives here; Calculate is injected by table
+	// headers. Both are sibling popovers that act like submenus.
+	const hideMenuOnInteractOutside = useCallback( ( event ) => {
+		const target = event.target;
+		if ( target && typeof target.closest === 'function' ) {
+			if (
+				target.closest( '.cortext-format-submenu' ) ||
+				target.closest( '.cortext-format-submenu__flyout' ) ||
+				target.closest( '.cortext-table-calculation-submenu' )
+			) {
+				return false;
+			}
+		}
+		return true;
+	}, [] );
+
+	// tech-debt.md#27: Ariakit only sees clicks in this iframe. Editor chrome
+	// clicks land in the parent document, so listen there too.
+	useEffect( () => {
+		if ( ! isMenuOpen ) {
+			return undefined;
+		}
+		let parentDoc;
+		try {
+			if ( window.parent && window.parent !== window ) {
+				parentDoc = window.parent.document;
+			}
+		} catch {
+			parentDoc = undefined;
+		}
+		if ( ! parentDoc || parentDoc === document ) {
+			return undefined;
+		}
+		const onParentMouseDown = ( event ) => {
+			if ( hideMenuOnInteractOutside( event ) ) {
+				closeMenu();
+			}
+		};
+		parentDoc.addEventListener( 'mousedown', onParentMouseDown );
+		return () =>
+			parentDoc.removeEventListener( 'mousedown', onParentMouseDown );
+	}, [ isMenuOpen, closeMenu, hideMenuOnInteractOutside ] );
+
+	const onDuplicate = useCallback( async () => {
+		try {
+			await duplicate.run( recordId );
+			onRowsChanged?.();
+		} catch {
+			// surfaced via duplicate.error.
+		}
+	}, [ duplicate, onRowsChanged, recordId ] );
+
+	const onConfirmDelete = useCallback( async () => {
+		try {
+			await remove.run( recordId );
+			onRowsChanged?.();
+		} finally {
+			setConfirmDelete( false );
+		}
+	}, [ remove, onRowsChanged, recordId ] );
+
+	const menuContext = {
+		Menu,
+		closeMenu,
+		label,
+		fieldType,
+		scheduleClose,
+		cancelClose,
+		hideMenuOnInteractOutside,
+	};
+
+	if ( isRenaming ) {
+		return (
+			<span className={ className }>
+				<RenameFieldInline
+					recordId={ recordId }
+					initialTitle={ label }
+					onDone={ () => setIsRenaming( false ) }
+				/>
+			</span>
+		);
+	}
+
+	return (
+		<span className={ className } ref={ optionsAnchorRef }>
+			<Menu
+				key={ menuKey ?? `field-actions-${ recordId }-${ fieldType }` }
+				open={ isMenuOpen }
+				onOpenChange={ onMenuOpenChange }
+			>
+				<Menu.TriggerButton
+					render={
+						triggerButton ?? (
+							<Button variant="tertiary" label={ label } />
+						)
+					}
+				>
+					{ triggerContent ?? label }
+				</Menu.TriggerButton>
+				{ /* tech-debt.md#29: portal avoids table-header text
+				     transform leaking into the menu. */ }
+				<Menu.Popover
+					className="cortext-field-actions-popover"
+					modal={ false }
+					portal
+					hideOnInteractOutside={ hideMenuOnInteractOutside }
+					style={ { minWidth: '240px' } }
+				>
+					<Menu.Group>
+						<Menu.Item
+							prefix={ <Icon icon={ pencil } /> }
+							onClick={ () => setIsRenaming( true ) }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Rename', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+						{ canFormat ? (
+							<Menu.Item
+								ref={ formatItemRef }
+								className="cortext-column-header-actions__submenu-item"
+								hideOnClick={ false }
+								suffix={
+									<Icon icon={ chevronRight } size={ 18 } />
+								}
+								onClick={ () => openFormat() }
+								onKeyDown={ openFormatFromKeyboard }
+								onMouseEnter={ () => openFormat() }
+								onMouseLeave={ scheduleClose }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Edit field', 'cortext' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) : null }
+						{ supportsOptions ? (
+							<Menu.Item
+								onClick={ () => setIsEditingOptions( true ) }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Edit options', 'cortext' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) : null }
+						{ canChangeType ? (
+							<Menu.Item
+								onClick={ () => setIsChangingType( true ) }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Change type…', 'cortext' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) : null }
+					</Menu.Group>
+					{ renderBetweenConfigAndLifecycle ? (
+						<>
+							<Menu.Separator />
+							{ renderBetweenConfigAndLifecycle( menuContext ) }
+						</>
+					) : null }
+					<Menu.Separator />
+					<Menu.Group>
+						{ renderLifecyclePrefix?.( menuContext ) }
+						<Menu.Item
+							prefix={ <Icon icon={ copy } /> }
+							onClick={ onDuplicate }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Duplicate', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+						{ /* tech-debt.md#28: Menu.Item has no destructive
+						     variant, so style Delete with a class. */ }
+						<Menu.Item
+							className="cortext-column-header-actions__destructive-item"
+							prefix={ <Icon icon={ trash } /> }
+							onClick={ () => setConfirmDelete( true ) }
+						>
+							<Menu.ItemLabel>
+								{ __( 'Delete', 'cortext' ) }
+							</Menu.ItemLabel>
+						</Menu.Item>
+					</Menu.Group>
+				</Menu.Popover>
+			</Menu>
+			{ isFormatting && canFormat ? (
+				<FieldFormatPopover
+					recordId={ recordId }
+					field={ activeField }
+					anchor={ formatItemRef.current }
+					focusOnMount={ shouldFocusFormat ? 'firstElement' : false }
+					onClose={ closeFormat }
+					onCloseWithFocus={ closeFormatAndFocusTrigger }
+					onMouseEnter={ () => openFormat() }
+					onMouseLeave={ scheduleClose }
+				/>
+			) : null }
+			{ confirmDelete ? (
+				<ConfirmDialog
+					onConfirm={ onConfirmDelete }
+					onCancel={ () => setConfirmDelete( false ) }
+					confirmButtonText={ __( 'Delete', 'cortext' ) }
+				>
+					<p>
+						{ __(
+							'Delete this field? Existing values for this field will be removed from every entry.',
+							'cortext'
+						) }
+					</p>
+					{ dependentRollups.length > 0 ? (
+						<p>
+							{ dependentRollups.length === 1
+								? __(
+										'This will also delete 1 rollup that depends on it:',
+										'cortext'
+								  )
+								: sprintf(
+										/* translators: %d: number of dependent rollup fields */
+										__(
+											'This will also delete %d rollups that depend on it:',
+											'cortext'
+										),
+										dependentRollups.length
+								  ) }{ ' ' }
+							{ dependentRollups
+								.map( ( candidate ) => candidate.label )
+								.join( ', ' ) }
+						</p>
+					) : null }
+				</ConfirmDialog>
+			) : null }
+			{ isEditingOptions && supportsOptions ? (
+				<Popover
+					anchor={ optionsAnchorRef.current }
+					placement="bottom-start"
+					onClose={ () => setIsEditingOptions( false ) }
+					focusOnMount="firstElement"
+					className="cortext-edit-options-popover-host"
+				>
+					<EditOptionsPopover
+						recordId={ recordId }
+						fieldType={ fieldType }
+						initialOptions={ initialOptions }
+						onOptionsSaved={ ( nextOptions ) =>
+							onFieldOptionsSaved?.( recordId, nextOptions )
+						}
+						onRowsChanged={ onRowsChanged }
+						onRequestClose={ () => setIsEditingOptions( false ) }
+					/>
+				</Popover>
+			) : null }
+			{ isChangingType && canChangeType ? (
+				<ChangeFieldTypePopover
+					anchor={ optionsAnchorRef.current }
+					collectionId={ collectionId }
+					recordId={ recordId }
+					currentType={ fieldType }
+					onClose={ () => {
+						setIsChangingType( false );
+						onRowsChanged?.();
+					} }
+				/>
+			) : null }
+		</span>
+	);
+}

--- a/src/components/fields/FieldActionsMenu.js
+++ b/src/components/fields/FieldActionsMenu.js
@@ -51,6 +51,7 @@ export default function FieldActionsMenu( {
 	triggerButton,
 	triggerContent,
 	renamingPrefix,
+	closeMenuRef,
 	onFieldOptionsSaved,
 	onFieldFormatSaved,
 	onOpenFormat,
@@ -149,6 +150,18 @@ export default function FieldActionsMenu( {
 		setIsMenuOpen( false );
 		onCloseMenu?.();
 	}, [ cancelClose, onCloseMenu ] );
+
+	useEffect( () => {
+		if ( ! closeMenuRef ) {
+			return undefined;
+		}
+		closeMenuRef.current = closeMenu;
+		return () => {
+			if ( closeMenuRef.current === closeMenu ) {
+				closeMenuRef.current = null;
+			}
+		};
+	}, [ closeMenu, closeMenuRef ] );
 
 	const closeFormatAndFocusTrigger = useCallback( () => {
 		closeFormat();

--- a/src/components/fields/FieldActionsMenu.js
+++ b/src/components/fields/FieldActionsMenu.js
@@ -51,6 +51,7 @@ export default function FieldActionsMenu( {
 	triggerButton,
 	triggerContent,
 	onFieldOptionsSaved,
+	onFieldFormatSaved,
 	onRowsChanged,
 	onCloseMenu,
 	renderBetweenConfigAndLifecycle,
@@ -70,7 +71,21 @@ export default function FieldActionsMenu( {
 	const remove = useDeleteField( collectionId );
 	const { fields } = useCollectionFieldsContext();
 	const mappedField = useMappedField( recordId );
-	const activeField = mappedField ?? field ?? null;
+	const activeField = useMemo( () => {
+		const source = mappedField ?? field ?? null;
+		if ( ! source || ! field ) {
+			return source;
+		}
+		return {
+			...source,
+			...( field.cortextElements !== undefined
+				? { cortextElements: field.cortextElements }
+				: {} ),
+			...( field.cortextFormat !== undefined
+				? { cortextFormat: field.cortextFormat }
+				: {} ),
+		};
+	}, [ field, mappedField ] );
 	const label = activeField?.label || `#${ recordId }`;
 	const fieldType =
 		activeField?.cortextType ??
@@ -359,6 +374,10 @@ export default function FieldActionsMenu( {
 					focusOnMount={ shouldFocusFormat ? 'firstElement' : false }
 					onClose={ closeFormat }
 					onCloseWithFocus={ closeFormatAndFocusTrigger }
+					onSaved={ ( nextFormat ) => {
+						onFieldFormatSaved?.( recordId, nextFormat );
+						onRowsChanged?.();
+					} }
 					onMouseEnter={ () => openFormat() }
 					onMouseLeave={ scheduleClose }
 				/>

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -828,14 +828,22 @@ export default function FieldFormatPopover( {
 	focusOnMount = false,
 	onClose,
 	onCloseWithFocus,
+	onSaved,
 	onMouseEnter,
 	onMouseLeave,
 } ) {
 	const panelRef = useRef( null );
 	// Read from the collection field list. Saves still go through core-data,
 	// which keeps the rest of the shell on the same write path.
-	const field = useMappedField( recordId ) ?? fallbackField;
-	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
+	const mappedField = useMappedField( recordId );
+	const field = useMemo( () => {
+		const source = mappedField ?? fallbackField ?? null;
+		if ( ! source || fallbackField?.cortextFormat === undefined ) {
+			return source;
+		}
+		return { ...source, cortextFormat: fallbackField.cortextFormat };
+	}, [ fallbackField, mappedField ] );
+	const { saveEntityRecord } = useDispatch( 'core' );
 
 	const type =
 		field?.cortextType ?? field?.cortextFieldType ?? field?.type ?? 'text';
@@ -849,10 +857,11 @@ export default function FieldFormatPopover( {
 			return;
 		}
 		const key = isNumber ? 'number_format' : 'date_format';
-		editEntityRecord( 'postType', 'crtxt_field', recordId, {
+		onSaved?.( next ?? null );
+		await saveEntityRecord( 'postType', 'crtxt_field', {
+			id: recordId,
 			meta: { [ key ]: next ? JSON.stringify( next ) : '' },
 		} );
-		await saveEditedEntityRecord( 'postType', 'crtxt_field', recordId );
 	};
 
 	if ( ! field || ( ! isNumber && ! isDate ) ) {
@@ -909,7 +918,6 @@ export default function FieldFormatPopover( {
 		event.stopPropagation();
 		onCloseWithFocus();
 	};
-
 	return (
 		<Popover
 			anchor={ anchor }

--- a/src/components/fields/FieldFormatPopover.js
+++ b/src/components/fields/FieldFormatPopover.js
@@ -823,6 +823,7 @@ function DateFormBody( {
 // tabbing enters the panel instead of moving to the next table column.
 export default function FieldFormatPopover( {
 	recordId,
+	field: fallbackField,
 	anchor,
 	focusOnMount = false,
 	onClose,
@@ -833,10 +834,11 @@ export default function FieldFormatPopover( {
 	const panelRef = useRef( null );
 	// Read from the collection field list. Saves still go through core-data,
 	// which keeps the rest of the shell on the same write path.
-	const field = useMappedField( recordId );
+	const field = useMappedField( recordId ) ?? fallbackField;
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
-	const type = field?.cortextType ?? 'text';
+	const type =
+		field?.cortextType ?? field?.cortextFieldType ?? field?.type ?? 'text';
 	const isNumber = type === 'number';
 	const isDate = type === 'date' || type === 'datetime';
 

--- a/src/components/fields/RenameFieldInline.js
+++ b/src/components/fields/RenameFieldInline.js
@@ -7,9 +7,13 @@ import { useMappedField } from '../CollectionFieldsContext';
 
 // Inline rename control for a column header. It starts from the collection's
 // mapped field data, so opening rename does not refetch the field record.
-export default function RenameFieldInline( { recordId, onDone } ) {
+export default function RenameFieldInline( {
+	recordId,
+	initialTitle: fallbackTitle = '',
+	onDone,
+} ) {
 	const mappedField = useMappedField( recordId );
-	const initialTitle = mappedField?.label ?? '';
+	const initialTitle = mappedField?.label ?? fallbackTitle;
 	const [ value, setValue ] = useState( initialTitle );
 	const inputRef = useRef( null );
 	const { run, isBusy } = useRenameField();

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -161,6 +161,8 @@ function WorkspacePane( { active, preservePaint = false, children } ) {
 const ROW_MUTATION_DEFAULT = {
 	optionOverrides: {},
 	updateFieldOptions: () => {},
+	formatOverrides: {},
+	updateFieldFormat: () => {},
 	refreshRows: () => {},
 };
 

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -2172,13 +2172,14 @@ test.describe( 'Collection view block', () => {
 				exact: true,
 			} );
 			await yearProperty.click();
-			await page.keyboard.press( 'ControlOrMeta+A' );
-			await page.keyboard.press( 'Backspace' );
-			await page.keyboard.type( '20a6' );
+			await expect( yearProperty ).toBeFocused();
+			await yearProperty.press( 'ControlOrMeta+A' );
+			await yearProperty.press( 'Backspace' );
+			await yearProperty.pressSequentially( '20a6' );
 			await expect( yearProperty ).toHaveValue( '206' );
-			await page.keyboard.press( 'ControlOrMeta+A' );
-			await page.keyboard.press( 'Backspace' );
-			await page.keyboard.type( '2026' );
+			await yearProperty.press( 'ControlOrMeta+A' );
+			await yearProperty.press( 'Backspace' );
+			await yearProperty.pressSequentially( '2026' );
 
 			await expect(
 				detail.getByRole( 'button', { name: 'Center modal' } )

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -1982,12 +1982,55 @@ test.describe( 'Collection view block', () => {
 			await expect( detailTitle ).toHaveText(
 				'The Left Hand of Darkness'
 			);
+			const authorLabelButton = detailCanvas.getByRole( 'button', {
+				name: 'Configure Author field',
+			} );
+			await expect( authorLabelButton ).toHaveCSS( 'cursor', 'pointer' );
+			await authorLabelButton.click();
+			await expect(
+				detailCanvas.getByRole( 'menuitem', {
+					name: /Change type/,
+				} )
+			).toBeVisible();
+			await page.keyboard.press( 'Escape' );
+			const yearLabelButton = detailCanvas.getByRole( 'button', {
+				name: 'Configure Year field',
+			} );
+			await expect( yearLabelButton ).toHaveCSS( 'cursor', 'pointer' );
+			await yearLabelButton.click();
+			await expect(
+				detailCanvas.getByRole( 'menuitem', {
+					name: 'Edit field',
+				} )
+			).toBeVisible();
+			await expect(
+				detailCanvas.getByRole( 'menuitem', {
+					name: /Change type/,
+				} )
+			).toBeVisible();
+			await page.keyboard.press( 'Escape' );
 			const tagsLabel = detailCanvas
 				.locator(
 					'.cortext-row-detail__properties--rows .cortext-row-detail__property-label'
 				)
 				.filter( { hasText: 'Tags' } );
-			await expect( tagsLabel ).toHaveCSS( 'cursor', 'default' );
+			await expect( tagsLabel ).toBeVisible();
+			const tagsLabelButton = detailCanvas.getByRole( 'button', {
+				name: 'Configure Tags field',
+			} );
+			await expect( tagsLabelButton ).toHaveCSS( 'cursor', 'pointer' );
+			await tagsLabelButton.click();
+			await expect(
+				detailCanvas.getByRole( 'menuitem', {
+					name: 'Edit options',
+				} )
+			).toBeVisible();
+			await expect(
+				detailCanvas.getByRole( 'menuitem', {
+					name: /Change type/,
+				} )
+			).toBeVisible();
+			await page.keyboard.press( 'Escape' );
 			const tagsTrigger = detailCanvas.getByRole( 'button', {
 				name: 'Tags',
 				exact: true,

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -2003,6 +2003,37 @@ test.describe( 'Collection view block', () => {
 					name: 'Edit field',
 				} )
 			).toBeVisible();
+			await detailCanvas
+				.getByRole( 'menuitem', {
+					name: 'Edit field',
+				} )
+				.click();
+			const formatPanel = page.locator( '.cortext-format-submenu' );
+			await expect( formatPanel ).toBeVisible();
+			await formatPanel
+				.getByRole( 'button', { name: /Number format/ } )
+				.click();
+			await page
+				.locator( '.cortext-format-submenu__flyout' )
+				.getByRole( 'menuitemradio', {
+					name: 'Number with commas',
+				} )
+				.click();
+			await expect
+				.poll( async () => {
+					const updatedField = await requestUtils.rest( {
+						path: `/wp/v2/crtxt_fields/${ fixture.yearField.id }`,
+						params: { context: 'edit' },
+					} );
+					return updatedField?.meta?.number_format ?? '';
+				} )
+				.toContain( 'comma' );
+			await expect(
+				detailCanvas.getByRole( 'textbox', {
+					name: 'Year',
+					exact: true,
+				} )
+			).toHaveValue( '1,969' );
 			await expect(
 				detailCanvas.getByRole( 'menuitem', {
 					name: /Change type/,

--- a/tests/js/components/RowProperties.test.js
+++ b/tests/js/components/RowProperties.test.js
@@ -75,6 +75,11 @@ jest.mock( '@dnd-kit/sortable', () => {
 	};
 } );
 
+jest.mock( '../../../src/components/fields/FieldActionsMenu', () => ( {
+	__esModule: true,
+	default: ( { triggerContent } ) => <span>{ triggerContent }</span>,
+} ) );
+
 jest.mock( '../../../src/components/EditableCell', () => {
 	const { createContext } = require( '@wordpress/element' );
 
@@ -83,11 +88,17 @@ jest.mock( '../../../src/components/EditableCell', () => {
 		default: () => null,
 		RowMutationContext: createContext( {} ),
 		dateOnlyValue: ( value ) => value,
-		formatDisplay: ( value ) => ( value ? String( value ) : '' ),
+		formatDisplay: ( value, type, options = {} ) => {
+			if ( type === 'number' && options.format?.style === 'currency' ) {
+				return `$${ value }`;
+			}
+			return value ? String( value ) : '';
+		},
 	};
 } );
 
 import { useDispatch, useSelect } from '@wordpress/data';
+import { RowMutationContext } from '../../../src/components/EditableCell';
 import RowProperties from '../../../src/components/RowProperties';
 
 describe( 'RowProperties', () => {
@@ -190,6 +201,41 @@ describe( 'RowProperties', () => {
 		expect( onLayoutReorder ).toHaveBeenCalledWith(
 			'created_at',
 			'field-7'
+		);
+	} );
+
+	it( 'uses format overrides for number properties', () => {
+		useSelect.mockReturnValue( {
+			title: 'Current title',
+			meta: { 'field-7': 42 },
+			hydratedMeta: {},
+		} );
+
+		render(
+			<RowMutationContext.Provider
+				value={ {
+					formatOverrides: {
+						'field-7': { style: 'currency', currency: 'USD' },
+					},
+				} }
+			>
+				<RowProperties
+					fields={ [
+						{
+							id: 'field-7',
+							label: 'Score',
+							cortextFieldType: 'number',
+							cortextRecordId: 7,
+							editable: true,
+						},
+					] }
+					row={ {} }
+				/>
+			</RowMutationContext.Provider>
+		);
+
+		expect( screen.getByRole( 'textbox', { name: 'Score' } ) ).toHaveValue(
+			'$42'
 		);
 	} );
 } );

--- a/tests/js/components/RowProperties.test.js
+++ b/tests/js/components/RowProperties.test.js
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 let mockDndProps;
 
@@ -81,7 +81,7 @@ jest.mock( '../../../src/components/fields/FieldActionsMenu', () => ( {
 } ) );
 
 jest.mock( '../../../src/components/EditableCell', () => {
-	const { createContext } = require( '@wordpress/element' );
+	const { createContext, createElement } = require( '@wordpress/element' );
 
 	return {
 		__esModule: true,
@@ -91,6 +91,13 @@ jest.mock( '../../../src/components/EditableCell', () => {
 		formatDisplay: ( value, type, options = {} ) => {
 			if ( type === 'number' && options.format?.style === 'currency' ) {
 				return `$${ value }`;
+			}
+			if ( type === 'number' && options.format?.display === 'rich' ) {
+				return createElement(
+					'span',
+					{ 'data-testid': 'rich-number-display' },
+					`Rich ${ value }`
+				);
 			}
 			return value ? String( value ) : '';
 		},
@@ -236,6 +243,48 @@ describe( 'RowProperties', () => {
 
 		expect( screen.getByRole( 'textbox', { name: 'Score' } ) ).toHaveValue(
 			'$42'
+		);
+	} );
+
+	it( 'shows rich number displays until the value is edited', () => {
+		useSelect.mockReturnValue( {
+			title: 'Current title',
+			meta: { 'field-7': 42 },
+			hydratedMeta: {},
+		} );
+
+		render(
+			<RowMutationContext.Provider
+				value={ {
+					formatOverrides: {
+						'field-7': { style: 'plain', display: 'rich' },
+					},
+				} }
+			>
+				<RowProperties
+					fields={ [
+						{
+							id: 'field-7',
+							label: 'Score',
+							cortextFieldType: 'number',
+							cortextRecordId: 7,
+							editable: true,
+						},
+					] }
+					row={ {} }
+				/>
+			</RowMutationContext.Provider>
+		);
+
+		const trigger = screen.getByRole( 'button', { name: 'Score' } );
+		expect( screen.getByTestId( 'rich-number-display' ) ).toHaveTextContent(
+			'Rich 42'
+		);
+
+		fireEvent.click( trigger );
+
+		expect( screen.getByRole( 'textbox', { name: 'Score' } ) ).toHaveValue(
+			'42'
 		);
 	} );
 } );

--- a/tests/js/components/RowProperties.test.js
+++ b/tests/js/components/RowProperties.test.js
@@ -241,9 +241,12 @@ describe( 'RowProperties', () => {
 			</RowMutationContext.Provider>
 		);
 
-		expect( screen.getByRole( 'textbox', { name: 'Score' } ) ).toHaveValue(
-			'$42'
-		);
+		const score = screen.getByRole( 'textbox', { name: 'Score' } );
+		expect( score ).toHaveValue( '$42' );
+
+		fireEvent.focus( score );
+
+		expect( score ).toHaveValue( '42' );
 	} );
 
 	it( 'shows rich number displays until the value is edited', () => {

--- a/tests/js/components/RowProperties.test.js
+++ b/tests/js/components/RowProperties.test.js
@@ -244,8 +244,9 @@ describe( 'RowProperties', () => {
 		const score = screen.getByRole( 'textbox', { name: 'Score' } );
 		expect( score ).toHaveValue( '$42' );
 
-		fireEvent.focus( score );
+		fireEvent.mouseDown( score );
 
+		expect( score ).toHaveFocus();
 		expect( score ).toHaveValue( '42' );
 	} );
 

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -170,6 +170,10 @@ jest.mock( '../../../../src/components/fields/FieldFormatPopover', () => ( {
 	),
 } ) );
 
+jest.mock( '../../../../src/components/TableCalculationMenu', () => ( {
+	TableCalculationPopover: () => <div data-testid="calculation-popover" />,
+} ) );
+
 jest.mock( '../../../../src/components/EditableCell', () => {
 	const { createContext } = require( '@wordpress/element' );
 
@@ -467,6 +471,49 @@ describe( 'ColumnHeaderActions', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Change type…' } )
 		).toBeInTheDocument();
+	} );
+
+	it( 'keeps table header submenus mutually exclusive', async () => {
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Score',
+					cortextType: 'number',
+				},
+			],
+		} );
+
+		render( <Harness collectionId={ 5 } recordId={ 77 } /> );
+
+		const editField = await screen.findByRole( 'button', {
+			name: 'Edit field',
+		} );
+		const calculate = screen.getByRole( 'button', {
+			name: 'Calculate',
+		} );
+
+		fireEvent.click( editField );
+		expect(
+			screen.getByRole( 'button', { name: 'Save mock format' } )
+		).toBeInTheDocument();
+
+		fireEvent.click( calculate );
+		expect(
+			screen.getByTestId( 'calculation-popover' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Save mock format' } )
+		).not.toBeInTheDocument();
+
+		fireEvent.click( editField );
+		expect(
+			screen.getByRole( 'button', { name: 'Save mock format' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'calculation-popover' )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'shows change type for plain text fields', async () => {

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-const mockDeleteRun = jest.fn();
-const mockDuplicateRun = jest.fn();
+const mockDeleteFieldRun = jest.fn();
+const mockDuplicateFieldRun = jest.fn();
+const mockFlushFieldRecord = jest.fn();
+const mockUpdateFieldOptionsRun = jest.fn();
+const mockChangeFieldTypeRun = jest.fn();
 
 jest.mock( '@wordpress/components', () => {
 	const {
@@ -107,8 +110,19 @@ jest.mock( '../../../../src/lock-unlock', () => {
 } );
 
 jest.mock( '../../../../src/hooks/useFieldMutations', () => ( {
-	useDeleteField: () => ( { run: mockDeleteRun } ),
-	useDuplicateField: () => ( { run: mockDuplicateRun } ),
+	useChangeFieldType: () => ( {
+		run: mockChangeFieldTypeRun,
+		isBusy: false,
+		error: null,
+	} ),
+	useDeleteField: () => ( { run: mockDeleteFieldRun } ),
+	useDuplicateField: () => ( { run: mockDuplicateFieldRun } ),
+	useFlushFieldRecord: () => mockFlushFieldRecord,
+	useUpdateFieldOptions: () => ( {
+		run: mockUpdateFieldOptionsRun,
+		isBusy: false,
+		error: null,
+	} ),
 } ) );
 
 jest.mock( '../../../../src/components/CollectionFieldsContext', () => {
@@ -184,7 +198,6 @@ function Harness( {
 describe( 'ColumnHeaderActions', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockDuplicateRun.mockResolvedValue( { id: 88, type: 'text' } );
 		useCollectionFieldsContext.mockReturnValue( { fields: [] } );
 		useEntityRecord.mockReturnValue( {
 			record: {
@@ -324,7 +337,7 @@ describe( 'ColumnHeaderActions', () => {
 	} );
 
 	it( 'refreshes rows when duplicating a rollup field', async () => {
-		mockDuplicateRun.mockResolvedValue( { id: 88, type: 'rollup' } );
+		mockDuplicateFieldRun.mockResolvedValue( { id: 88, type: 'rollup' } );
 		const onRowsChanged = jest.fn();
 		useCollectionFieldsContext.mockReturnValue( {
 			fields: [
@@ -350,7 +363,7 @@ describe( 'ColumnHeaderActions', () => {
 		);
 
 		await waitFor( () => expect( onRowsChanged ).toHaveBeenCalled() );
-		expect( mockDuplicateRun ).toHaveBeenCalledWith( 77 );
+		expect( mockDuplicateFieldRun ).toHaveBeenCalledWith( 77 );
 	} );
 
 	it( 'warns when deleting a field will also delete dependent rollups', async () => {
@@ -386,5 +399,121 @@ describe( 'ColumnHeaderActions', () => {
 			)
 		).toBeInTheDocument();
 		expect( screen.getByText( /Invoice total/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows select field options in the shared field menu', async () => {
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Tags',
+					cortextType: 'multiselect',
+					cortextElements: [],
+				},
+			],
+		} );
+
+		render( <Harness collectionId={ 5 } recordId={ 77 } /> );
+
+		expect(
+			await screen.findByRole( 'button', { name: 'Edit options' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'Change type…' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows format controls for number fields', async () => {
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Year',
+					cortextType: 'number',
+				},
+			],
+		} );
+
+		render( <Harness collectionId={ 5 } recordId={ 77 } /> );
+
+		expect(
+			await screen.findByRole( 'button', { name: 'Edit field' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'Change type…' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows change type for plain text fields', async () => {
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Author',
+					cortextType: 'text',
+				},
+			],
+		} );
+
+		render( <Harness collectionId={ 5 } recordId={ 77 } /> );
+
+		expect(
+			await screen.findByRole( 'button', { name: 'Change type…' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'hides change type for relation fields', async () => {
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Invoices',
+					cortextType: 'relation',
+				},
+			],
+		} );
+
+		render( <Harness collectionId={ 5 } recordId={ 77 } /> );
+
+		await screen.findByRole( 'button', { name: 'Rename' } );
+		expect(
+			screen.queryByRole( 'button', { name: 'Change type…' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'duplicates fields and refreshes rows from the shared field menu', async () => {
+		const onRowsChanged = jest.fn();
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Author',
+					cortextType: 'text',
+				},
+			],
+		} );
+		mockDuplicateFieldRun.mockResolvedValue( { id: 88 } );
+
+		render(
+			<Harness
+				collectionId={ 5 }
+				recordId={ 77 }
+				onRowsChanged={ onRowsChanged }
+			/>
+		);
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Duplicate' } )
+		);
+
+		await waitFor( () =>
+			expect( mockDuplicateFieldRun ).toHaveBeenCalledWith( 77 )
+		);
+		expect( onRowsChanged ).toHaveBeenCalled();
 	} );
 } );

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -161,10 +161,7 @@ jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
 jest.mock( '../../../../src/components/fields/FieldFormatPopover', () => ( {
 	__esModule: true,
 	default: ( { onSaved } ) => (
-		<button
-			type="button"
-			onClick={ () => onSaved?.( { style: 'comma' } ) }
-		>
+		<button type="button" onClick={ () => onSaved?.( { style: 'comma' } ) }>
 			Save mock format
 		</button>
 	),

--- a/tests/js/components/fields/ColumnHeaderActions.test.js
+++ b/tests/js/components/fields/ColumnHeaderActions.test.js
@@ -158,6 +158,27 @@ jest.mock( '../../../../src/components/fields/AddFieldPopover', () => ( {
 	),
 } ) );
 
+jest.mock( '../../../../src/components/fields/FieldFormatPopover', () => ( {
+	__esModule: true,
+	default: ( { onSaved } ) => (
+		<button
+			type="button"
+			onClick={ () => onSaved?.( { style: 'comma' } ) }
+		>
+			Save mock format
+		</button>
+	),
+} ) );
+
+jest.mock( '../../../../src/components/EditableCell', () => {
+	const { createContext } = require( '@wordpress/element' );
+
+	return {
+		__esModule: true,
+		RowMutationContext: createContext( { formatOverrides: {} } ),
+	};
+} );
+
 import ColumnHeaderActions from '../../../../src/components/fields/ColumnHeaderActions';
 import { useEntityRecord } from '@wordpress/core-data';
 import { useCollectionFieldsContext } from '../../../../src/components/CollectionFieldsContext';
@@ -168,6 +189,7 @@ function Harness( {
 	recordId,
 	view,
 	onFieldCreated = jest.fn(),
+	onFieldFormatSaved = jest.fn(),
 	onRowsChanged = jest.fn(),
 } ) {
 	return (
@@ -189,6 +211,7 @@ function Harness( {
 				view={ view ?? { fields: [] } }
 				onChangeView={ onChangeView }
 				onFieldCreated={ onFieldCreated }
+				onFieldFormatSaved={ onFieldFormatSaved }
 				onRowsChanged={ onRowsChanged }
 			/>
 		</div>
@@ -514,6 +537,42 @@ describe( 'ColumnHeaderActions', () => {
 		await waitFor( () =>
 			expect( mockDuplicateFieldRun ).toHaveBeenCalledWith( 77 )
 		);
+		expect( onRowsChanged ).toHaveBeenCalled();
+	} );
+
+	it( 'stores format changes and refreshes rows from the shared field menu', async () => {
+		const onFieldFormatSaved = jest.fn();
+		const onRowsChanged = jest.fn();
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					id: 'field-77',
+					recordId: 77,
+					label: 'Score',
+					cortextType: 'number',
+				},
+			],
+		} );
+
+		render(
+			<Harness
+				collectionId={ 5 }
+				recordId={ 77 }
+				onFieldFormatSaved={ onFieldFormatSaved }
+				onRowsChanged={ onRowsChanged }
+			/>
+		);
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Edit field' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save mock format' } )
+		);
+
+		expect( onFieldFormatSaved ).toHaveBeenCalledWith( 77, {
+			style: 'comma',
+		} );
 		expect( onRowsChanged ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## What

Row property labels in the document properties block now open the shared field settings menu from table headers, without table-only actions like sort, calculate, move column, or hide column. From row detail, users can rename a field, edit number/date formatting, edit select options, change supported field types, duplicate a field, or delete it.

Clicking a property value still edits the value.

## Why

When someone is looking at a row, the field label is the obvious place to manage that field. They should not have to jump back to the table just to change a property.

## How

- Reusing the field actions menu for table headers and row property labels.
- Keeping table-only actions attached to table headers.
- Refreshing row data after field changes so open row detail and table rows repaint.

## Testing Instructions

1. Open a collection row in row detail.
2. Click a custom property label and confirm the field settings menu opens.
3. Click the property value and confirm it still edits or picks the value.
4. Check a select or multiselect label and confirm "Edit options" appears.
5. Check a number or date label and confirm format settings appear.
6. Check a relation, rollup, or formula label and confirm "Change type" is not shown.

## Screen recording


https://github.com/user-attachments/assets/626dde05-2f93-40d1-929e-618be6de3881

