### PR TITLE
Fix: Remove trashed DataView rows from Favorites

### DIFF
--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -74,7 +74,8 @@ import { dataViewsFilterByForType } from '../hooks/fieldMapping';
 import { toDataViewId, toRecordId } from '../hooks/fieldIds';
 import useCollectionRows from '../hooks/useCollectionRows';
 import { useRecents } from '../hooks/useRecents';
-import { useFavoriteToggle } from '../documents';
+import { filterFavoritesByDeletedIds, useFavoriteToggle } from '../documents';
+import { useFavorites } from '../hooks/useFavorites';
 import { elementsFromOptions } from '../hooks/optionElements';
 import { notifyDocumentTrashChanged } from '../hooks/documentTrashInvalidation';
 import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
@@ -1069,6 +1070,7 @@ export default function CollectionDataViews( {
 		toggle: toggleRowFavorite,
 		disabled: areFavoriteActionsDisabled,
 	} = useFavoriteToggle( { onError: setRowActionError } );
+	const { setFavorites } = useFavorites();
 
 	const openRowInMode = useCallback(
 		( row, mode ) => {
@@ -1198,6 +1200,15 @@ export default function CollectionDataViews( {
 				refresh();
 				notifyDocumentTrashChanged();
 				notifyCollectionRowsChanged();
+				// Prune favorites for the rows we just trashed. The server cleans
+				// stale entries on the next read, but doing it here keeps the next
+				// favorites PUT from sending these row ids back.
+				setFavorites( ( current ) =>
+					filterFavoritesByDeletedIds( current, { row: deleted } )
+				).catch( () => {
+					// Keep this quiet. The next favorites read asks the server to
+					// prune stale rows anyway.
+				} );
 			}
 
 			if ( failedRows.length > 0 ) {
@@ -1227,7 +1238,14 @@ export default function CollectionDataViews( {
 				setRowActionError( deleteErrorMessage );
 			}
 		},
-		[ closeDocument, forgetDeletedRows, openRowId, postType, refresh ]
+		[
+			closeDocument,
+			forgetDeletedRows,
+			openRowId,
+			postType,
+			refresh,
+			setFavorites,
+		]
 	);
 
 	const requestDeleteSelectedRows = useCallback( () => {


### PR DESCRIPTION
## What

Rows trashed from a collection table now disappear from Favorites right away. Before, the table moved them to Trash, but Favorites could still keep the old row around until the next refresh.

## Why

That stale favorite could get written back on the next Favorites save.

## Testing Instructions

1. Add a collection row to Favorites.
2. Trash that row from the collection table.
3. Confirm the row disappears from the table and from Favorites.
4. Refresh the page and confirm the row does not return to Favorites.