### PR TITLE
Performance: Add a derived field value index

### DIFF
--- a/cortext.php
+++ b/cortext.php
@@ -45,12 +45,14 @@ register_activation_hook(
 	__FILE__,
 	static function () {
 		( new \Cortext\PostType\Page() )->register_post_type();
+		( new \Cortext\FieldValues\FieldValueIndex() )->activate();
 		flush_rewrite_rules();
 	}
 );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command( 'cortext seed', \Cortext\CLI\SeedDummyCollections::class );
+	\WP_CLI::add_command( 'cortext field-values', \Cortext\CLI\FieldValues::class );
 	\WP_CLI::add_command( 'cortext perf-seed', array( \Cortext\CLI\PerfBench::class, 'seed' ) );
 	\WP_CLI::add_command( 'cortext perf-bench', array( \Cortext\CLI\PerfBench::class, 'bench' ) );
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,16 @@ Running log of significant design decisions. Newest first. Each entry captures *
 
 Desktop-specific runtime and packaging decisions live in `docs/desktop-decisions.md`.
 
+## 2026-05-23 — Field values stay in postmeta while the sidecar proves itself
+
+**Decision.** Row field values still live in `wp_postmeta`. Cortext can also maintain a derived `cortext_field_values` table for row `field-*` values. If the host can create the table and the index is enabled, Cortext installs it and schedules a background rebuild/verify. Production reads stay on postmeta until the materialization benchmark shows at least a 10x filter or sort win at 50K rows without unacceptable write cost. The index covers row values only; collection schema, field definitions, column order, options, relation config, and rollup config stay in collection/field posts and postmeta.
+
+**Why.** WordPress REST, the editor, external plugins, and ad-hoc scripts already know how to work with row values in postmeta. The sidecar lets us test indexed filters, sorts, and aggregate reads without making custom table support mandatory. If table creation fails, sync drifts, or a host disables the feature through `cortext_field_values_index_enabled`, Cortext can fall back to the postmeta path.
+
+**Trade-off.** The index adds operational work: schema install, cron rebuild, verification, stale/ready status, hook-based sync, and extra writes. Keeping postmeta as the source of truth also means sidecar-owned storage would need a separate migration later, after the compatibility story is proven.
+
+**Revisit when.** The materialization suite in `wp cortext perf-bench --suite=materialization` shows a 10x+ filter or sort win at 50K rows, or when real row filters/sorts exceed the documented p95 gate and postmeta becomes the bottleneck.
+
 ## 2026-04-23 — Page URLs are id-based, slug is cosmetic
 
 **Decision.** Page URLs encode the post id as the authoritative identifier: `?page=cortext&p=/<slug>-<id>` (e.g. `?p=/about-us-42`), falling back to `?p=/<id>` when the slug is empty. `src/router/useResolveEntity.js` extracts the trailing digits via `parseIdFromUri` and fetches `GET /wp/v2/crtxt_pages/<id>?context=edit`. The slug prefix is cosmetic. When autosave assigns a real slug, `Sidebar` rewrites the URL via `history.replace` so the visible URL reflects the latest title.

--- a/includes/CLI/FieldValues.php
+++ b/includes/CLI/FieldValues.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * WP-CLI commands for Cortext's field-value index.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\CLI;
+
+use Cortext\FieldValues\FieldValueIndex;
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Field;
+
+final class FieldValues {
+
+	/**
+	 * Installs or updates the field-value index table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp cortext field-values install
+	 *
+	 * @when after_wp_load
+	 */
+	public function install(): void {
+		$this->ensure_post_types();
+		$index = new FieldValueIndex();
+		if ( $index->install() ) {
+			\WP_CLI::success( 'Field-value index table installed.' );
+			return;
+		}
+
+		\WP_CLI::warning( 'Field-value index table is unavailable; Cortext will keep using postmeta.' );
+		$this->print_status( $index->status() );
+	}
+
+	/**
+	 * Prints the field-value index status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp cortext field-values status
+	 *
+	 * @when after_wp_load
+	 */
+	public function status(): void {
+		$this->print_status( ( new FieldValueIndex() )->status() );
+	}
+
+	/**
+	 * Rebuilds the field-value index from postmeta.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--collection=<id>]
+	 * : Rebuild only one collection. Defaults to every collection.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp cortext field-values rebuild
+	 *     wp cortext field-values rebuild --collection=123
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function rebuild( array $args, array $assoc_args ): void {
+		unset( $args );
+
+		$this->ensure_post_types();
+		( new CollectionEntries() )->register_all();
+
+		$index          = new FieldValueIndex();
+		$collection_ids = $this->collection_ids_from_args( $assoc_args );
+		$total_rows     = 0;
+		$total_values   = 0;
+
+		foreach ( $collection_ids as $collection_id ) {
+			$result        = $index->rebuild_collection( $collection_id );
+			$total_rows   += (int) $result['indexedRows'];
+			$total_values += (int) $result['valueRows'];
+			\WP_CLI::line(
+				sprintf(
+					'Collection %d rebuilt: %d rows, %d indexed values.',
+					$collection_id,
+					(int) $result['indexedRows'],
+					(int) $result['valueRows']
+				)
+			);
+		}
+
+		\WP_CLI::success(
+			sprintf(
+				'Field-value index rebuilt: %d rows, %d indexed values.',
+				$total_rows,
+				$total_values
+			)
+		);
+	}
+
+	/**
+	 * Checks the field-value index against postmeta.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--collection=<id>]
+	 * : Verify only one collection. Defaults to every collection.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp cortext field-values verify
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function verify( array $args, array $assoc_args ): void {
+		unset( $args );
+
+		$this->ensure_post_types();
+		( new CollectionEntries() )->register_all();
+
+		$index   = new FieldValueIndex();
+		$passed  = true;
+		$results = array();
+
+		foreach ( $this->collection_ids_from_args( $assoc_args ) as $collection_id ) {
+			$result    = $index->verify_collection( $collection_id );
+			$results[] = $result;
+			$passed    = $passed && ! empty( $result['passed'] );
+		}
+
+		\WP_CLI\Utils\format_items( 'table', $results, array( 'collectionId', 'expectedRows', 'actualRows', 'missing', 'extra', 'passed' ) );
+
+		if ( ! $passed ) {
+			\WP_CLI::error( 'Field-value index does not match postmeta.' );
+			return;
+		}
+
+		\WP_CLI::success( 'Field-value index matches postmeta.' );
+	}
+
+	private function ensure_post_types(): void {
+		if ( ! post_type_exists( Collection::POST_TYPE ) ) {
+			( new Collection() )->register_post_type();
+		}
+		if ( ! post_type_exists( Field::POST_TYPE ) ) {
+			( new Field() )->register_post_type();
+		}
+	}
+
+	private function collection_ids_from_args( array $assoc_args ): array {
+		$collection_id = isset( $assoc_args['collection'] ) ? (int) $assoc_args['collection'] : 0;
+		if ( $collection_id > 0 ) {
+			return array( $collection_id );
+		}
+
+		return array_map(
+			'intval',
+			get_posts(
+				array(
+					'post_type'      => Collection::POST_TYPE,
+					'post_status'    => array( 'draft', 'private', 'publish' ),
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				)
+			)
+		);
+	}
+
+	private function print_status( array $status ): void {
+		\WP_CLI::line(
+			wp_json_encode(
+				$status,
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+			)
+		);
+	}
+}

--- a/includes/CLI/PerfBench.php
+++ b/includes/CLI/PerfBench.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\CLI;
 
+use Cortext\FieldValues\FieldValueIndex;
+use Cortext\FieldValues\FieldValueStore;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\PostType\Field;
@@ -135,6 +137,13 @@ final class PerfBench {
 	 * [--fail-on-budget]
 	 * : Exit with an error when a scenario exceeds its budget.
 	 *
+	 * [--suite=<suite>]
+	 * : Suite to run. Use "default" for CI budget checks or "materialization"
+	 * for field-value index work. Default: default.
+	 *
+	 * [--scenario=<pattern>]
+	 * : Run only scenario IDs containing this text.
+	 *
 	 * [--pretty]
 	 * : Pretty-print JSON.
 	 *
@@ -154,13 +163,15 @@ final class PerfBench {
 		$bench       = new self();
 		$iterations  = self::flag_int( $assoc_args, 'iterations', self::DEFAULT_ITERATIONS, 1 );
 		$warmup      = self::flag_int( $assoc_args, 'warmup', self::DEFAULT_WARMUP, 0 );
+		$suite       = (string) ( $assoc_args['suite'] ?? 'default' );
+		$scenario    = isset( $assoc_args['scenario'] ) ? (string) $assoc_args['scenario'] : '';
 		$budget_path = self::normalize_local_path(
 			(string) ( $assoc_args['budget'] ?? CORTEXT_PATH . 'includes/CLI/perf-budgets.json' )
 		);
 		$budget      = $bench->load_budget( $budget_path );
 
 		try {
-			$result = $bench->run_benchmark( $iterations, $warmup, $budget, $budget_path );
+			$result = $bench->run_benchmark( $iterations, $warmup, $budget, $budget_path, $suite, $scenario );
 		} catch ( RuntimeException $exception ) {
 			\WP_CLI::error( $exception->getMessage() );
 			return;
@@ -288,17 +299,40 @@ final class PerfBench {
 		$previous_suspend = wp_suspend_cache_invalidation( true );
 		wp_defer_term_counting( true );
 		wp_defer_comment_counting( true );
+		FieldValueIndex::suspend_sync();
 
 		try {
 			$manifest = $this->create_dataset( $config, $seed_user_id );
 		} finally {
+			FieldValueIndex::resume_sync();
 			wp_defer_comment_counting( false );
 			wp_defer_term_counting( false );
 			wp_suspend_cache_invalidation( $previous_suspend );
 		}
 
+		$this->rebuild_seeded_field_value_index( $manifest );
 		update_option( self::DATASET_OPTION, $manifest, false );
 		return $manifest;
+	}
+
+	/**
+	 * Bulk seeding writes postmeta first, then rebuilds the sidecar once.
+	 *
+	 * @param array<string,mixed> $manifest Dataset manifest.
+	 */
+	private function rebuild_seeded_field_value_index( array $manifest ): void {
+		$index = new FieldValueIndex();
+		if ( ! $index->install() ) {
+			return;
+		}
+
+		$this->register_dataset_collections( $manifest );
+		foreach ( $manifest['collections'] ?? array() as $collection ) {
+			$collection_id = (int) ( $collection['id'] ?? 0 );
+			if ( $collection_id > 0 ) {
+				$index->rebuild_collection( $collection_id );
+			}
+		}
 	}
 
 	/**
@@ -308,10 +342,12 @@ final class PerfBench {
 	 * @param int                 $warmup     Warm-up iterations.
 	 * @param array<string,mixed> $budget     Budget config.
 	 * @param string              $budget_path Budget file path.
+	 * @param string              $suite      Benchmark suite.
+	 * @param string              $scenario_filter Scenario ID filter.
 	 * @return array<string,mixed> Benchmark report.
 	 * @throws RuntimeException When the dataset is missing or a scenario fails.
 	 */
-	public function run_benchmark( int $iterations, int $warmup, array $budget, string $budget_path = 'includes/CLI/perf-budgets.json' ): array {
+	public function run_benchmark( int $iterations, int $warmup, array $budget, string $budget_path = 'includes/CLI/perf-budgets.json', string $suite = 'default', string $scenario_filter = '' ): array {
 		$started_at = hrtime( true );
 		$manifest   = get_option( self::DATASET_OPTION );
 		if ( ! is_array( $manifest ) || ! $this->manifest_is_usable( $manifest ) ) {
@@ -323,20 +359,40 @@ final class PerfBench {
 		$this->ensure_rest_routes();
 		wp_set_current_user( $this->default_seed_user_id() );
 
-		if ( count( $manifest['primary_row_ids'] ?? array() ) < self::PAGE_50_ROWS ) {
-			throw new RuntimeException( 'The benchmark needs at least 1250 primary rows for page 50.' );
+		if ( 'default' === $suite ) {
+			if ( count( $manifest['primary_row_ids'] ?? array() ) < self::PAGE_50_ROWS ) {
+				throw new RuntimeException( 'The benchmark needs at least 1250 primary rows for page 50.' );
+			}
+			if ( count( $manifest['migration_row_ids'] ?? array() ) < self::MIGRATION_CAP_ROWS ) {
+				throw new RuntimeException( 'The benchmark needs at least 1000 primary rows for the migration scenario.' );
+			}
+			if ( (int) ( $manifest['wide_collection_id'] ?? 0 ) < 1 || count( $manifest['wide_row_ids'] ?? array() ) < self::PAGE_SIZE ) {
+				throw new RuntimeException( 'The benchmark needs a third collection for the wide schema scenario.' );
+			}
+			$scenarios = $this->scenario_callbacks( $manifest );
+		} elseif ( 'materialization' === $suite ) {
+			if ( count( $manifest['primary_row_ids'] ?? array() ) < 10000 ) {
+				throw new RuntimeException( 'The materialization suite needs at least 10000 primary rows. Seed with `wp cortext perf-seed --reset --force --collections=1 --rows=10000 --relations=0 --rollups=0` or larger.' );
+			}
+			$scenarios = $this->materialization_scenario_callbacks( $manifest );
+		} else {
+			throw new RuntimeException( esc_html( "Unknown benchmark suite: {$suite}." ) );
 		}
-		if ( count( $manifest['migration_row_ids'] ?? array() ) < self::MIGRATION_CAP_ROWS ) {
-			throw new RuntimeException( 'The benchmark needs at least 1000 primary rows for the migration scenario.' );
-		}
-		if ( (int) ( $manifest['wide_collection_id'] ?? 0 ) < 1 || count( $manifest['wide_row_ids'] ?? array() ) < self::PAGE_SIZE ) {
-			throw new RuntimeException( 'The benchmark needs a third collection for the wide schema scenario.' );
-		}
-
-		$scenarios = $this->scenario_callbacks( $manifest );
+		$scenarios = $this->filter_scenarios( $scenarios, $scenario_filter );
 		$summaries = array();
 
 		foreach ( $scenarios as $name => $scenario ) {
+			if ( ! empty( $scenario['single'] ) ) {
+				if ( isset( $scenario['prepare'] ) && is_callable( $scenario['prepare'] ) ) {
+					$scenario['prepare']();
+				}
+				$summaries[ $name ] = array_merge(
+					array( 'label' => (string) $scenario['label'] ),
+					self::summarize_samples( array( $this->measure( $scenario['run'] ) ) )
+				);
+				continue;
+			}
+
 			if ( isset( $scenario['steps'] ) && is_array( $scenario['steps'] ) ) {
 				$summaries[ $name ] = $this->run_stepped_scenario( $scenario, $warmup, $iterations );
 				continue;
@@ -365,7 +421,9 @@ final class PerfBench {
 
 		return array(
 			'version'          => 1,
-			'seed_config_hash' => self::benchmark_config_hash( $manifest, $budget_path ),
+			'suite'            => $suite,
+			'scenarioFilter'   => $scenario_filter,
+			'seed_config_hash' => self::benchmark_config_hash( $manifest, $budget_path, $suite ),
 			'elapsedMs'        => self::elapsed_ms( $started_at ),
 			'dataset'          => self::public_dataset_summary( $manifest ),
 			'iterations'       => array(
@@ -376,6 +434,35 @@ final class PerfBench {
 			'failures'         => $budget_result['failures'],
 			'scenarios'        => $budget_result['scenarios'],
 		);
+	}
+
+	/**
+	 * Limits a benchmark run to matching scenario IDs.
+	 *
+	 * @param array<string,array<string,mixed>> $scenarios Scenario callbacks.
+	 * @param string                            $filter    Scenario ID substring.
+	 * @return array<string,array<string,mixed>>
+	 * @throws RuntimeException When no scenarios match.
+	 */
+	private function filter_scenarios( array $scenarios, string $filter ): array {
+		$filter = trim( $filter );
+		if ( '' === $filter ) {
+			return $scenarios;
+		}
+
+		$matches = array();
+
+		foreach ( $scenarios as $name => $scenario ) {
+			if ( str_contains( $name, $filter ) ) {
+				$matches[ $name ] = $scenario;
+			}
+		}
+
+		if ( count( $matches ) === 0 ) {
+			throw new RuntimeException( esc_html( "No benchmark scenarios matched: {$filter}." ) );
+		}
+
+		return $matches;
 	}
 
 	/**
@@ -463,6 +550,7 @@ final class PerfBench {
 		$wide_scalar_count = (int) ( $config['wide_fields'] ?? self::DEFAULT_WIDE_FIELDS );
 		$field_map         = $this->create_fields( $collections, (int) $config['fields'], $wide_scalar_count, (int) $config['relations'], (int) $config['rollups'] );
 		$row_map           = $this->create_rows( $collections, $field_map, (int) $config['rows'], $seed_user_id );
+		$target_collection = $collections[1] ?? null;
 
 		$manifest = array(
 			'seed'                  => self::DATASET_SEED,
@@ -473,7 +561,7 @@ final class PerfBench {
 			'primary_collection_id' => $collections[0]['id'],
 			'primary_slug'          => $collections[0]['slug'],
 			'primary_row_ids'       => $row_map[ $collections[0]['slug'] ],
-			'target_row_ids'        => $row_map[ $collections[1]['slug'] ] ?? array(),
+			'target_row_ids'        => is_array( $target_collection ) ? ( $row_map[ $target_collection['slug'] ] ?? array() ) : array(),
 			'wide_collection_id'    => is_array( $wide_collection ) ? (int) $wide_collection['id'] : 0,
 			'wide_slug'             => is_array( $wide_collection ) ? (string) $wide_collection['slug'] : '',
 			'wide_row_ids'          => is_array( $wide_collection ) ? ( $row_map[ $wide_collection['slug'] ] ?? array() ) : array(),
@@ -1018,6 +1106,7 @@ final class PerfBench {
 			}
 		}
 
+		FieldValueIndex::flush_runtime_caches();
 		delete_option( self::DATASET_OPTION );
 	}
 
@@ -1357,6 +1446,770 @@ final class PerfBench {
 	}
 
 	/**
+	 * Builds the field-value materialization benchmarks.
+	 *
+	 * The default suite measures full REST workflows. This suite times the
+	 * SQL/ID phase first, because hydration can hide the index cost. The
+	 * sidecar response check still hydrates through the existing REST include
+	 * path; it is not a production read path.
+	 *
+	 * @param array<string,mixed> $manifest Dataset manifest.
+	 * @return array<string,array{label:string,prepare?:callable,run:callable,single?:bool}>
+	 * @throws RuntimeException When the sidecar table cannot be prepared or verified.
+	 */
+	private function materialization_scenario_callbacks( array $manifest ): array {
+		$primary_collection_id = (int) $manifest['primary_collection_id'];
+		$primary_slug          = (string) $manifest['primary_slug'];
+		$primary_row_ids       = array_map( 'intval', $manifest['primary_row_ids'] );
+		$target_row_ids        = array_map( 'intval', $manifest['target_row_ids'] ?? array() );
+		$primary_field_ids     = array_map( 'intval', $manifest['fields']['primary']['scalar_field_ids'] ?? array() );
+		$relation_field_id     = (int) ( $manifest['relation_field_id'] ?? 0 );
+		$number_field_id       = $primary_field_ids[1] ?? 0;
+		$select_field_id       = $primary_field_ids[2] ?? 0;
+		$date_field_id         = $primary_field_ids[5] ?? 0;
+		$text_field_ids        = $this->materialization_text_field_ids( $manifest, $primary_slug );
+		$relation_target_id    = count( $target_row_ids ) > 0 ? $target_row_ids[ min( 59, count( $target_row_ids ) - 1 ) ] : 0;
+		$search_term           = 'Value 6 / 99';
+		$filter_minimum        = 9500.0;
+
+		if ( min( $primary_collection_id, $number_field_id, $select_field_id, $date_field_id ) < 1 || count( $text_field_ids ) === 0 ) {
+			throw new RuntimeException( 'The materialization suite needs number, select, and date fields on the primary collection.' );
+		}
+
+		$index = new FieldValueIndex();
+		if ( ! $index->install() ) {
+			throw new RuntimeException( 'This host cannot use the field-value index table, so the materialization suite cannot run.' );
+		}
+		$index->rebuild_collection( $primary_collection_id );
+
+		$this->assert_materialization_parity(
+			$index,
+			$primary_collection_id,
+			$primary_slug,
+			$number_field_id,
+			$select_field_id,
+			$date_field_id,
+			$filter_minimum
+		);
+		$this->assert_materialization_search_parity(
+			$index,
+			$primary_collection_id,
+			$primary_slug,
+			$text_field_ids,
+			$search_term,
+			$number_field_id,
+			$select_field_id,
+			$filter_minimum
+		);
+		if ( $relation_field_id > 0 && $relation_target_id > 0 ) {
+			$this->assert_materialization_relation_parity(
+				$index,
+				$primary_collection_id,
+				$primary_slug,
+				$relation_field_id,
+				$relation_target_id
+			);
+		}
+
+		$write_row_ids       = array_slice( $primary_row_ids, 0, min( self::MIGRATION_CAP_ROWS, count( $primary_row_ids ) ) );
+		$single_write_row_id = $write_row_ids[0] ?? $primary_row_ids[0];
+
+		$scenarios = array(
+			'mat_filter_two_fields_postmeta'         => array(
+				'label' => 'Field values: postmeta two-field filter IDs',
+				'run'   => fn() => $this->postmeta_filter_ids(
+					$primary_collection_id,
+					$primary_slug,
+					$number_field_id,
+					$filter_minimum,
+					$select_field_id,
+					'stable',
+					50
+				),
+			),
+			'mat_filter_two_fields_sidecar'          => array(
+				'label' => 'Field values: sidecar two-field filter IDs',
+				'run'   => fn() => $index->query_two_field_filter_ids(
+					$primary_collection_id,
+					$number_field_id,
+					$filter_minimum,
+					$select_field_id,
+					'stable',
+					50
+				),
+			),
+			'mat_sort_date_postmeta'                 => array(
+				'label' => 'Field values: postmeta date sort IDs',
+				'run'   => fn() => $this->postmeta_date_sort_ids( $primary_slug, $date_field_id, 50 ),
+			),
+			'mat_sort_date_sidecar'                  => array(
+				'label' => 'Field values: sidecar date sort IDs',
+				'run'   => fn() => $index->query_date_sort_ids( $primary_collection_id, $date_field_id, 50 ),
+			),
+			'mat_sort_date_filtered_postmeta'        => array(
+				'label' => 'Field values: postmeta filtered date sort IDs',
+				'run'   => fn() => $this->postmeta_date_sort_filtered_ids(
+					$primary_slug,
+					$date_field_id,
+					$number_field_id,
+					$filter_minimum,
+					$select_field_id,
+					'stable',
+					50
+				),
+			),
+			'mat_sort_date_filtered_sidecar'         => array(
+				'label' => 'Field values: sidecar filtered date sort IDs',
+				'run'   => fn() => $index->query_date_sort_filtered_ids(
+					$primary_collection_id,
+					$date_field_id,
+					$number_field_id,
+					$filter_minimum,
+					$select_field_id,
+					'stable',
+					50
+				),
+			),
+			'mat_search_text_postmeta'               => array(
+				'label' => 'Field values: postmeta text search IDs',
+				'run'   => fn() => $this->postmeta_text_search_ids( $primary_slug, $text_field_ids, $search_term, 50 ),
+			),
+			'mat_search_text_sidecar'                => array(
+				'label' => 'Field values: sidecar text search IDs',
+				'run'   => fn() => $index->query_text_search_ids( $primary_collection_id, $text_field_ids, $search_term, 50 ),
+			),
+			'mat_search_text_filtered_postmeta'      => array(
+				'label' => 'Field values: postmeta filtered text search IDs',
+				'run'   => fn() => $this->postmeta_text_search_filtered_ids(
+					$primary_slug,
+					$text_field_ids,
+					$search_term,
+					$number_field_id,
+					$filter_minimum,
+					$select_field_id,
+					'stable',
+					50
+				),
+			),
+			'mat_search_text_filtered_sidecar'       => array(
+				'label' => 'Field values: sidecar filtered text search IDs',
+				'run'   => fn() => $index->query_text_search_filtered_ids(
+					$primary_collection_id,
+					$text_field_ids,
+					$search_term,
+					$number_field_id,
+					$filter_minimum,
+					$select_field_id,
+					'stable',
+					50
+				),
+			),
+			'mat_rollup_sum_postmeta'                => array(
+				'label' => 'Field values: postmeta whole-collection sum',
+				'run'   => fn() => $this->postmeta_sum_number( $primary_slug, $number_field_id ),
+			),
+			'mat_rollup_sum_sidecar'                 => array(
+				'label' => 'Field values: sidecar whole-collection sum',
+				'run'   => fn() => $index->aggregate_number( $primary_collection_id, $number_field_id, 'sum' ),
+			),
+			'mat_rollup_count_postmeta'              => array(
+				'label' => 'Field values: postmeta whole-collection count',
+				'run'   => fn() => $this->postmeta_count_text( $primary_slug, $select_field_id, 'stable' ),
+			),
+			'mat_rollup_count_sidecar'               => array(
+				'label' => 'Field values: sidecar whole-collection count',
+				'run'   => fn() => $index->count_text_value( $primary_collection_id, $select_field_id, 'stable' ),
+			),
+			'mat_filter_response_sanity_postmeta'    => array(
+				'label' => 'Field values: postmeta filter plus REST response',
+				'run'   => fn() => $this->rest_request(
+					'GET',
+					'/cortext/v1/rows',
+					array(
+						'collection' => $primary_collection_id,
+						'page'       => 1,
+						'per_page'   => 50,
+						'filters'    => $this->materialization_filter_tree( $number_field_id, $select_field_id, $filter_minimum ),
+					)
+				),
+			),
+			'mat_filter_response_sanity_sidecar'     => array(
+				'label' => 'Field values: sidecar IDs plus REST response',
+				'run'   => fn() => $this->rest_request(
+					'GET',
+					'/cortext/v1/rows',
+					array(
+						'collection' => $primary_collection_id,
+						'include'    => $index->query_two_field_filter_ids(
+							$primary_collection_id,
+							$number_field_id,
+							$filter_minimum,
+							$select_field_id,
+							'stable',
+							50
+						),
+						'per_page'   => 50,
+					)
+				),
+			),
+			'mat_write_incremental_postmeta'         => array(
+				'label'   => 'Field values: postmeta 1000 sequential updates',
+				'prepare' => fn() => $this->prepare_materialization_writes( $write_row_ids, $number_field_id, 1000.0, $index, false ),
+				'run'     => fn() => $this->run_materialization_writes( $write_row_ids, $number_field_id, 2000.0, $index, false ),
+			),
+			'mat_write_incremental_sidecar'          => array(
+				'label'   => 'Field values: postmeta and sidecar 1000 sequential updates',
+				'prepare' => fn() => $this->prepare_materialization_writes( $write_row_ids, $number_field_id, 1000.0, $index, true ),
+				'run'     => fn() => $this->run_materialization_writes( $write_row_ids, $number_field_id, 2000.0, $index, true ),
+			),
+			'mat_write_sidecar_only'                 => array(
+				'label'   => 'Field values: sidecar reindex for 1000 updates',
+				'prepare' => fn() => $this->prepare_materialization_writes( $write_row_ids, $number_field_id, 2000.0, $index, false ),
+				'run'     => fn() => $this->run_materialization_sidecar_writes( $write_row_ids, $number_field_id, $index ),
+			),
+			'mat_write_sidecar_known_value'          => array(
+				'label'   => 'Field values: sidecar known-value 1000 updates',
+				'prepare' => fn() => $this->prepare_materialization_writes( $write_row_ids, $number_field_id, 3000.0, $index, false ),
+				'run'     => fn() => $this->run_materialization_sidecar_known_writes( $write_row_ids, $number_field_id, 4000.0, $primary_collection_id, $index ),
+			),
+			'mat_write_store_sidecar'                => array(
+				'label'   => 'Field values: FieldValueStore 1000 updates',
+				'prepare' => fn() => $this->prepare_materialization_writes( $write_row_ids, $number_field_id, 4000.0, $index, true ),
+				'run'     => fn() => $this->run_materialization_store_writes( $write_row_ids, $number_field_id, 5000.0, $primary_collection_id, $index ),
+			),
+			'mat_single_write_postmeta'              => array(
+				'label'   => 'Field values: single postmeta scalar update',
+				'prepare' => fn() => $this->prepare_materialization_writes( array( $single_write_row_id ), $number_field_id, 6000.0, $index, false ),
+				'run'     => fn() => $this->run_materialization_single_postmeta_write( $single_write_row_id, $number_field_id, 7000.0 ),
+			),
+			'mat_single_write_store_sidecar'         => array(
+				'label'   => 'Field values: single FieldValueStore scalar update',
+				'prepare' => fn() => $this->prepare_materialization_writes( array( $single_write_row_id ), $number_field_id, 7000.0, $index, true ),
+				'run'     => fn() => $this->run_materialization_store_writes( array( $single_write_row_id ), $number_field_id, 8000.0, $primary_collection_id, $index ),
+			),
+			'mat_single_rest_write_sidecar_disabled' => array(
+				'label'   => 'Field values: REST scalar update with sidecar off',
+				'prepare' => fn() => $this->prepare_materialization_writes( array( $single_write_row_id ), $number_field_id, 8000.0, $index, true ),
+				'run'     => fn() => $this->run_materialization_rest_write( $primary_collection_id, $single_write_row_id, $number_field_id, 9000.0, false ),
+			),
+			'mat_single_rest_write_sidecar_enabled'  => array(
+				'label'   => 'Field values: REST scalar update with sidecar on',
+				'prepare' => fn() => $this->prepare_materialization_writes( array( $single_write_row_id ), $number_field_id, 9000.0, $index, true ),
+				'run'     => fn() => $this->run_materialization_rest_write( $primary_collection_id, $single_write_row_id, $number_field_id, 10000.0, true ),
+			),
+			'mat_rebuild_full'                       => array(
+				'label'  => 'Field values: full sidecar rebuild',
+				'single' => true,
+				'run'    => fn() => $index->rebuild_collection( $primary_collection_id ),
+			),
+		);
+
+		if ( $relation_field_id > 0 && $relation_target_id > 0 ) {
+			$scenarios['mat_relation_contains_postmeta'] = array(
+				'label' => 'Field values: postmeta relation lookup IDs',
+				'run'   => fn() => $this->postmeta_relation_contains_ids( $primary_slug, $relation_field_id, $relation_target_id, 50 ),
+			);
+			$scenarios['mat_relation_contains_sidecar']  = array(
+				'label' => 'Field values: sidecar relation lookup IDs',
+				'run'   => fn() => $index->query_relation_contains_ids( $primary_collection_id, $relation_field_id, $relation_target_id, 50 ),
+			);
+		}
+
+		return $scenarios;
+	}
+
+	private function assert_materialization_parity(
+		FieldValueIndex $index,
+		int $collection_id,
+		string $slug,
+		int $number_field_id,
+		int $select_field_id,
+		int $date_field_id,
+		float $filter_minimum
+	): void {
+		$postmeta_filter = $this->postmeta_filter_ids( $collection_id, $slug, $number_field_id, $filter_minimum, $select_field_id, 'stable', 50 );
+		$sidecar_filter  = $index->query_two_field_filter_ids( $collection_id, $number_field_id, $filter_minimum, $select_field_id, 'stable', 50 );
+		if ( $postmeta_filter !== $sidecar_filter ) {
+			throw new RuntimeException( 'Postmeta and sidecar returned different IDs for the two-field filter scenario.' );
+		}
+
+		$postmeta_sort = $this->postmeta_date_sort_ids( $slug, $date_field_id, 50 );
+		$sidecar_sort  = $index->query_date_sort_ids( $collection_id, $date_field_id, 50 );
+		if ( $postmeta_sort !== $sidecar_sort ) {
+			throw new RuntimeException( 'Postmeta and sidecar returned different IDs for the date sort scenario.' );
+		}
+
+		$postmeta_filtered_sort = $this->postmeta_date_sort_filtered_ids( $slug, $date_field_id, $number_field_id, $filter_minimum, $select_field_id, 'stable', 50 );
+		$sidecar_filtered_sort  = $index->query_date_sort_filtered_ids( $collection_id, $date_field_id, $number_field_id, $filter_minimum, $select_field_id, 'stable', 50 );
+		if ( $postmeta_filtered_sort !== $sidecar_filtered_sort ) {
+			throw new RuntimeException( 'Postmeta and sidecar returned different IDs for the filtered date sort scenario.' );
+		}
+
+		$postmeta_sum = $this->postmeta_sum_number( $slug, $number_field_id );
+		$sidecar_sum  = $index->aggregate_number( $collection_id, $number_field_id, 'sum' );
+		if ( abs( (float) $postmeta_sum - (float) $sidecar_sum ) > 0.001 ) {
+			throw new RuntimeException( 'Postmeta and sidecar returned different sums.' );
+		}
+
+		$postmeta_count = $this->postmeta_count_text( $slug, $select_field_id, 'stable' );
+		$sidecar_count  = $index->count_text_value( $collection_id, $select_field_id, 'stable' );
+		if ( $postmeta_count !== $sidecar_count ) {
+			throw new RuntimeException( 'Postmeta and sidecar returned different counts.' );
+		}
+	}
+
+	private function assert_materialization_search_parity(
+		FieldValueIndex $index,
+		int $collection_id,
+		string $slug,
+		array $field_ids,
+		string $term,
+		int $number_field_id,
+		int $select_field_id,
+		float $filter_minimum
+	): void {
+		$postmeta_search = $this->postmeta_text_search_ids( $slug, $field_ids, $term, 50 );
+		$sidecar_search  = $index->query_text_search_ids( $collection_id, $field_ids, $term, 50 );
+		if ( $postmeta_search !== $sidecar_search ) {
+			throw new RuntimeException( 'Postmeta and sidecar returned different IDs for the text search scenario.' );
+		}
+
+		$postmeta_filtered_search = $this->postmeta_text_search_filtered_ids( $slug, $field_ids, $term, $number_field_id, $filter_minimum, $select_field_id, 'stable', 50 );
+		$sidecar_filtered_search  = $index->query_text_search_filtered_ids( $collection_id, $field_ids, $term, $number_field_id, $filter_minimum, $select_field_id, 'stable', 50 );
+		if ( $postmeta_filtered_search !== $sidecar_filtered_search ) {
+			throw new RuntimeException( 'Postmeta and sidecar returned different IDs for the filtered text search scenario.' );
+		}
+	}
+
+	private function assert_materialization_relation_parity(
+		FieldValueIndex $index,
+		int $collection_id,
+		string $slug,
+		int $field_id,
+		int $target_row_id
+	): void {
+		$postmeta_relation = $this->postmeta_relation_contains_ids( $slug, $field_id, $target_row_id, 50 );
+		$sidecar_relation  = $index->query_relation_contains_ids( $collection_id, $field_id, $target_row_id, 50 );
+		if ( $postmeta_relation !== $sidecar_relation ) {
+			throw new RuntimeException( 'Postmeta and sidecar returned different IDs for the relation lookup scenario.' );
+		}
+	}
+
+	private function materialization_text_field_ids( array $manifest, string $slug ): array {
+		$fields = $manifest['fields']['collections'][ $slug ] ?? array();
+		if ( ! is_array( $fields ) ) {
+			return array();
+		}
+
+		$field_ids = array();
+		foreach ( $fields as $field ) {
+			if ( ! is_array( $field ) ) {
+				continue;
+			}
+			if ( in_array( (string) ( $field['type'] ?? '' ), array( 'text', 'email', 'url' ), true ) ) {
+				$field_ids[] = (int) ( $field['id'] ?? 0 );
+			}
+		}
+
+		return array_values( array_filter( $field_ids ) );
+	}
+
+	private function postmeta_filter_ids(
+		int $collection_id,
+		string $slug,
+		int $number_field_id,
+		float $minimum,
+		int $select_field_id,
+		string $select_value,
+		int $limit
+	): array {
+		unset( $collection_id );
+		global $wpdb;
+
+		$post_type  = CollectionEntries::CPT_PREFIX . $slug;
+		$number_key = Relations::meta_key( $number_field_id );
+		$select_key = Relations::meta_key( $select_field_id );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark times the raw postmeta ID lookup.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT p.ID
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS n ON n.post_id = p.ID AND n.meta_key = %s
+				INNER JOIN {$wpdb->postmeta} AS s ON s.post_id = p.ID AND s.meta_key = %s
+				WHERE p.post_type = %s
+				AND p.post_status IN ('draft', 'private', 'publish')
+				AND CAST(n.meta_value AS DECIMAL(20,6)) > %f
+				AND s.meta_value = %s
+				ORDER BY p.ID ASC
+				LIMIT %d",
+				$number_key,
+				$select_key,
+				$post_type,
+				$minimum,
+				$select_value,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array_map( 'intval', $ids );
+	}
+
+	private function postmeta_text_search_ids( string $slug, array $field_ids, string $term, int $limit ): array {
+		$field_keys = array_map(
+			static fn( int $field_id ): string => Relations::meta_key( $field_id ),
+			array_values( array_filter( array_map( 'intval', $field_ids ) ) )
+		);
+		if ( count( $field_keys ) === 0 ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$post_type    = CollectionEntries::CPT_PREFIX . $slug;
+		$placeholders = implode( ', ', array_fill( 0, count( $field_keys ), '%s' ) );
+		$like         = '%' . $wpdb->esc_like( $term ) . '%';
+		$args         = array_merge( $field_keys, array( $post_type, $like, $limit ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark times the raw postmeta text search lookup.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT p.ID
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS pm ON pm.post_id = p.ID AND pm.meta_key IN ({$placeholders})
+				WHERE p.post_type = %s
+				AND p.post_status IN ('draft', 'private', 'publish')
+				AND pm.meta_value LIKE %s
+				ORDER BY p.ID ASC
+				LIMIT %d",
+				...$args
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return array_map( 'intval', $ids );
+	}
+
+	private function postmeta_text_search_filtered_ids(
+		string $slug,
+		array $field_ids,
+		string $term,
+		int $number_field_id,
+		float $minimum,
+		int $select_field_id,
+		string $select_value,
+		int $limit
+	): array {
+		$field_keys = array_map(
+			static fn( int $field_id ): string => Relations::meta_key( $field_id ),
+			array_values( array_filter( array_map( 'intval', $field_ids ) ) )
+		);
+		if ( count( $field_keys ) === 0 ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$post_type    = CollectionEntries::CPT_PREFIX . $slug;
+		$number_key   = Relations::meta_key( $number_field_id );
+		$select_key   = Relations::meta_key( $select_field_id );
+		$placeholders = implode( ', ', array_fill( 0, count( $field_keys ), '%s' ) );
+		$like         = '%' . $wpdb->esc_like( $term ) . '%';
+		$args         = array_merge( $field_keys, array( $number_key, $select_key, $post_type, $like, $minimum, $select_value, $limit ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark times the raw postmeta filtered text search lookup.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT p.ID
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS pm ON pm.post_id = p.ID AND pm.meta_key IN ({$placeholders})
+				INNER JOIN {$wpdb->postmeta} AS n ON n.post_id = p.ID AND n.meta_key = %s
+				INNER JOIN {$wpdb->postmeta} AS s ON s.post_id = p.ID AND s.meta_key = %s
+				WHERE p.post_type = %s
+				AND p.post_status IN ('draft', 'private', 'publish')
+				AND pm.meta_value LIKE %s
+				AND CAST(n.meta_value AS DECIMAL(20,6)) > %f
+				AND s.meta_value = %s
+				ORDER BY p.ID ASC
+				LIMIT %d",
+				...$args
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return array_map( 'intval', $ids );
+	}
+
+	private function postmeta_date_sort_ids( string $slug, int $date_field_id, int $limit ): array {
+		global $wpdb;
+
+		$post_type = CollectionEntries::CPT_PREFIX . $slug;
+		$date_key  = Relations::meta_key( $date_field_id );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark times the raw postmeta sort lookup.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT p.ID
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS d ON d.post_id = p.ID AND d.meta_key = %s
+				WHERE p.post_type = %s
+				AND p.post_status IN ('draft', 'private', 'publish')
+				AND d.meta_value != ''
+				ORDER BY d.meta_value ASC, p.ID ASC
+				LIMIT %d",
+				$date_key,
+				$post_type,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array_map( 'intval', $ids );
+	}
+
+	private function postmeta_date_sort_filtered_ids(
+		string $slug,
+		int $date_field_id,
+		int $number_field_id,
+		float $minimum,
+		int $select_field_id,
+		string $select_value,
+		int $limit
+	): array {
+		global $wpdb;
+
+		$post_type  = CollectionEntries::CPT_PREFIX . $slug;
+		$date_key   = Relations::meta_key( $date_field_id );
+		$number_key = Relations::meta_key( $number_field_id );
+		$select_key = Relations::meta_key( $select_field_id );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark times the raw postmeta filtered sort lookup.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT p.ID
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS d ON d.post_id = p.ID AND d.meta_key = %s
+				INNER JOIN {$wpdb->postmeta} AS n ON n.post_id = p.ID AND n.meta_key = %s
+				INNER JOIN {$wpdb->postmeta} AS s ON s.post_id = p.ID AND s.meta_key = %s
+				WHERE p.post_type = %s
+				AND p.post_status IN ('draft', 'private', 'publish')
+				AND d.meta_value != ''
+				AND CAST(n.meta_value AS DECIMAL(20,6)) > %f
+				AND s.meta_value = %s
+				ORDER BY d.meta_value ASC, p.ID ASC
+				LIMIT %d",
+				$date_key,
+				$number_key,
+				$select_key,
+				$post_type,
+				$minimum,
+				$select_value,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array_map( 'intval', $ids );
+	}
+
+	private function postmeta_relation_contains_ids( string $slug, int $relation_field_id, int $target_row_id, int $limit ): array {
+		global $wpdb;
+
+		$post_type = CollectionEntries::CPT_PREFIX . $slug;
+		$key       = Relations::meta_key( $relation_field_id );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark times the raw postmeta relation lookup.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT p.ID
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS r ON r.post_id = p.ID AND r.meta_key = %s
+				WHERE p.post_type = %s
+				AND p.post_status IN ('draft', 'private', 'publish')
+				AND r.meta_value = %s
+				ORDER BY p.ID ASC
+				LIMIT %d",
+				$key,
+				$post_type,
+				(string) $target_row_id,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array_map( 'intval', $ids );
+	}
+
+	private function postmeta_sum_number( string $slug, int $field_id ): float {
+		global $wpdb;
+
+		$post_type = CollectionEntries::CPT_PREFIX . $slug;
+		$key       = Relations::meta_key( $field_id );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark times the raw postmeta aggregate lookup.
+		return (float) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COALESCE(SUM(CAST(pm.meta_value AS DECIMAL(20,4))), 0)
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS pm ON pm.post_id = p.ID AND pm.meta_key = %s
+				WHERE p.post_type = %s
+				AND p.post_status IN ('draft', 'private', 'publish')",
+				$key,
+				$post_type
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	private function postmeta_count_text( string $slug, int $field_id, string $value ): int {
+		global $wpdb;
+
+		$post_type = CollectionEntries::CPT_PREFIX . $slug;
+		$key       = Relations::meta_key( $field_id );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark times the raw postmeta aggregate lookup.
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT p.ID)
+				FROM {$wpdb->posts} AS p
+				INNER JOIN {$wpdb->postmeta} AS pm ON pm.post_id = p.ID AND pm.meta_key = %s
+				WHERE p.post_type = %s
+				AND p.post_status IN ('draft', 'private', 'publish')
+				AND pm.meta_value = %s",
+				$key,
+				$post_type,
+				$value
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	private function materialization_filter_tree( int $number_field_id, int $select_field_id, float $minimum ): array {
+		return array(
+			array(
+				'relation' => 'AND',
+				'filters'  => array(
+					array(
+						'field'    => Relations::meta_key( $number_field_id ),
+						'operator' => 'greaterThan',
+						'value'    => (string) $minimum,
+					),
+					array(
+						'field'    => Relations::meta_key( $select_field_id ),
+						'operator' => 'is',
+						'value'    => 'stable',
+					),
+				),
+			),
+		);
+	}
+
+	private function prepare_materialization_writes( array $row_ids, int $field_id, float $base_value, FieldValueIndex $index, bool $sync_index ): void {
+		FieldValueIndex::suspend_sync();
+		try {
+			foreach ( array_values( $row_ids ) as $offset => $row_id ) {
+				update_post_meta( (int) $row_id, Relations::meta_key( $field_id ), (string) ( $base_value + $offset ) );
+			}
+		} finally {
+			FieldValueIndex::resume_sync();
+		}
+
+		if ( $sync_index ) {
+			foreach ( $row_ids as $row_id ) {
+				$index->index_row_field( (int) $row_id, $field_id );
+			}
+		}
+	}
+
+	private function run_materialization_writes( array $row_ids, int $field_id, float $base_value, FieldValueIndex $index, bool $sync_index ): int {
+		FieldValueIndex::suspend_sync();
+		try {
+			foreach ( array_values( $row_ids ) as $offset => $row_id ) {
+				update_post_meta( (int) $row_id, Relations::meta_key( $field_id ), (string) ( $base_value + $offset ) );
+			}
+		} finally {
+			FieldValueIndex::resume_sync();
+		}
+
+		if ( $sync_index ) {
+			foreach ( $row_ids as $row_id ) {
+				$index->index_row_field( (int) $row_id, $field_id );
+			}
+		}
+
+		return count( $row_ids );
+	}
+
+	private function run_materialization_sidecar_writes( array $row_ids, int $field_id, FieldValueIndex $index ): int {
+		foreach ( $row_ids as $row_id ) {
+			$index->index_row_field( (int) $row_id, $field_id );
+		}
+
+		return count( $row_ids );
+	}
+
+	private function run_materialization_single_postmeta_write( int $row_id, int $field_id, float $value ): int {
+		FieldValueIndex::suspend_sync();
+		try {
+			update_post_meta( $row_id, Relations::meta_key( $field_id ), (string) $value );
+		} finally {
+			FieldValueIndex::resume_sync();
+		}
+
+		return 1;
+	}
+
+	private function run_materialization_sidecar_known_writes( array $row_ids, int $field_id, float $base_value, int $collection_id, FieldValueIndex $index ): int {
+		foreach ( array_values( $row_ids ) as $offset => $row_id ) {
+			$index->index_known_value( (int) $row_id, $field_id, 'number', (string) ( $base_value + $offset ), $collection_id, 'private' );
+		}
+
+		return count( $row_ids );
+	}
+
+	private function run_materialization_rest_write( int $collection_id, int $row_id, int $field_id, float $value, bool $sidecar_enabled ): mixed {
+		$disable_sidecar = static fn(): bool => false;
+		if ( ! $sidecar_enabled ) {
+			add_filter( 'cortext_field_values_index_enabled', $disable_sidecar );
+		}
+
+		try {
+			return $this->rest_request(
+				'POST',
+				"/cortext/v1/collections/{$collection_id}/rows/{$row_id}",
+				array(
+					'collection_id' => $collection_id,
+					'row_id'        => $row_id,
+					'field'         => Relations::meta_key( $field_id ),
+					'value'         => (string) $value,
+				)
+			);
+		} finally {
+			if ( ! $sidecar_enabled ) {
+				remove_filter( 'cortext_field_values_index_enabled', $disable_sidecar );
+			}
+		}
+	}
+
+	private function run_materialization_store_writes( array $row_ids, int $field_id, float $base_value, int $collection_id, FieldValueIndex $index ): int {
+		$store = new FieldValueStore( $index );
+		foreach ( array_values( $row_ids ) as $offset => $row_id ) {
+			$store->write_value( (int) $row_id, $field_id, 'number', (string) ( $base_value + $offset ), $collection_id, 'private' );
+		}
+
+		return count( $row_ids );
+	}
+
+	/**
 	 * Builds the summary for a scenario split into steps. User-facing latency
 	 * is the sum of step latencies, SQL queries are summed, and memory uses the
 	 * highest step peak. Per-step fields only expose latency; SQL and memory
@@ -1636,8 +2489,9 @@ final class PerfBench {
 	 *
 	 * @param array<string,mixed> $manifest    Dataset manifest.
 	 * @param string              $budget_path Budget file path.
+	 * @param string              $suite       Benchmark suite.
 	 */
-	private static function benchmark_config_hash( array $manifest, string $budget_path ): string {
+	private static function benchmark_config_hash( array $manifest, string $budget_path, string $suite = 'default' ): string {
 		$config = isset( $manifest['config'] ) && is_array( $manifest['config'] )
 			? self::normalize_int_map( $manifest['config'] )
 			: array();
@@ -1646,6 +2500,7 @@ final class PerfBench {
 			(string) wp_json_encode(
 				array(
 					'seed'        => (string) ( $manifest['seed'] ?? self::DATASET_SEED ),
+					'suite'       => $suite,
 					'seed_args'   => $config,
 					'budget_path' => self::relative_local_path( $budget_path ),
 				),

--- a/includes/FieldValues/FieldValueIndex.php
+++ b/includes/FieldValues/FieldValueIndex.php
@@ -1,0 +1,1159 @@
+<?php
+/**
+ * Derived field-value index for collection rows.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\FieldValues;
+
+use Cortext\PostType\Collection;
+use Cortext\PostType\CollectionEntries;
+use Cortext\PostType\Field;
+use Cortext\Relations;
+use RuntimeException;
+use WP_Post;
+use WP_Query;
+
+final class FieldValueIndex {
+
+	public const STATUS_UNAVAILABLE = 'unavailable';
+	public const STATUS_INSTALLING  = 'installing';
+	public const STATUS_SYNCING     = 'syncing';
+	public const STATUS_READY       = 'ready';
+	public const STATUS_STALE       = 'stale';
+	public const STATUS_DISABLED    = 'disabled';
+
+	private const SCHEMA_VERSION         = 1;
+	private const STATUS_OPTION          = 'cortext_field_values_index_status';
+	private const STATUS_ERROR_OPTION    = 'cortext_field_values_index_error';
+	private const SCHEMA_VERSION_OPTION  = 'cortext_field_values_schema_version';
+	private const ENABLED_OPTION         = 'cortext_field_values_index_enabled';
+	private const DISABLED_SINCE_OPTION  = 'cortext_field_values_disabled_since';
+	private const INSTALL_ATTEMPT_OPTION = 'cortext_field_values_install_attempted_version';
+	private const AUTO_REBUILD_HOOK      = 'cortext_field_values_auto_rebuild';
+	private const AUTO_REBUILD_LOCK      = 'cortext_field_values_auto_rebuild_lock';
+	private const TEXT_INDEX_LENGTH      = 191;
+	private const PAGE_SIZE              = 500;
+
+	private static int $sync_suspensions             = 0;
+	private static array $collection_id_by_post_type = array();
+	private static array $table_exists_cache         = array();
+	private static array $pending_row_fields         = array();
+
+	public function register(): void {
+		add_action( 'added_post_meta', array( $this, 'sync_meta_change' ), 10, 4 );
+		add_action( 'updated_post_meta', array( $this, 'sync_meta_change' ), 10, 4 );
+		add_action( 'deleted_post_meta', array( $this, 'sync_meta_change' ), 10, 4 );
+		add_action( 'wp_trash_post', array( $this, 'sync_row_status' ), 20, 1 );
+		add_action( 'untrashed_post', array( $this, 'sync_row_status' ), 20, 1 );
+		add_action( 'before_delete_post', array( $this, 'cleanup_deleted_post' ), 20, 2 );
+		add_action( 'init', array( $this, 'maybe_auto_provision' ), 30 );
+		add_action( 'shutdown', array( $this, 'flush_pending_sync' ), 1 );
+		add_action( self::AUTO_REBUILD_HOOK, array( $this, 'run_auto_rebuild' ) );
+	}
+
+	public static function suspend_sync(): void {
+		++self::$sync_suspensions;
+	}
+
+	public static function resume_sync(): void {
+		self::$sync_suspensions = max( 0, self::$sync_suspensions - 1 );
+	}
+
+	public static function sync_is_suspended(): bool {
+		return self::$sync_suspensions > 0;
+	}
+
+	public static function flush_runtime_caches(): void {
+		self::$collection_id_by_post_type = array();
+		self::$table_exists_cache         = array();
+		self::$pending_row_fields         = array();
+	}
+
+	public function table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'cortext_field_values';
+	}
+
+	public function status(): array {
+		$enabled = $this->is_enabled();
+		return array(
+			'enabled'                 => $enabled,
+			'status'                  => $enabled ? (string) get_option( self::STATUS_OPTION, self::STATUS_UNAVAILABLE ) : self::STATUS_DISABLED,
+			'error'                   => (string) get_option( self::STATUS_ERROR_OPTION, '' ),
+			'schemaVersion'           => (int) get_option( self::SCHEMA_VERSION_OPTION, 0 ),
+			'disabledSince'           => (int) get_option( self::DISABLED_SINCE_OPTION, 0 ),
+			'installAttemptedVersion' => (int) get_option( self::INSTALL_ATTEMPT_OPTION, 0 ),
+			'table'                   => $this->table_name(),
+			'tableExists'             => $this->table_exists(),
+			'autoRebuildScheduled'    => false !== wp_next_scheduled( self::AUTO_REBUILD_HOOK ),
+		);
+	}
+
+	public function install(): bool {
+		if ( ! $this->is_enabled() ) {
+			return false;
+		}
+
+		update_option( self::INSTALL_ATTEMPT_OPTION, self::SCHEMA_VERSION, false );
+		$this->set_status( self::STATUS_INSTALLING );
+
+		$created = $this->create_table();
+		if ( ! $created || ! $this->table_exists() ) {
+			$this->set_status(
+				self::STATUS_UNAVAILABLE,
+				__( 'Cortext could not create the field-value index table.', 'cortext' )
+			);
+			return false;
+		}
+
+		update_option( self::SCHEMA_VERSION_OPTION, self::SCHEMA_VERSION, false );
+		if ( self::STATUS_READY !== (string) get_option( self::STATUS_OPTION, '' ) ) {
+			$this->set_status( self::STATUS_STALE );
+		}
+		return true;
+	}
+
+	public function activate(): void {
+		if ( ! $this->is_enabled() ) {
+			$this->record_disabled_state();
+			return;
+		}
+
+		if ( $this->install() ) {
+			$this->schedule_auto_rebuild();
+		}
+	}
+
+	public function maybe_auto_provision(): void {
+		if ( wp_installing() ) {
+			return;
+		}
+
+		if ( ! $this->is_enabled() ) {
+			$this->record_disabled_state();
+			return;
+		}
+
+		$was_disabled = (int) get_option( self::DISABLED_SINCE_OPTION, 0 ) > 0;
+		if ( $this->schema_is_current() && $this->table_exists() ) {
+			if ( $was_disabled ) {
+				$this->mark_stale( __( 'The field-value index was re-enabled and needs a rebuild.', 'cortext' ) );
+				$this->schedule_auto_rebuild();
+			} elseif ( ! $this->can_read() ) {
+				$this->schedule_auto_rebuild();
+			}
+			return;
+		}
+
+		$already_tried_current_schema = (int) get_option( self::INSTALL_ATTEMPT_OPTION, 0 ) === self::SCHEMA_VERSION;
+		if ( $already_tried_current_schema && ! $this->schema_is_current() ) {
+			return;
+		}
+
+		if ( $this->install() ) {
+			$this->schedule_auto_rebuild();
+		}
+	}
+
+	public function run_auto_rebuild(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		if ( ! $this->claim_auto_rebuild_lock() ) {
+			$this->schedule_auto_rebuild( 5 * MINUTE_IN_SECONDS );
+			return;
+		}
+
+		try {
+			if ( ! $this->install() ) {
+				return;
+			}
+
+			( new CollectionEntries() )->register_all();
+			$collection_ids = $this->collection_ids();
+			foreach ( $collection_ids as $collection_id ) {
+				$this->rebuild_collection( $collection_id );
+			}
+
+			$failed = array();
+			foreach ( $collection_ids as $collection_id ) {
+				$result = $this->verify_collection( $collection_id );
+				if ( empty( $result['passed'] ) ) {
+					$failed[] = $collection_id;
+				}
+			}
+
+			if ( count( $failed ) > 0 ) {
+				$this->mark_stale(
+					sprintf(
+						/* translators: %s: comma-separated collection IDs */
+						__( 'Field-value index verification failed for collections: %s.', 'cortext' ),
+						implode( ', ', $failed )
+					)
+				);
+				return;
+			}
+
+			$this->set_status( self::STATUS_READY );
+			delete_option( self::DISABLED_SINCE_OPTION );
+		} catch ( RuntimeException $exception ) {
+			$this->mark_stale( $exception->getMessage() );
+		} finally {
+			delete_option( self::AUTO_REBUILD_LOCK );
+		}
+	}
+
+	public function can_read(): bool {
+		return $this->is_enabled()
+			&& self::STATUS_READY === (string) get_option( self::STATUS_OPTION, self::STATUS_UNAVAILABLE )
+			&& (int) get_option( self::SCHEMA_VERSION_OPTION, 0 ) === self::SCHEMA_VERSION
+			&& $this->table_exists();
+	}
+
+	public function can_write(): bool {
+		return $this->is_enabled()
+			&& self::STATUS_UNAVAILABLE !== (string) get_option( self::STATUS_OPTION, self::STATUS_UNAVAILABLE )
+			&& (int) get_option( self::SCHEMA_VERSION_OPTION, 0 ) === self::SCHEMA_VERSION
+			&& $this->table_exists();
+	}
+
+	public function is_enabled(): bool {
+		$value = get_option( self::ENABLED_OPTION, true );
+		if ( is_bool( $value ) ) {
+			$enabled = $value;
+		} elseif ( is_numeric( $value ) ) {
+			$enabled = 0 !== (int) $value;
+		} else {
+			$enabled = ! in_array(
+				strtolower( trim( (string) $value ) ),
+				array( '0', 'false', 'no', 'off', 'disabled' ),
+				true
+			);
+		}
+
+		/**
+		 * Controls whether the derived field-value index can install, rebuild,
+		 * sync, or answer reads.
+		 *
+		 * Returning false leaves postmeta as the only active store for field values.
+		 *
+		 * @param bool $enabled Whether the index is enabled.
+		 */
+		return (bool) apply_filters( 'cortext_field_values_index_enabled', $enabled );
+	}
+
+	public function mark_stale( string $reason = '' ): void {
+		$this->set_status( self::STATUS_STALE, $reason );
+	}
+
+	public function rebuild_collection( int $collection_id ): array {
+		if ( ! $this->install() ) {
+			return array(
+				'indexedRows' => 0,
+				'valueRows'   => 0,
+				'status'      => $this->is_enabled() ? self::STATUS_UNAVAILABLE : self::STATUS_DISABLED,
+			);
+		}
+
+		$post_type = Relations::entry_post_type_for_collection( $collection_id );
+		if ( null === $post_type ) {
+			throw new RuntimeException( esc_html__( 'Collection row type is not registered.', 'cortext' ) );
+		}
+
+		$field_ids = array_values( array_filter( array_map( 'intval', get_post_meta( $collection_id, 'fields', false ) ) ) );
+		$this->set_status( self::STATUS_SYNCING );
+		$this->delete_collection( $collection_id );
+
+		$value_rows   = 0;
+		$indexed_rows = 0;
+		$page         = 1;
+
+		do {
+			$query = new WP_Query(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => array( 'draft', 'private', 'publish', 'trash' ),
+					'fields'         => 'ids',
+					'posts_per_page' => self::PAGE_SIZE,
+					'paged'          => $page,
+					'orderby'        => 'ID',
+					'order'          => 'ASC',
+				)
+			);
+
+			$row_ids = array_map( 'intval', $query->posts );
+			foreach ( $row_ids as $row_id ) {
+				++$indexed_rows;
+				foreach ( $field_ids as $field_id ) {
+					$value_rows += $this->index_row_field( $row_id, $field_id, $collection_id, false );
+				}
+			}
+
+			++$page;
+		} while ( $page <= (int) $query->max_num_pages );
+
+		$this->set_status( self::STATUS_READY );
+		delete_option( self::DISABLED_SINCE_OPTION );
+
+		return array(
+			'indexedRows' => $indexed_rows,
+			'valueRows'   => $value_rows,
+			'status'      => self::STATUS_READY,
+		);
+	}
+
+	public function verify_collection( int $collection_id ): array {
+		if ( ! $this->is_enabled() || ! $this->table_exists() ) {
+			return array(
+				'collectionId' => $collection_id,
+				'expectedRows' => 0,
+				'actualRows'   => 0,
+				'missing'      => 0,
+				'extra'        => 0,
+				'passed'       => false,
+			);
+		}
+
+		$post_type = Relations::entry_post_type_for_collection( $collection_id );
+		if ( null === $post_type ) {
+			throw new RuntimeException( esc_html__( 'Collection row type is not registered.', 'cortext' ) );
+		}
+
+		$field_ids = array_values( array_filter( array_map( 'intval', get_post_meta( $collection_id, 'fields', false ) ) ) );
+		$expected  = array();
+		$page      = 1;
+
+		do {
+			$query = new WP_Query(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => array( 'draft', 'private', 'publish', 'trash' ),
+					'fields'         => 'ids',
+					'posts_per_page' => self::PAGE_SIZE,
+					'paged'          => $page,
+					'orderby'        => 'ID',
+					'order'          => 'ASC',
+				)
+			);
+
+			foreach ( array_map( 'intval', $query->posts ) as $row_id ) {
+				foreach ( $field_ids as $field_id ) {
+					foreach ( $this->index_rows_for_row_field( $row_id, $field_id, $collection_id ) as $row ) {
+						$expected[ $this->signature( $row ) ] = true;
+					}
+				}
+			}
+
+			++$page;
+		} while ( $page <= (int) $query->max_num_pages );
+
+		$actual = array();
+		foreach ( $this->indexed_rows_for_collection( $collection_id ) as $row ) {
+			$actual[ $this->signature( $row ) ] = true;
+		}
+
+		$missing = array_diff_key( $expected, $actual );
+		$extra   = array_diff_key( $actual, $expected );
+
+		return array(
+			'collectionId' => $collection_id,
+			'expectedRows' => count( $expected ),
+			'actualRows'   => count( $actual ),
+			'missing'      => count( $missing ),
+			'extra'        => count( $extra ),
+			'passed'       => count( $missing ) === 0 && count( $extra ) === 0,
+		);
+	}
+
+	public function index_row_field( int $row_id, int $field_id, ?int $collection_id = null, bool $delete_existing = true ): int {
+		if ( ! $this->can_write() ) {
+			return 0;
+		}
+
+		$collection_id = $collection_id ?? $this->collection_id_for_row( $row_id );
+		if ( $collection_id < 1 ) {
+			return 0;
+		}
+
+		$rows = $this->index_rows_for_row_field( $row_id, $field_id, $collection_id );
+		return $this->write_index_rows( $row_id, $field_id, $rows, $delete_existing, $this->field_can_have_multiple_values( $field_id ) );
+	}
+
+	public function index_known_value( int $row_id, int $field_id, string $field_type, mixed $value, ?int $collection_id = null, ?string $post_status = null ): int {
+		if ( ! $this->can_write() || '' === $field_type || 'rollup' === $field_type ) {
+			return 0;
+		}
+
+		$collection_id = $collection_id ?? $this->collection_id_for_row( $row_id );
+		if ( $collection_id < 1 ) {
+			return 0;
+		}
+
+		$post_status = $post_status ?? (string) get_post_status( $row_id );
+		$rows        = array();
+		foreach ( $this->normalized_value_rows( $field_id, $field_type, $value, $post_status ) as $row ) {
+			$rows[] = array(
+				'row_id'        => $row_id,
+				'collection_id' => $collection_id,
+				'field_id'      => $row['field_id'],
+				'value_seq'     => $row['value_seq'],
+				'value_text'    => $row['value_text'],
+				'value_number'  => $row['value_number'],
+				'value_date'    => $row['value_date'],
+				'post_status'   => $row['post_status'],
+			);
+		}
+
+		return $this->write_index_rows( $row_id, $field_id, $rows, true, $this->known_type_can_have_multiple_values( $field_id, $field_type ) );
+	}
+
+	private function write_index_rows( int $row_id, int $field_id, array $rows, bool $delete_existing, bool $can_have_multiple_values ): int {
+		global $wpdb;
+
+		if ( $delete_existing && ! $can_have_multiple_values ) {
+			if ( count( $rows ) === 0 ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Updates the derived index for one row field.
+				$wpdb->delete(
+					$this->table_name(),
+					array(
+						'row_id'   => $row_id,
+						'field_id' => $field_id,
+					),
+					array( '%d', '%d' )
+				);
+				return 0;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Updates the derived index for one single-value row field.
+			$result = $wpdb->replace(
+				$this->table_name(),
+				$rows[0],
+				array( '%d', '%d', '%d', '%d', '%s', '%f', '%s', '%s' )
+			);
+			if ( false === $result ) {
+				$this->mark_stale( __( 'Cortext could not write to the field-value index.', 'cortext' ) );
+				return 0;
+			}
+			return 1;
+		}
+
+		if ( $delete_existing ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Updates the derived index for one row field.
+			$wpdb->delete(
+				$this->table_name(),
+				array(
+					'row_id'   => $row_id,
+					'field_id' => $field_id,
+				),
+				array( '%d', '%d' )
+			);
+		}
+
+		$inserted = 0;
+		foreach ( $rows as $row ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Updates the derived index for one row field.
+			$result = $wpdb->insert(
+				$this->table_name(),
+				$row,
+				array( '%d', '%d', '%d', '%d', '%s', '%f', '%s', '%s' )
+			);
+			if ( false === $result ) {
+				$this->mark_stale( __( 'Cortext could not write to the field-value index.', 'cortext' ) );
+				return $inserted;
+			}
+			++$inserted;
+		}
+
+		return $inserted;
+	}
+
+	public function sync_meta_change( mixed $meta_id, int $object_id, string $meta_key, mixed $meta_value = null ): void {
+		unset( $meta_id, $meta_value );
+
+		if ( self::sync_is_suspended() || ! $this->is_field_meta_key( $meta_key ) || ! $this->can_write() ) {
+			return;
+		}
+
+		$field_id = $this->field_id_from_meta_key( $meta_key );
+		if ( $field_id < 1 ) {
+			return;
+		}
+
+		$this->queue_row_field( $object_id, $field_id );
+	}
+
+	public function flush_pending_sync(): int {
+		if ( self::sync_is_suspended() || count( self::$pending_row_fields ) === 0 || ! $this->can_write() ) {
+			return 0;
+		}
+
+		$pending                  = self::$pending_row_fields;
+		self::$pending_row_fields = array();
+
+		$indexed = 0;
+		foreach ( $pending as $entry ) {
+			$indexed += $this->index_row_field(
+				(int) $entry['row_id'],
+				(int) $entry['field_id'],
+				isset( $entry['collection_id'] ) ? (int) $entry['collection_id'] : null
+			);
+		}
+
+		return $indexed;
+	}
+
+	private function queue_row_field( int $row_id, int $field_id, ?int $collection_id = null ): void {
+		self::$pending_row_fields[ "{$row_id}:{$field_id}" ] = array_filter(
+			array(
+				'row_id'        => $row_id,
+				'field_id'      => $field_id,
+				'collection_id' => $collection_id,
+			),
+			static fn( mixed $value ): bool => null !== $value
+		);
+	}
+
+	public function sync_row_status( int $post_id ): void {
+		if ( ! $this->can_write() || $this->collection_id_for_row( $post_id ) < 1 ) {
+			return;
+		}
+
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Keeps row status in the derived index current.
+		$result = $wpdb->update(
+			$this->table_name(),
+			array( 'post_status' => (string) get_post_status( $post_id ) ),
+			array( 'row_id' => $post_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		if ( false === $result ) {
+			$this->mark_stale( __( 'Cortext could not update field-value index status.', 'cortext' ) );
+		}
+	}
+
+	public function cleanup_deleted_post( int $post_id, ?WP_Post $post = null ): void {
+		if ( ! $this->is_enabled() || ! $this->table_exists() ) {
+			return;
+		}
+
+		$post_type = $post instanceof WP_Post ? $post->post_type : get_post_type( $post_id );
+		if ( Field::POST_TYPE === $post_type ) {
+			$this->delete_field( $post_id );
+			return;
+		}
+
+		if ( Collection::POST_TYPE === $post_type ) {
+			$this->delete_collection( $post_id );
+			self::$collection_id_by_post_type = array();
+			return;
+		}
+
+		if ( is_string( $post_type ) && $this->is_entry_post_type( $post_type ) ) {
+			$this->delete_row( $post_id );
+		}
+	}
+
+	public function query_two_field_filter_ids(
+		int $collection_id,
+		int $number_field_id,
+		float $minimum,
+		int $select_field_id,
+		string $select_value,
+		int $limit
+	): array {
+		$this->flush_pending_sync();
+
+		global $wpdb;
+
+		$table = $this->table_name();
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT n.row_id
+				FROM {$table} AS n
+				INNER JOIN {$table} AS s ON s.row_id = n.row_id
+				WHERE n.collection_id = %d
+				AND n.field_id = %d
+				AND n.value_number > %f
+				AND n.post_status IN ('draft', 'private', 'publish')
+				AND s.collection_id = %d
+				AND s.field_id = %d
+				AND s.value_text = %s
+				AND s.post_status IN ('draft', 'private', 'publish')
+				ORDER BY n.row_id ASC
+				LIMIT %d",
+				$collection_id,
+				$number_field_id,
+				$minimum,
+				$collection_id,
+				$select_field_id,
+				$select_value,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return array_map( 'intval', $ids );
+	}
+
+	public function query_date_sort_ids( int $collection_id, int $date_field_id, int $limit ): array {
+		$this->flush_pending_sync();
+
+		global $wpdb;
+
+		$table = $this->table_name();
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT row_id
+				FROM {$table}
+				WHERE collection_id = %d
+				AND field_id = %d
+				AND value_date IS NOT NULL
+				AND post_status IN ('draft', 'private', 'publish')
+				ORDER BY value_date ASC, row_id ASC
+				LIMIT %d",
+				$collection_id,
+				$date_field_id,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return array_map( 'intval', $ids );
+	}
+
+	public function query_relation_contains_ids( int $collection_id, int $relation_field_id, int $target_row_id, int $limit ): array {
+		$this->flush_pending_sync();
+
+		global $wpdb;
+
+		$table = $this->table_name();
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT row_id
+				FROM {$table}
+				WHERE collection_id = %d
+				AND field_id = %d
+				AND value_text = %s
+				AND post_status IN ('draft', 'private', 'publish')
+				ORDER BY row_id ASC
+				LIMIT %d",
+				$collection_id,
+				$relation_field_id,
+				(string) $target_row_id,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array_map( 'intval', $ids );
+	}
+
+	public function query_date_sort_filtered_ids(
+		int $collection_id,
+		int $date_field_id,
+		int $number_field_id,
+		float $minimum,
+		int $select_field_id,
+		string $select_value,
+		int $limit
+	): array {
+		$this->flush_pending_sync();
+
+		global $wpdb;
+
+		$table = $this->table_name();
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT d.row_id
+				FROM {$table} AS d
+				INNER JOIN {$table} AS n ON n.collection_id = d.collection_id AND n.row_id = d.row_id
+				INNER JOIN {$table} AS s ON s.collection_id = d.collection_id AND s.row_id = d.row_id
+				WHERE d.collection_id = %d
+				AND d.field_id = %d
+				AND d.value_date IS NOT NULL
+				AND d.post_status IN ('draft', 'private', 'publish')
+				AND n.field_id = %d
+				AND n.value_number > %f
+				AND n.post_status IN ('draft', 'private', 'publish')
+				AND s.field_id = %d
+				AND s.value_text = %s
+				AND s.post_status IN ('draft', 'private', 'publish')
+				ORDER BY d.value_date ASC, d.row_id ASC
+				LIMIT %d",
+				$collection_id,
+				$date_field_id,
+				$number_field_id,
+				$minimum,
+				$select_field_id,
+				$select_value,
+				$limit
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return array_map( 'intval', $ids );
+	}
+
+	public function query_text_search_ids( int $collection_id, array $field_ids, string $term, int $limit ): array {
+		$this->flush_pending_sync();
+
+		$field_ids = array_values( array_filter( array_map( 'intval', $field_ids ) ) );
+		if ( count( $field_ids ) === 0 ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$table        = $this->table_name();
+		$placeholders = implode( ', ', array_fill( 0, count( $field_ids ), '%d' ) );
+		$like         = '%' . $wpdb->esc_like( $term ) . '%';
+		$args         = array_merge( array( $collection_id ), $field_ids, array( $like, $limit ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT row_id
+				FROM {$table}
+				WHERE collection_id = %d
+				AND field_id IN ({$placeholders})
+				AND value_text LIKE %s
+				AND post_status IN ('draft', 'private', 'publish')
+				ORDER BY row_id ASC
+				LIMIT %d",
+				...$args
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return array_map( 'intval', $ids );
+	}
+
+	public function query_text_search_filtered_ids(
+		int $collection_id,
+		array $field_ids,
+		string $term,
+		int $number_field_id,
+		float $minimum,
+		int $select_field_id,
+		string $select_value,
+		int $limit
+	): array {
+		$this->flush_pending_sync();
+
+		$field_ids = array_values( array_filter( array_map( 'intval', $field_ids ) ) );
+		if ( count( $field_ids ) === 0 ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$table        = $this->table_name();
+		$placeholders = implode( ', ', array_fill( 0, count( $field_ids ), '%d' ) );
+		$like         = '%' . $wpdb->esc_like( $term ) . '%';
+		$args         = array_merge( array( $collection_id ), $field_ids, array( $like, $number_field_id, $minimum, $select_field_id, $select_value, $limit ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT t.row_id
+				FROM {$table} AS t
+				INNER JOIN {$table} AS n ON n.collection_id = t.collection_id AND n.row_id = t.row_id
+				INNER JOIN {$table} AS s ON s.collection_id = t.collection_id AND s.row_id = t.row_id
+				WHERE t.collection_id = %d
+				AND t.field_id IN ({$placeholders})
+				AND t.value_text LIKE %s
+				AND t.post_status IN ('draft', 'private', 'publish')
+				AND n.field_id = %d
+				AND n.value_number > %f
+				AND n.post_status IN ('draft', 'private', 'publish')
+				AND s.field_id = %d
+				AND s.value_text = %s
+				AND s.post_status IN ('draft', 'private', 'publish')
+				ORDER BY t.row_id ASC
+				LIMIT %d",
+				...$args
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return array_map( 'intval', $ids );
+	}
+
+	public function aggregate_number( int $collection_id, int $field_id, string $operation ): float|int {
+		$this->flush_pending_sync();
+
+		global $wpdb;
+
+		$function = 'count' === $operation ? 'COUNT(value_number)' : 'COALESCE(SUM(value_number), 0)';
+		$table    = $this->table_name();
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		$value = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT {$function}
+				FROM {$table}
+				WHERE collection_id = %d
+				AND field_id = %d
+				AND value_number IS NOT NULL
+				AND post_status IN ('draft', 'private', 'publish')",
+				$collection_id,
+				$field_id
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return 'count' === $operation ? (int) $value : (float) $value;
+	}
+
+	public function count_text_value( int $collection_id, int $field_id, string $value ): int {
+		$this->flush_pending_sync();
+
+		global $wpdb;
+
+		$table = $this->table_name();
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*)
+				FROM {$table}
+				WHERE collection_id = %d
+				AND field_id = %d
+				AND value_text = %s
+				AND post_status IN ('draft', 'private', 'publish')",
+				$collection_id,
+				$field_id,
+				$value
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	public function normalized_value_rows( int $field_id, string $field_type, mixed $stored, string $post_status = 'private' ): array {
+		$values = is_array( $stored ) ? array_values( $stored ) : array( $stored );
+		$rows   = array();
+		$seq    = 0;
+
+		foreach ( $values as $value ) {
+			if ( null === $value || '' === $value ) {
+				continue;
+			}
+
+			$text   = is_scalar( $value ) ? (string) $value : wp_json_encode( $value );
+			$text   = is_string( $text ) ? $text : '';
+			$number = is_numeric( $value ) ? (float) $value : null;
+			$date   = null;
+
+			if ( 'checkbox' === $field_type ) {
+				$number = Relations::is_truthy( $value ) ? 1.0 : 0.0;
+				$text   = Relations::is_truthy( $value ) ? '1' : '0';
+			} elseif ( in_array( $field_type, array( 'date', 'datetime' ), true ) ) {
+				$date = $this->normalized_date_for_index( $value, $field_type );
+			}
+
+			if ( 'number' !== $field_type ) {
+				$number = 'checkbox' === $field_type ? $number : null;
+			}
+
+			$rows[] = array(
+				'field_id'     => $field_id,
+				'value_seq'    => $seq,
+				'value_text'   => substr( $text, 0, self::TEXT_INDEX_LENGTH ),
+				'value_number' => $number,
+				'value_date'   => $date,
+				'post_status'  => $post_status,
+			);
+			++$seq;
+		}
+
+		return $rows;
+	}
+
+	private function create_table(): bool {
+		global $wpdb;
+
+		$table           = $this->table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$sql = "CREATE TABLE {$table} (
+			row_id bigint(20) unsigned NOT NULL,
+			collection_id bigint(20) unsigned NOT NULL,
+			field_id bigint(20) unsigned NOT NULL,
+			value_seq smallint(5) unsigned NOT NULL DEFAULT 0,
+			value_text varchar(191) DEFAULT NULL,
+			value_number decimal(20,4) DEFAULT NULL,
+			value_date datetime DEFAULT NULL,
+			post_status varchar(20) NOT NULL DEFAULT 'publish',
+			PRIMARY KEY  (row_id, field_id, value_seq),
+			KEY collection_field_text (collection_id, field_id, value_text, row_id),
+			KEY collection_field_number (collection_id, field_id, value_number, row_id),
+			KEY collection_field_date (collection_id, field_id, value_date, row_id),
+			KEY collection_row (collection_id, row_id)
+		) {$charset_collate};";
+
+		dbDelta( $sql );
+		return $this->table_exists( true );
+	}
+
+	private function table_exists( bool $refresh = false ): bool {
+		global $wpdb;
+
+		$table = $this->table_name();
+		if ( ! $refresh && array_key_exists( $table, self::$table_exists_cache ) ) {
+			return self::$table_exists_cache[ $table ];
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema health check.
+		self::$table_exists_cache[ $table ] = $table === (string) $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		return self::$table_exists_cache[ $table ];
+	}
+
+	private function schema_is_current(): bool {
+		return (int) get_option( self::SCHEMA_VERSION_OPTION, 0 ) === self::SCHEMA_VERSION;
+	}
+
+	private function set_status( string $status, string $error = '' ): void {
+		update_option( self::STATUS_OPTION, $status, false );
+		update_option( self::STATUS_ERROR_OPTION, $error, false );
+	}
+
+	private function record_disabled_state(): void {
+		if ( (int) get_option( self::DISABLED_SINCE_OPTION, 0 ) > 0 ) {
+			return;
+		}
+
+		update_option( self::DISABLED_SINCE_OPTION, time(), false );
+	}
+
+	private function schedule_auto_rebuild( int $delay = 10 ): void {
+		if ( false !== wp_next_scheduled( self::AUTO_REBUILD_HOOK ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time() + $delay, self::AUTO_REBUILD_HOOK );
+	}
+
+	private function claim_auto_rebuild_lock(): bool {
+		$locked_at = (int) get_option( self::AUTO_REBUILD_LOCK, 0 );
+		if ( $locked_at > time() - ( 15 * MINUTE_IN_SECONDS ) ) {
+			return false;
+		}
+
+		update_option( self::AUTO_REBUILD_LOCK, time(), false );
+		return true;
+	}
+
+	private function collection_ids(): array {
+		return array_map(
+			'intval',
+			get_posts(
+				array(
+					'post_type'      => Collection::POST_TYPE,
+					'post_status'    => array( 'draft', 'private', 'publish' ),
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				)
+			)
+		);
+	}
+
+	private function delete_collection( int $collection_id ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Rebuild clears the derived index for one collection.
+		$wpdb->delete(
+			$this->table_name(),
+			array( 'collection_id' => $collection_id ),
+			array( '%d' )
+		);
+	}
+
+	private function delete_row( int $row_id ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Deletes derived index rows for a deleted row.
+		$wpdb->delete(
+			$this->table_name(),
+			array( 'row_id' => $row_id ),
+			array( '%d' )
+		);
+	}
+
+	private function delete_field( int $field_id ): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Deletes derived index rows for a deleted field.
+		$wpdb->delete(
+			$this->table_name(),
+			array( 'field_id' => $field_id ),
+			array( '%d' )
+		);
+	}
+
+	private function index_rows_for_row_field( int $row_id, int $field_id, int $collection_id ): array {
+		$field_type = (string) get_post_meta( $field_id, 'type', true );
+		if ( '' === $field_type || 'rollup' === $field_type ) {
+			return array();
+		}
+
+		$key         = Relations::meta_key( $field_id );
+		$is_multiple = 'multiselect' === $field_type || ( 'relation' === $field_type && Relations::relation_is_multiple( $field_id ) );
+		$stored      = get_post_meta( $row_id, $key, ! $is_multiple );
+		$post_status = (string) get_post_status( $row_id );
+		$rows        = array();
+
+		foreach ( $this->normalized_value_rows( $field_id, $field_type, $stored, $post_status ) as $row ) {
+			$rows[] = array(
+				'row_id'        => $row_id,
+				'collection_id' => $collection_id,
+				'field_id'      => $row['field_id'],
+				'value_seq'     => $row['value_seq'],
+				'value_text'    => $row['value_text'],
+				'value_number'  => $row['value_number'],
+				'value_date'    => $row['value_date'],
+				'post_status'   => $row['post_status'],
+			);
+		}
+
+		return $rows;
+	}
+
+	private function field_can_have_multiple_values( int $field_id ): bool {
+		$field_type = (string) get_post_meta( $field_id, 'type', true );
+		return $this->known_type_can_have_multiple_values( $field_id, $field_type );
+	}
+
+	private function known_type_can_have_multiple_values( int $field_id, string $field_type ): bool {
+		return 'multiselect' === $field_type || ( 'relation' === $field_type && Relations::relation_is_multiple( $field_id ) );
+	}
+
+	private function indexed_rows_for_collection( int $collection_id ): array {
+		global $wpdb;
+
+		$table = $this->table_name();
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verification compares the derived index to the postmeta source of truth.
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT row_id, collection_id, field_id, value_seq, value_text, value_number, value_date, post_status
+				FROM {$table}
+				WHERE collection_id = %d",
+				$collection_id
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	private function signature( array $row ): string {
+		return implode(
+			'|',
+			array(
+				(int) $row['row_id'],
+				(int) $row['collection_id'],
+				(int) $row['field_id'],
+				(int) $row['value_seq'],
+				(string) ( $row['value_text'] ?? '' ),
+				null === ( $row['value_number'] ?? null ) ? '' : (string) (float) $row['value_number'],
+				(string) ( $row['value_date'] ?? '' ),
+				(string) ( $row['post_status'] ?? '' ),
+			)
+		);
+	}
+
+	private function collection_id_for_row( int $row_id ): int {
+		$post = get_post( $row_id );
+		if ( ! $post instanceof WP_Post || ! $this->is_entry_post_type( $post->post_type ) ) {
+			return 0;
+		}
+
+		$slug = substr( $post->post_type, strlen( CollectionEntries::CPT_PREFIX ) );
+		if ( '' === $slug ) {
+			self::$collection_id_by_post_type[ $post->post_type ] = 0;
+			return 0;
+		}
+
+		if ( array_key_exists( $post->post_type, self::$collection_id_by_post_type ) ) {
+			$cached_id = self::$collection_id_by_post_type[ $post->post_type ];
+			if ( $cached_id < 1 ) {
+				return 0;
+			}
+			if ( Collection::POST_TYPE === get_post_type( $cached_id ) && (string) get_post_meta( $cached_id, 'slug', true ) === $slug ) {
+				return $cached_id;
+			}
+			unset( self::$collection_id_by_post_type[ $post->post_type ] );
+		}
+
+		foreach ( CollectionEntries::known_collection_ids() as $collection_id ) {
+			if ( (string) get_post_meta( $collection_id, 'slug', true ) === $slug ) {
+				self::$collection_id_by_post_type[ $post->post_type ] = (int) $collection_id;
+				return self::$collection_id_by_post_type[ $post->post_type ];
+			}
+		}
+
+		$collections = get_posts(
+			array(
+				'post_type'      => Collection::POST_TYPE,
+				'post_status'    => array( 'draft', 'pending', 'private', 'publish' ),
+				'posts_per_page' => -1,
+			)
+		);
+		foreach ( $collections as $collection ) {
+			if ( (string) get_post_meta( $collection->ID, 'slug', true ) === $slug ) {
+				self::$collection_id_by_post_type[ $post->post_type ] = (int) $collection->ID;
+				return self::$collection_id_by_post_type[ $post->post_type ];
+			}
+		}
+
+		self::$collection_id_by_post_type[ $post->post_type ] = 0;
+		return 0;
+	}
+
+	private function is_entry_post_type( string $post_type ): bool {
+		return str_starts_with( $post_type, CollectionEntries::CPT_PREFIX )
+			&& ! in_array( $post_type, array( Collection::POST_TYPE, Field::POST_TYPE ), true );
+	}
+
+	private function is_field_meta_key( string $meta_key ): bool {
+		return 1 === preg_match( '/^field-\d+$/', $meta_key );
+	}
+
+	private function field_id_from_meta_key( string $meta_key ): int {
+		return $this->is_field_meta_key( $meta_key ) ? (int) substr( $meta_key, 6 ) : 0;
+	}
+
+	private function normalized_date_for_index( mixed $value, string $field_type ): ?string {
+		$text = trim( (string) $value );
+		if ( '' === $text ) {
+			return null;
+		}
+
+		$timestamp = strtotime( $text );
+		if ( false === $timestamp ) {
+			return null;
+		}
+
+		return 'date' === $field_type
+			? gmdate( 'Y-m-d 00:00:00', $timestamp )
+			: gmdate( 'Y-m-d H:i:s', $timestamp );
+	}
+}

--- a/includes/FieldValues/FieldValueStore.php
+++ b/includes/FieldValues/FieldValueStore.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Postmeta-backed field-value store with optional index maintenance.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\FieldValues;
+
+use Cortext\Relations;
+
+final class FieldValueStore {
+
+	private FieldValueIndex $index;
+
+	public function __construct( ?FieldValueIndex $index = null ) {
+		$this->index = $index ?? new FieldValueIndex();
+	}
+
+	public function write_value( int $row_id, int $field_id, string $field_type, mixed $value, ?int $collection_id = null, ?string $post_status = null ): void {
+		FieldValueIndex::suspend_sync();
+		try {
+			$stored_value = $this->write_postmeta_value( $row_id, $field_id, $field_type, $value );
+		} finally {
+			FieldValueIndex::resume_sync();
+		}
+
+		$this->index->index_known_value( $row_id, $field_id, $field_type, $stored_value, $collection_id, $post_status );
+	}
+
+	private function write_postmeta_value( int $row_id, int $field_id, string $field_type, mixed $value ): mixed {
+		$key = Relations::meta_key( $field_id );
+
+		if ( 'multiselect' === $field_type ) {
+			$this->delete_row_meta( $row_id, $key );
+			$entries = is_array( $value ) ? $value : array( $value );
+			$stored  = array();
+			foreach ( $entries as $entry ) {
+				$text = sanitize_text_field( (string) $entry );
+				if ( '' !== $text ) {
+					$this->add_row_meta( $row_id, $key, $text );
+					$stored[] = $text;
+				}
+			}
+			return $stored;
+		}
+
+		if ( null === $value || '' === $value ) {
+			$this->delete_row_meta( $row_id, $key );
+			return null;
+		}
+
+		$existing = get_post_meta( $row_id, $key, false );
+		if ( is_array( $existing ) && count( $existing ) > 1 ) {
+			$this->delete_row_meta( $row_id, $key );
+		}
+
+		if ( 'number' === $field_type ) {
+			$stored = is_numeric( $value ) ? (float) $value : $value;
+			$this->update_row_meta( $row_id, $key, $stored );
+			return $stored;
+		}
+
+		if ( 'checkbox' === $field_type ) {
+			$stored = (bool) $value;
+			$this->update_row_meta( $row_id, $key, $stored );
+			return $stored;
+		}
+
+		if ( 'date' === $field_type || 'datetime' === $field_type ) {
+			$stored = $this->normalize_date_field_value( $value, $field_type );
+			$this->update_row_meta( $row_id, $key, $stored );
+			return $stored;
+		}
+
+		$stored = sanitize_text_field( (string) $value );
+		$this->update_row_meta( $row_id, $key, $stored );
+		return $stored;
+	}
+
+	private function update_row_meta( int $row_id, string $key, mixed $value ): void {
+		update_metadata( 'post', $row_id, $key, $value );
+	}
+
+	private function add_row_meta( int $row_id, string $key, mixed $value ): void {
+		add_metadata( 'post', $row_id, $key, $value );
+	}
+
+	private function delete_row_meta( int $row_id, string $key ): void {
+		delete_metadata( 'post', $row_id, $key );
+	}
+
+	private function normalize_date_field_value( mixed $value, string $field_type ): string {
+		$text = trim( (string) $value );
+		if ( '' === $text ) {
+			return '';
+		}
+
+		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})/', $text, $matches ) ) {
+			if ( 'date' === $field_type ) {
+				return $matches[1];
+			}
+			$timestamp = strtotime( $text );
+			return false === $timestamp ? sanitize_text_field( $text ) : gmdate( DATE_RFC3339, $timestamp );
+		}
+
+		$timestamp = strtotime( $text );
+		if ( false === $timestamp ) {
+			return sanitize_text_field( $text );
+		}
+
+		return 'date' === $field_type ? gmdate( 'Y-m-d', $timestamp ) : gmdate( DATE_RFC3339, $timestamp );
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -16,6 +16,7 @@ use Cortext\Editor\DocumentIconBlock;
 use Cortext\Editor\DocumentPropertiesBlock;
 use Cortext\Editor\PageHeaderActionsBlock;
 use Cortext\Editor\RevisionThrottle;
+use Cortext\FieldValues\FieldValueIndex;
 use Cortext\Frontend\Assets;
 use Cortext\Frontend\Template;
 use Cortext\PostType\Cascade\CollectionToRowTrashCascade;
@@ -54,6 +55,7 @@ final class Plugin {
 		( new Collection() )->register();
 		( new Field() )->register();
 		( new CollectionEntries() )->register();
+		( new FieldValueIndex() )->register();
 
 		// Single cascade engine: the same instance registers the WordPress
 		// hooks and answers `descendants_for_root` for the REST endpoints.

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Cortext\Rest;
 
 use Cortext\Fields\FieldTypeConverter;
+use Cortext\FieldValues\FieldValueStore;
 use Cortext\PostType\Collection;
 use Cortext\PostType\CollectionEntries;
 use Cortext\Relations;
@@ -535,7 +536,7 @@ final class RowsController {
 				return $synced;
 			}
 		} else {
-			$this->write_field_value( $row_id, $field_id, $field_type, $value );
+			$this->write_field_value( $row_id, $field_id, $field_type, $value, $collection_id, $row->post_status );
 		}
 
 		$touch = wp_update_post( array( 'ID' => $row_id ), true );
@@ -885,72 +886,8 @@ final class RowsController {
 		return $id > 0 ? $id : null;
 	}
 
-	private function write_field_value( int $row_id, int $field_id, string $field_type, mixed $value ): void {
-		$key = Relations::meta_key( $field_id );
-
-		if ( 'multiselect' === $field_type ) {
-			delete_post_meta( $row_id, $key );
-			$entries = is_array( $value ) ? $value : array( $value );
-			foreach ( $entries as $entry ) {
-				$text = sanitize_text_field( (string) $entry );
-				if ( '' !== $text ) {
-					add_post_meta( $row_id, $key, $text );
-				}
-			}
-			return;
-		}
-
-		if ( null === $value || '' === $value ) {
-			delete_post_meta( $row_id, $key );
-			return;
-		}
-
-		// A single-value edit should clear leftover multi-row values first.
-		// Otherwise `update_post_meta` updates only row 0 and stale chips can
-		// come back after another type change.
-		$existing = get_post_meta( $row_id, $key, false );
-		if ( is_array( $existing ) && count( $existing ) > 1 ) {
-			delete_post_meta( $row_id, $key );
-		}
-
-		if ( 'number' === $field_type ) {
-			update_post_meta( $row_id, $key, is_numeric( $value ) ? (float) $value : $value );
-			return;
-		}
-
-		if ( 'checkbox' === $field_type ) {
-			update_post_meta( $row_id, $key, (bool) $value );
-			return;
-		}
-
-		if ( 'date' === $field_type || 'datetime' === $field_type ) {
-			update_post_meta( $row_id, $key, $this->normalize_date_field_value( $value, $field_type ) );
-			return;
-		}
-
-		update_post_meta( $row_id, $key, sanitize_text_field( (string) $value ) );
-	}
-
-	private function normalize_date_field_value( mixed $value, string $field_type ): string {
-		$text = trim( (string) $value );
-		if ( '' === $text ) {
-			return '';
-		}
-
-		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})/', $text, $matches ) ) {
-			if ( 'date' === $field_type ) {
-				return $matches[1];
-			}
-			$timestamp = strtotime( $text );
-			return false === $timestamp ? sanitize_text_field( $text ) : gmdate( DATE_RFC3339, $timestamp );
-		}
-
-		$timestamp = strtotime( $text );
-		if ( false === $timestamp ) {
-			return sanitize_text_field( $text );
-		}
-
-		return 'date' === $field_type ? gmdate( 'Y-m-d', $timestamp ) : gmdate( DATE_RFC3339, $timestamp );
+	private function write_field_value( int $row_id, int $field_id, string $field_type, mixed $value, ?int $collection_id = null, ?string $post_status = null ): void {
+		( new FieldValueStore() )->write_value( $row_id, $field_id, $field_type, $value, $collection_id, $post_status );
 	}
 
 	/**

--- a/tests/php/test-cli-perf-bench.php
+++ b/tests/php/test-cli-perf-bench.php
@@ -194,6 +194,40 @@ final class Test_CLI_Perf_Bench extends BaseTestCase {
 		$this->assertSame( 'p95_ms', $result['failures'][0]['metric'] );
 	}
 
+	public function test_scenario_filter_limits_run_to_matching_ids(): void {
+		$method = ( new \ReflectionClass( PerfBench::class ) )->getMethod( 'filter_scenarios' );
+		$method->setAccessible( true );
+
+		$scenarios = array(
+			'rows_page_1'                   => array(
+				'label' => 'Rows page 1',
+				'run'   => static fn() => null,
+			),
+			'mat_single_write_postmeta'     => array(
+				'label' => 'Single postmeta write',
+				'run'   => static fn() => null,
+			),
+			'mat_single_write_sidecar'      => array(
+				'label' => 'Single sidecar write',
+				'run'   => static fn() => null,
+			),
+			'mat_filter_two_fields_sidecar' => array(
+				'label' => 'Sidecar filter',
+				'run'   => static fn() => null,
+			),
+		);
+
+		$filtered = $method->invoke( new PerfBench(), $scenarios, 'mat_single' );
+
+		$this->assertSame(
+			array(
+				'mat_single_write_postmeta',
+				'mat_single_write_sidecar',
+			),
+			array_keys( $filtered )
+		);
+	}
+
 	public function test_seed_dataset_creates_small_deterministic_fixture(): void {
 		wp_set_current_user( $this->create_admin_user() );
 

--- a/tests/php/test-field-value-index.php
+++ b/tests/php/test-field-value-index.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for Cortext field-value indexing.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\FieldValues\FieldValueIndex;
+use Cortext\FieldValues\FieldValueStore;
+use Cortext\Relations;
+use WorDBless\BaseTestCase;
+
+final class Test_Field_Value_Index extends BaseTestCase {
+
+	public function tear_down(): void {
+		FieldValueIndex::resume_sync();
+		FieldValueIndex::flush_runtime_caches();
+		delete_option( 'cortext_field_values_index_enabled' );
+		delete_option( 'cortext_field_values_disabled_since' );
+		delete_option( 'cortext_field_values_index_status' );
+		delete_option( 'cortext_field_values_index_error' );
+		delete_option( 'cortext_field_values_schema_version' );
+		delete_option( 'cortext_field_values_install_attempted_version' );
+		delete_option( 'cortext_field_values_auto_rebuild_lock' );
+		remove_all_filters( 'cortext_field_values_index_enabled' );
+		parent::tear_down();
+	}
+
+	public function test_normalizes_scalar_values_for_index_columns(): void {
+		$index = new FieldValueIndex();
+
+		$number = $index->normalized_value_rows( 10, 'number', '42.50' );
+		$date   = $index->normalized_value_rows( 11, 'date', '2026-05-23' );
+		$text   = $index->normalized_value_rows( 12, 'text', str_repeat( 'a', 220 ) );
+
+		$this->assertSame( 42.5, $number[0]['value_number'] );
+		$this->assertSame( '42.50', $number[0]['value_text'] );
+		$this->assertSame( '2026-05-23 00:00:00', $date[0]['value_date'] );
+		$this->assertSame( 191, strlen( $text[0]['value_text'] ) );
+	}
+
+	public function test_normalizes_multivalue_rows_with_stable_sequence(): void {
+		$index = new FieldValueIndex();
+
+		$rows = $index->normalized_value_rows( 10, 'multiselect', array( 'alpha', '', 'beta' ) );
+
+		$this->assertCount( 2, $rows );
+		$this->assertSame( 0, $rows[0]['value_seq'] );
+		$this->assertSame( 'alpha', $rows[0]['value_text'] );
+		$this->assertSame( 1, $rows[1]['value_seq'] );
+		$this->assertSame( 'beta', $rows[1]['value_text'] );
+	}
+
+	public function test_field_value_store_keeps_postmeta_as_source_of_truth(): void {
+		$row_id   = 123;
+		$field_id = 456;
+		$key      = Relations::meta_key( $field_id );
+		$store    = new FieldValueStore();
+
+		$store->write_value( $row_id, $field_id, 'multiselect', array( 'alpha', 'beta' ) );
+		$this->assertSame( array( 'alpha', 'beta' ), get_post_meta( $row_id, $key, false ) );
+
+		$store->write_value( $row_id, $field_id, 'number', '12.75' );
+		$this->assertSame( 12.75, get_post_meta( $row_id, $key, true ) );
+	}
+
+	public function test_pending_meta_sync_coalesces_repeated_row_field_changes(): void {
+		$index      = new FieldValueIndex();
+		$reflection = new \ReflectionClass( FieldValueIndex::class );
+
+		update_option( 'cortext_field_values_index_status', FieldValueIndex::STATUS_READY, false );
+		update_option( 'cortext_field_values_schema_version', 1, false );
+
+		$table_cache = $reflection->getProperty( 'table_exists_cache' );
+		$table_cache->setAccessible( true );
+		$table_cache->setValue( null, array( $index->table_name() => true ) );
+
+		$index->sync_meta_change( 1, 101, Relations::meta_key( 202 ), '1' );
+		$index->sync_meta_change( 2, 101, Relations::meta_key( 202 ), '2' );
+
+		$pending_property = $reflection->getProperty( 'pending_row_fields' );
+		$pending_property->setAccessible( true );
+		$pending = $pending_property->getValue();
+
+		$this->assertCount( 1, $pending );
+		$this->assertSame(
+			array(
+				'row_id'   => 101,
+				'field_id' => 202,
+			),
+			$pending['101:202']
+		);
+	}
+
+	public function test_index_can_be_disabled_with_option_and_filter(): void {
+		$index = new FieldValueIndex();
+
+		$this->assertTrue( $index->is_enabled() );
+
+		update_option( 'cortext_field_values_index_enabled', '0', false );
+		$this->assertFalse( $index->is_enabled() );
+		$this->assertSame( FieldValueIndex::STATUS_DISABLED, $index->status()['status'] );
+
+		update_option( 'cortext_field_values_index_enabled', '1', false );
+		add_filter( 'cortext_field_values_index_enabled', '__return_false' );
+		$this->assertFalse( $index->is_enabled() );
+	}
+
+	public function test_disabled_index_records_that_reenabling_needs_rebuild(): void {
+		$index = new FieldValueIndex();
+
+		update_option( 'cortext_field_values_index_enabled', '0', false );
+		$index->maybe_auto_provision();
+
+		$this->assertGreaterThan( 0, (int) get_option( 'cortext_field_values_disabled_since', 0 ) );
+		$this->assertSame( FieldValueIndex::STATUS_DISABLED, $index->status()['status'] );
+	}
+}


### PR DESCRIPTION
## What

Part of #177.

Adds the production write/sync path for the field-value sidecar. Row values still live in postmeta, and Cortext now mirrors them into a sidecar table when the database supports it. Production reads still use postmeta in this PR; the sidecar read queries are benchmarked here so we can wire the read planner in a follow-up. If the table cannot be created, or if the index is disabled, Cortext keeps using postmeta.

## Why

Postmeta is fine for small collections, but it gets expensive once large tables start filtering, sorting, searching, or rolling up field values. This gives us an indexed path we can measure and build on without making custom table support mandatory.

## How

- Keeping postmeta as the source of truth.
- Rebuilding the sidecar automatically after install or seed.
- Syncing row edits and direct postmeta changes into the index.
- Leaving production reads on postmeta for now, with sidecar reads covered by the materialization benchmark suite.
- Adding WP-CLI commands to check, rebuild, and verify the index.
- Extending the perf suite so postmeta and sidecar reads/writes can be compared directly.

## Testing Instructions

1. Create a local site with a collection and a few row fields.
2. Run `wp cortext field-values status` and confirm the index reports its table/status.
3. Edit a scalar row field in the app.
4. Run `wp cortext field-values verify` and confirm the index matches postmeta.
5. Seed a larger perf dataset and run `wp cortext perf-bench --suite=materialization` to compare postmeta and sidecar scenarios.
