### PR TITLE
Frontend: Honour width constraints for align none/wide/full

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -446,15 +446,7 @@ That makes row reorder sensitive to DataViews DOM changes: density classes, bulk
 
 **Solution.** DataViews could expose stable row ids/refs, a row-handle render prop, keyboard-aware reorder callbacks, a table/list gap model, and row preview/drop indicator hooks. Cortext would keep the REST/manual-order policy and drop the selectors, MutationObserver, portals, and transform bookkeeping.
 
-## 50. Public page layout doesn't use WordPress align classes `[internal]`
-
-**What.** The public template constrains non-block content to 650 px via a blanket `max-width` on `.cortext-public-page__body > :not(.wp-block-cortext-data-view)`. The data-view block breaks out of that constraint by virtue of the exclusion. This is fragile — it doesn't honor `alignwide`, `alignfull`, or any other block alignment, and will break for other wide blocks. The proper fix is to adopt WordPress's `align*` layout classes and `theme.json` content/wide widths so blocks opt into breakout with standard markup rather than CSS exclusions.
-
-**Where.** `src/frontend.scss`, the `.cortext-public-page__body` rule with the FIXME comment.
-
-**Solution.** Use `wp_get_layout_style` or emit the `is-layout-constrained` class with `contentSize` / `wideSize` on the body wrapper, then add `alignwide` or `alignfull` to the data-view block's wrapper attributes in `DataView.php`. Remove the exclusion hack.
-
-## 51. DataView block shares a frontend bundle with page chrome `[internal]`
+## 50. DataView block shares a frontend bundle with page chrome `[internal]`
 
 **What.** The `cortext-frontend` script and style handle serves double duty: it hydrates the DataView block (React, DataViews, field renderers) and provides general page chrome (body font, content column, title styles). Both `Assets.php` and the render callback in `DataView.php` enqueue the same handle, creating a registration race where the first caller's dependency list wins and the second is silently ignored. The DataView block should provision its own script and style (e.g. `cortext-data-view-view`) via `viewScript`/`viewStyle` in `block.json` or its own dedicated handles in the render callback, so its dependencies (`wp-components`, `wp-api-fetch`, etc.) are self-contained. `cortext-frontend`, if it makes sense to exist, should only cover general concerns: page chrome, light/dark mode toggle, etc.
 

--- a/src/frontend.scss
+++ b/src/frontend.scss
@@ -36,10 +36,17 @@
 .cortext-public-page__body {
 	font-size: 1rem;
 
-	// FIXME honor alignwide, alignfull, etc. (tech-debt.md#50)
-	> :not(.wp-block-cortext-data-view) {
-		margin: auto;
-		max-width: 650px;
+	> * {
+		margin-inline: auto;
+		max-width: var(--wp--style--global--content-size);
+	}
+
+	> .alignwide {
+		max-width: var(--wp--style--global--wide-size);
+	}
+
+	> .alignfull {
+		max-width: none;
 	}
 }
 

--- a/templates/single-crtxt_page.php
+++ b/templates/single-crtxt_page.php
@@ -36,7 +36,7 @@ defined( 'ABSPATH' ) || exit;
 			// See tech-debt.md#32.
 			?>
 			<h1 class="cortext-public-page__title"><?php the_title(); ?></h1>
-			<div class="cortext-public-page__body">
+			<div class="cortext-public-page__body is-layout-constrained">
 				<?php the_content(); ?>
 			</div>
 		</article>


### PR DESCRIPTION
Part of #88 

Let published pages on the frontend enforce the same width constraints as the editor as regards default content, align-wide, and align-full.

In the editor, via the block toolbar, change the `align` attribute of a block. Ensure that the change leads the correct width constraints on the published page.

The special treatment of the Collection View block is eliminated, meaning that the block's default value (`wide`) will be assumed unless specified. **This is a change in behaviour** from rendering these blocks as full-width.