### PR TITLE
Fix: Show the empty row prompt under row properties

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -514,13 +514,13 @@ The brittle bit is the sizing. The skeleton copies DataViews row heights for com
 
 **Solution.** DataViews exposes a table loading slot, or at least row-height CSS variables. Then Cortext can follow the table instead of copying its constants. Until then, keep the skeleton rules next to the DataViews table rules and check for visual drift after DataViews upgrades.
 
-## 56. Block movers do not understand Cortext's header boundary `[upstream]`
+## 56. Block editor controls do not understand Cortext's header boundary `[upstream]`
 
-**What.** Gutenberg block locks keep cover, icon, and title from moving, but they do not stop other root blocks from being inserted or moved above that locked prefix. Cortext can repair the root order with block-editor store actions and can hide protected insertion points, but the first body block's "move up" button is still rendered by Gutenberg as if moving above the title were allowed. To leave the button visible but greyed out, Cortext watches the active root selection, finds `.block-editor-block-mover-button.is-up-button` when the toolbar mounts, and toggles `disabled` / `aria-disabled` itself. If Gutenberg renames that class or changes where the mover renders, the guard will need another pass.
+**What.** Gutenberg block locks keep cover, icon, title, and row properties from moving, but the root list still has no idea that Cortext's body starts after those blocks. Cortext repairs bad order with block-editor store actions and hides protected insertion points, but two bits of Gutenberg UI still leak through. First, the first body block gets a live "move up" button even though moving it above the title would be wrong; Cortext waits for the toolbar, finds `.block-editor-block-mover-button.is-up-button`, and sets `disabled` / `aria-disabled` itself. Second, Gutenberg only shows the default empty-body appender when the whole root list is empty. A row with title/properties and no body is not empty by that test, so Cortext supplies its own first-block prompt after the header. If Gutenberg renames mover classes or changes the appender contract, this code needs another pass.
 
-**Where.** `HeaderPrefixToolbarGuard`, `syncHeaderBoundaryMoveUpButtons`, and the header-prefix correction in `src/components/EditorBody.js`, with coverage in `tests/e2e/specs/editor-header-blocks.spec.js`.
+**Where.** `HeaderPrefixToolbarGuard`, `syncHeaderBoundaryMoveUpButtons`, `HeaderAwareRootAppender`, and the header-prefix correction in `src/components/EditorBody.js`, with coverage in `tests/e2e/specs/editor-header-blocks.spec.js` and `tests/e2e/specs/data-view-block.spec.js`.
 
-**Solution.** Gutenberg exposes a block-list boundary policy for root lists: a minimum insertion index, a minimum move target, and mover button state derived from that policy. Then Cortext can declare "body blocks start after the title" once and drop the toolbar DOM query, the mutation observer, and the local button-state restoration.
+**Solution.** Gutenberg exposes a block-list boundary policy for root lists: a minimum insertion index, a minimum move target, empty-body detection that ignores locked chrome, and mover/appender state from that same boundary. Then Cortext can declare "body blocks start after the title/properties prefix" once and drop the toolbar DOM query, the mutation observer, the local button-state restoration, and the custom root appender.
 
 ## 57. Row detail toolbars rely on local editor-surface isolation `[upstream, soft]`
 

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -13,6 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	BlockCanvas,
 	BlockList,
+	Inserter,
 	store as blockEditorStore,
 	useSettings,
 } from '@wordpress/block-editor';
@@ -22,6 +23,7 @@ import { useEntityProp, useEntityRecord } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 import {
 	useEffect,
 	useLayoutEffect,
@@ -76,6 +78,13 @@ function getHeaderBlockNames( postType ) {
 
 function isHeaderBlock( block, postType ) {
 	return getHeaderBlockNames( postType ).has( block?.name );
+}
+
+function isHeaderChromeBlock( block, postType ) {
+	return (
+		block?.name === LEGACY_HEADER_ACTIONS_BLOCK ||
+		isHeaderBlock( block, postType )
+	);
 }
 
 function syncHeaderBoundaryMoveUpClass() {
@@ -822,6 +831,70 @@ function HideHeaderBlockKebab( { postType } ) {
 	return null;
 }
 
+function HeaderAwareRootAppender( { postType } ) {
+	// tech-debt.md#56: Gutenberg's root appender only treats a fully empty
+	// root list as empty. Cortext's locked header blocks are chrome, so the
+	// body still needs a first-block prompt after them.
+	const { bodyEmpty, insertionIndex } = useSelect(
+		( select ) => {
+			const blocks = select( blockEditorStore ).getBlocks();
+			const headerEndIndex = blocks.reduce(
+				( lastIndex, block, index ) =>
+					isHeaderChromeBlock( block, postType ) ? index : lastIndex,
+				-1
+			);
+			return {
+				bodyEmpty:
+					blocks.length > 0 &&
+					blocks.every( ( block ) =>
+						isHeaderChromeBlock( block, postType )
+					),
+				insertionIndex: headerEndIndex + 1,
+			};
+		},
+		[ postType ]
+	);
+	const { insertDefaultBlock, startTyping } = useDispatch( blockEditorStore );
+
+	if ( ! bodyEmpty ) {
+		return null;
+	}
+
+	const onAppend = () => {
+		insertDefaultBlock( undefined, ROOT_BLOCK_LIST, insertionIndex );
+		startTyping();
+	};
+
+	return (
+		<div className="block-editor-default-block-appender has-visible-prompt">
+			<p
+				tabIndex="0"
+				// Match core's default appender semantics so focusing the
+				// prompt immediately creates the first editable body block.
+				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+				role="button"
+				aria-label={ __( 'Add default block', 'cortext' ) }
+				className="block-editor-default-block-appender__content"
+				onKeyDown={ ( event ) => {
+					if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+						onAppend();
+					}
+				} }
+				onClick={ onAppend }
+				onFocus={ onAppend }
+			>
+				{ __( 'Type / to choose a block', 'cortext' ) }
+			</p>
+			<Inserter
+				rootClientId={ ROOT_BLOCK_LIST }
+				position="bottom right"
+				isAppender
+				__experimentalIsQuick
+			/>
+		</div>
+	);
+}
+
 function TrashedNotice( { postId, postType, onRestored } ) {
 	const [ isRestoring, setIsRestoring ] = useState( false );
 	const [ error, setError ] = useState( null );
@@ -1079,6 +1152,24 @@ export default function EditorBody( {
 			'trash',
 		[]
 	);
+	const shouldUseHeaderAwareAppender = useSelect(
+		( select ) => {
+			if ( getCanvasOwnerBlockName( postType ) ) {
+				return false;
+			}
+			const blocks = select( blockEditorStore ).getBlocks();
+			return (
+				blocks.length > 0 &&
+				blocks.every( ( block ) =>
+					isHeaderChromeBlock( block, postType )
+				)
+			);
+		},
+		[ postType ]
+	);
+	const renderAppender = shouldUseHeaderAwareAppender
+		? () => <HeaderAwareRootAppender postType={ postType } />
+		: undefined;
 
 	const blockCanvas = (
 		<div className="cortext-canvas__block-canvas" ref={ blockCanvasRef }>
@@ -1107,6 +1198,7 @@ export default function EditorBody( {
 					<BlockList
 						className="wp-block-post-content is-layout-constrained has-global-padding"
 						layout={ { type: 'constrained', ...layout } }
+						renderAppender={ renderAppender }
 					/>
 				</div>
 				<CanvasReadyEffect

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -2232,6 +2232,112 @@ test.describe( 'Collection view block', () => {
 		}
 	} );
 
+	test( 'shows the default body prompt below row properties when the row body is empty', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture( requestUtils )
+			);
+
+			fixture.page = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_pages',
+				data: {
+					title: 'Empty row body prompt page',
+					status: 'private',
+					content: createDataViewBlockMarkup( fixture.collection.id ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ fixture.page.id }`
+			);
+
+			await page.waitForFunction(
+				( postId ) =>
+					window.wp?.data
+						?.select( 'core/editor' )
+						?.getCurrentPostId?.() === postId,
+				fixture.page.id,
+				{ timeout: 15_000 }
+			);
+
+			const canvas = page
+				.getByRole( 'region', { name: 'Content' } )
+				.frameLocator( 'iframe[name="editor-canvas"]' );
+			const firstRow = canvas
+				.locator( '.cortext-data-view tbody tr' )
+				.first();
+			const openRowButton = canvas
+				.locator( '.cortext-title-cell__open' )
+				.first();
+			await firstRow.hover();
+			await openRowButton.click();
+
+			const detail = page.getByRole( 'dialog', {
+				name: 'Row detail',
+			} );
+			await expect( detail ).toBeVisible();
+
+			const detailCanvas = activeRowDetailCanvas( detail );
+			const propertiesSlot = detailCanvas.locator(
+				'.cortext-document-properties'
+			);
+			const prompt = detailCanvas.locator(
+				'.block-editor-default-block-appender.has-visible-prompt .block-editor-default-block-appender__content'
+			);
+
+			await expect( propertiesSlot ).toBeVisible();
+			await expect( prompt ).toContainText( 'Type / to choose a block' );
+			await expect
+				.poll( async () => {
+					const [ propertiesBox, promptBox ] = await Promise.all( [
+						propertiesSlot.boundingBox(),
+						prompt.boundingBox(),
+					] );
+					if ( ! propertiesBox || ! promptBox ) {
+						return false;
+					}
+					return (
+						promptBox.y >=
+						propertiesBox.y + propertiesBox.height - 2
+					);
+				} )
+				.toBe( true );
+
+			await prompt.click();
+			await expect(
+				detailCanvas.locator( '[data-type="core/paragraph"]' )
+			).toHaveCount( 1 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry &&
+					`/wp/v2/crtxt_${ fixture.slug }/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_pages/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_collections/${ fixture.collection.id }`
+			);
+		}
+	} );
+
 	test( 'renders typed cells for url, checkbox, number, select, and multiselect', async ( {
 		admin,
 		page,


### PR DESCRIPTION
## What

Rows with properties now show "Type / to choose a block" right under the properties when the row body is empty. Clicking it starts the body in the right spot, after the locked title/properties area.

## Why

Once row properties moved into the canvas, Gutenberg stopped seeing those rows as empty. Technically they had blocks: title, properties, and other locked chrome. But from a user's point of view, there was nowhere obvious to start writing.

## How

- Treat the locked header/property blocks as chrome when checking whether the row body is empty.
- Keep collection canvases locked to their owner block, so they do not get this prompt.
- Update the tech debt note for the header-boundary workaround.

## Testing Instructions

1. Open a collection page with a row that has properties.
2. Open a row with no body content.
3. Check that "Type / to choose a block" appears below the properties.
4. Click the prompt and confirm a paragraph appears there.

## Before / After

| Before | After |
| --- | --- |
| <img width="735" height="1178" alt="image" src="https://github.com/user-attachments/assets/c70f915d-4b4d-4645-820d-0d42f58b171e" /> | <img width="518" height="1189" alt="image" src="https://github.com/user-attachments/assets/0f0e875c-e5ae-4843-883f-4eb566e49344" /> |
