### PR TITLE
Grid layout: revamp the design to make it usable

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -26,13 +26,13 @@ Full-page collection creation hit the same schema-cache edge. A new collection r
 
 **Where.** `src/hooks/useCollectionRows.js`, `src/hooks/useCollectionRowsByIds.js`, `src/hooks/rowInvalidation.js`, `src/hooks/documentTrashInvalidation.js`, and `src/hooks/useTrashedDocuments.js`, with call sites in `src/components/CollectionDataViews.js` (`saveRowField`, `onCreated`, row trash), `src/components/SidebarTrash.js`, `src/router/EntityRoute.js`, `src/blocks/data-view/edit.js`, `src/components/Sidebar.js` (post-type entity-config invalidation after collection creation), and `src/components/relations/RelationEditor.js` (paged target-row search and selected-row label lookup).
 
-**Solution.** Switch to `useEntityRecords('postType', \`crtxt\_${slug}\`, query)`plus`saveEntityRecord`for writes once the remaining query shapes can be expressed there.`core-data` would then own caching, race protection, and post-mutation invalidation. Knock-on workarounds it deletes:
+**Solution.** Switch to `useEntityRecords('postType', \`crtxt_${slug}\`, query)` plus `saveEntityRecord` for writes once the remaining query shapes can be expressed there. `core-data` would then own caching, race protection, and post-mutation invalidation. Knock-on workarounds it deletes:
 
--   The `refresh()` handles and invalidation events exist only because rows aren't reactive.
--   Half of `RowMutationContext` (also driven by #1) exists because cells can't reach a `core-data` store that isn't there.
--   `onCreated` runs optimistic `lastPage = ceil((totalItems+1)/perPage)` arithmetic against possibly stale `paginationInfo`. With reactive pagination we'd watch `totalPages` in an effect.
--   The server/client planner becomes normal resolver queries instead of a local fetch policy.
--   Relation label lookup becomes a normal entity-record resolver instead of a one-off include query.
+- The `refresh()` handles and invalidation events exist only because rows aren't reactive.
+- Half of `RowMutationContext` (also driven by #1) exists because cells can't reach a `core-data` store that isn't there.
+- `onCreated` still runs optimistic `lastPage = ceil((totalItems+1)/perPage)` arithmetic for unconstrained views. With reactive pagination we'd watch `totalPages` instead of guessing.
+- The server/client planner becomes normal resolver queries instead of a local fetch policy.
+- Relation label lookup becomes a normal entity-record resolver instead of a one-off include query.
 
 Worth a small spike before committing. Dynamic post-type discovery also needs a real answer: either `core-data` learns about new row CPTs after collection creation, or each collection-creation path keeps the post-type entity-config invalidation nearby.
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -8,11 +8,11 @@ Pair with [decisions.md](decisions.md) for choices we've made peace with and [ro
 
 ## 1. DataViews has no inline cell editing `[upstream]`
 
-**What.** DataViews v6 ships display layouts and a separate `DataForm` for editing, but no way to make a table cell editable in place. So we mount our own editor from `field.render` (a display renderer in the docs, but the only seam we have), keep edit state per cell, and route saves back through a `RowMutationContext` since `field.render` only gets `{ item }`. Tab and Shift+Tab between cells live in the same layer: editors intercept Tab, ask the parent for the next editable cell via `requestNext`, and the target cell pops open via the `editRequest` channel that also handles auto-focusing the title cell of a fresh row.
+**What.** DataViews v6 can render values and edit them through a separate `DataForm`, but it cannot turn a rendered value into an inline editor. Cortext mounts its own editor from `field.render` (documented as a display renderer, but the only hook available), keeps edit state per cell, and sends saves through `RowMutationContext` because `field.render` only receives `{ item }`. Tab and Shift+Tab live in the same layer: editors catch Tab, ask the parent for the next editable cell through `requestNext`, and the target cell opens through the same `editRequest` channel used to focus the title cell in a fresh row. Table and grid opt into that editing surface. List stays read-only until we design row/value editing for it on purpose.
 
 **Where.** `src/components/EditableCell.js`, `RowMutationContext` and `requestNext` in `src/components/CollectionDataViews.js`, plus a sliver of `src/components/CollectionDataViews.scss`.
 
-**Solution.** What we'd want upstream: an `editable` mode on the table layout that uses each field's `Edit` per cell, an `onSaveItem(item, changes)` prop on `<DataViews>`, native cell-to-cell keyboard navigation, and a layout contract for "this control is rendered inline." With those, `RowMutationContext`, `requestNext`, most of `EditableCell`, and the layout couplings tracked in #5 all go away. It's the biggest entry on this page (~530 lines of `EditableCell` plus context wiring and the navigation walker). File a Gutenberg issue with the use case and proposed shape; `docs/roadmap.md` lists upstream issues as a stretch success metric.
+**Solution.** Upstream would need an `editable` mode on DataViews layouts that uses each field's `Edit` per value, an `onSaveItem(item, changes)` prop on `<DataViews>`, native cell-to-cell keyboard navigation where the layout supports it, and a documented path for controls rendered inline. That would remove `RowMutationContext`, `requestNext`, most of `EditableCell`, and the layout couplings tracked in #5. This is still the largest workaround on the page: roughly 530 lines of `EditableCell`, plus context wiring and the navigation walker. File a Gutenberg issue with the use case and proposed API; `docs/roadmap.md` lists upstream issues as a stretch success metric.
 
 ## 2. Rows aren't in `core-data`'s entity store `[internal]`
 
@@ -84,13 +84,13 @@ The cost is another split support matrix. The client checks field type, operator
 
 **Solution.** A `multiselect` dataform-control upstream that DataForm and a future inline-edit mode (#1) resolve from `Edit: 'multiselect'`. It would need hooks for custom option rendering and option management, not just a token input, otherwise Cortext would still need the picker.
 
-## 7. DataViews has no `footer` slot `[upstream, soft]`
+## 7. DataViews has no footer or layout append slot `[upstream, soft]`
 
-**What.** The "+ New" affordance lives in our own div outside `<DataViews>`, with a small CSS layer to make the wrapper flex correctly around DataViews' default `height: 100%`. `<DataViews>` has a `header` slot but no symmetric footer.
+**What.** DataViews has nowhere to put "+ New" at the bottom of a layout. Table and list use a Cortext footer just outside `<DataViews>`, with a small CSS layer to keep the wrapper working around DataViews' default `height: 100%`. Grid is trickier: the button needs to sit with the cards, so Cortext finds the rendered `.dataviews-view-grid` node and portals `DataViewNewRowButton` into it. Empty grid views use a local grid shell until DataViews renders a real grid node.
 
-**Where.** `src/components/CollectionDataViews.js` (`cortext-data-view__footer` div) and `src/components/CollectionDataViews.scss` (`.cortext-data-view` flex layout).
+**Where.** `DataViewNewRowButton` in `src/components/DataViewNewRowButton.js`, `GridNewRowPortal` in `src/components/GridNewRowPortal.js`, the footer mount in `src/components/CollectionDataViews.js`, and the `.cortext-data-view__footer` / `.cortext-data-view__new-row-card` rules in `src/components/CollectionDataViews.scss` and `src/components/CollectionDataViews.grid.scss`.
 
-**Solution.** More "tidy up later" than tech debt: switch to DataViews free composition (already supported via `children`) and lay out `<DataViews.Layout />` and `<DataViews.Pagination />` ourselves. Free composition works today; an upstream `footer` prop would just be neater. This is separate from table-internal footer rows for calculations; see #36 for that harder gap.
+**Solution.** For table and list, switch fully to DataViews free composition (already supported through `children`) and lay out `<DataViews.Layout />` and `<DataViews.Pagination />` ourselves. For grid, DataViews needs an append-item or empty-item slot, or a layout hook that can place a card after the data items without a DOM lookup. This is separate from table footer rows for calculations; see #36 for that harder gap.
 
 ## 8. `CheckboxControl` ignores `hideLabelFromVision` `[upstream]`
 
@@ -496,15 +496,15 @@ Drag/drop and `menu_order` accounting look at both pages and collections through
 
 **Solution.** Add a relation-aware schema copy step. It should clone and remap the forward and reverse fields together, or skip every dependent field, including rollups that point at skipped relations. The duplicate should never carry references back to the source collection's fields. Once that exists, the sidebar notice can name the exact skipped field types instead of treating them all as generic missing columns.
 
-## 55. Loading table skeleton tracks DataViews layout `[upstream, soft]`
+## 55. Loading collection skeletons track DataViews layouts `[upstream, soft]`
 
-**What.** DataViews does not give us a table-body loading slot. Cortext renders `CollectionRowsSkeleton` beside `<DataViews>` and covers the table while the first page loads; without that, the collection pane collapses and jumps when rows show up.
+**What.** DataViews has no loading slot for individual layouts. Cortext renders `CollectionRowsSkeleton` beside `<DataViews>` while the first page loads; without it, the collection pane collapses and jumps when rows arrive. The placeholder now has table/list row variants and a grid card variant, so switching layouts does not briefly show the wrong shape.
 
-The brittle bit is the sizing. The skeleton copies DataViews row heights for compact, balanced, and comfortable density. It lines up in the current build, but a DataViews density change could make the placeholder drift from the real table.
+The brittle part is sizing. The table/list skeleton copies DataViews row heights for compact, balanced, and comfortable density. The grid skeleton copies Cortext's card min size and spacing, which sit on top of DataViews' grid classes. The two match in the current build, but a DataViews density or markup change could make the placeholder drift from the real view.
 
 **Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/components/Skeleton.scss` and `src/components/CollectionDataViews.scss`.
 
-**Solution.** DataViews exposes a table loading slot, or at least row-height CSS variables. Then Cortext can follow the table instead of copying its constants. Until then, keep the skeleton rules next to the DataViews table rules and check for visual drift after DataViews upgrades.
+**Solution.** DataViews exposes a loading slot per layout, or at least row/card size CSS variables. Cortext could then follow the active layout instead of copying its constants. Until then, keep the skeleton rules next to the DataViews layout rules and check for visual drift after DataViews upgrades.
 
 ## 56. Block editor controls do not understand Cortext's header boundary `[upstream]`
 
@@ -541,3 +541,13 @@ This is acceptable for now and covered by e2e, but it is still a timing bridge b
 **Where.** `Collection::build_data_view_block_markup()` and `Collection::maybe_seed_data_view_block()` in `includes/PostType/Collection.php`, `includes/PostType/CollectionContentBackfill.php`, `src/components/CanvasOwnerInspector.js`, owner-block handling in `src/components/EditorBody.js`, `src/blocks/data-view/edit.js`, `src/components/PageInspectorSidebar.js`, and the owner rules in `src/styles/global/_shell-root.scss`.
 
 **Solution.** Replace this with a direct owner-block path: either an upstream dynamic block-template hook or a local body-owner contract. It should read attributes from the current post, lock the body to that block, own inserter/chrome/inspector policy, and keep public serialization predictable. Then the post-insert seed, backfill, editor fallback, SlotFill routing, and owner CSS can shrink or disappear.
+
+## 60. DataViews view state has one active layout shape `[internal, soft]`
+
+**What.** DataViews emits one active `view` shape: one `type`, one `fields` array, and one `layout` object. Cortext needs layout switches to preserve table columns, grid/list display fields, density, card media settings, and query state without one layout overwriting another. The adapter stores Cortext-owned buckets (`layoutByType` and `fieldsByType`) beside the DataViews view, hydrates the active layout before render, and merges DataViews changes back into the canonical view after each change.
+
+This is fine for the baseline, but block attributes and public DataViews state now carry keys upstream does not know about. When a new layout setting is added, the adapter, normalizer, and public renderer all need to move together.
+
+**Where.** `src/components/dataViewAdapter.js`, `src/components/dataViewViewState.js`, `normalizeView` in `src/components/dataViewColumns.js`, the DataViews mounts in `src/components/CollectionDataViews.js` and `src/components/PublicDataView.js`, and the data-view block attributes in `src/blocks/data-view/block.json`.
+
+**Solution.** If DataViews adds native per-layout settings, map to those instead of carrying separate buckets. If Cortext saved views become their own schema, move `layoutByType` / `fieldsByType` there and treat DataViews' `view` as a render adapter only. Until one of those exists, keep this adapter small and covered by round-trip tests.

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -3486,7 +3486,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 							$collection_ids['albums'] ?? 0,
 							array(
 								'type'       => 'grid',
-								'perPage'    => 12,
+								'perPage'    => 25,
 								'mediaField' => 'cover',
 							)
 						),

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -22,7 +22,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 	private const WORKSPACE_HOME_META_KEY = 'cortext_workspace_home';
 	private const FAVORITES_META_KEY      = 'cortext_favorites';
-	private const PAGE_CONTENT_VERSION    = 'rich-connected-seed-2026-05-07-no-about-cover';
+	private const PAGE_CONTENT_VERSION    = 'rich-connected-seed-2026-05-26-albums-grid';
 	private const ENTRY_CONTENT_VERSION   = 'rich-connected-row-seed-2026-05-07';
 
 	private bool $seed_full_dataset = false;
@@ -3482,7 +3482,14 @@ final class SeedDummyCollections extends WP_CLI_Command {
 					array(
 						$this->paragraph( 'The music cluster adds a denser relationship graph: albums belong to artists and labels, while tracks belong to albums and feed album-level rollups.' ),
 						$this->heading( 'Albums and tracks', 2 ),
-						$this->data_view_block( $collection_ids['albums'] ?? 0 ),
+						$this->data_view_block(
+							$collection_ids['albums'] ?? 0,
+							array(
+								'type'       => 'grid',
+								'perPage'    => 12,
+								'mediaField' => 'cover',
+							)
+						),
 						$this->data_view_block( $collection_ids['tracks'] ?? 0 ),
 						$this->heading( 'Artists and labels', 2 ),
 						$this->data_view_block( $collection_ids['musicians'] ?? 0 ),
@@ -4523,10 +4530,11 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 	/**
 	 * Attaches a bundled cover image to a row when one is provided in
-	 * `seed-assets/covers/<slug>-<title-slug>.jpg`. Covers are opt-in per
-	 * row (no live fetch), so add a file under that path to give a row a
-	 * featured image. Skips rows that already have `_thumbnail_id`, so a
-	 * manually-set cover survives a reseed.
+	 * `seed-assets/covers/<slug>-<title-slug>.jpg`. A few album rows also use
+	 * their bundled album-art icon when there is no separate cover asset or
+	 * requested live cover. That gives the seeded grid a mix of covered and
+	 * uncovered cards while still working offline. Skips rows that already
+	 * have `_thumbnail_id`, so a manually-set cover survives a reseed.
 	 *
 	 * @param int    $entry_id        Row post ID.
 	 * @param string $collection_slug Source collection slug.
@@ -4552,10 +4560,12 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		if ( ! $this->fetch_real_images ) {
+			$this->maybe_apply_album_icon_as_row_cover( $entry_id, $collection_slug, $title );
 			return;
 		}
 		$url = $this->real_cover_url( $collection_slug, $title );
 		if ( null === $url ) {
+			$this->maybe_apply_album_icon_as_row_cover( $entry_id, $collection_slug, $title );
 			return;
 		}
 		$cover_id = $this->ensure_attachment_from_url( $url );
@@ -4563,6 +4573,36 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			update_post_meta( $entry_id, '_thumbnail_id', $cover_id );
 			$source = false !== strpos( $url, 'openlibrary.org' ) ? 'open-library' : 'cover-art-archive';
 			WP_CLI::log( sprintf( '  Cover (%s) attached to entry %d.', $source, $entry_id ) );
+			return;
+		}
+
+		$this->maybe_apply_album_icon_as_row_cover( $entry_id, $collection_slug, $title );
+	}
+
+	private function maybe_apply_album_icon_as_row_cover( int $entry_id, string $collection_slug, string $title ): void {
+		if ( 'albums' !== sanitize_title( $collection_slug ) ) {
+			return;
+		}
+
+		$covered_album_keys = array(
+			'abbey-road',
+			'the-dark-side-of-the-moon',
+			'purple-rain',
+			'save-rock-and-roll',
+		);
+		if ( ! in_array( sanitize_title( $title ), $covered_album_keys, true ) ) {
+			return;
+		}
+
+		$path = $this->bundle_icon_path( $collection_slug, $title );
+		if ( ! file_exists( $path ) ) {
+			return;
+		}
+
+		$cover_id = $this->ensure_attachment_from_path( $path );
+		if ( $cover_id > 0 ) {
+			update_post_meta( $entry_id, '_thumbnail_id', $cover_id );
+			WP_CLI::log( sprintf( '  Cover (album icon bundle) attached to entry %d.', $entry_id ) );
 		}
 	}
 
@@ -4738,32 +4778,82 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		};
 	}
 
-	private function data_view_block( int $collection_id ): string {
+	private function data_view_block( int $collection_id, array $view_overrides = array() ): string {
 		if ( $collection_id <= 0 ) {
 			return '';
 		}
 
 		$styles = $this->data_view_layout_styles( $collection_id );
 
-		$attributes = array(
-			'collectionId' => $collection_id,
-			'view'         => array(
-				'type'    => 'table',
-				'fields'  => array(),
-				'sort'    => null,
-				'filters' => array(),
-				'perPage' => 25,
-				'page'    => 1,
-				'search'  => '',
-				'layout'  => array(
+		$view = array(
+			'type'          => 'table',
+			'fields'        => array(),
+			'sort'          => null,
+			'filters'       => array(),
+			'calculations'  => array(),
+			'perPage'       => 25,
+			'page'          => 1,
+			'search'        => '',
+			'layout'        => array(
+				'density' => 'compact',
+			),
+			'layoutByType'  => array(
+				'table' => array(
 					'density' => 'compact',
 				),
+				'grid'  => array(),
+				'list'  => array(),
 			),
+			'fieldsByType'  => array(
+				'grid' => array(),
+				'list' => array(),
+			),
+			'rowDetailMode' => 'side',
 		);
 
 		if ( $styles ) {
-			$attributes['view']['layout']['styles'] = $styles;
+			$view['layout']['styles']                = $styles;
+			$view['layoutByType']['table']['styles'] = $styles;
 		}
+
+		if ( $view_overrides ) {
+			$layout_by_type_overrides = isset( $view_overrides['layoutByType'] ) && is_array( $view_overrides['layoutByType'] )
+				? $view_overrides['layoutByType']
+				: array();
+			$fields_by_type_overrides = isset( $view_overrides['fieldsByType'] ) && is_array( $view_overrides['fieldsByType'] )
+				? $view_overrides['fieldsByType']
+				: array();
+			unset( $view_overrides['layoutByType'], $view_overrides['fieldsByType'] );
+
+			$view = array_merge( $view, $view_overrides );
+			if ( $layout_by_type_overrides ) {
+				$view['layoutByType'] = array_replace( $view['layoutByType'], $layout_by_type_overrides );
+			}
+			if ( $fields_by_type_overrides ) {
+				$view['fieldsByType'] = array_replace( $view['fieldsByType'], $fields_by_type_overrides );
+			}
+		}
+
+		$type = 'table';
+		if ( isset( $view['type'] ) && in_array( $view['type'], array( 'table', 'grid', 'list' ), true ) ) {
+			$type = $view['type'];
+		}
+
+		$view['type'] = $type;
+
+		if ( ! isset( $view['layoutByType'][ $type ] ) || ! is_array( $view['layoutByType'][ $type ] ) ) {
+			$view['layoutByType'][ $type ] = array();
+		}
+		$view['layout'] = $view['layoutByType'][ $type ];
+
+		if ( 'grid' === $type && empty( $view['mediaField'] ) ) {
+			$view['mediaField'] = 'cover';
+		}
+
+		$attributes = array(
+			'collectionId' => $collection_id,
+			'view'         => $view,
+		);
 
 		return sprintf(
 			'<!-- wp:cortext/data-view %s /-->',

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -1490,23 +1490,40 @@ final class RowsController {
 
 		$created_by_id  = (int) $post->post_author;
 		$modified_by_id = (int) get_post_meta( $post->ID, '_modified_by', true );
+		$cover_id       = (int) get_post_thumbnail_id( $post );
+		$cover          = null;
+		if ( $cover_id > 0 ) {
+			$cover_src = wp_get_attachment_image_src( $cover_id, 'large' );
+			if ( ! is_array( $cover_src ) ) {
+				$cover_src = wp_get_attachment_image_src( $cover_id, 'full' );
+			}
+			if ( is_array( $cover_src ) && ! empty( $cover_src[0] ) ) {
+				$cover = array(
+					'id'  => $cover_id,
+					'url' => $cover_src[0],
+					'alt' => (string) get_post_meta( $cover_id, '_wp_attachment_image_alt', true ),
+				);
+			}
+		}
 
 		return array(
-			'id'          => $post->ID,
+			'id'             => $post->ID,
 			// `kind` keeps the row self-describing on the wire. Without it,
 			// JS helpers like `kindFromRecord` see no `type` either (the
 			// cortext endpoint trims that) and would fall back to `null`.
-			'kind'        => 'row',
-			'title'       => array(
+			'kind'           => 'row',
+			'title'          => array(
 				'raw'      => $post->post_title,
 				'rendered' => $post->post_title,
 			),
-			'status'      => $post->post_status,
-			'created_at'  => $this->format_gmt_date( $post->post_date_gmt ),
-			'modified_at' => $this->format_gmt_date( $post->post_modified_gmt ),
-			'created_by'  => $this->display_name_for( $created_by_id ),
-			'modified_by' => $this->display_name_for( $modified_by_id > 0 ? $modified_by_id : $created_by_id ),
-			'meta'        => $meta,
+			'status'         => $post->post_status,
+			'created_at'     => $this->format_gmt_date( $post->post_date_gmt ),
+			'modified_at'    => $this->format_gmt_date( $post->post_modified_gmt ),
+			'created_by'     => $this->display_name_for( $created_by_id ),
+			'modified_by'    => $this->display_name_for( $modified_by_id > 0 ? $modified_by_id : $created_by_id ),
+			'featured_media' => $cover_id,
+			'cover'          => $cover,
+			'meta'           => $meta,
 		);
 	}
 

--- a/src/blocks/data-view/block.json
+++ b/src/blocks/data-view/block.json
@@ -35,6 +35,17 @@
 				"page": 1,
 				"search": "",
 				"layout": {},
+				"layoutByType": {
+					"table": {
+						"density": "compact"
+					},
+					"grid": {},
+					"list": {}
+				},
+				"fieldsByType": {
+					"grid": [],
+					"list": []
+				},
 				"rowDetailMode": "side"
 			}
 		}

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -89,6 +89,15 @@ function createDefaultView() {
 		page: 1,
 		search: '',
 		layout: { density: 'compact' },
+		layoutByType: {
+			table: { density: 'compact' },
+			grid: {},
+			list: {},
+		},
+		fieldsByType: {
+			grid: [],
+			list: [],
+		},
 		rowDetailMode: 'side',
 	};
 }
@@ -344,6 +353,10 @@ function CollectionInspectorControls( {
 	} = useCollectionFieldsContext();
 	const isCollectionValid = ! isResolving && collectionId && collection;
 	const visibleFieldIds = view?.fields ?? [];
+	const tableLayout = {
+		...( view?.layoutByType?.table ?? {} ),
+		...( view?.type === 'table' ? view?.layout ?? {} : {} ),
+	};
 
 	// Checked fields follow the table order. Unchecked fields keep schema order.
 	const visibleFieldsInOrder = visibleFieldIds
@@ -517,14 +530,24 @@ function CollectionInspectorControls( {
 						) }
 						<SelectControl
 							label={ __( 'Density', 'cortext' ) }
-							value={ view?.layout?.density ?? 'compact' }
+							value={ tableLayout.density ?? 'compact' }
 							options={ DENSITY_OPTIONS }
 							onChange={ ( density ) =>
 								onChangeView( {
 									...view,
-									layout: {
-										...( view?.layout ?? {} ),
-										density,
+									layout:
+										view?.type === 'table'
+											? {
+													...( view?.layout ?? {} ),
+													density,
+											  }
+											: view?.layout,
+									layoutByType: {
+										...( view?.layoutByType ?? {} ),
+										table: {
+											...tableLayout,
+											density,
+										},
 									},
 								} )
 							}

--- a/src/components/CollectionDataViewChrome.js
+++ b/src/components/CollectionDataViewChrome.js
@@ -1,0 +1,175 @@
+import {
+	Button,
+	CheckboxControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { DataViews } from '@wordpress/dataviews';
+import { useMemo } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { closeSmall, trash } from '@wordpress/icons';
+
+export function DataViewsChrome( { footer } ) {
+	return (
+		<>
+			<HStack
+				alignment="top"
+				justify="space-between"
+				className="dataviews__view-actions"
+				spacing={ 1 }
+			>
+				<HStack
+					justify="start"
+					expanded={ false }
+					className="dataviews__search"
+				>
+					<DataViews.Search />
+					<DataViews.FiltersToggle />
+				</HStack>
+				<HStack
+					spacing={ 1 }
+					expanded={ false }
+					style={ { flexShrink: 0 } }
+				>
+					<DataViews.LayoutSwitcher />
+					<DataViews.ViewConfig />
+				</HStack>
+			</HStack>
+			<DataViews.Filters className="dataviews-filters__container" />
+			<DataViews.Layout />
+			{ footer }
+		</>
+	);
+}
+
+export function DataViewsBulkSelectionControls( {
+	className = 'dataviews-bulk-actions-footer__container',
+	selectedIds,
+	visibleIds,
+	onClearSelection,
+	onDeleteSelected,
+	onToggleVisibleSelection,
+} ) {
+	const selectedSet = useMemo(
+		() => new Set( selectedIds ),
+		[ selectedIds ]
+	);
+	const selectedCount = selectedIds.length;
+	const visibleCount = visibleIds.length;
+	const selectedVisibleCount = visibleIds.filter( ( id ) =>
+		selectedSet.has( id )
+	).length;
+	const allVisibleSelected =
+		visibleCount > 0 && selectedVisibleCount === visibleCount;
+	const hasVisibleSelection = selectedVisibleCount > 0;
+
+	const countLabel =
+		selectedCount > 0
+			? sprintf(
+					/* translators: %d: number of selected rows. */
+					_n(
+						'%d row selected',
+						'%d rows selected',
+						selectedCount,
+						'cortext'
+					),
+					selectedCount
+			  )
+			: sprintf(
+					/* translators: %d: number of visible rows. */
+					_n( '%d row', '%d rows', visibleCount, 'cortext' ),
+					visibleCount
+			  );
+
+	return (
+		<HStack expanded={ false } className={ className } spacing={ 3 }>
+			<CheckboxControl
+				className="dataviews-view-table-selection-checkbox"
+				__nextHasNoMarginBottom
+				checked={ allVisibleSelected }
+				indeterminate={ ! allVisibleSelected && hasVisibleSelection }
+				onChange={ onToggleVisibleSelection }
+				aria-label={
+					allVisibleSelected
+						? __( 'Deselect visible rows', 'cortext' )
+						: __( 'Select visible rows', 'cortext' )
+				}
+			/>
+			<span className="dataviews-bulk-actions-footer__item-count">
+				{ countLabel }
+			</span>
+			<HStack
+				className="dataviews-bulk-actions-footer__action-buttons"
+				expanded={ false }
+				spacing={ 1 }
+			>
+				{ selectedCount > 0 && (
+					<Button
+						icon={ trash }
+						isDestructive
+						label={ __( 'Trash selected rows', 'cortext' ) }
+						onClick={ onDeleteSelected }
+						size="compact"
+						showTooltip
+						tooltipPosition="top"
+					/>
+				) }
+				{ selectedCount > 0 && (
+					<Button
+						icon={ closeSmall }
+						label={ __( 'Clear selection', 'cortext' ) }
+						onClick={ onClearSelection }
+						size="compact"
+						showTooltip
+						tooltipPosition="top"
+					/>
+				) }
+			</HStack>
+		</HStack>
+	);
+}
+
+export function DataViewsSelectionFooter( {
+	enabled,
+	selectedIds,
+	visibleIds,
+	totalItems,
+	totalPages,
+	onClearSelection,
+	onDeleteSelected,
+	onToggleVisibleSelection,
+} ) {
+	const showBulkControls = enabled && totalItems > 0;
+	const showPagination = totalItems > 0 && totalPages > 1;
+
+	if ( ! showBulkControls && ! showPagination ) {
+		return null;
+	}
+
+	return (
+		<HStack expanded={ false } justify="end" className="dataviews-footer">
+			{ showBulkControls ? (
+				<DataViewsBulkSelectionControls
+					selectedIds={ selectedIds }
+					visibleIds={ visibleIds }
+					onClearSelection={ onClearSelection }
+					onDeleteSelected={ onDeleteSelected }
+					onToggleVisibleSelection={ onToggleVisibleSelection }
+				/>
+			) : null }
+			<DataViews.Pagination />
+		</HStack>
+	);
+}
+
+export function DataViewStateShell( { children, status } ) {
+	return (
+		<div className="cortext-data-view-shell">
+			<div
+				className={ `cortext-data-view cortext-data-view--${ status }` }
+			>
+				<div className="cortext-data-view__state">{ children }</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/CollectionDataViewFields.js
+++ b/src/components/CollectionDataViewFields.js
@@ -1,0 +1,198 @@
+import { Button } from '@wordpress/components';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+import EditableCell from './EditableCell';
+import PageIcon from './PageIcon';
+import { ROW_DETAIL_MODE_ICONS } from './RowDetailView';
+import { COVER_FIELD_ID, TITLE_FIELD_ID } from './dataViewColumns';
+import { dataViewsFilterByForType } from '../hooks/fieldMapping';
+
+export const TITLE_LABEL = __( 'Title', 'cortext' );
+const TITLE_FILTER_OPERATORS = [
+	'is',
+	'isNot',
+	'contains',
+	'notContains',
+	'startsWith',
+	'endsWith',
+	'isEmpty',
+	'isNotEmpty',
+];
+
+export const OpenRowActionContext = createContext( {
+	enabled: false,
+	icon: ROW_DETAIL_MODE_ICONS.side,
+	openRowId: null,
+	requestOpenRow: null,
+	showInlineOpen: true,
+} );
+
+// The peek panel cannot render until the editor is ready. On slower loads a
+// row click can feel like nothing happened, so pointerdown applies a short
+// "opening" state immediately.
+const OPENING_FEEDBACK_TIMEOUT_MS = 600;
+
+function TitleCell( { item } ) {
+	const { enabled, icon, openRowId, requestOpenRow, showInlineOpen } =
+		useContext( OpenRowActionContext );
+	const canOpenRow = Boolean( enabled && requestOpenRow );
+	const isOpenRow = canOpenRow && String( item?.id ) === String( openRowId );
+	const documentIcon = item?.meta?.cortext_document_icon ?? '';
+	const [ isOpening, setIsOpening ] = useState( false );
+	const openingTimeoutRef = useRef( null );
+
+	const clearOpeningTimeout = useCallback( () => {
+		if ( openingTimeoutRef.current ) {
+			clearTimeout( openingTimeoutRef.current );
+			openingTimeoutRef.current = null;
+		}
+	}, [] );
+
+	useEffect( () => clearOpeningTimeout, [ clearOpeningTimeout ] );
+
+	// Once this row owns the open peek, --is-open handles the visual state.
+	// Drop the short-lived opening state so it cannot linger after a quick close.
+	useEffect( () => {
+		if ( isOpenRow && isOpening ) {
+			clearOpeningTimeout();
+			setIsOpening( false );
+		}
+	}, [ clearOpeningTimeout, isOpening, isOpenRow ] );
+
+	const openRow = useCallback(
+		( event ) => {
+			event.preventDefault();
+			event.stopPropagation();
+			requestOpenRow?.( item );
+		},
+		[ item, requestOpenRow ]
+	);
+	const handleOpenPointerDown = useCallback(
+		( event ) => {
+			event.stopPropagation();
+			if ( ! canOpenRow || isOpenRow ) {
+				return;
+			}
+			setIsOpening( true );
+			clearOpeningTimeout();
+			openingTimeoutRef.current = setTimeout( () => {
+				openingTimeoutRef.current = null;
+				setIsOpening( false );
+			}, OPENING_FEEDBACK_TIMEOUT_MS );
+		},
+		[ canOpenRow, clearOpeningTimeout, isOpenRow ]
+	);
+	const stopPropagation = useCallback( ( event ) => {
+		event.stopPropagation();
+	}, [] );
+
+	return (
+		<div
+			className={
+				'cortext-title-cell' +
+				( canOpenRow && showInlineOpen
+					? ' cortext-title-cell--with-open-action'
+					: '' ) +
+				( isOpenRow ? ' cortext-title-cell--is-open' : '' ) +
+				( isOpening && ! isOpenRow
+					? ' cortext-title-cell--is-opening'
+					: '' )
+			}
+		>
+			{ documentIcon ? (
+				<span className="cortext-title-cell__icon" aria-hidden="true">
+					<PageIcon icon={ documentIcon } size={ 16 } />
+				</span>
+			) : null }
+			<EditableCell
+				item={ item }
+				fieldId="title"
+				fieldType="title"
+				label={ TITLE_LABEL }
+				readOnly={ ! showInlineOpen }
+				getValue={ ( ctx ) =>
+					ctx.item?.title?.raw ?? ctx.item?.title?.rendered ?? ''
+				}
+			/>
+			{ canOpenRow && showInlineOpen ? (
+				<Button
+					className="cortext-title-cell__open"
+					icon={ icon }
+					label={ __( 'Open row', 'cortext' ) }
+					size="small"
+					variant="tertiary"
+					onClick={ openRow }
+					onMouseDown={ stopPropagation }
+					onPointerDown={ handleOpenPointerDown }
+				>
+					{ __( 'Open', 'cortext' ) }
+				</Button>
+			) : null }
+		</div>
+	);
+}
+
+export const TITLE_FIELD = {
+	id: TITLE_FIELD_ID,
+	type: 'text',
+	label: TITLE_LABEL,
+	header: (
+		<span className="cortext-column-header-label">{ TITLE_LABEL }</span>
+	),
+	// Prefer `title.raw` over `title.rendered` so sort comparisons use
+	// the unfiltered string (the_title encodes `&` as `&#038;`, which
+	// would otherwise sort under that literal entity). Same reason as
+	// `mapField`'s label fallback in `src/hooks/fieldMapping.js`.
+	getValue: ( { item } ) => {
+		const title = item?.title;
+		return typeof title === 'string'
+			? title
+			: title?.raw ?? title?.rendered ?? '';
+	},
+	render: ( { item } ) => <TitleCell item={ item } />,
+	editable: true,
+	cortextType: 'title',
+	sortable: true,
+	filterable: true,
+	operators: TITLE_FILTER_OPERATORS,
+	filterBy: dataViewsFilterByForType( 'text', TITLE_FILTER_OPERATORS ),
+	enableGlobalSearch: true,
+	// The title column can't be hidden (it's the row identity), but it
+	// reorders and resizes like any other column. `normalizeView` re-adds
+	// the id to `view.fields` if something corrupts the saved state.
+	enableHiding: false,
+};
+
+export const COVER_FIELD = {
+	id: COVER_FIELD_ID,
+	type: 'media',
+	label: __( 'Cover', 'cortext' ),
+	header: <span>{ __( 'Cover', 'cortext' ) }</span>,
+	enableSorting: false,
+	enableGlobalSearch: false,
+	editable: false,
+	getValue: ( { item } ) => item?.cover?.url ?? '',
+	render: ( { item } ) => {
+		const cover = item?.cover;
+		if ( ! cover?.url ) {
+			return null;
+		}
+		return (
+			<img
+				className="cortext-data-view__cover-image"
+				src={ cover.url }
+				alt={ cover.alt ?? '' }
+				loading="lazy"
+				decoding="async"
+			/>
+		);
+	},
+};

--- a/src/components/CollectionDataViews.grid.scss
+++ b/src/components/CollectionDataViews.grid.scss
@@ -1,0 +1,345 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+$grid-card-background: $white;
+$grid-card-content-background: #f8f8f8;
+$grid-card-content-hover-background: #f3f3f3;
+
+.cortext-data-view
+.dataviews-view-grid__card:hover
+.cortext-title-cell__open.components-button,
+.cortext-data-view
+.dataviews-view-grid__card:focus-within
+.cortext-title-cell__open.components-button {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.cortext-data-view {
+
+	&__grid-new-row {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(var(--cortext-grid-card-min, 240px), 1fr));
+		grid-auto-rows: minmax(var(--cortext-grid-card-height, 220px), auto);
+		gap: $grid-unit-20;
+		padding: 0 $grid-unit-20 $grid-unit-20;
+	}
+
+	&__new-row-card-wrapper {
+		box-sizing: border-box;
+		height: 100%;
+		min-height: var(--cortext-grid-card-height, 220px);
+		min-width: 0;
+		order: 1;
+	}
+
+	&__new-row-card.components-button {
+		align-items: center;
+		flex-direction: column;
+		gap: $grid-unit-05;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		min-height: var(--cortext-grid-card-height, 220px);
+		padding: $grid-unit-20;
+		border: $border-width solid $gray-200;
+		border-radius: 6px;
+		background: $white;
+		color: $gray-700;
+		text-align: center;
+		text-decoration: none;
+		transition:
+			background-color 120ms ease,
+			border-color 120ms ease,
+			box-shadow 120ms ease,
+			transform 120ms ease;
+
+		&.has-icon.has-text {
+			justify-content: center;
+			padding: $grid-unit-20;
+		}
+
+		&:focus-visible,
+		&:hover:not(:disabled) {
+			border-color: $gray-300;
+			background: $gray-100;
+			color: $gray-900;
+			box-shadow:
+				0 1px 2px rgba(0, 0, 0, 0.06),
+				0 0 0 1px rgba(0, 0, 0, 0.02);
+		}
+
+		&:active:not(:disabled) {
+			transform: translateY(1px);
+			box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03);
+		}
+	}
+
+	&__cover-image {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.dataviews-view-grid {
+		grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+		grid-template-rows: none;
+		grid-auto-rows: minmax(var(--cortext-grid-card-height, 220px), auto);
+		grid-auto-flow: row;
+		gap: $grid-unit-20;
+		row-gap: $grid-unit-20;
+		column-gap: $grid-unit-20;
+		padding: $grid-unit-20;
+		align-items: stretch;
+	}
+
+	.dataviews-view-grid__card {
+		position: relative;
+		box-sizing: border-box;
+		height: 100%;
+		min-height: var(--cortext-grid-card-height, 220px);
+		min-width: 0;
+		order: 0;
+		overflow: hidden;
+		padding: 0;
+		border: $border-width solid $gray-200;
+		border-radius: 6px;
+		background: $grid-card-background;
+		transition:
+			background-color 120ms ease,
+			border-color 120ms ease,
+			box-shadow 120ms ease,
+			transform 120ms ease;
+
+		[data-grid-card-clickable="true"] & {
+			cursor: pointer;
+		}
+
+		&:hover,
+		&:focus-within {
+			border-color: $gray-400;
+			background: $grid-card-background;
+			box-shadow:
+				0 2px 8px rgba(0, 0, 0, 0.08),
+				0 0 0 1px rgba(0, 0, 0, 0.03);
+		}
+
+		&:active {
+			box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03);
+		}
+
+		&:has(.cortext-title-cell--is-open),
+		&:has(.cortext-title-cell--is-opening) {
+			border-color: var(--cortext-accent);
+			background: $grid-card-background;
+			box-shadow:
+				0 2px 8px rgba(0, 0, 0, 0.08),
+				0 0 0 1px var(--cortext-accent);
+		}
+	}
+
+	.dataviews-view-grid .dataviews-view-grid__card .dataviews-view-grid__title-actions {
+		gap: $grid-unit-10;
+		align-items: center;
+		order: 1;
+		width: 100%;
+		box-sizing: border-box;
+		padding: $grid-unit-15 $grid-unit-20 $grid-unit-05;
+		border-bottom: 0;
+		background: $grid-card-content-background;
+		transition: background-color 120ms ease;
+	}
+
+	.dataviews-view-grid__title-field {
+		flex: 1 1 0;
+		min-width: 0;
+		font-weight: 500;
+		color: $gray-900;
+
+		.cortext-title-cell {
+			gap: $grid-unit-10;
+		}
+
+		.cortext-title-cell__icon {
+			align-items: center;
+			justify-content: center;
+			width: 16px;
+			height: 16px;
+		}
+
+		.cortext-document-icon--emoji {
+			transform: translateY(-1px);
+		}
+	}
+
+	.dataviews-view-grid__fields {
+		padding-top: $grid-unit-05;
+	}
+
+	.dataviews-view-grid__field {
+		align-items: baseline;
+		justify-content: flex-start;
+		min-height: $grid-unit-20 + $grid-unit-05;
+		text-align: start;
+	}
+
+	.dataviews-view-grid__field-name {
+		display: none;
+	}
+
+	.dataviews-view-grid__field-value {
+		flex: 1 1 auto;
+		width: 100%;
+		min-width: 0;
+		color: $gray-900;
+		line-height: 1.4;
+		overflow-wrap: anywhere;
+		text-align: start;
+	}
+
+	.dataviews-view-grid__field-value .cortext-editable-cell {
+		width: 100%;
+	}
+
+	.dataviews-view-grid__field-value .cortext-editable-cell > :first-child {
+		min-height: $grid-unit-30;
+		padding: 0 $grid-unit-30 0 $grid-unit-05;
+		border-radius: 4px;
+		box-shadow: inset 0 0 0 1px transparent;
+		position: relative;
+		transition:
+			background-color 120ms ease,
+			box-shadow 120ms ease;
+	}
+
+	.dataviews-view-grid__field-value .cortext-editable-cell__shell:hover {
+		background: transparent;
+		box-shadow: inset 0 0 0 1px transparent;
+	}
+
+	.dataviews-view-grid__field-value .cortext-editable-cell__shell:focus-visible {
+		background: transparent;
+		box-shadow: inset 0 0 0 1px var(--cortext-accent);
+		outline: none;
+	}
+
+	.dataviews-view-grid__field-value .cortext-editable-cell__edit-indicator {
+		position: absolute;
+		top: 50%;
+		right: $grid-unit-05;
+		display: block;
+		color: $gray-700;
+		opacity: 0;
+		transform: translateY(-50%);
+		transition:
+			color 120ms ease,
+			opacity 120ms ease;
+	}
+
+	.dataviews-view-grid__field-value .cortext-editable-cell__shell:hover .cortext-editable-cell__edit-indicator,
+	.dataviews-view-grid__field-value .cortext-editable-cell__shell:focus-visible .cortext-editable-cell__edit-indicator {
+		color: $gray-900;
+		opacity: 1;
+	}
+
+	.dataviews-view-grid__field-value .cortext-editable-cell__display {
+		white-space: normal;
+	}
+
+	.dataviews-view-grid .cortext-relation-ref,
+	.dataviews-view-grid .cortext-relation-ref-more,
+	.dataviews-view-grid .cortext-chip {
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+		box-shadow: inset 0 0 0 1px color-mix(in oklch, currentcolor 20%, transparent);
+	}
+
+	.dataviews-view-grid .cortext-chip--neutral {
+		background-color: $gray-100;
+		box-shadow: inset 0 0 0 1px $gray-300;
+		color: $gray-700;
+	}
+
+	.dataviews-view-grid__badge-fields {
+		justify-content: flex-start;
+		padding-top: $grid-unit-05;
+	}
+
+	.dataviews-view-grid__card > .components-v-stack {
+		order: 2;
+		width: 100%;
+		min-width: 0;
+		box-sizing: border-box;
+		padding: $grid-unit-10 $grid-unit-20 $grid-unit-15;
+		background: $grid-card-content-background;
+		transition: background-color 120ms ease;
+	}
+
+	.dataviews-view-grid__card:hover .dataviews-view-grid__title-actions,
+	.dataviews-view-grid__card:focus-within .dataviews-view-grid__title-actions,
+	.dataviews-view-grid__card:hover > .components-v-stack,
+	.dataviews-view-grid__card:focus-within > .components-v-stack {
+		background: $grid-card-content-hover-background;
+	}
+
+	.dataviews-view-grid__media {
+		position: relative;
+		order: 0;
+		width: 100%;
+		height: auto;
+		min-height: 0;
+		aspect-ratio: 16 / 9;
+		background: $white;
+		border-radius: 0;
+		overflow: hidden;
+
+		img {
+			display: block;
+			border-radius: 0;
+		}
+
+		&::after {
+			display: none;
+		}
+	}
+
+	.dataviews-view-grid__media .cortext-data-view__cover-image {
+		border-radius: 0;
+	}
+
+	.dataviews-view-grid__title-actions .components-button {
+		color: $gray-700;
+
+		&:hover,
+		&:focus-visible {
+			background: $gray-100;
+			color: $gray-900;
+		}
+	}
+
+	.dataviews-view-grid__title-actions .dataviews-all-actions-button.components-button {
+		display: inline-flex;
+		flex: 0 0 auto;
+		align-items: center;
+		justify-content: center;
+		width: $grid-unit-40;
+		min-width: $grid-unit-40;
+		height: $grid-unit-40;
+		margin-inline-start: $grid-unit-10;
+		border-radius: 4px;
+		background: transparent;
+		box-shadow: none;
+		opacity: 1;
+
+		svg {
+			color: currentcolor;
+			fill: currentcolor;
+		}
+
+		&:hover,
+		&:focus-visible {
+			background: $gray-100;
+			box-shadow: none;
+		}
+	}
+}

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -48,6 +48,7 @@ import {
 	adaptViewForDataViews,
 	mergeDataViewsChange,
 } from './dataViewAdapter';
+import { nextViewAfterRowCreated } from './dataViewCreation';
 import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
 import ColumnHeaderActions from './fields/ColumnHeaderActions';
@@ -579,29 +580,19 @@ export default function CollectionDataViews( {
 
 	const onCreated = useCallback(
 		( created ) => {
-			// Without an explicit sort, rows use their stored order and new
-			// rows append to the end. Move to the last page before refreshing
-			// so the new row is visible instead of sending the user back to
-			// page 1. With a user-chosen sort, the new row could land anywhere;
-			// refresh in place and leave the view alone.
+			// In an unconstrained view, rows append to the stored order, so the
+			// new row belongs on the last page. Search, filters, and explicit
+			// sorts make that guess unsafe; refresh in place instead.
 			//
 			// tech-debt.md#2: lastPage arithmetic is optimistic against
 			// possibly stale paginationInfo. With rows in core-data this
 			// becomes a useEffect on totalPages.
-			const hasExplicitSort = Boolean( view?.sort?.field );
-			if ( ! hasExplicitSort ) {
-				const perPage = view?.perPage ?? 25;
-				const expectedTotal =
-					( activePaginationInfo?.totalItems ?? 0 ) + 1;
-				const lastPage = Math.max(
-					1,
-					Math.ceil( expectedTotal / perPage )
-				);
-				if ( ( view?.page ?? 1 ) !== lastPage ) {
-					onChangeView( { ...view, page: lastPage } );
-				} else {
-					refresh();
-				}
+			const nextView = nextViewAfterRowCreated(
+				view,
+				activePaginationInfo
+			);
+			if ( nextView !== view ) {
+				onChangeView( nextView );
 			} else {
 				refresh();
 			}

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1,16 +1,8 @@
 import apiFetch from '@wordpress/api-fetch';
-import {
-	Button,
-	CheckboxControl,
-	Notice,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import {
-	createContext,
 	useCallback,
-	useContext,
 	useEffect,
 	useLayoutEffect,
 	useMemo,
@@ -18,32 +10,44 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import {
-	closeSmall,
-	copy,
-	plus,
-	starEmpty,
-	starFilled,
-	trash,
-} from '@wordpress/icons';
+import { copy, starEmpty, starFilled, trash } from '@wordpress/icons';
 
 import './CollectionDataViews.scss';
+import './CollectionDataViews.grid.scss';
+import './CollectionDataViews.list.scss';
 
 import DataViewColumnInteractions from './DataViewColumnInteractions';
+import {
+	DataViewStateShell,
+	DataViewsBulkSelectionControls,
+	DataViewsChrome,
+	DataViewsSelectionFooter,
+} from './CollectionDataViewChrome';
+import DataViewNewRowButton from './DataViewNewRowButton';
 import DataViewRowReorder from './DataViewRowReorder';
 import {
 	useDocumentPeekActions,
 	useDocumentPeekState,
 } from './DocumentPeekProvider';
 import { CurrentViewModeProvider } from './CurrentViewModeContext';
-import EditableCell, { RowMutationContext } from './EditableCell';
-import PageIcon from './PageIcon';
+import { RowMutationContext } from './EditableCell';
+import {
+	COVER_FIELD,
+	OpenRowActionContext,
+	TITLE_FIELD,
+} from './CollectionDataViewFields';
+import GridNewRowPortal from './GridNewRowPortal';
 import { CollectionRowsSkeleton } from './Skeleton';
 import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
 } from '../hooks/useDelayedFlag';
 import afterNextPaint from '../hooks/afterNextPaint';
 import allSettledWithConcurrency from './allSettledWithConcurrency';
+import {
+	DEFAULT_LAYOUTS,
+	adaptViewForDataViews,
+	mergeDataViewsChange,
+} from './dataViewAdapter';
 import { filterSortAndPaginateWithGroups } from './groupedFilters';
 import TableCalculationsFooter from './TableCalculationsFooter';
 import ColumnHeaderActions from './fields/ColumnHeaderActions';
@@ -51,12 +55,15 @@ import { ROW_DETAIL_MODE_ICONS, ROW_DETAIL_MODE_LABELS } from './RowDetailView';
 import {
 	GHOST_FIELD_ID,
 	MANUAL_SORT_ID,
-	TITLE_FIELD_ID,
 	isDefaultVisibleField,
 	normalizeView,
 	pruneFiltersForFields,
 	withNewlyVisibleFields,
 } from './dataViewColumns';
+import {
+	INTERACTIVE_DATA_VIEW_ITEM_IGNORE_SELECTOR,
+	findDataViewItemFromEvent,
+} from './dataViewItemLookup';
 import { scrollToEndQuickly } from './dataViewScroll';
 import { getRowDetailMode, withRowDetailMode } from './rowDetailUtils';
 import {
@@ -70,7 +77,6 @@ import {
 	toggleVisibleSelection,
 } from './dataViewSelection';
 import { useCollectionFieldsContext } from './CollectionFieldsContext';
-import { dataViewsFilterByForType } from '../hooks/fieldMapping';
 import { toDataViewId, toRecordId } from '../hooks/fieldIds';
 import useCollectionRows from '../hooks/useCollectionRows';
 import { useRecents } from '../hooks/useRecents';
@@ -80,448 +86,11 @@ import { elementsFromOptions } from '../hooks/optionElements';
 import { notifyDocumentTrashChanged } from '../hooks/documentTrashInvalidation';
 import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
 
-const DEFAULT_LAYOUTS = { table: { density: 'compact' }, grid: {}, list: {} };
-const TITLE_LABEL = __( 'Title', 'cortext' );
-const TITLE_FILTER_OPERATORS = [
-	'is',
-	'isNot',
-	'contains',
-	'notContains',
-	'startsWith',
-	'endsWith',
-	'isEmpty',
-	'isNotEmpty',
-];
 function hasActiveCalculations( view ) {
 	return Object.values( view?.calculations ?? {} ).some( Boolean );
 }
 
-const OpenRowActionContext = createContext( {
-	enabled: false,
-	icon: ROW_DETAIL_MODE_ICONS.side,
-	openRowId: null,
-	requestOpenRow: null,
-} );
-
-// The peek panel cannot render until the editor is ready. On slower loads a
-// row click can feel like nothing happened, so pointerdown applies a short
-// "opening" state immediately.
-const OPENING_FEEDBACK_TIMEOUT_MS = 600;
-
-function TitleCell( { item } ) {
-	const { enabled, icon, openRowId, requestOpenRow } =
-		useContext( OpenRowActionContext );
-	const canOpenRow = Boolean( enabled && requestOpenRow );
-	const isOpenRow = canOpenRow && String( item?.id ) === String( openRowId );
-	const documentIcon = item?.meta?.cortext_document_icon ?? '';
-	const [ isOpening, setIsOpening ] = useState( false );
-	const openingTimeoutRef = useRef( null );
-
-	const clearOpeningTimeout = useCallback( () => {
-		if ( openingTimeoutRef.current ) {
-			clearTimeout( openingTimeoutRef.current );
-			openingTimeoutRef.current = null;
-		}
-	}, [] );
-
-	useEffect( () => clearOpeningTimeout, [ clearOpeningTimeout ] );
-
-	// Once this row owns the open peek, --is-open handles the visual state.
-	// Drop the short-lived opening state so it cannot linger after a quick close.
-	useEffect( () => {
-		if ( isOpenRow && isOpening ) {
-			clearOpeningTimeout();
-			setIsOpening( false );
-		}
-	}, [ clearOpeningTimeout, isOpening, isOpenRow ] );
-
-	const openRow = useCallback(
-		( event ) => {
-			event.preventDefault();
-			event.stopPropagation();
-			requestOpenRow?.( item );
-		},
-		[ item, requestOpenRow ]
-	);
-	const handleOpenPointerDown = useCallback(
-		( event ) => {
-			event.stopPropagation();
-			if ( ! canOpenRow || isOpenRow ) {
-				return;
-			}
-			setIsOpening( true );
-			clearOpeningTimeout();
-			openingTimeoutRef.current = setTimeout( () => {
-				openingTimeoutRef.current = null;
-				setIsOpening( false );
-			}, OPENING_FEEDBACK_TIMEOUT_MS );
-		},
-		[ canOpenRow, clearOpeningTimeout, isOpenRow ]
-	);
-	const stopPropagation = useCallback( ( event ) => {
-		event.stopPropagation();
-	}, [] );
-
-	return (
-		<div
-			className={
-				'cortext-title-cell' +
-				( canOpenRow ? ' cortext-title-cell--with-open-action' : '' ) +
-				( isOpenRow ? ' cortext-title-cell--is-open' : '' ) +
-				( isOpening && ! isOpenRow
-					? ' cortext-title-cell--is-opening'
-					: '' )
-			}
-		>
-			{ documentIcon ? (
-				<span className="cortext-title-cell__icon" aria-hidden="true">
-					<PageIcon icon={ documentIcon } size={ 16 } />
-				</span>
-			) : null }
-			<EditableCell
-				item={ item }
-				fieldId="title"
-				fieldType="title"
-				label={ TITLE_LABEL }
-				getValue={ ( ctx ) =>
-					ctx.item?.title?.raw ?? ctx.item?.title?.rendered ?? ''
-				}
-			/>
-			{ canOpenRow ? (
-				<Button
-					className="cortext-title-cell__open"
-					icon={ icon }
-					label={ __( 'Open row', 'cortext' ) }
-					size="small"
-					variant="tertiary"
-					onClick={ openRow }
-					onMouseDown={ stopPropagation }
-					onPointerDown={ handleOpenPointerDown }
-				>
-					{ __( 'Open', 'cortext' ) }
-				</Button>
-			) : null }
-		</div>
-	);
-}
-
-const TITLE_FIELD = {
-	id: TITLE_FIELD_ID,
-	type: 'text',
-	label: TITLE_LABEL,
-	header: (
-		<span className="cortext-column-header-label">{ TITLE_LABEL }</span>
-	),
-	// Prefer `title.raw` over `title.rendered` so sort comparisons use
-	// the unfiltered string (the_title encodes `&` as `&#038;`, which
-	// would otherwise sort under that literal entity). Same reason as
-	// `mapField`'s label fallback in `src/hooks/fieldMapping.js`.
-	getValue: ( { item } ) => {
-		const title = item?.title;
-		return typeof title === 'string'
-			? title
-			: title?.raw ?? title?.rendered ?? '';
-	},
-	render: ( { item } ) => <TitleCell item={ item } />,
-	editable: true,
-	cortextType: 'title',
-	sortable: true,
-	filterable: true,
-	operators: TITLE_FILTER_OPERATORS,
-	filterBy: dataViewsFilterByForType( 'text', TITLE_FILTER_OPERATORS ),
-	enableGlobalSearch: true,
-	// The title column can't be hidden (it's the row identity), but it
-	// reorders and resizes like any other column. `normalizeView` re-adds
-	// the id to `view.fields` if something corrupts the saved state.
-	enableHiding: false,
-};
-
-// Pulls a "single equality" prefill out of the active filters: only filters
-// whose operator is `is` and whose value is a single scalar contribute.
-// Multi-value operators (`isAny`, `isNone`, …) are skipped
-// because the issue scopes prefill to single equality clauses only.
-//
-// The server now applies filters via GET /cortext/v1/rows, so prefill
-// is a side effect of real filtering rather than its only consumer.
-function prefillFromFilters( filters, fieldIds ) {
-	const prefill = {};
-	if ( ! Array.isArray( filters ) ) {
-		return prefill;
-	}
-	for ( const filter of filters ) {
-		if ( ! filter || typeof filter !== 'object' ) {
-			continue;
-		}
-		const op = filter.operator;
-		if ( op !== 'is' ) {
-			continue;
-		}
-		const { field, value } = filter;
-		if ( ! field || field === 'title' ) {
-			continue;
-		}
-		if ( Array.isArray( value ) || value === null || value === undefined ) {
-			continue;
-		}
-		if ( ! fieldIds.has( field ) ) {
-			continue;
-		}
-		prefill[ field ] = value;
-	}
-	return prefill;
-}
-
-function NewRowButton( { slug, view, fields, onCreated, disabled } ) {
-	const [ isCreating, setIsCreating ] = useState( false );
-	const [ error, setError ] = useState( null );
-
-	const prefillableFieldIds = useMemo(
-		() =>
-			new Set(
-				fields
-					.filter(
-						( f ) =>
-							f.editable !== false && f.cortextType !== 'rollup'
-					)
-					.map( ( f ) => f.id )
-			),
-		[ fields ]
-	);
-
-	const onClick = useCallback( async () => {
-		setIsCreating( true );
-		setError( null );
-		const meta = prefillFromFilters( view?.filters, prefillableFieldIds );
-		try {
-			// FIXME: Consider supporting row creation via /cortext/v1/rows.
-			const created = await apiFetch( {
-				path: `/wp/v2/crtxt_${ slug }`,
-				method: 'POST',
-				data: {
-					status: 'private',
-					title: '',
-					...( Object.keys( meta ).length ? { meta } : {} ),
-				},
-			} );
-			onCreated( created );
-		} catch ( err ) {
-			setError(
-				err?.message ?? __( 'Could not create row.', 'cortext' )
-			);
-		} finally {
-			setIsCreating( false );
-		}
-	}, [ slug, view, prefillableFieldIds, onCreated ] );
-
-	return (
-		<>
-			<Button
-				className="cortext-data-view__new-row"
-				variant="tertiary"
-				icon={ plus }
-				onClick={ onClick }
-				isBusy={ isCreating }
-				disabled={ disabled || isCreating || ! slug }
-			>
-				{ __( 'New', 'cortext' ) }
-			</Button>
-			{ error ? (
-				<Notice
-					status="error"
-					isDismissible
-					onRemove={ () => setError( null ) }
-				>
-					{ error }
-				</Notice>
-			) : null }
-		</>
-	);
-}
-
-const TABLE_ROW_SELECTOR =
-	'.dataviews-view-table tbody > tr:not(.dataviews-view-table__group-header-row)';
-const GRID_CARD_SELECTOR = '.dataviews-view-grid__card';
-const INTERACTIVE_SELECTION_IGNORE_SELECTOR =
-	'button, a, input, textarea, select, [contenteditable="true"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], .components-button';
 const BULK_DELETE_CONCURRENCY = 4;
-
-function findDataViewItemFromEvent( event, wrapper, layout, rows ) {
-	const target = event.target;
-	if ( ! target || ! wrapper ) {
-		return null;
-	}
-
-	const selector =
-		layout === 'grid' ? GRID_CARD_SELECTOR : TABLE_ROW_SELECTOR;
-	const itemElement = target.closest?.( selector );
-	if ( ! itemElement || ! wrapper.contains( itemElement ) ) {
-		return null;
-	}
-
-	const renderedItems = Array.from( wrapper.querySelectorAll( selector ) );
-	const index = renderedItems.indexOf( itemElement );
-	if ( index < 0 || ! rows[ index ]?.id ) {
-		return null;
-	}
-
-	return {
-		id: normalizeRowId( rows[ index ].id ),
-		row: rows[ index ],
-	};
-}
-
-function DataViewsChrome( { footer } ) {
-	return (
-		<>
-			<HStack
-				alignment="top"
-				justify="space-between"
-				className="dataviews__view-actions"
-				spacing={ 1 }
-			>
-				<HStack
-					justify="start"
-					expanded={ false }
-					className="dataviews__search"
-				>
-					<DataViews.Search />
-					<DataViews.FiltersToggle />
-				</HStack>
-				<HStack
-					spacing={ 1 }
-					expanded={ false }
-					style={ { flexShrink: 0 } }
-				>
-					<DataViews.LayoutSwitcher />
-					<DataViews.ViewConfig />
-				</HStack>
-			</HStack>
-			<DataViews.Filters className="dataviews-filters__container" />
-			<DataViews.Layout />
-			{ footer }
-		</>
-	);
-}
-
-function DataViewsBulkSelectionControls( {
-	className = 'dataviews-bulk-actions-footer__container',
-	selectedIds,
-	visibleIds,
-	onClearSelection,
-	onDeleteSelected,
-	onToggleVisibleSelection,
-} ) {
-	const selectedSet = useMemo(
-		() => new Set( selectedIds ),
-		[ selectedIds ]
-	);
-	const selectedCount = selectedIds.length;
-	const visibleCount = visibleIds.length;
-	const selectedVisibleCount = visibleIds.filter( ( id ) =>
-		selectedSet.has( id )
-	).length;
-	const allVisibleSelected =
-		visibleCount > 0 && selectedVisibleCount === visibleCount;
-	const hasVisibleSelection = selectedVisibleCount > 0;
-
-	const countLabel =
-		selectedCount > 0
-			? sprintf(
-					/* translators: %d: number of selected rows. */
-					_n(
-						'%d row selected',
-						'%d rows selected',
-						selectedCount,
-						'cortext'
-					),
-					selectedCount
-			  )
-			: sprintf(
-					/* translators: %d: number of visible rows. */
-					_n( '%d row', '%d rows', visibleCount, 'cortext' ),
-					visibleCount
-			  );
-
-	return (
-		<HStack expanded={ false } className={ className } spacing={ 3 }>
-			<CheckboxControl
-				className="dataviews-view-table-selection-checkbox"
-				__nextHasNoMarginBottom
-				checked={ allVisibleSelected }
-				indeterminate={ ! allVisibleSelected && hasVisibleSelection }
-				onChange={ onToggleVisibleSelection }
-				aria-label={
-					allVisibleSelected
-						? __( 'Deselect visible rows', 'cortext' )
-						: __( 'Select visible rows', 'cortext' )
-				}
-			/>
-			<span className="dataviews-bulk-actions-footer__item-count">
-				{ countLabel }
-			</span>
-			<HStack
-				className="dataviews-bulk-actions-footer__action-buttons"
-				expanded={ false }
-				spacing={ 1 }
-			>
-				{ selectedCount > 0 && (
-					<Button
-						icon={ trash }
-						isDestructive
-						label={ __( 'Trash selected rows', 'cortext' ) }
-						onClick={ onDeleteSelected }
-						size="compact"
-						showTooltip
-						tooltipPosition="top"
-					/>
-				) }
-				{ selectedCount > 0 && (
-					<Button
-						icon={ closeSmall }
-						label={ __( 'Clear selection', 'cortext' ) }
-						onClick={ onClearSelection }
-						size="compact"
-						showTooltip
-						tooltipPosition="top"
-					/>
-				) }
-			</HStack>
-		</HStack>
-	);
-}
-
-function DataViewsSelectionFooter( {
-	enabled,
-	selectedIds,
-	visibleIds,
-	totalItems,
-	totalPages,
-	onClearSelection,
-	onDeleteSelected,
-	onToggleVisibleSelection,
-} ) {
-	const showBulkControls = enabled && totalItems > 0;
-	const showPagination = totalItems > 0 && totalPages > 1;
-
-	if ( ! showBulkControls && ! showPagination ) {
-		return null;
-	}
-
-	return (
-		<HStack expanded={ false } justify="end" className="dataviews-footer">
-			{ showBulkControls ? (
-				<DataViewsBulkSelectionControls
-					selectedIds={ selectedIds }
-					visibleIds={ visibleIds }
-					onClearSelection={ onClearSelection }
-					onDeleteSelected={ onDeleteSelected }
-					onToggleVisibleSelection={ onToggleVisibleSelection }
-				/>
-			) : null }
-			<DataViews.Pagination />
-		</HStack>
-	);
-}
 
 export default function CollectionDataViews( {
 	collectionId,
@@ -543,9 +112,22 @@ export default function CollectionDataViews( {
 	const knownFieldIdsRef = useRef( null );
 
 	const availableFields = useMemo(
-		() => [ TITLE_FIELD, ...fields ],
+		() => [ TITLE_FIELD, COVER_FIELD, ...fields ],
 		[ fields ]
 	);
+	const dataViewsView = useMemo(
+		() => adaptViewForDataViews( view ),
+		[ view ]
+	);
+	const viewRef = useRef( view );
+	viewRef.current = view;
+	const onChangeViewRef = useRef( onChangeView );
+	onChangeViewRef.current = onChangeView;
+	const onDataViewsChange = useCallback( ( nextView ) => {
+		onChangeViewRef.current(
+			mergeDataViewsChange( viewRef.current, nextView )
+		);
+	}, [] );
 
 	// Compute a reconciled view synchronously so that useCollectionRows
 	// never fetches with stale/deleted field references. While fields are
@@ -600,11 +182,17 @@ export default function CollectionDataViews( {
 
 	const isTableLayout = view?.type === 'table';
 	const isGridLayout = view?.type === 'grid';
+	const isListLayout = view?.type === 'list';
+	let skeletonLayout = 'table';
+	if ( isGridLayout ) {
+		skeletonLayout = 'grid';
+	} else if ( isListLayout ) {
+		skeletonLayout = 'list';
+	}
 	const supportsRowSelection = isTableLayout || isGridLayout;
 	const isServerPaginated = queryMode === 'server';
 	const dataViewFields = availableFields;
-	const isRowsLoadingShell =
-		! rowsResolved && data.length === 0 && isTableLayout;
+	const isRowsLoadingShell = ! rowsResolved && data.length === 0;
 	// Treat field loading and first-page row loading as one shell state. While
 	// either is still running, hide DataViews chrome and show the rows skeleton
 	// so the user does not see three quick states: generic placeholder, empty
@@ -660,12 +248,12 @@ export default function CollectionDataViews( {
 	// tech-debt.md#1: DataViews would own this if inline editing were
 	// upstream, and this walker would go away.
 	const editableVisibleFields = useMemo( () => {
-		const order = view?.fields ?? [];
+		const order = dataViewsView?.fields ?? [];
 		const byId = new Map( availableFields.map( ( f ) => [ f.id, f ] ) );
 		return order
 			.map( ( id ) => byId.get( id ) )
 			.filter( ( f ) => f && f.editable );
-	}, [ availableFields, view?.fields ] );
+	}, [ availableFields, dataViewsView?.fields ] );
 
 	const { data: dataFiltered, paginationInfo: clientPaginationInfo } =
 		useMemo( () => {
@@ -707,8 +295,13 @@ export default function CollectionDataViews( {
 		: clientPaginationInfo;
 
 	const dataFilteredInRenderOrder = useMemo(
-		() => rowsInDataViewRenderOrder( dataFiltered, view, dataViewFields ),
-		[ dataFiltered, view, dataViewFields ]
+		() =>
+			rowsInDataViewRenderOrder(
+				dataFiltered,
+				dataViewsView,
+				dataViewFields
+			),
+		[ dataFiltered, dataViewsView, dataViewFields ]
 	);
 	const visibleRowIds = useMemo(
 		() => rowIds( dataFilteredInRenderOrder ),
@@ -847,7 +440,9 @@ export default function CollectionDataViews( {
 				return;
 			}
 
-			if ( target.closest( INTERACTIVE_SELECTION_IGNORE_SELECTOR ) ) {
+			if (
+				target.closest( INTERACTIVE_DATA_VIEW_ITEM_IGNORE_SELECTOR )
+			) {
 				return;
 			}
 
@@ -957,6 +552,7 @@ export default function CollectionDataViews( {
 	const mutationContext = useMemo(
 		() => ( {
 			saveRowField,
+			canEditCells: isTableLayout || isGridLayout,
 			editRequest,
 			clearEditRequest,
 			requestNext,
@@ -968,6 +564,8 @@ export default function CollectionDataViews( {
 		} ),
 		[
 			saveRowField,
+			isGridLayout,
+			isTableLayout,
 			editRequest,
 			clearEditRequest,
 			requestNext,
@@ -1026,10 +624,6 @@ export default function CollectionDataViews( {
 		]
 	);
 
-	const viewRef = useRef( view );
-	viewRef.current = view;
-	const onChangeViewRef = useRef( onChangeView );
-	onChangeViewRef.current = onChangeView;
 	const previousVisibleFieldsRef = useRef( null );
 	const savedRowDetailMode = getRowDetailMode( view );
 	const postType = slug ? `crtxt_${ slug }` : null;
@@ -1088,12 +682,61 @@ export default function CollectionDataViews( {
 
 	const openRowActionContext = useMemo(
 		() => ( {
-			enabled: isTableLayout,
+			enabled: isTableLayout || isGridLayout,
 			icon: ROW_DETAIL_MODE_ICONS[ savedRowDetailMode ],
 			openRowId,
 			requestOpenRow,
+			showInlineOpen: isTableLayout,
 		} ),
-		[ isTableLayout, openRowId, requestOpenRow, savedRowDetailMode ]
+		[
+			isGridLayout,
+			isTableLayout,
+			openRowId,
+			requestOpenRow,
+			savedRowDetailMode,
+		]
+	);
+	const handleDataViewClick = useCallback(
+		( event ) => {
+			if ( ! isGridLayout || event.defaultPrevented ) {
+				return;
+			}
+			if (
+				event.metaKey ||
+				event.ctrlKey ||
+				event.shiftKey ||
+				event.altKey
+			) {
+				return;
+			}
+			const target = event.target;
+			if ( ! target?.closest ) {
+				return;
+			}
+			if (
+				target.closest( INTERACTIVE_DATA_VIEW_ITEM_IGNORE_SELECTOR )
+			) {
+				return;
+			}
+			const rowInfo = findDataViewItemFromEvent(
+				event,
+				tableWrapperRef.current,
+				'grid',
+				dataFilteredInRenderOrder
+			);
+			if ( ! rowInfo?.row ) {
+				return;
+			}
+			requestOpenRow( rowInfo.row );
+		},
+		[ dataFilteredInRenderOrder, isGridLayout, requestOpenRow ]
+	);
+	const handleDataViewClickCapture = useCallback(
+		( event ) => {
+			captureSelectionIntent( event );
+			handleDataViewClick( event );
+		},
+		[ captureSelectionIntent, handleDataViewClick ]
 	);
 
 	const [ rowActionError, setRowActionError ] = useState( null );
@@ -1368,12 +1011,10 @@ export default function CollectionDataViews( {
 	// they sit outside `normalizeView`'s scope. Other view settings
 	// (perPage, search, layout.density) are left alone.
 	useEffect( () => {
-		// Don't run while we have no data at all *or* while the field
-		// records are mid-refetch — during a refetch `fieldRecords` is
-		// briefly empty for a new include query, and stripping orphan
-		// IDs against that transient state would wipe the user's
-		// `view.fields` (and their persisted view) until the refetch
-		// completes.
+		// Skip while we have no data, or while field records are refetching.
+		// `fieldRecords` can briefly be empty for a new include query; pruning
+		// against that temporary state would wipe the saved `view.fields`
+		// until the refetch completes.
 		if ( isResolving || ! fieldsResolved ) {
 			return;
 		}
@@ -1630,24 +1271,31 @@ export default function CollectionDataViews( {
 
 	if ( ! isResolving && collectionId && ! collection ) {
 		return (
-			invalid ?? (
-				<p>
-					{ __(
-						'This collection is no longer available.',
-						'cortext'
-					) }
-				</p>
-			)
+			<DataViewStateShell status="invalid">
+				{ invalid ?? (
+					<p>
+						{ __(
+							'This collection is no longer available.',
+							'cortext'
+						) }
+					</p>
+				) }
+			</DataViewStateShell>
 		);
 	}
 
 	if ( ! isResolving && rowError ) {
 		return (
-			error ?? (
-				<p>
-					{ __( 'Collection rows could not be loaded.', 'cortext' ) }
-				</p>
-			)
+			<DataViewStateShell status="error">
+				{ error ?? (
+					<p>
+						{ __(
+							'Collection rows could not be loaded.',
+							'cortext'
+						) }
+					</p>
+				) }
+			</DataViewStateShell>
 		);
 	}
 
@@ -1678,7 +1326,6 @@ export default function CollectionDataViews( {
 			onToggleVisibleSelection={ toggleVisibleRows }
 		/>
 	);
-
 	return (
 		<CurrentViewModeProvider value={ savedRowDetailMode }>
 			<RowMutationContext.Provider value={ mutationContext }>
@@ -1691,7 +1338,10 @@ export default function CollectionDataViews( {
 						<div
 							className="cortext-data-view"
 							ref={ tableWrapperRef }
-							onClickCapture={ captureSelectionIntent }
+							onClickCapture={ handleDataViewClickCapture }
+							data-grid-card-clickable={
+								isGridLayout ? 'true' : undefined
+							}
 							data-loading-shell={
 								showLoadingShell ? 'true' : undefined
 							}
@@ -1741,6 +1391,7 @@ export default function CollectionDataViews( {
 										density={
 											view?.layout?.density ?? 'compact'
 										}
+										layout={ skeletonLayout }
 									/>
 								</div>
 							) }
@@ -1749,8 +1400,8 @@ export default function CollectionDataViews( {
 									<DataViews
 										data={ dataFiltered }
 										fields={ dataViewFields }
-										view={ view }
-										onChangeView={ onChangeView }
+										view={ dataViewsView }
+										onChangeView={ onDataViewsChange }
 										paginationInfo={ activePaginationInfo }
 										defaultLayouts={ DEFAULT_LAYOUTS }
 										getItemId={ ( item ) =>
@@ -1770,6 +1421,16 @@ export default function CollectionDataViews( {
 											footer={ dataViewsFooter }
 										/>
 									</DataViews>
+									{ isGridLayout && (
+										<GridNewRowPortal
+											wrapperRef={ tableWrapperRef }
+											slug={ slug }
+											view={ dataViewsView }
+											fields={ fields }
+											onCreated={ onCreated }
+											hasRows={ dataFiltered.length > 0 }
+										/>
+									) }
 									<DataViewRowReorder
 										wrapperRef={ tableWrapperRef }
 										view={ view }
@@ -1818,17 +1479,19 @@ export default function CollectionDataViews( {
 											onRowsChanged={ refresh }
 										/>
 									) }
-									{ /* tech-debt.md#7: DataViews has no footer slot, so the
-									   New-row affordance and its CSS layout sit outside the
-									   component instead of inside its layout chrome. */ }
-									<div className="cortext-data-view__footer">
-										<NewRowButton
-											slug={ slug }
-											view={ view }
-											fields={ fields }
-											onCreated={ onCreated }
-										/>
-									</div>
+									{ /* tech-debt.md#7: table/list render New just
+									   outside DataViews because there is no append
+									   slot in the layout chrome. */ }
+									{ ! isGridLayout && (
+										<div className="cortext-data-view__footer">
+											<DataViewNewRowButton
+												slug={ slug }
+												view={ view }
+												fields={ fields }
+												onCreated={ onCreated }
+											/>
+										</div>
+									) }
 								</>
 							) }
 						</div>

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -1,0 +1,74 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.cortext-data-view {
+
+	.dataviews-view-list {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-05;
+		padding: $grid-unit-10 $grid-unit-20 $grid-unit-20;
+	}
+
+	.dataviews-view-list [role="row"] {
+		border: $border-width solid transparent;
+		border-radius: 6px;
+		border-bottom-color: $gray-200;
+
+		&:hover,
+		&:focus-within,
+		&.is-selected {
+			border-color: $gray-300;
+			background: $gray-100;
+		}
+	}
+
+	.dataviews-view-list__item-wrapper {
+		padding: $grid-unit-15;
+	}
+
+	.dataviews-view-list__field-wrapper {
+		min-width: 0;
+		width: 100%;
+	}
+
+	.dataviews-view-list__item-actions {
+		margin-left: auto;
+		flex: 0 0 auto;
+	}
+
+	.dataviews-view-list__fields {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		gap: $grid-unit-10 $grid-unit-30;
+		width: 100%;
+	}
+
+	.dataviews-view-list__field {
+		display: grid;
+		grid-template-columns: minmax(72px, max-content) minmax(0, 1fr);
+		gap: $grid-unit-10;
+		align-items: baseline;
+		min-width: 0;
+	}
+
+	.dataviews-view-list__field-label.components-visually-hidden {
+		position: static !important;
+		width: auto !important;
+		height: auto !important;
+		margin: 0 !important;
+		overflow: visible !important;
+		clip: auto !important;
+		clip-path: none !important;
+		white-space: normal !important;
+		color: $gray-700;
+		font-size: 12px;
+		line-height: 1.4;
+	}
+
+	.dataviews-view-list__field-value {
+		min-width: 0;
+		color: $gray-900;
+		overflow-wrap: anywhere;
+	}
+}

--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -260,6 +260,16 @@ tbody > tr > td:not(:first-child) {
 		}
 	}
 
+	&__content {
+		display: block;
+		min-width: 0;
+		max-width: 100%;
+	}
+
+	&__edit-indicator {
+		display: none;
+	}
+
 	// Wrap text content with an ellipsis when the column is narrower than
 	// the cell value. Chip/link displays carry their own truncation
 	// (`.cortext-chip` already sets text-overflow), so this rule only ever
@@ -460,6 +470,15 @@ tr:has(.cortext-title-cell--is-opening)
 
 .cortext-cell-readonly {
 	color: $gray-700;
+}
+
+.cortext-title-cell .cortext-cell-readonly {
+	display: block;
+	min-width: 0;
+	overflow: hidden;
+	color: inherit;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .cortext-cell-link {
@@ -850,8 +869,8 @@ tr:has(.cortext-title-cell--is-opening)
 	width: 100%;
 	min-width: 0;
 
-	// tech-debt.md#55: cover the table area while the shell loads, so search,
-	// filters, header, and rows appear together instead of in two beats.
+	// tech-debt.md#55: hold the layout area while rows load, so search,
+	// filters, header, and rows/cards appear together.
 	&__rows-skeleton {
 		position: absolute;
 		inset: 0;
@@ -999,6 +1018,29 @@ tr:has(.cortext-title-cell--is-opening)
 		&:hover:not(:disabled) {
 			background: $gray-100;
 			color: $gray-900;
+		}
+	}
+
+	&__state {
+		display: grid;
+		align-content: center;
+		min-height: 180px;
+		padding: $grid-unit-30;
+		color: $gray-700;
+		text-align: center;
+	}
+
+	.dataviews-no-results,
+	.dataviews-loading {
+		display: grid;
+		align-content: center;
+		min-height: 160px;
+		padding: $grid-unit-30;
+		color: $gray-700;
+		text-align: center;
+
+		p {
+			margin: 0;
 		}
 	}
 

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -1,0 +1,130 @@
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Notice } from '@wordpress/components';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+
+// Pull a simple `is` prefill from the active filters. Multi-value operators
+// are ignored for now; this path only handles one scalar value per field.
+// Filters already run on GET /cortext/v1/rows, so prefill is only a convenience
+// for new rows, not the reason filtering works.
+function prefillFromFilters( filters, fieldIds ) {
+	const prefill = {};
+	if ( ! Array.isArray( filters ) ) {
+		return prefill;
+	}
+	for ( const filter of filters ) {
+		if ( ! filter || typeof filter !== 'object' ) {
+			continue;
+		}
+		const op = filter.operator;
+		if ( op !== 'is' ) {
+			continue;
+		}
+		const { field, value } = filter;
+		if ( ! field || field === 'title' ) {
+			continue;
+		}
+		if ( Array.isArray( value ) || value === null || value === undefined ) {
+			continue;
+		}
+		if ( ! fieldIds.has( field ) ) {
+			continue;
+		}
+		prefill[ field ] = value;
+	}
+	return prefill;
+}
+
+export default function DataViewNewRowButton( {
+	slug,
+	view,
+	fields,
+	onCreated,
+	disabled,
+	presentation = 'footer',
+} ) {
+	const [ isCreating, setIsCreating ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const prefillableFieldIds = useMemo(
+		() =>
+			new Set(
+				fields
+					.filter(
+						( f ) =>
+							f.editable !== false && f.cortextType !== 'rollup'
+					)
+					.map( ( f ) => f.id )
+			),
+		[ fields ]
+	);
+
+	const onClick = useCallback( async () => {
+		setIsCreating( true );
+		setError( null );
+		const meta = prefillFromFilters( view?.filters, prefillableFieldIds );
+		try {
+			// FIXME: Consider supporting row creation via /cortext/v1/rows.
+			const created = await apiFetch( {
+				path: `/wp/v2/crtxt_${ slug }`,
+				method: 'POST',
+				data: {
+					status: 'private',
+					title: '',
+					...( Object.keys( meta ).length ? { meta } : {} ),
+				},
+			} );
+			onCreated( created );
+		} catch ( err ) {
+			setError(
+				err?.message ?? __( 'Could not create row.', 'cortext' )
+			);
+		} finally {
+			setIsCreating( false );
+		}
+	}, [ slug, view, prefillableFieldIds, onCreated ] );
+
+	const button = (
+		<Button
+			className={
+				'cortext-data-view__new-row' +
+				( presentation === 'grid-card'
+					? ' cortext-data-view__new-row-card'
+					: '' )
+			}
+			variant="tertiary"
+			icon={ plus }
+			onClick={ onClick }
+			isBusy={ isCreating }
+			disabled={ disabled || isCreating || ! slug }
+		>
+			{ __( 'New', 'cortext' ) }
+		</Button>
+	);
+	const notice = error ? (
+		<Notice
+			status="error"
+			isDismissible
+			onRemove={ () => setError( null ) }
+		>
+			{ error }
+		</Notice>
+	) : null;
+
+	if ( presentation === 'grid-card' ) {
+		return (
+			<div className="cortext-data-view__new-row-card-wrapper">
+				{ button }
+				{ notice }
+			</div>
+		);
+	}
+
+	return (
+		<>
+			{ button }
+			{ notice }
+		</>
+	);
+}

--- a/src/components/DataViewRowReorder.js
+++ b/src/components/DataViewRowReorder.js
@@ -993,8 +993,12 @@ function linearRowGaps( renderedRows, activeRow ) {
 		const lineTop = before
 			? before.rect.top
 			: after.rect.top + after.rect.height;
-		const top = Math.max( rawTop, lineTop - ROW_DROP_ZONE_MAX_SIDE );
-		const bottom = Math.min( rawBottom, lineTop + ROW_DROP_ZONE_MAX_SIDE );
+		const top = after
+			? Math.max( rawTop, lineTop - ROW_DROP_ZONE_MAX_SIDE )
+			: lineTop - ROW_DROP_ZONE_MAX_SIDE;
+		const bottom = before
+			? Math.min( rawBottom, lineTop + ROW_DROP_ZONE_MAX_SIDE )
+			: lineTop + ROW_DROP_ZONE_MAX_SIDE;
 		const tableContainerRect = anchor.el?.closest( '.dataviews-view-table' )
 			? rowViewportContainer( anchor.el )?.getBoundingClientRect?.()
 			: null;

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -19,7 +19,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { Icon, check } from '@wordpress/icons';
+import { Icon, check, pencil } from '@wordpress/icons';
 
 import MultiselectEdit from './MultiselectEdit';
 import Chip from './fields/Chip';
@@ -50,6 +50,7 @@ function siteLocale() {
 // the cell could call `saveEntityRecord` directly.
 export const RowMutationContext = createContext( {
 	saveRowField: null,
+	canEditCells: true,
 	// `{ rowId, fieldId }` of the cell that should pop into edit mode.
 	// Set by the parent when a new row is created (open the title) or
 	// when Tab navigation hops between cells.
@@ -496,12 +497,22 @@ function CellShell( { children, onActivate, ariaLabel, className, disabled } ) {
 			aria-label={ ariaLabel }
 			aria-hidden={ disabled }
 		>
-			{ isText ? (
-				<span className="cortext-editable-cell__display">
-					{ children }
-				</span>
-			) : (
-				children
+			<span className="cortext-editable-cell__content">
+				{ isText ? (
+					<span className="cortext-editable-cell__display">
+						{ children }
+					</span>
+				) : (
+					children
+				) }
+			</span>
+			{ ! disabled && (
+				<Icon
+					className="cortext-editable-cell__edit-indicator"
+					icon={ pencil }
+					size={ 14 }
+					aria-hidden="true"
+				/>
 			) }
 		</div>
 	);
@@ -743,6 +754,7 @@ export default function EditableCell( {
 } ) {
 	const {
 		saveRowField,
+		canEditCells,
 		editRequest,
 		clearEditRequest,
 		requestNext,
@@ -781,6 +793,7 @@ export default function EditableCell( {
 			editRequest?.rowId === rowId &&
 			editRequest?.fieldId === fieldId &&
 			! readOnly &&
+			canEditCells &&
 			saveRowField;
 		if ( ! targeted ) {
 			return;
@@ -801,12 +814,13 @@ export default function EditableCell( {
 		editRequest,
 		isEditing,
 		readOnly,
+		canEditCells,
 		saveRowField,
 		fieldType,
 		clearEditRequest,
 	] );
 
-	if ( readOnly || ! saveRowField ) {
+	if ( readOnly || ! canEditCells || ! saveRowField ) {
 		return <span className="cortext-cell-readonly">{ display }</span>;
 	}
 

--- a/src/components/GridNewRowPortal.js
+++ b/src/components/GridNewRowPortal.js
@@ -1,0 +1,62 @@
+import { createPortal, useLayoutEffect, useState } from '@wordpress/element';
+
+import DataViewNewRowButton from './DataViewNewRowButton';
+
+const GRID_VIEW_SELECTOR = '.dataviews-view-grid';
+
+// tech-debt.md#7: DataViews has no grid append-card slot, so rows with data use
+// a portal into the rendered grid.
+export default function GridNewRowPortal( {
+	wrapperRef,
+	slug,
+	view,
+	fields,
+	onCreated,
+	disabled,
+	hasRows,
+} ) {
+	const [ gridElement, setGridElement ] = useState( null );
+
+	useLayoutEffect( () => {
+		const grids = Array.from(
+			wrapperRef.current?.querySelectorAll( GRID_VIEW_SELECTOR ) ?? []
+		);
+		const nextGrid = grids.length ? grids[ grids.length - 1 ] : null;
+		setGridElement( ( currentGrid ) =>
+			currentGrid === nextGrid ? currentGrid : nextGrid
+		);
+	}, [ hasRows, wrapperRef ] );
+
+	const newRowCard = (
+		<DataViewNewRowButton
+			slug={ slug }
+			view={ view }
+			fields={ fields }
+			onCreated={ onCreated }
+			disabled={ disabled }
+			presentation="grid-card"
+		/>
+	);
+
+	if ( gridElement ) {
+		return createPortal( newRowCard, gridElement );
+	}
+
+	if ( ! hasRows ) {
+		const previewSize = view?.layout?.previewSize;
+		return (
+			<div
+				className="cortext-data-view__grid-new-row"
+				style={
+					previewSize
+						? { '--cortext-grid-card-min': `${ previewSize }px` }
+						: undefined
+				}
+			>
+				{ newRowCard }
+			</div>
+		);
+	}
+
+	return null;
+}

--- a/src/components/PublicDataView.js
+++ b/src/components/PublicDataView.js
@@ -4,8 +4,11 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import usePublicRows from '../hooks/usePublicRows';
 import { buildPublicFields } from '../hooks/publicFieldMapping';
 import { normalizeView } from './dataViewColumns';
-
-const DEFAULT_LAYOUTS = { table: { density: 'compact' }, grid: {}, list: {} };
+import {
+	DEFAULT_LAYOUTS,
+	adaptViewForDataViews,
+	mergeDataViewsChange,
+} from './dataViewAdapter';
 
 export default function PublicDataView( { collectionId, view: initialView } ) {
 	const [ view, setView ] = useState( () => ( {
@@ -17,6 +20,15 @@ export default function PublicDataView( { collectionId, view: initialView } ) {
 		sort: {},
 		filters: [],
 		layout: {},
+		layoutByType: {
+			table: { density: 'compact' },
+			grid: {},
+			list: {},
+		},
+		fieldsByType: {
+			grid: [],
+			list: [],
+		},
 		...initialView,
 	} ) );
 
@@ -55,19 +67,23 @@ export default function PublicDataView( { collectionId, view: initialView } ) {
 		// reorder updates land in state exactly as DataViews
 		// produced them. The reconciledView memo above handles
 		// cleanup on the next render.
-		setView( next );
+		setView( ( current ) => mergeDataViewsChange( current, next ) );
 	}, [] );
 
 	const { data: dataFiltered, paginationInfo } = useMemo(
 		() => filterSortAndPaginate( data, reconciledView, fields ),
 		[ data, reconciledView, fields ]
 	);
+	const dataViewsView = useMemo(
+		() => adaptViewForDataViews( reconciledView ),
+		[ reconciledView ]
+	);
 
 	return (
 		<DataViews
 			data={ dataFiltered }
 			fields={ fields }
-			view={ reconciledView }
+			view={ dataViewsView }
 			onChangeView={ onChangeView }
 			paginationInfo={ paginationInfo }
 			defaultLayouts={ DEFAULT_LAYOUTS }

--- a/src/components/RowDragHandle.js
+++ b/src/components/RowDragHandle.js
@@ -100,8 +100,7 @@ export default function RowDragHandle( { row } ) {
 	}
 
 	return createPortal(
-		<button
-			type="button"
+		<span
 			ref={ setHandleRef }
 			className="cortext-row-drag-handle"
 			aria-label={ sprintf(
@@ -112,9 +111,12 @@ export default function RowDragHandle( { row } ) {
 			data-dragging={ isDragging ? 'true' : 'false' }
 			onClick={ stopClick }
 			onFocus={ stopPropagation }
+			onKeyDown={ stopPropagation }
 			onMouseDown={ stopInteractionStart }
 			onTouchStart={ stopInteractionStart }
 			{ ...attributes }
+			role="button"
+			tabIndex={ 0 }
 			{ ...guardedListeners }
 		/>,
 		row.handleEl

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -96,24 +96,56 @@ export function SidebarListSkeleton( { itemCount = 5 } ) {
 	);
 }
 
-// tech-debt.md#55: match DataViews row heights so the loading table holds the
-// same space as real rows. Cap the row count so perPage=25 stays reasonable.
+// tech-debt.md#55: keep loading placeholders close to the real row/card shapes.
+// Cap the count so perPage=25 does not paint an oversized skeleton.
 const COLLECTION_SKELETON_ROW_CAP = 15;
 
 export function CollectionRowsSkeleton( {
 	rowCount = 8,
 	columnCount = 4,
 	density = 'compact',
+	layout = 'table',
 } ) {
 	const safeColumns = Math.max( 1, columnCount );
 	const safeRows = Math.max(
 		1,
 		Math.min( rowCount, COLLECTION_SKELETON_ROW_CAP )
 	);
+	if ( layout === 'grid' ) {
+		return (
+			<div
+				className="cortext-collection-skeleton cortext-collection-skeleton--grid"
+				aria-hidden="true"
+			>
+				{ Array.from( { length: Math.min( safeRows, 9 ) } ).map(
+					( _, cardIndex ) => (
+						<div
+							key={ cardIndex }
+							className="cortext-collection-skeleton__card"
+						>
+							<SkeletonLine className="cortext-collection-skeleton__card-title" />
+							{ Array.from( {
+								length: Math.min( safeColumns, 4 ),
+							} ).map( ( __, fieldIndex ) => (
+								<div
+									key={ fieldIndex }
+									className="cortext-collection-skeleton__card-field"
+								>
+									<SkeletonLine className="cortext-collection-skeleton__card-label" />
+									<SkeletonLine className="cortext-collection-skeleton__card-value" />
+								</div>
+							) ) }
+						</div>
+					)
+				) }
+			</div>
+		);
+	}
 	return (
 		<div
 			className={ joinClassName(
 				'cortext-collection-skeleton',
+				layout === 'list' ? 'cortext-collection-skeleton--list' : null,
 				`cortext-collection-skeleton--${ density }`
 			) }
 			aria-hidden="true"

--- a/src/components/Skeleton.scss
+++ b/src/components/Skeleton.scss
@@ -53,9 +53,9 @@
 	}
 }
 
-// tech-debt.md#55: table-shaped placeholder while useCollectionRows fetches.
-// It sits beside <DataViews>; the wrapper handles placement. Heights follow
-// the DataViews v6 density rules closely enough to keep the page steady.
+// tech-debt.md#55: placeholder shaped like the active layout while
+// useCollectionRows fetches. It sits beside <DataViews>; the wrapper handles
+// placement. Heights track DataViews v6 closely enough to keep the page steady.
 .cortext-collection-skeleton {
 	display: flex;
 	flex-direction: column;
@@ -90,6 +90,50 @@
 
 	&__cell--first {
 		flex: 0 0 28%;
+	}
+
+	&--list &__row {
+		height: auto;
+		min-height: var(--cortext-data-view-row-height-balanced, #{$grid-unit-50 + 2 * $grid-unit-15});
+		align-items: flex-start;
+		padding-block: $grid-unit-15;
+	}
+
+	&--grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+		gap: $grid-unit-20;
+		padding: $grid-unit-20;
+	}
+
+	&__card {
+		display: grid;
+		gap: $grid-unit-15;
+		min-height: 168px;
+		padding: $grid-unit-20;
+		border: $border-width solid var(--cortext-canvas-border, #e0e0e0);
+		border-radius: 6px;
+		background: var(--cortext-canvas-surface, #fff);
+	}
+
+	&__card-title {
+		width: 72%;
+		height: 16px;
+	}
+
+	&__card-field {
+		display: grid;
+		grid-template-columns: 72px minmax(0, 1fr);
+		gap: $grid-unit-15;
+		align-items: center;
+	}
+
+	&__card-label {
+		opacity: 0.65;
+	}
+
+	&__card-value {
+		width: 82%;
 	}
 }
 

--- a/src/components/dataViewAdapter.js
+++ b/src/components/dataViewAdapter.js
@@ -1,0 +1,183 @@
+import { COVER_FIELD_ID, TITLE_FIELD_ID } from './dataViewColumns';
+
+// tech-debt.md#60: DataViews only carries the active layout shape. Cortext keeps
+// per-layout buckets and hydrates the active shape before rendering.
+export const DATA_VIEW_LAYOUT_TYPES = [ 'table', 'grid', 'list' ];
+export const DATA_VIEW_FIELD_LAYOUT_TYPES = [ 'grid', 'list' ];
+
+export const DEFAULT_LAYOUTS = {
+	table: { layout: { density: 'compact' } },
+	grid: { layout: {} },
+	list: {},
+};
+
+function isObject( value ) {
+	return Boolean(
+		value && typeof value === 'object' && ! Array.isArray( value )
+	);
+}
+
+function normalizeType( type ) {
+	return DATA_VIEW_LAYOUT_TYPES.includes( type ) ? type : 'table';
+}
+
+function cloneLayout( layout ) {
+	return isObject( layout ) ? { ...layout } : {};
+}
+
+function defaultLayoutForType( type ) {
+	return cloneLayout( DEFAULT_LAYOUTS[ type ]?.layout );
+}
+
+function uniqueFields( fields = [] ) {
+	const seen = new Set();
+	return fields.filter( ( fieldId ) => {
+		if ( ! fieldId || seen.has( fieldId ) ) {
+			return false;
+		}
+		seen.add( fieldId );
+		return true;
+	} );
+}
+
+function tableFields( fields = [] ) {
+	const withoutTitle = uniqueFields( fields ).filter(
+		( fieldId ) => fieldId !== TITLE_FIELD_ID
+	);
+	return [ TITLE_FIELD_ID, ...withoutTitle ];
+}
+
+function displayFields( fields = [] ) {
+	return uniqueFields( fields ).filter(
+		( fieldId ) => fieldId !== TITLE_FIELD_ID
+	);
+}
+
+function layoutByTypeFromView( view = {} ) {
+	const currentType = normalizeType( view?.type );
+	const buckets = {};
+	const stored = isObject( view?.layoutByType ) ? view.layoutByType : {};
+
+	DATA_VIEW_LAYOUT_TYPES.forEach( ( type ) => {
+		buckets[ type ] = {
+			...defaultLayoutForType( type ),
+			...cloneLayout( stored[ type ] ),
+		};
+	} );
+
+	if ( isObject( view?.layout ) ) {
+		buckets[ currentType ] = {
+			...buckets[ currentType ],
+			...view.layout,
+		};
+	}
+
+	return buckets;
+}
+
+function fieldsByTypeFromView( view = {} ) {
+	const buckets = {};
+	const stored = isObject( view?.fieldsByType ) ? view.fieldsByType : {};
+
+	DATA_VIEW_FIELD_LAYOUT_TYPES.forEach( ( type ) => {
+		buckets[ type ] = Array.isArray( stored[ type ] )
+			? displayFields( stored[ type ] )
+			: [];
+	} );
+
+	return buckets;
+}
+
+function withActiveLayout( view, type, layoutByType, fieldsByType ) {
+	const layout = cloneLayout( layoutByType[ type ] );
+	const next = {
+		...view,
+		type,
+		layout,
+		layoutByType,
+		fieldsByType,
+	};
+
+	if ( type === 'table' ) {
+		delete next.titleField;
+		delete next.mediaField;
+		delete next.descriptionField;
+		return next;
+	}
+
+	next.titleField = TITLE_FIELD_ID;
+	if ( type === 'grid' && ! next.mediaField ) {
+		next.mediaField = COVER_FIELD_ID;
+	}
+	next.fields = fieldsByType[ type ] ?? [];
+	return next;
+}
+
+export function adaptViewForDataViews( view = {} ) {
+	const type = normalizeType( view?.type );
+	return withActiveLayout(
+		view,
+		type,
+		layoutByTypeFromView( view ),
+		fieldsByTypeFromView( view )
+	);
+}
+
+export function mergeDataViewsChange( previousView = {}, nextView = {} ) {
+	const previousType = normalizeType( previousView?.type );
+	const nextType = normalizeType( nextView?.type );
+	const layoutByType = layoutByTypeFromView( previousView );
+	const fieldsByType = fieldsByTypeFromView( previousView );
+
+	if ( isObject( nextView?.fieldsByType ) ) {
+		DATA_VIEW_FIELD_LAYOUT_TYPES.forEach( ( type ) => {
+			if ( Array.isArray( nextView.fieldsByType[ type ] ) ) {
+				fieldsByType[ type ] = displayFields(
+					nextView.fieldsByType[ type ]
+				);
+			}
+		} );
+	}
+
+	if ( isObject( previousView?.layout ) ) {
+		layoutByType[ previousType ] = cloneLayout( previousView.layout );
+	}
+	if ( previousType === nextType && isObject( nextView?.layout ) ) {
+		layoutByType[ nextType ] = cloneLayout( nextView.layout );
+	}
+
+	const canonicalFields = tableFields(
+		Array.isArray( previousView?.fields ) ? previousView.fields : []
+	);
+	let fields = canonicalFields;
+	if (
+		nextType === 'table' &&
+		previousType === nextType &&
+		Array.isArray( nextView?.fields )
+	) {
+		fields = tableFields( nextView.fields );
+	}
+	if (
+		nextType !== 'table' &&
+		previousType === nextType &&
+		Array.isArray( nextView?.fields )
+	) {
+		fieldsByType[ nextType ] = displayFields( nextView.fields );
+	}
+
+	const next = {
+		...previousView,
+		...nextView,
+		type: nextType,
+		fields,
+		fieldsByType,
+		layout: cloneLayout( layoutByType[ nextType ] ),
+		layoutByType,
+	};
+
+	if ( next.titleField === TITLE_FIELD_ID ) {
+		delete next.titleField;
+	}
+
+	return next;
+}

--- a/src/components/dataViewColumns.js
+++ b/src/components/dataViewColumns.js
@@ -8,8 +8,16 @@
 
 import { sanitizeCalculations } from './tableCalculations';
 import { hasSystemFieldIcon } from './fields/systemFieldIconIds';
+import {
+	DISPLAY_FIELD_KEYS,
+	sanitizeDisplayFieldKeys,
+	sanitizeFieldsByType,
+	sanitizeLayoutByType,
+	sanitizeLayoutForFields,
+} from './dataViewViewState';
 
 export const TITLE_FIELD_ID = 'title';
+export const COVER_FIELD_ID = 'cover';
 export const GHOST_FIELD_ID = '__add_field';
 export const MANUAL_SORT_ID = 'manual';
 export const MAX_COLUMN_WIDTH = 640;
@@ -59,23 +67,6 @@ export function clampWidth( width, fieldType, fieldId ) {
 		return min;
 	}
 	return Math.max( min, Math.min( MAX_COLUMN_WIDTH, Math.round( value ) ) );
-}
-
-// Sanitize-only clamp used by normalizeView when reading persisted widths.
-// Guards numeric widths against negatives or absurd values from a hand-edited
-// block attribute, but preserves CSS string widths supported by DataViews
-// (for example `240px` or `20ch`). It also doesn't enforce per-type minimums
-// — those evolve over time and shouldn't quietly rewrite saves on render.
-function sanitizeWidth( width ) {
-	if ( typeof width === 'string' ) {
-		return width;
-	}
-
-	const value = Number( width );
-	if ( ! Number.isFinite( value ) ) {
-		return 0;
-	}
-	return Math.max( 0, Math.min( MAX_COLUMN_WIDTH, Math.round( value ) ) );
 }
 
 function sameShallowObject( a, b ) {
@@ -149,29 +140,20 @@ export function normalizeView( view, validIds, options = {} ) {
 	}
 
 	const layout = view?.layout ?? {};
-	const styles = layout.styles ?? {};
-	const nextStyles = {};
-	let stylesChanged = false;
-	for ( const id of Object.keys( styles ) ) {
-		if ( ! validSet.has( id ) ) {
-			stylesChanged = true;
-			continue;
-		}
-		const entry = styles[ id ];
-		if ( ! entry || typeof entry !== 'object' ) {
-			stylesChanged = true;
-			continue;
-		}
-		const next = { ...entry };
-		if ( entry.width !== undefined ) {
-			const clamped = sanitizeWidth( entry.width );
-			if ( clamped !== entry.width ) {
-				stylesChanged = true;
-			}
-			next.width = clamped;
-		}
-		nextStyles[ id ] = next;
-	}
+	const layoutResult = sanitizeLayoutForFields( layout, validSet, {
+		maxColumnWidth: MAX_COLUMN_WIDTH,
+	} );
+	const layoutByTypeResult = sanitizeLayoutByType(
+		view?.layoutByType,
+		validSet,
+		{ maxColumnWidth: MAX_COLUMN_WIDTH }
+	);
+	const fieldsByTypeResult = sanitizeFieldsByType(
+		view?.fieldsByType,
+		validSet,
+		{ titleId: TITLE_FIELD_ID }
+	);
+	const displayFieldResult = sanitizeDisplayFieldKeys( view, validSet );
 
 	const fieldsChanged =
 		currentFields.length !== nextFields.length ||
@@ -195,23 +177,43 @@ export function normalizeView( view, validIds, options = {} ) {
 	const calculationsChanged =
 		( rawCalculations !== undefined && ! hasCalculationObject ) ||
 		! sameShallowObject( currentCalculations, nextCalculations );
+	const layoutChanged =
+		layoutResult.changed ||
+		layoutByTypeResult.changed ||
+		fieldsByTypeResult.changed ||
+		displayFieldResult.changed;
 
-	if ( ! fieldsChanged && ! stylesChanged && ! calculationsChanged ) {
+	if ( ! fieldsChanged && ! layoutChanged && ! calculationsChanged ) {
 		return view;
-	}
-
-	const nextLayout = { ...layout };
-	if ( Object.keys( nextStyles ).length > 0 ) {
-		nextLayout.styles = nextStyles;
-	} else {
-		delete nextLayout.styles;
 	}
 
 	const nextView = {
 		...view,
 		fields: nextFields,
-		layout: nextLayout,
+		layout: layoutResult.layout,
 	};
+	for ( const key of DISPLAY_FIELD_KEYS ) {
+		if (
+			Object.prototype.hasOwnProperty.call(
+				displayFieldResult.values,
+				key
+			)
+		) {
+			nextView[ key ] = displayFieldResult.values[ key ];
+		} else {
+			delete nextView[ key ];
+		}
+	}
+	if ( layoutByTypeResult.layoutByType !== undefined ) {
+		nextView.layoutByType = layoutByTypeResult.layoutByType;
+	} else {
+		delete nextView.layoutByType;
+	}
+	if ( fieldsByTypeResult.fieldsByType !== undefined ) {
+		nextView.fieldsByType = fieldsByTypeResult.fieldsByType;
+	} else {
+		delete nextView.fieldsByType;
+	}
 	if ( Object.keys( nextCalculations ).length > 0 ) {
 		nextView.calculations = nextCalculations;
 	} else {

--- a/src/components/dataViewCreation.js
+++ b/src/components/dataViewCreation.js
@@ -1,0 +1,38 @@
+function positiveInteger( value, fallback ) {
+	const number = Number( value );
+	return Number.isFinite( number ) && number >= 1
+		? Math.floor( number )
+		: fallback;
+}
+
+function hasQueryConstraints( view = {} ) {
+	const search =
+		typeof view.search === 'string' ? view.search.trim() : view.search;
+	return (
+		Boolean( search ) ||
+		( Array.isArray( view.filters ) && view.filters.length > 0 )
+	);
+}
+
+export function nextViewAfterRowCreated( view = {}, paginationInfo = {} ) {
+	if ( view?.sort?.field || hasQueryConstraints( view ) ) {
+		return view;
+	}
+
+	const page = positiveInteger( view?.page, 1 );
+	const perPage = positiveInteger( view?.perPage, 25 );
+	const totalItems = Math.max(
+		0,
+		positiveInteger( paginationInfo?.totalItems, 0 )
+	);
+	const lastPage = Math.max( 1, Math.ceil( ( totalItems + 1 ) / perPage ) );
+
+	if ( page === lastPage ) {
+		return view;
+	}
+
+	return {
+		...view,
+		page: lastPage,
+	};
+}

--- a/src/components/dataViewItemLookup.js
+++ b/src/components/dataViewItemLookup.js
@@ -1,0 +1,33 @@
+import { normalizeRowId } from './dataViewSelection';
+
+const TABLE_ROW_SELECTOR =
+	'.dataviews-view-table tbody > tr:not(.dataviews-view-table__group-header-row)';
+const GRID_CARD_SELECTOR = '.dataviews-view-grid__card';
+
+export const INTERACTIVE_DATA_VIEW_ITEM_IGNORE_SELECTOR =
+	'button, a, input, textarea, select, [contenteditable="true"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], .components-button, .cortext-editable-cell';
+
+export function findDataViewItemFromEvent( event, wrapper, layout, rows ) {
+	const target = event.target;
+	if ( ! target || ! wrapper ) {
+		return null;
+	}
+
+	const selector =
+		layout === 'grid' ? GRID_CARD_SELECTOR : TABLE_ROW_SELECTOR;
+	const itemElement = target.closest?.( selector );
+	if ( ! itemElement || ! wrapper.contains( itemElement ) ) {
+		return null;
+	}
+
+	const renderedItems = Array.from( wrapper.querySelectorAll( selector ) );
+	const index = renderedItems.indexOf( itemElement );
+	if ( index < 0 || ! rows[ index ]?.id ) {
+		return null;
+	}
+
+	return {
+		id: normalizeRowId( rows[ index ].id ),
+		row: rows[ index ],
+	};
+}

--- a/src/components/dataViewViewState.js
+++ b/src/components/dataViewViewState.js
@@ -1,0 +1,221 @@
+export const DISPLAY_FIELD_KEYS = [
+	'titleField',
+	'mediaField',
+	'descriptionField',
+];
+
+const LAYOUT_TYPES = [ 'table', 'grid', 'list' ];
+const DISPLAY_FIELD_LAYOUT_TYPES = [ 'grid', 'list' ];
+
+// normalizeView uses this only when reading saved widths. It rejects negative
+// or extreme numbers from hand-edited block attributes, while preserving CSS
+// string widths that DataViews supports (`240px`, `20ch`). It does not enforce
+// per-type minimums because those change over time and should not rewrite saves
+// during render.
+function sanitizeWidth( width, maxColumnWidth ) {
+	if ( typeof width === 'string' ) {
+		return width;
+	}
+
+	const value = Number( width );
+	if ( ! Number.isFinite( value ) ) {
+		return 0;
+	}
+	return Math.max( 0, Math.min( maxColumnWidth, Math.round( value ) ) );
+}
+
+export function sanitizeLayoutForFields(
+	layout = {},
+	validSet,
+	{ maxColumnWidth = 640 } = {}
+) {
+	if ( ! layout || typeof layout !== 'object' || Array.isArray( layout ) ) {
+		return { layout: {}, changed: Boolean( layout ) };
+	}
+
+	const hasStylesObject =
+		layout.styles &&
+		typeof layout.styles === 'object' &&
+		! Array.isArray( layout.styles );
+	const styles = hasStylesObject ? layout.styles : {};
+	const nextStyles = {};
+	let stylesChanged =
+		layout.styles !== undefined &&
+		layout.styles !== null &&
+		! hasStylesObject;
+	for ( const id of Object.keys( styles ) ) {
+		if ( ! validSet.has( id ) ) {
+			stylesChanged = true;
+			continue;
+		}
+		const entry = styles[ id ];
+		if ( ! entry || typeof entry !== 'object' ) {
+			stylesChanged = true;
+			continue;
+		}
+		const next = { ...entry };
+		if ( entry.width !== undefined ) {
+			const clamped = sanitizeWidth( entry.width, maxColumnWidth );
+			if ( clamped !== entry.width ) {
+				stylesChanged = true;
+			}
+			next.width = clamped;
+		}
+		nextStyles[ id ] = next;
+	}
+
+	const nextLayout = { ...layout };
+	if ( Object.keys( nextStyles ).length > 0 ) {
+		nextLayout.styles = nextStyles;
+	} else {
+		delete nextLayout.styles;
+	}
+
+	const hasBadgeFields = Object.prototype.hasOwnProperty.call(
+		layout,
+		'badgeFields'
+	);
+	const currentBadgeFields = Array.isArray( layout.badgeFields )
+		? layout.badgeFields
+		: null;
+	let badgeFieldsChanged = hasBadgeFields && ! currentBadgeFields;
+	if ( currentBadgeFields ) {
+		const nextBadgeFields = currentBadgeFields.filter( ( id ) =>
+			validSet.has( id )
+		);
+		badgeFieldsChanged =
+			nextBadgeFields.length !== currentBadgeFields.length;
+		if ( nextBadgeFields.length > 0 ) {
+			nextLayout.badgeFields = nextBadgeFields;
+		} else {
+			delete nextLayout.badgeFields;
+		}
+	} else if ( hasBadgeFields ) {
+		delete nextLayout.badgeFields;
+	}
+
+	return {
+		layout: nextLayout,
+		changed: stylesChanged || badgeFieldsChanged,
+	};
+}
+
+export function sanitizeLayoutByType( layoutByType, validSet, options = {} ) {
+	if ( layoutByType === undefined ) {
+		return { layoutByType: undefined, changed: false };
+	}
+	if (
+		! layoutByType ||
+		typeof layoutByType !== 'object' ||
+		Array.isArray( layoutByType )
+	) {
+		return { layoutByType: undefined, changed: true };
+	}
+
+	const next = {};
+	let changed = false;
+	for ( const type of LAYOUT_TYPES ) {
+		if ( ! Object.prototype.hasOwnProperty.call( layoutByType, type ) ) {
+			continue;
+		}
+		const result = sanitizeLayoutForFields(
+			layoutByType[ type ],
+			validSet,
+			options
+		);
+		next[ type ] = result.layout;
+		if ( result.changed ) {
+			changed = true;
+		}
+	}
+	if (
+		Object.keys( layoutByType ).some(
+			( type ) => ! LAYOUT_TYPES.includes( type )
+		)
+	) {
+		changed = true;
+	}
+	return { layoutByType: next, changed };
+}
+
+function sanitizeDisplayFields( fields, validSet, titleId ) {
+	if ( ! Array.isArray( fields ) ) {
+		return { fields: [], changed: fields !== undefined };
+	}
+
+	const seen = new Set();
+	const next = [];
+	let changed = false;
+	for ( const id of fields ) {
+		if ( id === titleId || ! validSet.has( id ) || seen.has( id ) ) {
+			changed = true;
+			continue;
+		}
+		seen.add( id );
+		next.push( id );
+	}
+	return { fields: next, changed };
+}
+
+export function sanitizeFieldsByType(
+	fieldsByType,
+	validSet,
+	{ titleId = 'title' } = {}
+) {
+	if ( fieldsByType === undefined ) {
+		return { fieldsByType: undefined, changed: false };
+	}
+	if (
+		! fieldsByType ||
+		typeof fieldsByType !== 'object' ||
+		Array.isArray( fieldsByType )
+	) {
+		return { fieldsByType: undefined, changed: true };
+	}
+
+	const next = {};
+	let changed = false;
+	for ( const type of DISPLAY_FIELD_LAYOUT_TYPES ) {
+		if ( ! Object.prototype.hasOwnProperty.call( fieldsByType, type ) ) {
+			continue;
+		}
+		const result = sanitizeDisplayFields(
+			fieldsByType[ type ],
+			validSet,
+			titleId
+		);
+		next[ type ] = result.fields;
+		if ( result.changed ) {
+			changed = true;
+		}
+	}
+	if (
+		Object.keys( fieldsByType ).some(
+			( type ) => ! DISPLAY_FIELD_LAYOUT_TYPES.includes( type )
+		)
+	) {
+		changed = true;
+	}
+	return { fieldsByType: next, changed };
+}
+
+export function sanitizeDisplayFieldKeys(
+	view,
+	validSet,
+	displayFieldKeys = DISPLAY_FIELD_KEYS
+) {
+	const values = {};
+	let changed = false;
+	for ( const key of displayFieldKeys ) {
+		const value = view?.[ key ];
+		if ( value === undefined ) {
+			continue;
+		}
+		if ( validSet.has( value ) ) {
+			values[ key ] = value;
+			continue;
+		}
+		changed = true;
+	}
+	return { values, changed };
+}

--- a/src/hooks/publicFieldMapping.js
+++ b/src/hooks/publicFieldMapping.js
@@ -21,6 +21,22 @@ const TITLE_FIELD = {
 	render: ( { item } ) => item?.title?.rendered ?? '',
 };
 
+const COVER_FIELD = {
+	id: 'cover',
+	label: __( 'Cover', 'cortext' ),
+	type: 'media',
+	enableGlobalSearch: false,
+	enableSorting: false,
+	getValue: ( { item } ) => item?.cover?.url ?? '',
+	render: ( { item } ) => {
+		const cover = item?.cover;
+		if ( ! cover?.url ) {
+			return null;
+		}
+		return <img src={ cover.url } alt={ cover.alt ?? '' } loading="lazy" />;
+	},
+};
+
 const SYSTEM_FIELDS = [
 	{
 		id: 'created_at',
@@ -117,5 +133,5 @@ function mapPublicField( fieldDef ) {
  */
 export function buildPublicFields( fieldDefs ) {
 	const customFields = fieldDefs.map( mapPublicField );
-	return [ TITLE_FIELD, ...customFields, ...SYSTEM_FIELDS ];
+	return [ TITLE_FIELD, COVER_FIELD, ...customFields, ...SYSTEM_FIELDS ];
 }

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -287,14 +287,18 @@ export function buildQueryArgs( collectionId, view, fields = [] ) {
 
 // Builds the fields[] projection for the server. Return null when sending it
 // would not trim the row payload: before the visibility seeder fills
-// `view.fields`, or after it has selected every custom field. We keep the
-// request key the same for both states so seeding does not cause a second fetch.
+// `view.fields`, or after it has selected every custom field. Grid/list can
+// request layout-specific fields without adding them to the table columns.
 // Sorting also keeps column reorders from changing the key.
 function projectedFields( view, fields ) {
 	if ( ! Array.isArray( view?.fields ) || view.fields.length === 0 ) {
 		return null;
 	}
 	const requested = new Set( view.fields );
+	const activeLayoutFields = view?.fieldsByType?.[ view?.type ];
+	if ( Array.isArray( activeLayoutFields ) ) {
+		activeLayoutFields.forEach( ( id ) => requested.add( id ) );
+	}
 	const customFieldIds = fields
 		.filter( ( f ) => typeof f?.id === 'string' && /^field-/.test( f.id ) )
 		.map( ( f ) => f.id );
@@ -304,7 +308,7 @@ function projectedFields( view, fields ) {
 	if ( ! skipsCustomField ) {
 		return null;
 	}
-	return [ ...view.fields ].sort();
+	return [ ...requested ].sort();
 }
 
 function buildServerQueryArgs( collectionId, view, filters = [], fields = [] ) {

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -71,6 +71,15 @@ const DEFAULT_VIEW = {
 	page: 1,
 	search: '',
 	layout: {},
+	layoutByType: {
+		table: { density: 'compact' },
+		grid: {},
+		list: {},
+	},
+	fieldsByType: {
+		grid: [],
+		list: [],
+	},
 	rowDetailMode: 'side',
 };
 

--- a/tests/js/components/DataViewRowReorder.test.js
+++ b/tests/js/components/DataViewRowReorder.test.js
@@ -680,6 +680,23 @@ describe( 'DataViewRowReorder', () => {
 		).toBe( '20px' );
 	} );
 
+	it( 'extends edge gap hitboxes beyond the first and last rows', async () => {
+		await renderReorder( {}, { rowHeights: [ 40, 40, 40 ] } );
+
+		const gaps = document.querySelectorAll(
+			'.cortext-row-drop-indicator--gap'
+		);
+
+		expect( gaps[ 0 ] ).toHaveStyle( {
+			top: '-40px',
+			height: '60px',
+		} );
+		expect( gaps[ 3 ] ).toHaveStyle( {
+			top: '100px',
+			height: '60px',
+		} );
+	} );
+
 	it( 'covers balanced row gaps without leaving a dead band', async () => {
 		await renderReorder( {}, { rowHeights: [ 64, 64, 64 ] } );
 

--- a/tests/js/components/dataViewAdapter.test.js
+++ b/tests/js/components/dataViewAdapter.test.js
@@ -168,13 +168,10 @@ describe( 'dataViewAdapter', () => {
 			type: 'list',
 			layout: canonicalView.layoutByType.list,
 		};
-		const listCanonical = mergeDataViewsChange(
-			previousListView,
-			{
-				...adaptViewForDataViews( previousListView ),
-				fields: [ 'field-2' ],
-			}
-		);
+		const listCanonical = mergeDataViewsChange( previousListView, {
+			...adaptViewForDataViews( previousListView ),
+			fields: [ 'field-2' ],
+		} );
 
 		expect( listCanonical.fields ).toEqual( [
 			'title',

--- a/tests/js/components/dataViewAdapter.test.js
+++ b/tests/js/components/dataViewAdapter.test.js
@@ -1,0 +1,205 @@
+import {
+	adaptViewForDataViews,
+	mergeDataViewsChange,
+} from '../../../src/components/dataViewAdapter';
+
+describe( 'dataViewAdapter', () => {
+	const canonicalView = {
+		type: 'table',
+		fields: [ 'title', 'field-1', 'field-2' ],
+		sort: { field: 'field-1', direction: 'asc' },
+		filters: [ { field: 'field-2', operator: 'is', value: 'open' } ],
+		search: 'needle',
+		page: 2,
+		perPage: 25,
+		layout: { density: 'compact', styles: { title: { width: 280 } } },
+		layoutByType: {
+			table: { density: 'compact', styles: { title: { width: 280 } } },
+			grid: { previewSize: 290, badgeFields: [ 'field-2' ] },
+			list: {},
+		},
+		fieldsByType: {
+			grid: [],
+			list: [],
+		},
+		rowDetailMode: 'side',
+	};
+
+	it( 'keeps the table view shape canonical for DataViews', () => {
+		const view = adaptViewForDataViews( canonicalView );
+
+		expect( view.type ).toBe( 'table' );
+		expect( view.fields ).toEqual( [ 'title', 'field-1', 'field-2' ] );
+		expect( view.layout ).toEqual( {
+			density: 'compact',
+			styles: { title: { width: 280 } },
+		} );
+		expect( view.titleField ).toBeUndefined();
+		expect( view.mediaField ).toBeUndefined();
+	} );
+
+	it( 'uses titleField for grid without inheriting table fields', () => {
+		const view = adaptViewForDataViews( {
+			...canonicalView,
+			type: 'grid',
+			layout: canonicalView.layoutByType.grid,
+		} );
+
+		expect( view.type ).toBe( 'grid' );
+		expect( view.titleField ).toBe( 'title' );
+		expect( view.mediaField ).toBe( 'cover' );
+		expect( view.fields ).toEqual( [] );
+		expect( view.layout ).toEqual( {
+			previewSize: 290,
+			badgeFields: [ 'field-2' ],
+		} );
+	} );
+
+	it( 'uses titleField for list without inheriting table fields', () => {
+		const view = adaptViewForDataViews( {
+			...canonicalView,
+			type: 'list',
+			layout: canonicalView.layoutByType.list,
+			fieldsByType: { grid: [], list: [ 'field-2' ] },
+		} );
+
+		expect( view.type ).toBe( 'list' );
+		expect( view.titleField ).toBe( 'title' );
+		expect( view.fields ).toEqual( [ 'field-2' ] );
+	} );
+
+	it( 'round-trips table to grid to table without losing layout buckets', () => {
+		const gridRenderView = adaptViewForDataViews( {
+			...canonicalView,
+			type: 'grid',
+			layout: canonicalView.layoutByType.grid,
+		} );
+		const gridCanonical = mergeDataViewsChange(
+			canonicalView,
+			gridRenderView
+		);
+		const tableCanonical = mergeDataViewsChange( gridCanonical, {
+			...gridCanonical,
+			type: 'table',
+			fields: [ 'title', 'field-1', 'field-2' ],
+			layout: { density: 'balanced' },
+		} );
+
+		expect( tableCanonical.type ).toBe( 'table' );
+		expect( tableCanonical.layout ).toEqual( {
+			density: 'compact',
+			styles: { title: { width: 280 } },
+		} );
+		expect( tableCanonical.layoutByType.grid ).toEqual( {
+			previewSize: 290,
+			badgeFields: [ 'field-2' ],
+		} );
+		expect( tableCanonical.layoutByType.table ).toEqual( {
+			density: 'compact',
+			styles: { title: { width: 280 } },
+		} );
+		expect( tableCanonical.fields ).toEqual( [
+			'title',
+			'field-1',
+			'field-2',
+		] );
+		expect( tableCanonical.fieldsByType ).toEqual( {
+			grid: [],
+			list: [],
+		} );
+	} );
+
+	it( 'does not copy table fields into grid when switching layouts', () => {
+		const gridCanonical = mergeDataViewsChange( canonicalView, {
+			type: 'grid',
+			fields: [ 'title', 'field-1', 'field-2' ],
+			layout: {},
+		} );
+
+		expect( gridCanonical.type ).toBe( 'grid' );
+		expect( gridCanonical.fields ).toEqual( [
+			'title',
+			'field-1',
+			'field-2',
+		] );
+		expect( gridCanonical.fieldsByType.grid ).toEqual( [] );
+	} );
+
+	it( 'stores grid field changes in the grid bucket only', () => {
+		const gridCanonical = mergeDataViewsChange(
+			{
+				...canonicalView,
+				type: 'grid',
+				layout: canonicalView.layoutByType.grid,
+			},
+			{
+				...adaptViewForDataViews( {
+					...canonicalView,
+					type: 'grid',
+					layout: canonicalView.layoutByType.grid,
+				} ),
+				fields: [ 'field-2', 'title', 'field-2' ],
+			}
+		);
+
+		expect( gridCanonical.fields ).toEqual( [
+			'title',
+			'field-1',
+			'field-2',
+		] );
+		expect( gridCanonical.fieldsByType.grid ).toEqual( [ 'field-2' ] );
+	} );
+
+	it( 'updates the active layout bucket when the type does not change', () => {
+		const tableCanonical = mergeDataViewsChange( canonicalView, {
+			...canonicalView,
+			layout: { density: 'balanced' },
+		} );
+
+		expect( tableCanonical.layout ).toEqual( { density: 'balanced' } );
+		expect( tableCanonical.layoutByType.table ).toEqual( {
+			density: 'balanced',
+		} );
+	} );
+
+	it( 'preserves query state and stores list fields outside table columns', () => {
+		const previousListView = {
+			...canonicalView,
+			type: 'list',
+			layout: canonicalView.layoutByType.list,
+		};
+		const listCanonical = mergeDataViewsChange(
+			previousListView,
+			{
+				...adaptViewForDataViews( previousListView ),
+				fields: [ 'field-2' ],
+			}
+		);
+
+		expect( listCanonical.fields ).toEqual( [
+			'title',
+			'field-1',
+			'field-2',
+		] );
+		expect( listCanonical.fieldsByType.list ).toEqual( [ 'field-2' ] );
+		expect( listCanonical.sort ).toEqual( canonicalView.sort );
+		expect( listCanonical.filters ).toEqual( canonicalView.filters );
+		expect( listCanonical.search ).toBe( 'needle' );
+		expect( listCanonical.page ).toBe( 2 );
+		expect( listCanonical.perPage ).toBe( 25 );
+		expect( listCanonical.titleField ).toBeUndefined();
+	} );
+
+	it( 'preserves query state when DataViews emits a partial view change', () => {
+		const tableCanonical = mergeDataViewsChange( canonicalView, {
+			type: 'table',
+			layout: { density: 'comfortable' },
+		} );
+
+		expect( tableCanonical.sort ).toEqual( canonicalView.sort );
+		expect( tableCanonical.filters ).toEqual( canonicalView.filters );
+		expect( tableCanonical.search ).toBe( 'needle' );
+		expect( tableCanonical.page ).toBe( 2 );
+		expect( tableCanonical.perPage ).toBe( 25 );
+	} );
+} );

--- a/tests/js/components/dataViewColumns.test.js
+++ b/tests/js/components/dataViewColumns.test.js
@@ -329,6 +329,107 @@ describe( 'normalizeView', () => {
 		expect( next.layout.density ).toBe( 'compact' );
 	} );
 
+	it( 'prunes stale display field ids', () => {
+		const view = {
+			...baseView(),
+			titleField: TITLE_FIELD_ID,
+			mediaField: 'field-removed',
+			descriptionField: 'field-1',
+		};
+		const next = normalizeView(
+			view,
+			new Set( [ TITLE_FIELD_ID, 'field-1' ] )
+		);
+
+		expect( next.titleField ).toBe( TITLE_FIELD_ID );
+		expect( next.descriptionField ).toBe( 'field-1' );
+		expect( next.mediaField ).toBeUndefined();
+	} );
+
+	it( 'prunes stale grid badge fields', () => {
+		const view = {
+			...baseView(),
+			type: 'grid',
+			layout: {
+				previewSize: 290,
+				badgeFields: [ 'field-1', 'field-removed' ],
+			},
+		};
+		const next = normalizeView(
+			view,
+			new Set( [ TITLE_FIELD_ID, 'field-1' ] )
+		);
+
+		expect( next.layout ).toEqual( {
+			previewSize: 290,
+			badgeFields: [ 'field-1' ],
+		} );
+	} );
+
+	it( 'prunes stale fields from layoutByType buckets', () => {
+		const view = {
+			...baseView(),
+			layoutByType: {
+				table: {
+					density: 'compact',
+					styles: {
+						'field-1': { width: 200 },
+						'field-removed': { width: 240 },
+					},
+				},
+				grid: {
+					previewSize: 290,
+					badgeFields: [ 'field-1', 'field-removed' ],
+				},
+				list: {},
+				gallery: { something: 'ignored' },
+			},
+		};
+		const next = normalizeView(
+			view,
+			new Set( [ TITLE_FIELD_ID, 'field-1' ] )
+		);
+
+		expect( next.layoutByType ).toEqual( {
+			table: {
+				density: 'compact',
+				styles: {
+					'field-1': { width: 200 },
+				},
+			},
+			grid: {
+				previewSize: 290,
+				badgeFields: [ 'field-1' ],
+			},
+			list: {},
+		} );
+	} );
+
+	it( 'prunes stale fields from fieldsByType buckets', () => {
+		const view = {
+			...baseView(),
+			fieldsByType: {
+				grid: [
+					'field-1',
+					TITLE_FIELD_ID,
+					'field-removed',
+					'field-1',
+				],
+				list: [ 'field-removed' ],
+				table: [ 'field-1' ],
+			},
+		};
+		const next = normalizeView(
+			view,
+			new Set( [ TITLE_FIELD_ID, 'field-1' ] )
+		);
+
+		expect( next.fieldsByType ).toEqual( {
+			grid: [ 'field-1' ],
+			list: [],
+		} );
+	} );
+
 	it( 'keeps calculations for hidden fields that still exist', () => {
 		const view = {
 			...baseView(),

--- a/tests/js/components/dataViewColumns.test.js
+++ b/tests/js/components/dataViewColumns.test.js
@@ -409,12 +409,7 @@ describe( 'normalizeView', () => {
 		const view = {
 			...baseView(),
 			fieldsByType: {
-				grid: [
-					'field-1',
-					TITLE_FIELD_ID,
-					'field-removed',
-					'field-1',
-				],
+				grid: [ 'field-1', TITLE_FIELD_ID, 'field-removed', 'field-1' ],
 				list: [ 'field-removed' ],
 				table: [ 'field-1' ],
 			},

--- a/tests/js/components/dataViewCreation.test.js
+++ b/tests/js/components/dataViewCreation.test.js
@@ -1,0 +1,63 @@
+import { nextViewAfterRowCreated } from '../../../src/components/dataViewCreation';
+
+describe( 'nextViewAfterRowCreated', () => {
+	const baseView = {
+		type: 'grid',
+		page: 1,
+		perPage: 12,
+		search: '',
+		filters: [],
+		sort: null,
+	};
+
+	it( 'moves an unconstrained view to the last page when a row would append there', () => {
+		const next = nextViewAfterRowCreated( baseView, { totalItems: 12 } );
+
+		expect( next ).toEqual( {
+			...baseView,
+			page: 2,
+		} );
+	} );
+
+	it( 'refreshes in place when search means the new row may not match', () => {
+		const view = {
+			...baseView,
+			search: 'purple',
+		};
+
+		expect( nextViewAfterRowCreated( view, { totalItems: 12 } ) ).toBe(
+			view
+		);
+	} );
+
+	it( 'refreshes in place when filters mean the new row may not match', () => {
+		const view = {
+			...baseView,
+			filters: [
+				{
+					field: 'field-1',
+					operator: 'is',
+					value: 'Rock',
+				},
+			],
+		};
+
+		expect( nextViewAfterRowCreated( view, { totalItems: 12 } ) ).toBe(
+			view
+		);
+	} );
+
+	it( 'refreshes in place when a sort can place the new row anywhere', () => {
+		const view = {
+			...baseView,
+			sort: {
+				field: 'title',
+				direction: 'asc',
+			},
+		};
+
+		expect( nextViewAfterRowCreated( view, { totalItems: 12 } ) ).toBe(
+			view
+		);
+	} );
+} );

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -926,6 +926,25 @@ describe( 'useCollectionRows', () => {
 		expect( args[ 'fields[2]' ] ).toBe( 'title' );
 	} );
 
+	it( 'includes active layout fields in the server projection', () => {
+		const args = buildQueryArgs(
+			7,
+			{
+				type: 'grid',
+				fields: [ 'title', 'field-20' ],
+				fieldsByType: {
+					grid: [ 'field-10' ],
+					list: [],
+				},
+			},
+			baseFields
+		);
+
+		expect( args[ 'fields[0]' ] ).toBe( 'field-10' );
+		expect( args[ 'fields[1]' ] ).toBe( 'field-20' );
+		expect( args[ 'fields[2]' ] ).toBe( 'title' );
+	} );
+
 	it( 'omits fields[] when every custom field is visible', () => {
 		// This is the auto-seeded default: title plus every custom field.
 		// Asking the server for the same set would only change the request key

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -545,6 +545,8 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertSame( 'row', $row['kind'] );
 		$this->assertSame( 'My Entry', $row['title']['raw'] );
 		$this->assertSame( 'publish', $row['status'] );
+		$this->assertSame( 0, $row['featured_media'] );
+		$this->assertNull( $row['cover'] );
 		$this->assertSame( 'hello', $row['meta']["field-{$field_id}"] );
 	}
 
@@ -1534,6 +1536,8 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertArrayHasKey( 'modified_at', $subset );
 		$this->assertArrayHasKey( 'created_by', $subset );
 		$this->assertArrayHasKey( 'modified_by', $subset );
+		$this->assertArrayHasKey( 'featured_media', $subset );
+		$this->assertArrayHasKey( 'cover', $subset );
 	}
 
 	public function test_rollup_projection_does_not_include_source_fields(): void {


### PR DESCRIPTION
## What

Part of #103.

This PR turns the grid into a layout we can actually use for browsing. Cards open rows when clicked, expose the same row actions as the table, let visible properties be edited, and include a New card at the end of the grid. Switching between table, grid, and list keeps the current search, filters, sort, pagination, and layout settings. The seed data now opens Music Catalog > Albums as a grid, with some cards showing covers and some left plain.

## Why

Grid was the roughest part of the DataView baseline; this gets it to a decent first pass. The list layout is still next, on a separate PR.

## How

- Keeps each layout's settings separate so table, grid, and list do not overwrite each other.
- Builds on the native DataViews grid instead of replacing it.
- Adds cover data to rows so cards can show images.
- Uses grid-shaped loading states instead of table-shaped placeholders.

## Testing Instructions

1. Open a seeded workspace and go to Music Catalog. Albums should render as a grid with a mix of covered and plain cards.
2. Switch a collection from table to grid to list and back to table. Search, filters, sort, pagination, and layout settings should survive.
3. In the grid, click a card to open the row. Use the row menu to duplicate, favorite, and trash it.
4. Add a visible property in the grid, then hover or keyboard-focus the value and edit it.
5. Add a new row from the grid. New should appear as a card in the grid.

## Screen recording

https://github.com/user-attachments/assets/e9f7179e-8d1f-43d7-93ac-c9de003e06fd

