### PR TITLE
List layout: revamp the design to make it usable

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -8,7 +8,7 @@ Pair with [decisions.md](decisions.md) for choices we've made peace with and [ro
 
 ## 1. DataViews has no inline cell editing `[upstream]`
 
-**What.** DataViews v6 can render values and edit them through a separate `DataForm`, but it cannot turn a rendered value into an inline editor. Cortext mounts its own editor from `field.render` (documented as a display renderer, but the only hook available), keeps edit state per cell, and sends saves through `RowMutationContext` because `field.render` only receives `{ item }`. Tab and Shift+Tab live in the same layer: editors catch Tab, ask the parent for the next editable cell through `requestNext`, and the target cell opens through the same `editRequest` channel used to focus the title cell in a fresh row. Table and grid opt into that editing surface. List stays read-only until we design row/value editing for it on purpose.
+**What.** DataViews v6 can render values and edit them through a separate `DataForm`, but it cannot turn a rendered value into an inline editor. Cortext mounts its own editor from `field.render` (documented as a display renderer, but the only hook available), keeps edit state per cell, and sends saves through `RowMutationContext` because `field.render` only receives `{ item }`. Tab and Shift+Tab live in the same layer: editors catch Tab, ask the parent for the next editable cell through `requestNext`, and the target cell opens through the same `editRequest` channel used to focus the title cell in a fresh row. Table, grid, and list opt into that editing surface for supported visible fields.
 
 **Where.** `src/components/EditableCell.js`, `RowMutationContext` and `requestNext` in `src/components/CollectionDataViews.js`, plus a sliver of `src/components/CollectionDataViews.scss`.
 

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -8,7 +8,7 @@ Pair with [decisions.md](decisions.md) for choices we've made peace with and [ro
 
 ## 1. DataViews has no inline cell editing `[upstream]`
 
-**What.** DataViews v6 can render values and edit them through a separate `DataForm`, but it cannot turn a rendered value into an inline editor. Cortext mounts its own editor from `field.render` (documented as a display renderer, but the only hook available), keeps edit state per cell, and sends saves through `RowMutationContext` because `field.render` only receives `{ item }`. Tab and Shift+Tab live in the same layer: editors catch Tab, ask the parent for the next editable cell through `requestNext`, and the target cell opens through the same `editRequest` channel used to focus the title cell in a fresh row. Table, grid, and list opt into that editing surface for supported visible fields.
+**What.** DataViews v6 can render values and edit them through a separate `DataForm`, but it cannot turn a rendered value into an inline editor. Cortext mounts its own editor from `field.render` (documented as a display renderer, but the only hook available), keeps edit state per cell, and sends saves through `RowMutationContext` because `field.render` only receives `{ item }`. Tab and Shift+Tab live in the same layer: editors catch Tab, ask the parent for the next editable cell through `requestNext`, and the target cell opens through the same `editRequest` channel used to focus the title cell in a fresh row. Table, grid, and list use that surface when a visible field supports it.
 
 **Where.** `src/components/EditableCell.js`, `RowMutationContext` and `requestNext` in `src/components/CollectionDataViews.js`, plus a sliver of `src/components/CollectionDataViews.scss`.
 
@@ -553,3 +553,13 @@ This is fine for the baseline, but block attributes and public DataViews state n
 **Where.** `src/components/dataViewAdapter.js`, `src/components/dataViewViewState.js`, `normalizeView` in `src/components/dataViewColumns.js`, the DataViews mounts in `src/components/CollectionDataViews.js` and `src/components/PublicDataView.js`, and the data-view block attributes in `src/blocks/data-view/block.json`.
 
 **Solution.** If DataViews adds native per-layout settings, map to those instead of carrying separate buckets. If Cortext saved views become their own schema, move `layoutByType` / `fieldsByType` there and treat DataViews' `view` as a render adapter only. Until one of those exists, keep this adapter small and covered by round-trip tests.
+
+## 61. DataViews list lacks row-open and compact metadata hooks `[upstream, soft]`
+
+**What.** DataViews list is close enough to use, but it does not expose the pieces Cortext needs for the list we want: opening a row from the blank part of the row, keeping focus without a selected-row state, showing metadata as a compact inline run, and placing "+ New" as the last row. Cortext keeps the native layout and fills those gaps locally. The list gets an empty controlled selection, capture-phase pointer and keyboard handlers for row open, CSS that reshapes DataViews' title/media/field/action DOM, and a footer button styled like a row.
+
+That keeps us out of a custom React layout for now, but it depends on DataViews markup and event timing. The parts to watch are the `.dataviews-view-list > [role="row"]` lookup, `.dataviews-view-list__item` as the focus/open target, and the CSS grid/contents overrides that put title, metadata, media, and actions on one row.
+
+**Where.** List open/focus handling in `src/components/CollectionDataViews.js`, list row lookup in `src/components/dataViewItemLookup.js`, list reorder decoration in `src/components/DataViewRowReorder.js`, `DataViewNewRowButton`'s `list-row` presentation, and the list rules in `src/components/CollectionDataViews.list.scss`.
+
+**Solution.** DataViews could make this cleaner with row activation/focus hooks, a way to disable selected-row state without losing focus, a compact metadata list variant, and an append-row/item slot. With those, Cortext could drop the capture-phase list handlers, the empty-selection shim, most list DOM selectors, and the CSS reshaping. If the native list never grows that shape, write a small Cortext list layout instead of piling more CSS on DataViews internals.

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -22,7 +22,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 	private const WORKSPACE_HOME_META_KEY = 'cortext_workspace_home';
 	private const FAVORITES_META_KEY      = 'cortext_favorites';
-	private const PAGE_CONTENT_VERSION    = 'rich-connected-seed-2026-05-27-task-list';
+	private const PAGE_CONTENT_VERSION    = 'rich-connected-seed-2026-05-27-music-list-fields';
 	private const ENTRY_CONTENT_VERSION   = 'rich-connected-row-seed-2026-05-07';
 
 	private bool $seed_full_dataset = false;
@@ -3305,12 +3305,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 							)
 						),
 						$this->data_view_block( $collection_ids['projects'] ?? 0 ),
-						$this->data_view_block(
-							$collection_ids['tasks'] ?? 0,
-							array(
-								'type' => 'list',
-							)
-						),
+						$this->data_view_block( $collection_ids['tasks'] ?? 0 ),
 						$this->data_view_block( $collection_ids['people'] ?? 0 ),
 					)
 				),
@@ -3490,15 +3485,43 @@ final class SeedDummyCollections extends WP_CLI_Command {
 						$this->data_view_block(
 							$collection_ids['albums'] ?? 0,
 							array(
-								'type'       => 'grid',
-								'perPage'    => 25,
-								'mediaField' => 'cover',
+								'type'         => 'grid',
+								'perPage'      => 25,
+								'mediaField'   => 'cover',
+								'fieldsByType' => array(
+									'grid' => $this->data_view_field_ids_by_titles(
+										$collection_ids['albums'] ?? 0,
+										array( 'Artist', 'Year', 'Genre', 'Format' )
+									),
+								),
 							)
 						),
 						$this->data_view_block( $collection_ids['tracks'] ?? 0 ),
 						$this->heading( 'Artists and labels', 2 ),
-						$this->data_view_block( $collection_ids['musicians'] ?? 0 ),
-						$this->data_view_block( $collection_ids['labels'] ?? 0 ),
+						$this->data_view_block(
+							$collection_ids['musicians'] ?? 0,
+							array(
+								'type'         => 'list',
+								'fieldsByType' => array(
+									'list' => $this->data_view_field_ids_by_titles(
+										$collection_ids['musicians'] ?? 0,
+										array( 'Country', 'Genres', 'Album count' )
+									),
+								),
+							)
+						),
+						$this->data_view_block(
+							$collection_ids['labels'] ?? 0,
+							array(
+								'type'         => 'list',
+								'fieldsByType' => array(
+									'list' => $this->data_view_field_ids_by_titles(
+										$collection_ids['labels'] ?? 0,
+										array( 'Country', 'Focus', 'Release count' )
+									),
+								),
+							)
+						),
 					)
 				),
 			),
@@ -4864,6 +4887,30 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			'<!-- wp:cortext/data-view %s /-->',
 			wp_json_encode( $attributes )
 		);
+	}
+
+	/**
+	 * Returns DataViews field ids for visible list/grid fields by seeded title.
+	 *
+	 * @param int      $collection_id Collection post ID.
+	 * @param string[] $titles        Field titles, in display order.
+	 * @return string[]
+	 */
+	private function data_view_field_ids_by_titles( int $collection_id, array $titles ): array {
+		if ( $collection_id <= 0 ) {
+			return array();
+		}
+
+		$by_title = $this->attached_fields_by_title( $collection_id );
+		$ids      = array();
+		foreach ( $titles as $title ) {
+			$title = (string) $title;
+			if ( isset( $by_title[ $title ] ) ) {
+				$ids[] = 'field-' . (int) $by_title[ $title ];
+			}
+		}
+
+		return array_values( array_unique( $ids ) );
 	}
 
 	/**

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -22,7 +22,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 	private const WORKSPACE_HOME_META_KEY = 'cortext_workspace_home';
 	private const FAVORITES_META_KEY      = 'cortext_favorites';
-	private const PAGE_CONTENT_VERSION    = 'rich-connected-seed-2026-05-26-albums-grid';
+	private const PAGE_CONTENT_VERSION    = 'rich-connected-seed-2026-05-27-task-list';
 	private const ENTRY_CONTENT_VERSION   = 'rich-connected-row-seed-2026-05-07';
 
 	private bool $seed_full_dataset = false;
@@ -3305,7 +3305,12 @@ final class SeedDummyCollections extends WP_CLI_Command {
 							)
 						),
 						$this->data_view_block( $collection_ids['projects'] ?? 0 ),
-						$this->data_view_block( $collection_ids['tasks'] ?? 0 ),
+						$this->data_view_block(
+							$collection_ids['tasks'] ?? 0,
+							array(
+								'type' => 'list',
+							)
+						),
 						$this->data_view_block( $collection_ids['people'] ?? 0 ),
 					)
 				),

--- a/src/components/CollectionDataViewFields.js
+++ b/src/components/CollectionDataViewFields.js
@@ -109,7 +109,7 @@ function TitleCell( { item } ) {
 		>
 			{ documentIcon ? (
 				<span className="cortext-title-cell__icon" aria-hidden="true">
-					<PageIcon icon={ documentIcon } size={ 16 } />
+					<PageIcon icon={ documentIcon } />
 				</span>
 			) : null }
 			<EditableCell

--- a/src/components/CollectionDataViews.grid.scss
+++ b/src/components/CollectionDataViews.grid.scss
@@ -173,6 +173,10 @@ $grid-card-content-hover-background: #f3f3f3;
 		text-align: start;
 	}
 
+	.dataviews-view-grid__field:has(.cortext-editable-cell__shell--empty) {
+		display: none;
+	}
+
 	.dataviews-view-grid__field-name {
 		display: none;
 	}

--- a/src/components/CollectionDataViews.grid.scss
+++ b/src/components/CollectionDataViews.grid.scss
@@ -160,17 +160,6 @@ $grid-card-content-hover-background: #f3f3f3;
 		.cortext-title-cell {
 			gap: $grid-unit-10;
 		}
-
-		.cortext-title-cell__icon {
-			align-items: center;
-			justify-content: center;
-			width: 16px;
-			height: 16px;
-		}
-
-		.cortext-document-icon--emoji {
-			transform: translateY(-1px);
-		}
 	}
 
 	.dataviews-view-grid__fields {

--- a/src/components/CollectionDataViews.grid.scss
+++ b/src/components/CollectionDataViews.grid.scss
@@ -96,6 +96,8 @@ $grid-card-content-hover-background: #f3f3f3;
 
 	.dataviews-view-grid__card {
 		position: relative;
+		display: flex;
+		flex-direction: column;
 		box-sizing: border-box;
 		height: 100%;
 		min-height: var(--cortext-grid-card-height, 220px);
@@ -259,6 +261,7 @@ $grid-card-content-hover-background: #f3f3f3;
 	}
 
 	.dataviews-view-grid__card > .components-v-stack {
+		flex: 1 1 auto;
 		order: 2;
 		width: 100%;
 		min-width: 0;

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -92,6 +92,12 @@ function hasActiveCalculations( view ) {
 }
 
 const BULK_DELETE_CONCURRENCY = 4;
+// tech-debt.md#61: DataViews ties list focus to its own selection. Cortext
+// uses blank-row clicks and keyboard activation to open the row instead.
+const EMPTY_DATA_VIEW_SELECTION = [];
+const LIST_ROW_EMPTY_CLICK_TARGET_SELECTOR = '.dataviews-view-list__item';
+const LIST_ROW_SELECTOR = '.dataviews-view-list > [role="row"]';
+const ignoreDataViewsSelectionChange = () => {};
 
 export default function CollectionDataViews( {
 	collectionId,
@@ -391,6 +397,31 @@ export default function CollectionDataViews( {
 		},
 		[ supportsRowSelection, updateSelectedRowIds, visibleRowIds ]
 	);
+	const dataViewsSelectionProps = useMemo( () => {
+		if ( supportsRowSelection ) {
+			return {
+				selection: selectedRowIds,
+				onChangeSelection,
+			};
+		}
+
+		// DataViews list keeps an internal selected row when uncontrolled.
+		// Cortext uses list clicks for row open / cell edit, so keep selection
+		// controlled and empty in this layout.
+		if ( isListLayout ) {
+			return {
+				selection: EMPTY_DATA_VIEW_SELECTION,
+				onChangeSelection: ignoreDataViewsSelectionChange,
+			};
+		}
+
+		return {};
+	}, [
+		isListLayout,
+		onChangeSelection,
+		selectedRowIds,
+		supportsRowSelection,
+	] );
 
 	const clearSelection = useCallback( () => {
 		setSelectedRowIds( [] );
@@ -734,6 +765,126 @@ export default function CollectionDataViews( {
 			isListLayout,
 			requestOpenRow,
 		]
+	);
+	const handleDataViewPointerDownCapture = useCallback(
+		( event ) => {
+			if ( ! isListLayout || event.defaultPrevented ) {
+				return;
+			}
+			if ( event.button !== undefined && event.button !== 0 ) {
+				return;
+			}
+			if (
+				event.metaKey ||
+				event.ctrlKey ||
+				event.shiftKey ||
+				event.altKey
+			) {
+				return;
+			}
+			const target = event.target;
+			if ( ! target?.closest ) {
+				return;
+			}
+			if (
+				target.closest( INTERACTIVE_DATA_VIEW_ITEM_IGNORE_SELECTOR )
+			) {
+				return;
+			}
+			if ( ! target.closest( LIST_ROW_EMPTY_CLICK_TARGET_SELECTOR ) ) {
+				return;
+			}
+			const rowInfo = findDataViewItemFromEvent(
+				event,
+				tableWrapperRef.current,
+				'list',
+				dataFilteredInRenderOrder
+			);
+			if ( ! rowInfo?.row ) {
+				return;
+			}
+			event.preventDefault();
+			event.stopPropagation();
+			requestOpenRow( rowInfo.row );
+		},
+		[ dataFilteredInRenderOrder, isListLayout, requestOpenRow ]
+	);
+	const handleDataViewKeyDownCapture = useCallback(
+		( event ) => {
+			if ( ! isListLayout || event.defaultPrevented ) {
+				return;
+			}
+			const target = event.target;
+			if (
+				! target?.closest ||
+				! target.matches?.( LIST_ROW_EMPTY_CLICK_TARGET_SELECTOR )
+			) {
+				return;
+			}
+
+			const wrapper = tableWrapperRef.current;
+			const rowElement = target.closest( LIST_ROW_SELECTOR );
+			if (
+				! wrapper ||
+				! rowElement ||
+				! wrapper.contains( rowElement )
+			) {
+				return;
+			}
+
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				const rowInfo = findDataViewItemFromEvent(
+					event,
+					wrapper,
+					'list',
+					dataFilteredInRenderOrder
+				);
+				if ( ! rowInfo?.row ) {
+					return;
+				}
+				event.preventDefault();
+				event.stopPropagation();
+				requestOpenRow( rowInfo.row );
+				return;
+			}
+
+			const renderedRows = Array.from(
+				wrapper.querySelectorAll( LIST_ROW_SELECTOR )
+			);
+			const currentIndex = renderedRows.indexOf( rowElement );
+			if ( currentIndex < 0 ) {
+				return;
+			}
+
+			let nextIndex = null;
+			if ( event.key === 'ArrowDown' ) {
+				nextIndex = Math.min(
+					currentIndex + 1,
+					renderedRows.length - 1
+				);
+			} else if ( event.key === 'ArrowUp' ) {
+				nextIndex = Math.max( currentIndex - 1, 0 );
+			} else if ( event.key === 'Home' ) {
+				nextIndex = 0;
+			} else if ( event.key === 'End' ) {
+				nextIndex = renderedRows.length - 1;
+			}
+
+			if ( nextIndex === null || nextIndex === currentIndex ) {
+				return;
+			}
+			const nextTarget = renderedRows[ nextIndex ]?.querySelector(
+				LIST_ROW_EMPTY_CLICK_TARGET_SELECTOR
+			);
+			if ( ! nextTarget ) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			nextTarget.focus();
+		},
+		[ dataFilteredInRenderOrder, isListLayout, requestOpenRow ]
 	);
 	const handleDataViewClickCapture = useCallback(
 		( event ) => {
@@ -1338,6 +1489,10 @@ export default function CollectionDataViews( {
 						<div
 							className="cortext-data-view"
 							ref={ tableWrapperRef }
+							onPointerDownCapture={
+								handleDataViewPointerDownCapture
+							}
+							onKeyDownCapture={ handleDataViewKeyDownCapture }
 							onClickCapture={ handleDataViewClickCapture }
 							data-grid-card-clickable={
 								isGridLayout ? 'true' : undefined
@@ -1413,12 +1568,7 @@ export default function CollectionDataViews( {
 										isLoading={ isLoading }
 										empty={ empty }
 										actions={ dataViewActions }
-										{ ...( supportsRowSelection
-											? {
-													selection: selectedRowIds,
-													onChangeSelection,
-											  }
-											: {} ) }
+										{ ...dataViewsSelectionProps }
 									>
 										<DataViewsChrome
 											footer={ dataViewsFooter }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -581,10 +581,18 @@ export default function CollectionDataViews( {
 		[ collectionId, refresh, touchRecent ]
 	);
 
+	let dataViewLayoutType = 'table';
+	if ( isGridLayout ) {
+		dataViewLayoutType = 'grid';
+	}
+	if ( isListLayout ) {
+		dataViewLayoutType = 'list';
+	}
 	const mutationContext = useMemo(
 		() => ( {
 			saveRowField,
 			canEditCells: isTableLayout || isGridLayout || isListLayout,
+			layoutType: dataViewLayoutType,
 			editRequest,
 			clearEditRequest,
 			requestNext,
@@ -596,6 +604,7 @@ export default function CollectionDataViews( {
 		} ),
 		[
 			saveRowField,
+			dataViewLayoutType,
 			isGridLayout,
 			isListLayout,
 			isTableLayout,

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -553,7 +553,7 @@ export default function CollectionDataViews( {
 	const mutationContext = useMemo(
 		() => ( {
 			saveRowField,
-			canEditCells: isTableLayout || isGridLayout,
+			canEditCells: isTableLayout || isGridLayout || isListLayout,
 			editRequest,
 			clearEditRequest,
 			requestNext,
@@ -566,6 +566,7 @@ export default function CollectionDataViews( {
 		[
 			saveRowField,
 			isGridLayout,
+			isListLayout,
 			isTableLayout,
 			editRequest,
 			clearEditRequest,
@@ -673,7 +674,7 @@ export default function CollectionDataViews( {
 
 	const openRowActionContext = useMemo(
 		() => ( {
-			enabled: isTableLayout || isGridLayout,
+			enabled: isTableLayout || isGridLayout || isListLayout,
 			icon: ROW_DETAIL_MODE_ICONS[ savedRowDetailMode ],
 			openRowId,
 			requestOpenRow,
@@ -681,6 +682,7 @@ export default function CollectionDataViews( {
 		} ),
 		[
 			isGridLayout,
+			isListLayout,
 			isTableLayout,
 			openRowId,
 			requestOpenRow,
@@ -689,7 +691,13 @@ export default function CollectionDataViews( {
 	);
 	const handleDataViewClick = useCallback(
 		( event ) => {
-			if ( ! isGridLayout || event.defaultPrevented ) {
+			let clickLayout = null;
+			if ( isGridLayout ) {
+				clickLayout = 'grid';
+			} else if ( isListLayout ) {
+				clickLayout = 'list';
+			}
+			if ( ! clickLayout || event.defaultPrevented ) {
 				return;
 			}
 			if (
@@ -712,7 +720,7 @@ export default function CollectionDataViews( {
 			const rowInfo = findDataViewItemFromEvent(
 				event,
 				tableWrapperRef.current,
-				'grid',
+				clickLayout,
 				dataFilteredInRenderOrder
 			);
 			if ( ! rowInfo?.row ) {
@@ -720,7 +728,12 @@ export default function CollectionDataViews( {
 			}
 			requestOpenRow( rowInfo.row );
 		},
-		[ dataFilteredInRenderOrder, isGridLayout, requestOpenRow ]
+		[
+			dataFilteredInRenderOrder,
+			isGridLayout,
+			isListLayout,
+			requestOpenRow,
+		]
 	);
 	const handleDataViewClickCapture = useCallback(
 		( event ) => {
@@ -921,9 +934,8 @@ export default function CollectionDataViews( {
 
 	const rowActions = useMemo( () => {
 		const actions = [];
-		// List and grid get one primary Open action, matching the saved
-		// detail mode. Table already has the inline Open button in the title
-		// cell, so these actions stay inside the menu there.
+		// The row itself opens in grid/list, and table has the inline Open
+		// button in the title cell. Keep the mode choices in the row menu.
 		for ( const mode of [ 'side', 'modal', 'full' ] ) {
 			actions.push( {
 				id: `open-in-${ mode }`,
@@ -933,7 +945,6 @@ export default function CollectionDataViews( {
 					ROW_DETAIL_MODE_LABELS[ mode ]
 				),
 				icon: ROW_DETAIL_MODE_ICONS[ mode ],
-				isPrimary: ! isTableLayout && mode === savedRowDetailMode,
 				context: 'single',
 				callback: ( items ) => openRowInMode( items?.[ 0 ], mode ),
 			} );
@@ -980,10 +991,8 @@ export default function CollectionDataViews( {
 		areFavoriteActionsDisabled,
 		duplicateRow,
 		isRowFavorite,
-		isTableLayout,
 		openRowInMode,
 		requestDeleteRows,
-		savedRowDetailMode,
 		toggleRowFavorite,
 	] );
 
@@ -1333,6 +1342,9 @@ export default function CollectionDataViews( {
 							data-grid-card-clickable={
 								isGridLayout ? 'true' : undefined
 							}
+							data-list-row-clickable={
+								isListLayout ? 'true' : undefined
+							}
 							data-loading-shell={
 								showLoadingShell ? 'true' : undefined
 							}
@@ -1474,12 +1486,24 @@ export default function CollectionDataViews( {
 									   outside DataViews because there is no append
 									   slot in the layout chrome. */ }
 									{ ! isGridLayout && (
-										<div className="cortext-data-view__footer">
+										<div
+											className={
+												'cortext-data-view__footer' +
+												( isListLayout
+													? ' cortext-data-view__footer--list'
+													: '' )
+											}
+										>
 											<DataViewNewRowButton
 												slug={ slug }
 												view={ view }
 												fields={ fields }
 												onCreated={ onCreated }
+												presentation={
+													isListLayout
+														? 'list-row'
+														: 'footer'
+												}
 											/>
 										</div>
 									) }

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -292,6 +292,12 @@ $list-row-open-background: #f3f3f3;
 		max-width: 100%;
 	}
 
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay:has(.cortext-editable-cell__compact-input) {
+		right: -$grid-unit-05;
+		width: calc(100% + #{$grid-unit-20});
+		max-width: none;
+	}
+
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-base-control,
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-base-control__field {
 		width: 100%;
@@ -352,6 +358,17 @@ $list-row-open-background: #f3f3f3;
 		background-color: $gray-100;
 		box-shadow: none;
 		color: $gray-700;
+	}
+
+	.dataviews-view-list__field-value .cortext-multiselect-edit__toggle .cortext-chips {
+		flex-wrap: nowrap;
+		width: auto;
+		overflow: hidden;
+	}
+
+	.dataviews-view-list__field-value .cortext-select-edit__toggle .cortext-chip,
+	.dataviews-view-list__field-value .cortext-multiselect-edit__toggle .cortext-chip {
+		flex: 0 0 auto;
 	}
 
 	@media (min-width: 600px) {

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -165,7 +165,7 @@ $list-row-open-background: #f3f3f3;
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
-		gap: $grid-unit-05 $grid-unit-15;
+		gap: $grid-unit-05 $grid-unit-10;
 		width: 100%;
 		margin-top: $grid-unit-05;
 		color: $gray-700;
@@ -181,7 +181,7 @@ $list-row-open-background: #f3f3f3;
 
 	.dataviews-view-list__field-value {
 		min-width: 0;
-		color: $gray-900;
+		color: $gray-700;
 		line-height: 1.5;
 		overflow-wrap: anywhere;
 	}

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -269,4 +269,35 @@ $list-row-open-background: #f3f3f3;
 		box-shadow: inset 0 0 0 1px $gray-300;
 		color: $gray-700;
 	}
+
+	@media (min-width: 782px) {
+
+		.dataviews-view-list__field-wrapper {
+			display: grid !important;
+			grid-template-columns: minmax(160px, 1fr) minmax(0, max-content) auto;
+			column-gap: $grid-unit-20;
+			align-items: center;
+		}
+
+		.dataviews-view-list__field-wrapper > .components-h-stack {
+			display: contents;
+		}
+
+		.dataviews-view-list .dataviews-title-field {
+			grid-column: 1;
+		}
+
+		.dataviews-view-list__fields {
+			grid-column: 2;
+			justify-content: flex-end;
+			width: auto;
+			max-width: min(620px, 54vw);
+			margin-top: 0;
+		}
+
+		.dataviews-view-list__item-actions {
+			grid-column: 3;
+			margin-left: 0;
+		}
+	}
 }

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -1,52 +1,179 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
+$list-row-hover-background: #f8f8f8;
+$list-row-open-background: #f3f3f3;
+
 .cortext-data-view {
+
+	&__footer--list {
+		padding: 0 $grid-unit-20 $grid-unit-20;
+	}
+
+	&__new-row-list.components-button {
+		justify-content: flex-start;
+		width: 100%;
+		min-height: $grid-unit-60;
+		padding: $grid-unit-15 $grid-unit-20;
+		border: $border-width solid transparent;
+		border-bottom-color: $gray-200;
+		border-radius: 6px;
+		color: $gray-700;
+		text-align: start;
+		transition:
+			background-color 120ms ease,
+			border-color 120ms ease,
+			color 120ms ease;
+
+		&.has-icon.has-text {
+			justify-content: flex-start;
+			padding: $grid-unit-15 $grid-unit-20;
+		}
+
+		&:focus-visible,
+		&:hover:not(:disabled) {
+			border-color: $gray-300;
+			background: $list-row-hover-background;
+			color: $gray-900;
+			box-shadow: none;
+		}
+	}
 
 	.dataviews-view-list {
 		display: flex;
 		flex-direction: column;
 		gap: $grid-unit-05;
-		padding: $grid-unit-10 $grid-unit-20 $grid-unit-20;
+		margin: 0;
+		padding: $grid-unit-10 $grid-unit-20 $grid-unit-10;
 	}
 
-	.dataviews-view-list [role="row"] {
+	.dataviews-view-list div[role="row"] {
+		position: relative;
+		margin: 0;
 		border: $border-width solid transparent;
-		border-radius: 6px;
 		border-bottom-color: $gray-200;
+		border-radius: 6px;
+		color: $gray-900;
+		background: transparent;
+		transition:
+			background-color 120ms ease,
+			border-color 120ms ease,
+			box-shadow 120ms ease;
 
 		&:hover,
-		&:focus-within,
+		&.is-hovered,
+		&:focus-within {
+			border-color: $gray-300;
+			background: $list-row-hover-background;
+			color: $gray-900;
+		}
+
 		&.is-selected {
 			border-color: $gray-300;
-			background: $gray-100;
+			background: $list-row-hover-background;
+		}
+
+		&:has(.cortext-title-cell--is-open),
+		&:has(.cortext-title-cell--is-opening) {
+			border-color: var(--cortext-accent);
+			background: $list-row-open-background;
+			box-shadow: inset 3px 0 0 var(--cortext-accent);
 		}
 	}
 
+	&[data-list-row-clickable="true"] .dataviews-view-list div[role="row"] {
+		cursor: pointer;
+	}
+
 	.dataviews-view-list__item-wrapper {
-		padding: $grid-unit-15;
+		position: relative;
+		box-sizing: border-box;
+		width: 100%;
+		min-width: 0;
+		padding: $grid-unit-15 $grid-unit-20;
+	}
+
+	.dataviews-view-list__item-wrapper > .components-h-stack {
+		position: relative;
+		z-index: 1;
+		width: 100%;
+		min-width: 0;
+	}
+
+	.dataviews-view-list__item {
+		z-index: 0;
+	}
+
+	.dataviews-view-list__media-wrapper {
+		width: $grid-unit-60;
+		height: $grid-unit-60;
+		border-radius: 4px;
+		background: $white;
+	}
+
+	.dataviews-view-list__media-wrapper::after {
+		border-radius: 4px;
 	}
 
 	.dataviews-view-list__field-wrapper {
 		min-width: 0;
 		width: 100%;
+		min-height: 0;
+		flex: 1 1 auto;
+	}
+
+	.dataviews-view-list__field-wrapper > .components-h-stack {
+		width: 100%;
+		min-width: 0;
+		gap: $grid-unit-10;
+		align-items: center;
+	}
+
+	.dataviews-view-list .dataviews-title-field {
+		flex: 1 1 auto;
+		min-width: 0;
+		min-height: $grid-unit-30;
+		line-height: 1.4;
+		font-weight: 500;
+		color: $gray-900;
+	}
+
+	.dataviews-view-list .dataviews-title-field .cortext-title-cell {
+		gap: $grid-unit-10;
 	}
 
 	.dataviews-view-list__item-actions {
-		margin-left: auto;
+		position: relative;
+		z-index: 2;
 		flex: 0 0 auto;
+		margin-left: auto;
+	}
+
+	.dataviews-view-list__item-actions .components-button {
+		border-radius: 4px;
+		color: $gray-700;
+
+		&:hover,
+		&:focus-visible {
+			background: $gray-100;
+			color: $gray-900;
+			box-shadow: none;
+		}
 	}
 
 	.dataviews-view-list__fields {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-		gap: $grid-unit-10 $grid-unit-30;
+		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+		gap: $grid-unit-05 $grid-unit-30;
 		width: 100%;
+		margin-top: $grid-unit-05;
+		color: $gray-700;
+		font-size: 12px;
 	}
 
 	.dataviews-view-list__field {
 		display: grid;
-		grid-template-columns: minmax(72px, max-content) minmax(0, 1fr);
+		grid-template-columns: minmax(84px, max-content) minmax(0, 1fr);
 		gap: $grid-unit-10;
 		align-items: baseline;
 		min-width: 0;
@@ -63,12 +190,89 @@
 		white-space: normal !important;
 		color: $gray-700;
 		font-size: 12px;
-		line-height: 1.4;
+		line-height: 1.5;
 	}
 
 	.dataviews-view-list__field-value {
 		min-width: 0;
 		color: $gray-900;
+		line-height: 1.5;
 		overflow-wrap: anywhere;
+	}
+
+	.dataviews-view-list div[role="row"].is-selected .dataviews-title-field,
+	.dataviews-view-list div[role="row"].is-selected .dataviews-view-list__fields,
+	.dataviews-view-list div[role="row"]:not(.is-selected):hover .dataviews-title-field,
+	.dataviews-view-list div[role="row"]:not(.is-selected):hover .dataviews-view-list__fields,
+	.dataviews-view-list div[role="row"]:not(.is-selected).is-hovered .dataviews-title-field,
+	.dataviews-view-list div[role="row"]:not(.is-selected).is-hovered .dataviews-view-list__fields,
+	.dataviews-view-list div[role="row"]:not(.is-selected):focus-within .dataviews-title-field,
+	.dataviews-view-list div[role="row"]:not(.is-selected):focus-within .dataviews-view-list__fields {
+		color: $gray-900;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell {
+		width: 100%;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell > :first-child {
+		position: relative;
+		display: inline-flex;
+		max-width: 100%;
+		vertical-align: top;
+		min-height: $grid-unit-30;
+		padding: 0 $grid-unit-30 0 $grid-unit-05;
+		border-radius: 4px;
+		box-shadow: inset 0 0 0 1px transparent;
+		transition:
+			background-color 120ms ease,
+			box-shadow 120ms ease;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__shell:hover {
+		background: transparent;
+		box-shadow: inset 0 0 0 1px transparent;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__shell:focus-visible {
+		background: transparent;
+		box-shadow: inset 0 0 0 1px var(--cortext-accent);
+		outline: none;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__edit-indicator {
+		position: absolute;
+		top: 50%;
+		right: $grid-unit-05;
+		display: block;
+		color: $gray-700;
+		opacity: 0;
+		transform: translateY(-50%);
+		transition:
+			color 120ms ease,
+			opacity 120ms ease;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__shell:hover .cortext-editable-cell__edit-indicator,
+	.dataviews-view-list__field-value .cortext-editable-cell__shell:focus-visible .cortext-editable-cell__edit-indicator {
+		color: $gray-900;
+		opacity: 1;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__display {
+		white-space: normal;
+	}
+
+	.dataviews-view-list .cortext-relation-ref,
+	.dataviews-view-list .cortext-relation-ref-more,
+	.dataviews-view-list .cortext-chip {
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+		box-shadow: inset 0 0 0 1px color-mix(in oklch, currentcolor 20%, transparent);
+	}
+
+	.dataviews-view-list .cortext-chip--neutral {
+		background-color: $gray-100;
+		box-shadow: inset 0 0 0 1px $gray-300;
+		color: $gray-700;
 	}
 }

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -5,6 +5,8 @@ $list-row-hover-background: #f8f8f8;
 $list-row-open-background: #f3f3f3;
 
 .cortext-data-view {
+	// tech-debt.md#61: DataViews has no compact metadata list variant, so this
+	// file reshapes its current list DOM for Cortext's baseline.
 
 	&__footer--list {
 		padding: 0 $grid-unit-20 $grid-unit-20;
@@ -16,7 +18,6 @@ $list-row-open-background: #f3f3f3;
 		min-height: $grid-unit-60;
 		padding: $grid-unit-15 $grid-unit-20;
 		border: $border-width solid transparent;
-		border-bottom-color: $gray-200;
 		border-radius: 6px;
 		color: $gray-700;
 		text-align: start;
@@ -51,7 +52,6 @@ $list-row-open-background: #f3f3f3;
 		position: relative;
 		margin: 0;
 		border: 0;
-		border-bottom: $border-width solid $gray-200;
 		border-radius: 0;
 		color: $gray-900;
 		background: transparent;
@@ -61,7 +61,7 @@ $list-row-open-background: #f3f3f3;
 
 		&:hover,
 		&.is-hovered,
-		&:focus-within {
+		&:has(:focus-visible) {
 			background: $list-row-hover-background;
 			color: $gray-900;
 		}
@@ -73,7 +73,6 @@ $list-row-open-background: #f3f3f3;
 		&:has(.cortext-title-cell--is-open),
 		&:has(.cortext-title-cell--is-opening) {
 			background: $list-row-open-background;
-			box-shadow: inset 3px 0 0 var(--cortext-accent);
 		}
 	}
 
@@ -81,12 +80,21 @@ $list-row-open-background: #f3f3f3;
 		cursor: pointer;
 	}
 
-	.dataviews-view-list__item-wrapper {
+	.dataviews-view-list div[role="row"]:not(:hover):not(.is-hovered):not(:has(.cortext-title-cell--is-open)):not(:has(.cortext-title-cell--is-opening)):focus-within:not(:has(:focus-visible)) {
+		background: transparent;
+		color: $gray-900;
+	}
+
+	.dataviews-view-list div[role="row"] .dataviews-view-list__item-wrapper {
 		position: relative;
 		box-sizing: border-box;
 		width: 100%;
 		min-width: 0;
-		padding: $grid-unit-15 $grid-unit-20;
+		padding: $grid-unit-10 $grid-unit-20;
+	}
+
+	.dataviews-view-list div[role="row"]:has(.cortext-row-drag-handle) .dataviews-view-list__item-wrapper {
+		padding-left: var(--cortext-row-drag-content-offset);
 	}
 
 	.dataviews-view-list__item-wrapper > .components-h-stack {
@@ -100,19 +108,29 @@ $list-row-open-background: #f3f3f3;
 		z-index: 0;
 	}
 
+	.dataviews-view-list .dataviews-title-field .cortext-title-cell {
+		gap: $grid-unit-10;
+		min-height: $grid-unit-30;
+	}
+
 	.dataviews-view-list__media-wrapper {
-		width: $grid-unit-60;
-		height: $grid-unit-60;
+		display: block;
+		flex: 0 0 $grid-unit-30;
+		width: $grid-unit-30;
+		height: $grid-unit-30;
 		border-radius: 4px;
-		background: $white;
+		background: transparent;
+		overflow: hidden;
+	}
+
+	.dataviews-view-list__media-wrapper img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
 	}
 
 	.dataviews-view-list__media-wrapper::after {
 		border-radius: 4px;
-	}
-
-	.dataviews-view-list__media-wrapper:not(:has(img)) {
-		display: none;
 	}
 
 	.dataviews-view-list__field-wrapper {
@@ -138,15 +156,17 @@ $list-row-open-background: #f3f3f3;
 		color: $gray-900;
 	}
 
-	.dataviews-view-list .dataviews-title-field .cortext-title-cell {
-		gap: $grid-unit-10;
-	}
-
 	.dataviews-view-list__item-actions {
 		position: relative;
 		z-index: 2;
 		flex: 0 0 auto;
 		margin-left: auto;
+	}
+
+	.dataviews-view-list div[role="row"] .dataviews-view-list__item-actions > :not(:last-child) {
+		flex: 0 0 0;
+		width: 0;
+		overflow: hidden;
 	}
 
 	.dataviews-view-list__item-actions .components-button {
@@ -211,7 +231,7 @@ $list-row-open-background: #f3f3f3;
 		max-width: 100%;
 		vertical-align: top;
 		min-height: $grid-unit-30;
-		padding: 0 $grid-unit-30 0 $grid-unit-05;
+		padding: 0 $grid-unit-05;
 		border-radius: 4px;
 		box-shadow: inset 0 0 0 1px transparent;
 		transition:
@@ -231,22 +251,7 @@ $list-row-open-background: #f3f3f3;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell__edit-indicator {
-		position: absolute;
-		top: 50%;
-		right: $grid-unit-05;
-		display: block;
-		color: $gray-700;
-		opacity: 0;
-		transform: translateY(-50%);
-		transition:
-			color 120ms ease,
-			opacity 120ms ease;
-	}
-
-	.dataviews-view-list__field-value .cortext-editable-cell__shell:hover .cortext-editable-cell__edit-indicator,
-	.dataviews-view-list__field-value .cortext-editable-cell__shell:focus-visible .cortext-editable-cell__edit-indicator {
-		color: $gray-900;
-		opacity: 1;
+		display: none;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell__display {
@@ -256,13 +261,12 @@ $list-row-open-background: #f3f3f3;
 	.dataviews-view-list .cortext-relation-ref,
 	.dataviews-view-list .cortext-relation-ref-more,
 	.dataviews-view-list .cortext-chip {
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
-		box-shadow: inset 0 0 0 1px color-mix(in oklch, currentcolor 20%, transparent);
+		box-shadow: none;
 	}
 
 	.dataviews-view-list .cortext-chip--neutral {
 		background-color: $gray-100;
-		box-shadow: inset 0 0 0 1px $gray-300;
+		box-shadow: none;
 		color: $gray-700;
 	}
 

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -50,32 +50,28 @@ $list-row-open-background: #f3f3f3;
 	.dataviews-view-list div[role="row"] {
 		position: relative;
 		margin: 0;
-		border: $border-width solid transparent;
-		border-bottom-color: $gray-200;
-		border-radius: 6px;
+		border: 0;
+		border-bottom: $border-width solid $gray-200;
+		border-radius: 0;
 		color: $gray-900;
 		background: transparent;
 		transition:
 			background-color 120ms ease,
-			border-color 120ms ease,
 			box-shadow 120ms ease;
 
 		&:hover,
 		&.is-hovered,
 		&:focus-within {
-			border-color: $gray-300;
 			background: $list-row-hover-background;
 			color: $gray-900;
 		}
 
 		&.is-selected {
-			border-color: $gray-300;
 			background: $list-row-hover-background;
 		}
 
 		&:has(.cortext-title-cell--is-open),
 		&:has(.cortext-title-cell--is-opening) {
-			border-color: var(--cortext-accent);
 			background: $list-row-open-background;
 			box-shadow: inset 3px 0 0 var(--cortext-accent);
 		}

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -266,7 +266,7 @@ $list-row-open-background: #f3f3f3;
 		color: $gray-700;
 	}
 
-	@media (min-width: 782px) {
+	@media (min-width: 600px) {
 
 		.dataviews-view-list__field-wrapper {
 			display: grid !important;
@@ -281,18 +281,27 @@ $list-row-open-background: #f3f3f3;
 
 		.dataviews-view-list .dataviews-title-field {
 			grid-column: 1;
+			grid-row: 1;
 		}
 
 		.dataviews-view-list__fields {
 			grid-column: 2;
+			grid-row: 1;
+			flex-wrap: nowrap;
 			justify-content: flex-end;
 			width: auto;
 			max-width: min(620px, 54vw);
 			margin-top: 0;
+			overflow: hidden;
+		}
+
+		.dataviews-view-list__field-value .cortext-editable-cell__display {
+			white-space: nowrap;
 		}
 
 		.dataviews-view-list__item-actions {
 			grid-column: 3;
+			grid-row: 1;
 			margin-left: 0;
 		}
 	}

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -267,14 +267,13 @@ $list-row-open-background: #f3f3f3;
 		z-index: 3;
 	}
 
-	.dataviews-view-list__field-value .cortext-editable-cell--editing .cortext-editable-cell__shell {
-		display: none;
-	}
-
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay {
-		position: static;
-		inset: auto;
-		z-index: auto;
+		position: absolute;
+		top: 50%;
+		right: 0;
+		bottom: auto;
+		left: auto;
+		z-index: 4;
 		display: inline-flex;
 		flex-direction: row;
 		align-items: center;
@@ -282,6 +281,7 @@ $list-row-open-background: #f3f3f3;
 		width: auto;
 		min-width: 0;
 		max-width: min(320px, 48vw);
+		transform: translateY(-50%);
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay > * {
@@ -293,6 +293,17 @@ $list-row-open-background: #f3f3f3;
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-base-control__field {
 		width: min(180px, 48vw);
 		max-width: 100%;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="text"],
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="email"],
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="url"],
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="number"] {
+		height: $grid-unit-30;
+		min-height: $grid-unit-30;
+		padding-block: 0;
+		font-size: inherit;
+		line-height: 1.4;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-dropdown {

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -303,12 +303,28 @@ $list-row-open-background: #f3f3f3;
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="url"],
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="number"] {
 		width: 100%;
+		box-sizing: border-box;
 		height: $grid-unit-30;
 		min-height: $grid-unit-30;
 		min-width: 0;
-		padding-block: 0;
 		font-size: inherit;
 		line-height: 1.4;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__compact-input {
+		border: $border-width solid var(--cortext-accent);
+		border-radius: 2px;
+		background: $white;
+		box-shadow: none;
+		color: $gray-900;
+		font: inherit;
+		padding: 0 $grid-unit-05;
+
+		&:focus {
+			border-color: var(--cortext-accent);
+			box-shadow: none;
+			outline: 0;
+		}
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-dropdown {

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -163,7 +163,7 @@ $list-row-open-background: #f3f3f3;
 
 	.dataviews-view-list__fields {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 		gap: $grid-unit-05 $grid-unit-30;
 		width: 100%;
 		margin-top: $grid-unit-05;
@@ -172,25 +172,8 @@ $list-row-open-background: #f3f3f3;
 	}
 
 	.dataviews-view-list__field {
-		display: grid;
-		grid-template-columns: minmax(84px, max-content) minmax(0, 1fr);
-		gap: $grid-unit-10;
-		align-items: baseline;
+		display: block;
 		min-width: 0;
-	}
-
-	.dataviews-view-list__field-label.components-visually-hidden {
-		position: static !important;
-		width: auto !important;
-		height: auto !important;
-		margin: 0 !important;
-		overflow: visible !important;
-		clip: auto !important;
-		clip-path: none !important;
-		white-space: normal !important;
-		color: $gray-700;
-		font-size: 12px;
-		line-height: 1.5;
 	}
 
 	.dataviews-view-list__field-value {

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -42,7 +42,7 @@ $list-row-open-background: #f3f3f3;
 	.dataviews-view-list {
 		display: flex;
 		flex-direction: column;
-		gap: $grid-unit-05;
+		gap: 0;
 		margin: 0;
 		padding: $grid-unit-10 $grid-unit-20 $grid-unit-10;
 	}
@@ -115,6 +115,10 @@ $list-row-open-background: #f3f3f3;
 		border-radius: 4px;
 	}
 
+	.dataviews-view-list__media-wrapper:not(:has(img)) {
+		display: none;
+	}
+
 	.dataviews-view-list__field-wrapper {
 		min-width: 0;
 		width: 100%;
@@ -177,6 +181,10 @@ $list-row-open-background: #f3f3f3;
 		flex: 0 1 auto;
 		min-width: 0;
 		max-width: 100%;
+	}
+
+	.dataviews-view-list__field:has(.cortext-editable-cell__shell--empty) {
+		display: none;
 	}
 
 	.dataviews-view-list__field-value {

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -162,9 +162,10 @@ $list-row-open-background: #f3f3f3;
 	}
 
 	.dataviews-view-list__fields {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-		gap: $grid-unit-05 $grid-unit-30;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: $grid-unit-05 $grid-unit-15;
 		width: 100%;
 		margin-top: $grid-unit-05;
 		color: $gray-700;
@@ -172,8 +173,10 @@ $list-row-open-background: #f3f3f3;
 	}
 
 	.dataviews-view-list__field {
-		display: block;
+		display: flex;
+		flex: 0 1 auto;
 		min-width: 0;
+		max-width: 100%;
 	}
 
 	.dataviews-view-list__field-value {

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -210,6 +210,10 @@ $list-row-open-background: #f3f3f3;
 		overflow-wrap: anywhere;
 	}
 
+	.dataviews-view-list__fields:has(.cortext-editable-cell--editing) {
+		overflow: visible;
+	}
+
 	.dataviews-view-list div[role="row"].is-selected .dataviews-title-field,
 	.dataviews-view-list div[role="row"].is-selected .dataviews-view-list__fields,
 	.dataviews-view-list div[role="row"]:not(.is-selected):hover .dataviews-title-field,
@@ -222,7 +226,7 @@ $list-row-open-background: #f3f3f3;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell {
-		width: 100%;
+		width: auto;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell > :first-child {
@@ -256,6 +260,54 @@ $list-row-open-background: #f3f3f3;
 
 	.dataviews-view-list__field-value .cortext-editable-cell__display {
 		white-space: normal;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell--editing {
+		position: relative;
+		z-index: 3;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell--editing .cortext-editable-cell__shell {
+		display: none;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay {
+		position: static;
+		inset: auto;
+		z-index: auto;
+		display: inline-flex;
+		flex-direction: row;
+		align-items: center;
+		justify-content: flex-start;
+		width: auto;
+		min-width: 0;
+		max-width: min(320px, 48vw);
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay > * {
+		width: auto;
+		max-width: 100%;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-base-control,
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-base-control__field {
+		width: min(180px, 48vw);
+		max-width: 100%;
+	}
+
+	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-dropdown {
+		width: auto;
+		max-width: 100%;
+	}
+
+	.dataviews-view-list__field-value .cortext-select-edit__toggle.components-button,
+	.dataviews-view-list__field-value .cortext-date-edit__toggle.components-button,
+	.dataviews-view-list__field-value .cortext-multiselect-edit__toggle.components-button,
+	.dataviews-view-list__field-value .cortext-relation-edit__toggle.components-button {
+		width: auto;
+		min-width: 0;
+		max-width: min(320px, 48vw);
+		height: $grid-unit-30;
 	}
 
 	.dataviews-view-list .cortext-relation-ref,

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -226,7 +226,10 @@ $list-row-open-background: #f3f3f3;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell {
+		display: inline-block;
 		width: auto;
+		max-width: 100%;
+		vertical-align: top;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell > :first-child {
@@ -278,20 +281,20 @@ $list-row-open-background: #f3f3f3;
 		flex-direction: row;
 		align-items: center;
 		justify-content: flex-start;
-		width: auto;
+		width: 100%;
 		min-width: 0;
-		max-width: min(320px, 48vw);
+		max-width: 100%;
 		transform: translateY(-50%);
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay > * {
-		width: auto;
+		width: 100%;
 		max-width: 100%;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-base-control,
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-base-control__field {
-		width: min(180px, 48vw);
+		width: 100%;
 		max-width: 100%;
 	}
 
@@ -299,15 +302,17 @@ $list-row-open-background: #f3f3f3;
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="email"],
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="url"],
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay input[type="number"] {
+		width: 100%;
 		height: $grid-unit-30;
 		min-height: $grid-unit-30;
+		min-width: 0;
 		padding-block: 0;
 		font-size: inherit;
 		line-height: 1.4;
 	}
 
 	.dataviews-view-list__field-value .cortext-editable-cell__overlay .components-dropdown {
-		width: auto;
+		width: 100%;
 		max-width: 100%;
 	}
 
@@ -315,9 +320,9 @@ $list-row-open-background: #f3f3f3;
 	.dataviews-view-list__field-value .cortext-date-edit__toggle.components-button,
 	.dataviews-view-list__field-value .cortext-multiselect-edit__toggle.components-button,
 	.dataviews-view-list__field-value .cortext-relation-edit__toggle.components-button {
-		width: auto;
+		width: 100%;
 		min-width: 0;
-		max-width: min(320px, 48vw);
+		max-width: 100%;
 		height: $grid-unit-30;
 	}
 

--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -1,6 +1,8 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
+$title-cell-icon-size: $grid-unit-20;
+
 .cortext-collection-pane {
 	position: relative;
 	display: flex;
@@ -375,7 +377,11 @@ tbody > tr > td:not(:first-child) {
 
 	&__icon {
 		display: inline-flex;
-		flex: 0 0 auto;
+		align-items: center;
+		justify-content: center;
+		width: $title-cell-icon-size;
+		height: $title-cell-icon-size;
+		flex: 0 0 $title-cell-icon-size;
 		line-height: 0;
 	}
 

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -91,6 +91,9 @@ export default function DataViewNewRowButton( {
 				'cortext-data-view__new-row' +
 				( presentation === 'grid-card'
 					? ' cortext-data-view__new-row-card'
+					: '' ) +
+				( presentation === 'list-row'
+					? ' cortext-data-view__new-row-list'
 					: '' )
 			}
 			variant="tertiary"

--- a/src/components/DataViewRowReorder.js
+++ b/src/components/DataViewRowReorder.js
@@ -59,9 +59,9 @@ const HOVER_SUPPRESSION_RELEASE_DELAY = 120;
 const ROW_SELECTORS = {
 	table: '.dataviews-view-table tbody > tr',
 	list: [
-		'.dataviews-view-list__item',
-		'.dataviews-view-list li',
-		'.dataviews-view-list [role="row"]',
+		'.dataviews-view-list > [role="row"]',
+		'.dataviews-view-list > li',
+		'.dataviews-view-list > .dataviews-view-list__item',
 	].join( ',' ),
 };
 

--- a/src/components/DataViewRowReorder.js
+++ b/src/components/DataViewRowReorder.js
@@ -624,7 +624,12 @@ function useRenderedRows( wrapperRef, view, rows ) {
 
 		sync();
 		const observer = new window.MutationObserver( sync );
-		observer.observe( wrapper, { childList: true, subtree: true } );
+		observer.observe( wrapper, {
+			attributeFilter: [ 'class' ],
+			attributes: true,
+			childList: true,
+			subtree: true,
+		} );
 		// Pull `ResizeObserver` from the wrapper's window so the block editor
 		// iframe uses its own constructor. We watch both the outer wrapper
 		// and DataViews' inner scroller: the preview width comes from the
@@ -650,7 +655,7 @@ function useRenderedRows( wrapperRef, view, rows ) {
 
 		// Leave decoration classes in place between subscriptions. Sort changes
 		// and refetches can re-run this effect during the drop freeze; removing
-		// `cortext-row-reorder-cell` here collapses the 24px handle padding for
+		// `cortext-row-reorder-cell` here collapses the drag-handle offset for
 		// one frame. sync() handles rows that leave the set, and the unmount
 		// effect below does the final cleanup.
 		return () => {
@@ -1380,6 +1385,7 @@ export default function DataViewRowReorder( {
 				<RowDragHandle
 					key={ `row-handle:${ row.rowId }` }
 					row={ row }
+					keyboardFocusable={ view?.type !== 'list' }
 				/>
 			) ) }
 			{ rowGaps.map( ( gap ) => (

--- a/src/components/DataViewRowReorder.scss
+++ b/src/components/DataViewRowReorder.scss
@@ -1,6 +1,12 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
+.cortext-data-view {
+	--cortext-row-drag-handle-size: 24px;
+	--cortext-row-drag-content-gap: 6px;
+	--cortext-row-drag-content-offset: calc(var(--cortext-row-drag-handle-size) + var(--cortext-row-drag-content-gap));
+}
+
 .cortext-row-reorder-cell {
 	position: relative;
 }
@@ -11,7 +17,7 @@ tbody > tr > td.cortext-row-reorder-cell,
 .cortext-data-view
 .dataviews-view-table.has-compact-density
 tbody > tr > td.cortext-row-reorder-cell {
-	padding-left: 30px;
+	padding-left: var(--cortext-row-drag-content-offset);
 }
 
 // Row reorder transitions are off at rest. The drop freeze applies transforms
@@ -53,8 +59,8 @@ body.cortext-row-reorder-no-transition .cortext-row-reorder-target {
 	position: absolute;
 	top: 50%;
 	left: 0;
-	width: 24px;
-	height: 24px;
+	width: var(--cortext-row-drag-handle-size);
+	height: var(--cortext-row-drag-handle-size);
 	padding: 0;
 	border: 0;
 	border-radius: 2px;

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -51,6 +51,7 @@ function siteLocale() {
 export const RowMutationContext = createContext( {
 	saveRowField: null,
 	canEditCells: true,
+	layoutType: 'table',
 	// `{ rowId, fieldId }` of the cell that should pop into edit mode.
 	// Set by the parent when a new row is created (open the title) or
 	// when Tab navigation hops between cells.
@@ -579,6 +580,7 @@ function TextLikeEditor( {
 	onTab,
 	shouldAutoFocus,
 	label,
+	compact = false,
 } ) {
 	const [ local, setLocal ] = useState( value ?? '' );
 	const inputRef = useRef( null );
@@ -616,6 +618,22 @@ function TextLikeEditor( {
 	};
 
 	if ( type === 'number' ) {
+		if ( compact ) {
+			return (
+				<input
+					ref={ inputRef }
+					className="cortext-editable-cell__compact-input"
+					type="text"
+					inputMode="decimal"
+					value={ local ?? '' }
+					onChange={ ( event ) => setLocal( event.target.value ) }
+					onBlur={ commit }
+					onKeyDown={ handleKeyDown }
+					aria-label={ label }
+				/>
+			);
+		}
+
 		// `spinControls="none"` drops both NumberControl's custom spin
 		// buttons (the default "custom" mode renders them as a suffix
 		// inside the input, which widens the cell on focus) and the
@@ -631,6 +649,21 @@ function TextLikeEditor( {
 				label={ label }
 				hideLabelFromVision
 				__next40pxDefaultSize
+			/>
+		);
+	}
+
+	if ( compact ) {
+		return (
+			<input
+				ref={ inputRef }
+				className="cortext-editable-cell__compact-input"
+				value={ local ?? '' }
+				onChange={ ( event ) => setLocal( event.target.value ) }
+				onBlur={ commit }
+				onKeyDown={ handleKeyDown }
+				type={ inputTypeFor( type ) }
+				aria-label={ label }
 			/>
 		);
 	}
@@ -674,6 +707,7 @@ export function SelectEditor( {
 	defaultOpen = true,
 	triggerClassName = 'cortext-select-edit__toggle',
 	placeholder = __( 'Select…', 'cortext' ),
+	popoverVariant = 'default',
 } ) {
 	const [ anchor, setAnchor ] = useState( null );
 	const [ isOpen, setIsOpen ] = useState( defaultOpen );
@@ -735,6 +769,7 @@ export function SelectEditor( {
 						fieldType="select"
 						initialOptions={ items }
 						value={ value }
+						variant={ popoverVariant }
 						onOptionsSaved={ onOptionsSaved }
 						onRowsChanged={ onRowsChanged }
 						onRequestClose={ onRequestClose }
@@ -817,6 +852,7 @@ export default function EditableCell( {
 		editRequest,
 		clearEditRequest,
 		requestNext,
+		layoutType,
 		optionOverrides,
 		updateFieldOptions,
 		formatOverrides,
@@ -841,6 +877,7 @@ export default function EditableCell( {
 		format: effectiveFormat,
 		relation,
 	} );
+	const isListLayout = layoutType === 'list';
 
 	// Open this cell when the parent targets it via editRequest (new-row
 	// title auto-open, Tab navigation, etc.), then clear the request so
@@ -971,6 +1008,7 @@ export default function EditableCell( {
 					onRequestClose={ closeEditor }
 					onCancel={ closeEditor }
 					label={ label }
+					popoverVariant={ isListLayout ? 'compact' : 'default' }
 				/>
 			);
 		} else if ( fieldType === 'relation' ) {
@@ -1005,6 +1043,7 @@ export default function EditableCell( {
 						requestNext?.( rowId, fieldId, direction )
 					}
 					label={ label }
+					popoverVariant={ isListLayout ? 'compact' : 'default' }
 				/>
 			);
 		} else if ( fieldType === 'date' || fieldType === 'datetime' ) {
@@ -1033,6 +1072,7 @@ export default function EditableCell( {
 					}
 					shouldAutoFocus
 					label={ label }
+					compact={ isListLayout }
 				/>
 			);
 		}

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -98,6 +98,8 @@ function FieldError( { message } ) {
 // http(s) URLs. Anything else (relative paths, mailto:, plain strings) is
 // rendered as text so we never produce a broken link.
 const URL_PATTERN = /^https?:\/\//i;
+const NESTED_DISPLAY_INTERACTIVE_SELECTOR =
+	'a, button, input, textarea, select, [contenteditable="true"], [role="button"]';
 
 // Clamp decimals to a sane range; Intl.NumberFormat throws above 100.
 function clampDecimals( decimals ) {
@@ -478,12 +480,41 @@ function CellShell( { children, onActivate, ariaLabel, className, disabled } ) {
 	// nowrap` above `flex-wrap: wrap` chips made multiselect cells overflow
 	// into adjacent columns.
 	const isText = typeof children === 'string';
+	const activateFromNestedInteractive = ( event ) => {
+		if ( disabled ) {
+			return;
+		}
+		const target = event.target;
+		const nestedInteractive = target?.closest?.(
+			NESTED_DISPLAY_INTERACTIVE_SELECTOR
+		);
+		if (
+			! nestedInteractive ||
+			nestedInteractive === event.currentTarget ||
+			! event.currentTarget.contains( nestedInteractive )
+		) {
+			return;
+		}
+		event.preventDefault();
+		event.stopPropagation();
+		onActivate();
+	};
 	return (
 		<div
 			role={ disabled ? undefined : 'button' }
 			tabIndex={ disabled ? -1 : 0 }
 			className={ className }
+			onClickCapture={ activateFromNestedInteractive }
 			onClick={ disabled ? undefined : onActivate }
+			onKeyDownCapture={
+				disabled
+					? undefined
+					: ( event ) => {
+							if ( event.key === 'Enter' || event.key === ' ' ) {
+								activateFromNestedInteractive( event );
+							}
+					  }
+			}
 			onKeyDown={
 				disabled
 					? undefined

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -428,6 +428,11 @@ export function formatDisplay( value, type, options = {} ) {
 	}
 
 	if ( type === 'relation' ) {
+		const refs = Array.isArray( value ) ? value : [ value ];
+		const hasReference = refs.some( ( ref ) => ref && ref.id );
+		if ( ! hasReference ) {
+			return '';
+		}
 		return <RelationReferences value={ value } />;
 	}
 

--- a/src/components/MultiselectEdit.js
+++ b/src/components/MultiselectEdit.js
@@ -32,6 +32,7 @@ export default function MultiselectEdit( {
 	label,
 	defaultOpen = true,
 	triggerClassName = 'cortext-multiselect-edit__toggle',
+	popoverVariant = 'default',
 } ) {
 	const [ anchor, setAnchor ] = useState( null );
 	const [ isOpen, setIsOpen ] = useState( defaultOpen );
@@ -105,6 +106,7 @@ export default function MultiselectEdit( {
 						fieldType="multiselect"
 						initialOptions={ items }
 						value={ current }
+						variant={ popoverVariant }
 						onOptionsSaved={ onOptionsSaved }
 						onRowsChanged={ onRowsChanged }
 						onRequestClose={ onRequestClose }

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -21,6 +21,9 @@ import { ICON_COLOR_BY_NAME } from './iconColors';
 const PageIconWp = lazy( () =>
 	import( /* webpackChunkName: "page-icon-wp" */ './PageIconWp' )
 );
+const DEFAULT_PAGE_ICON_SIZE = 16;
+const EMOJI_VISUAL_SCALE = 0.875;
+const GLYPH_VISUAL_SCALE = 1.4;
 
 // Three shapes are persisted in the cortext_document_icon meta:
 //   { type: 'emoji', value: '📘' }
@@ -128,9 +131,22 @@ function ImageIcon( { id, size, alt, className } ) {
 	);
 }
 
-export default function PageIcon( { icon, size = 16, alt, className } ) {
+export default function PageIcon( {
+	icon,
+	size = DEFAULT_PAGE_ICON_SIZE,
+	alt,
+	className,
+} ) {
 	const parsed = useMemo( () => parsePageIcon( icon ), [ icon ] );
 	const classes = [ 'cortext-document-icon' ];
+	const numericSize = typeof size === 'number' ? size : parseFloat( size );
+	const hasNumericSize = Number.isFinite( numericSize );
+	const emojiSize = hasNumericSize
+		? Math.max( Math.round( numericSize * EMOJI_VISUAL_SCALE ), 1 )
+		: size;
+	const glyphSize = hasNumericSize
+		? Math.round( numericSize * GLYPH_VISUAL_SCALE )
+		: size;
 	// `display: inline-flex` is the load-bearing bit: spans are inline by
 	// default, so width/height get ignored and the emoji variant ends up
 	// sized by `font-size * line-height` — taller than the SVG-based
@@ -145,6 +161,11 @@ export default function PageIcon( { icon, size = 16, alt, className } ) {
 		height: size,
 		lineHeight: 1,
 	};
+	const glyphBoxStyle = {
+		...boxStyle,
+		'--cortext-page-icon-glyph-size':
+			typeof glyphSize === 'number' ? `${ glyphSize }px` : glyphSize,
+	};
 	if ( className ) {
 		classes.push( className );
 	}
@@ -155,10 +176,10 @@ export default function PageIcon( { icon, size = 16, alt, className } ) {
 				className={ classes
 					.concat( 'cortext-document-icon--fallback' )
 					.join( ' ' ) }
-				style={ boxStyle }
+				style={ glyphBoxStyle }
 				aria-hidden="true"
 			>
-				<Icon icon={ pageGlyph } size={ size } />
+				<Icon icon={ pageGlyph } size={ glyphSize } />
 			</span>
 		);
 	}
@@ -169,7 +190,7 @@ export default function PageIcon( { icon, size = 16, alt, className } ) {
 				className={ classes
 					.concat( 'cortext-document-icon--emoji' )
 					.join( ' ' ) }
-				style={ { ...boxStyle, fontSize: size } }
+				style={ { ...boxStyle, fontSize: emojiSize } }
 				aria-hidden={ alt ? undefined : 'true' }
 				role={ alt ? 'img' : undefined }
 				aria-label={ alt }
@@ -188,15 +209,15 @@ export default function PageIcon( { icon, size = 16, alt, className } ) {
 				className={ classes
 					.concat( 'cortext-document-icon--wp' )
 					.join( ' ' ) }
-				style={ { ...boxStyle, ...colorStyle } }
+				style={ { ...glyphBoxStyle, ...colorStyle } }
 				aria-hidden={ alt ? undefined : 'true' }
 				role={ alt ? 'img' : undefined }
 				aria-label={ alt }
 			>
 				<Suspense
-					fallback={ <Icon icon={ pageGlyph } size={ size } /> }
+					fallback={ <Icon icon={ pageGlyph } size={ glyphSize } /> }
 				>
-					<PageIconWp name={ parsed.name } size={ size } />
+					<PageIconWp name={ parsed.name } size={ glyphSize } />
 				</Suspense>
 			</span>
 		);

--- a/src/components/PageIcon.scss
+++ b/src/components/PageIcon.scss
@@ -23,6 +23,15 @@
 		border-radius: 3px;
 	}
 
+	&--fallback svg,
+	&--wp svg {
+		width: var(--cortext-page-icon-glyph-size);
+		min-width: var(--cortext-page-icon-glyph-size);
+		height: var(--cortext-page-icon-glyph-size);
+		flex: 0 0 var(--cortext-page-icon-glyph-size);
+		max-width: none;
+	}
+
 	// Wrapper for image icons. The swatch stays under the <img> until the image
 	// has loaded; REST returning a URL is not enough.
 	&--image-wrap {

--- a/src/components/RowDragHandle.js
+++ b/src/components/RowDragHandle.js
@@ -20,7 +20,7 @@ function primeRowHoverSuppression() {
 	}, HOVER_SUPPRESSION_PRIME_TIMEOUT );
 }
 
-export default function RowDragHandle( { row } ) {
+export default function RowDragHandle( { row, keyboardFocusable = true } ) {
 	const {
 		attributes,
 		listeners,
@@ -116,7 +116,7 @@ export default function RowDragHandle( { row } ) {
 			onTouchStart={ stopInteractionStart }
 			{ ...attributes }
 			role="button"
-			tabIndex={ 0 }
+			tabIndex={ keyboardFocusable ? 0 : -1 }
 			{ ...guardedListeners }
 		/>,
 		row.handleEl

--- a/src/components/dataViewItemLookup.js
+++ b/src/components/dataViewItemLookup.js
@@ -6,7 +6,7 @@ const GRID_CARD_SELECTOR = '.dataviews-view-grid__card';
 const LIST_ROW_SELECTOR = '.dataviews-view-list > [role="row"]';
 
 export const INTERACTIVE_DATA_VIEW_ITEM_IGNORE_SELECTOR =
-	'button, a, input, textarea, select, [contenteditable="true"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], .components-button, .cortext-editable-cell';
+	'button, a, input, textarea, select, [contenteditable="true"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], .components-button, .cortext-editable-cell, .cortext-row-drag-handle';
 
 export function findDataViewItemFromEvent( event, wrapper, layout, rows ) {
 	const target = event.target;

--- a/src/components/dataViewItemLookup.js
+++ b/src/components/dataViewItemLookup.js
@@ -3,6 +3,7 @@ import { normalizeRowId } from './dataViewSelection';
 const TABLE_ROW_SELECTOR =
 	'.dataviews-view-table tbody > tr:not(.dataviews-view-table__group-header-row)';
 const GRID_CARD_SELECTOR = '.dataviews-view-grid__card';
+const LIST_ROW_SELECTOR = '.dataviews-view-list > [role="row"]';
 
 export const INTERACTIVE_DATA_VIEW_ITEM_IGNORE_SELECTOR =
 	'button, a, input, textarea, select, [contenteditable="true"], [role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"], .components-button, .cortext-editable-cell';
@@ -13,8 +14,12 @@ export function findDataViewItemFromEvent( event, wrapper, layout, rows ) {
 		return null;
 	}
 
-	const selector =
-		layout === 'grid' ? GRID_CARD_SELECTOR : TABLE_ROW_SELECTOR;
+	let selector = TABLE_ROW_SELECTOR;
+	if ( layout === 'grid' ) {
+		selector = GRID_CARD_SELECTOR;
+	} else if ( layout === 'list' ) {
+		selector = LIST_ROW_SELECTOR;
+	}
 	const itemElement = target.closest?.( selector );
 	if ( ! itemElement || ! wrapper.contains( itemElement ) ) {
 		return null;

--- a/src/components/fields/EditOptionsPopover.js
+++ b/src/components/fields/EditOptionsPopover.js
@@ -175,6 +175,7 @@ export default function EditOptionsPopover( {
 	fieldType,
 	initialOptions,
 	value,
+	variant = 'default',
 	onPick,
 	onOptionsSaved,
 	onRowsChanged,
@@ -218,6 +219,7 @@ export default function EditOptionsPopover( {
 
 	const isPickMode = typeof onPick === 'function';
 	const isMultiselect = fieldType === 'multiselect';
+	const isCompact = variant === 'compact';
 
 	useEffect( () => {
 		if ( ! openMenuValue || typeof onRequestClose !== 'function' ) {
@@ -417,6 +419,9 @@ export default function EditOptionsPopover( {
 	const inputPrompt = isPickMode
 		? __( 'Search or create option', 'cortext' )
 		: __( 'Add option', 'cortext' );
+	const inputPlaceholder = isCompact
+		? __( 'Search options', 'cortext' )
+		: inputPrompt;
 
 	const handleCreateAndPick = async () => {
 		const created = await handleAdd();
@@ -430,7 +435,13 @@ export default function EditOptionsPopover( {
 	};
 
 	return (
-		<div className="cortext-edit-options-popover" ref={ popoverRef }>
+		<div
+			className={
+				'cortext-edit-options-popover' +
+				( isCompact ? ' cortext-edit-options-popover--compact' : '' )
+			}
+			ref={ popoverRef }
+		>
 			{ update.error ? (
 				<Notice status="error" isDismissible={ false }>
 					{ update.error?.message ||
@@ -440,7 +451,9 @@ export default function EditOptionsPopover( {
 			<div
 				className={
 					'cortext-edit-options-popover__token-input' +
-					( selectedOptions.length === 0 ? ' is-empty' : '' )
+					( isCompact || selectedOptions.length === 0
+						? ' is-empty'
+						: '' )
 				}
 				onPointerDown={ ( event ) => {
 					if ( event.target === event.currentTarget ) {
@@ -448,21 +461,24 @@ export default function EditOptionsPopover( {
 					}
 				} }
 			>
-				{ selectedOptions.map( ( opt ) => (
-					<Chip
-						key={ opt.value }
-						label={ opt.label }
-						color={ opt.color }
-						onRemove={ () => handleRemoveSelected( opt.value ) }
-					/>
-				) ) }
+				{ ! isCompact &&
+					selectedOptions.map( ( opt ) => (
+						<Chip
+							key={ opt.value }
+							label={ opt.label }
+							color={ opt.color }
+							onRemove={ () => handleRemoveSelected( opt.value ) }
+						/>
+					) ) }
 				<input
 					ref={ searchInputRef }
 					type="text"
 					className="cortext-edit-options-popover__token-input-field"
 					value={ search }
 					placeholder={
-						selectedOptions.length > 0 ? '' : inputPrompt
+						! isCompact && selectedOptions.length > 0
+							? ''
+							: inputPlaceholder
 					}
 					aria-label={ inputPrompt }
 					onChange={ ( event ) => setSearch( event.target.value ) }
@@ -477,6 +493,7 @@ export default function EditOptionsPopover( {
 							return;
 						}
 						if (
+							! isCompact &&
 							event.key === 'Backspace' &&
 							search === '' &&
 							selectedOptions.length > 0

--- a/src/components/fields/EditOptionsPopover.scss
+++ b/src/components/fields/EditOptionsPopover.scss
@@ -103,8 +103,8 @@
 		cursor: text;
 
 		&:focus-within {
-			border-color: var(--cortext-accent, #3858e9);
-			box-shadow: 0 0 0 1px var(--cortext-accent, #3858e9);
+			border-color: $gray-400;
+			box-shadow: inset 0 0 0 1px $gray-400;
 		}
 	}
 

--- a/src/components/fields/EditOptionsPopover.scss
+++ b/src/components/fields/EditOptionsPopover.scss
@@ -7,6 +7,12 @@
 	padding: $grid-unit-15;
 	width: 320px;
 
+	&--compact {
+		gap: $grid-unit-05;
+		width: 240px;
+		padding: $grid-unit-10;
+	}
+
 	&__header {
 		font-size: 11px;
 		font-weight: 600;
@@ -130,6 +136,16 @@
 		min-height: $grid-unit-30 - 4px;
 		appearance: none;
 
+		.cortext-edit-options-popover--compact & {
+			flex-basis: auto;
+			width: 100%;
+			min-width: 0;
+			min-height: $grid-unit-30 - 2px;
+			padding: 0;
+			font-size: 12px;
+			line-height: 1.4;
+		}
+
 		&:focus,
 		&:focus-visible {
 			border: 0;
@@ -140,6 +156,23 @@
 		&::placeholder {
 			color: $gray-700;
 		}
+	}
+
+	&--compact &__token-input {
+		flex-wrap: nowrap;
+		min-height: $grid-unit-30;
+		padding: 0 $grid-unit-10;
+		border-color: $gray-300;
+		border-radius: 4px;
+
+		&:focus-within {
+			border-color: $gray-400;
+			box-shadow: none;
+		}
+	}
+
+	&--compact &__row {
+		padding: 1px;
 	}
 
 	&__create {

--- a/tests/js/components/DataViewRowReorder.test.js
+++ b/tests/js/components/DataViewRowReorder.test.js
@@ -176,6 +176,57 @@ function createWrapper( heights = [ 40, 40, 40 ] ) {
 	return wrapper;
 }
 
+function createListWrapper( heights = [ 88, 88, 88 ] ) {
+	const wrapper = document.createElement( 'div' );
+	wrapper.innerHTML = `
+		<div class="dataviews-view-list">
+			<div role="row">
+				<div class="dataviews-view-list__item-wrapper">
+					<div role="gridcell">
+						<button class="dataviews-view-list__item" type="button"></button>
+					</div>
+					<div class="dataviews-view-list__field-wrapper">One</div>
+				</div>
+			</div>
+			<div role="row">
+				<div class="dataviews-view-list__item-wrapper">
+					<div role="gridcell">
+						<button class="dataviews-view-list__item" type="button"></button>
+					</div>
+					<div class="dataviews-view-list__field-wrapper">Two</div>
+				</div>
+			</div>
+			<div role="row">
+				<div class="dataviews-view-list__item-wrapper">
+					<div role="gridcell">
+						<button class="dataviews-view-list__item" type="button"></button>
+					</div>
+					<div class="dataviews-view-list__field-wrapper">Three</div>
+				</div>
+			</div>
+		</div>
+	`;
+	let top = 0;
+	Array.from( wrapper.querySelectorAll( '[role="row"]' ) ).forEach(
+		( row, index ) => {
+			const height = heights[ index ] ?? 88;
+			const rowTop = top;
+			top += height;
+			row.getClientRects = () => [ {} ];
+			row.getBoundingClientRect = () => ( {
+				top: rowTop,
+				left: 10,
+				width: 520,
+				height,
+				right: 530,
+				bottom: rowTop + height,
+			} );
+		}
+	);
+	document.body.appendChild( wrapper );
+	return wrapper;
+}
+
 function draggableDataFor( rowId ) {
 	return (
 		[ ...useDraggable.mock.calls ]
@@ -312,6 +363,53 @@ function dragOver( drop ) {
 }
 
 describe( 'DataViewRowReorder', () => {
+	it( 'uses the outer list rows and skips the internal DataViews item buttons', async () => {
+		const wrapper = createListWrapper();
+
+		render(
+			<DataViewRowReorder
+				wrapperRef={ { current: wrapper } }
+				view={ {
+					type: 'list',
+					sort: null,
+				} }
+				onChangeView={ jest.fn() }
+				collectionId={ 7 }
+				rows={ rows }
+				onReordered={ jest.fn() }
+			/>
+		);
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'dnd-context' ) ).toBeInTheDocument()
+		);
+		await waitFor( () =>
+			expect( useDraggable ).toHaveBeenCalledTimes( 3 )
+		);
+
+		const listRows = wrapper.querySelectorAll(
+			'.dataviews-view-list > [role="row"]'
+		);
+		const itemButtons = wrapper.querySelectorAll(
+			'.dataviews-view-list__item'
+		);
+		expect( listRows ).toHaveLength( 3 );
+		expect( itemButtons ).toHaveLength( 3 );
+		expect( listRows[ 0 ] ).toHaveClass( 'cortext-row-reorder-target' );
+		expect( listRows[ 1 ] ).toHaveClass( 'cortext-row-reorder-target' );
+		expect( listRows[ 2 ] ).toHaveClass( 'cortext-row-reorder-target' );
+		expect( itemButtons[ 0 ] ).not.toHaveClass(
+			'cortext-row-reorder-target'
+		);
+		expect( itemButtons[ 1 ] ).not.toHaveClass(
+			'cortext-row-reorder-target'
+		);
+		expect( itemButtons[ 2 ] ).not.toHaveClass(
+			'cortext-row-reorder-target'
+		);
+		expect( screen.getAllByLabelText( /^Reorder row:/ ) ).toHaveLength( 3 );
+	} );
+
 	it( 'shows a row preview while dragging', async () => {
 		await renderReorder();
 

--- a/tests/js/components/DataViewRowReorder.test.js
+++ b/tests/js/components/DataViewRowReorder.test.js
@@ -363,7 +363,7 @@ function dragOver( drop ) {
 }
 
 describe( 'DataViewRowReorder', () => {
-	it( 'uses the outer list rows and skips the internal DataViews item buttons', async () => {
+	it( 'decorates outer list rows, not the internal DataViews buttons', async () => {
 		const wrapper = createListWrapper();
 
 		render(
@@ -407,7 +407,9 @@ describe( 'DataViewRowReorder', () => {
 		expect( itemButtons[ 2 ] ).not.toHaveClass(
 			'cortext-row-reorder-target'
 		);
-		expect( screen.getAllByLabelText( /^Reorder row:/ ) ).toHaveLength( 3 );
+		const handles = screen.getAllByLabelText( /^Reorder row:/ );
+		expect( handles ).toHaveLength( 3 );
+		expect( handles[ 0 ] ).toHaveAttribute( 'tabindex', '-1' );
 	} );
 
 	it( 'shows a row preview while dragging', async () => {

--- a/tests/js/components/EditOptionsPopover.test.js
+++ b/tests/js/components/EditOptionsPopover.test.js
@@ -299,6 +299,26 @@ describe( 'EditOptionsPopover', () => {
 		expect( onPick ).toHaveBeenCalledWith( 'stale' );
 	} );
 
+	it( 'uses a compact picker without selected token chips', () => {
+		render(
+			<EditOptionsPopover
+				recordId={ 7 }
+				fieldType="multiselect"
+				initialOptions={ [ { value: 'known', label: 'Known' } ] }
+				value={ [ 'known' ] }
+				variant="compact"
+				onPick={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByPlaceholderText( 'Search options' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Remove' } )
+		).not.toBeInTheDocument();
+	} );
+
 	it( 'does not pick a newly-created option when saving it fails', async () => {
 		const onPick = jest.fn();
 		mockUpdateRun.mockRejectedValueOnce( new Error( 'nope' ) );

--- a/tests/js/components/EditableCell.test.js
+++ b/tests/js/components/EditableCell.test.js
@@ -402,6 +402,14 @@ describe( 'formatDisplay', () => {
 			expect( screen.queryByText( 'LP' ) ).toBeNull();
 		} );
 	} );
+
+	describe( 'relation', () => {
+		it( 'returns the empty string when no relation references are present', () => {
+			expect( formatDisplay( [], 'relation' ) ).toBe( '' );
+			expect( formatDisplay( [ null ], 'relation' ) ).toBe( '' );
+			expect( formatDisplay( { id: 0 }, 'relation' ) ).toBe( '' );
+		} );
+	} );
 } );
 
 describe( 'dateOnlyValue', () => {

--- a/tests/js/components/EditableCell.test.js
+++ b/tests/js/components/EditableCell.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import {
 	dateOnlyValue,
@@ -436,5 +436,36 @@ describe( 'EditableCell option overrides', () => {
 		);
 
 		expect( screen.getByText( 'High' ) ).toHaveClass( 'cortext-chip--red' );
+	} );
+
+	it( 'starts editing when a displayed link is clicked', () => {
+		render(
+			<RowMutationContext.Provider
+				value={ {
+					saveRowField: jest.fn(),
+					canEditCells: true,
+				} }
+			>
+				<EditableCell
+					item={ {
+						id: 1,
+						meta: { website: 'https://example.com/path' },
+					} }
+					fieldId="website"
+					fieldType="url"
+					label="Website"
+				/>
+			</RowMutationContext.Provider>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'link', {
+				name: 'https://example.com/path',
+			} )
+		);
+
+		expect(
+			screen.getByRole( 'textbox', { name: 'Website' } )
+		).toHaveValue( 'https://example.com/path' );
 	} );
 } );

--- a/tests/js/components/PageIcon.test.js
+++ b/tests/js/components/PageIcon.test.js
@@ -1,0 +1,144 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { render, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/core-data', () => ( {
+	__esModule: true,
+	useEntityRecord: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/hooks/useDelayedFlag', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+
+jest.mock( '../../../src/components/PageIconWp', () => ( {
+	__esModule: true,
+	default: ( { size } ) => (
+		<svg data-testid="wp-glyph" width={ size } height={ size } />
+	),
+} ) );
+
+import { useEntityRecord } from '@wordpress/core-data';
+
+import PageIcon, { parsePageIcon } from '../../../src/components/PageIcon';
+
+const DEFAULT_SLOT_SIZE = '16px';
+const DEFAULT_GLYPH_SIZE = '22px';
+
+function iconMeta( value ) {
+	return JSON.stringify( value );
+}
+
+function renderedIcon( container ) {
+	return container.querySelector( '.cortext-document-icon' );
+}
+
+function expectStableSlot( element, size = DEFAULT_SLOT_SIZE ) {
+	expect( element ).toHaveStyle( {
+		width: size,
+		height: size,
+	} );
+}
+
+describe( 'PageIcon', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useEntityRecord.mockReturnValue( { record: null } );
+	} );
+
+	it( 'parses supported document icon metadata', () => {
+		expect(
+			parsePageIcon( iconMeta( { type: 'emoji', value: '\u{1F600}' } ) )
+		).toEqual( { type: 'emoji', value: '\u{1F600}' } );
+		expect(
+			parsePageIcon( iconMeta( { type: 'image', id: 42 } ) )
+		).toEqual( { type: 'image', id: 42 } );
+		expect(
+			parsePageIcon(
+				iconMeta( { type: 'wp', name: 'bell', color: 'blue' } )
+			)
+		).toEqual( { type: 'wp', name: 'bell', color: 'blue' } );
+		expect( parsePageIcon( '{' ) ).toBeNull();
+		expect(
+			parsePageIcon( iconMeta( { type: 'image', id: 0 } ) )
+		).toBeNull();
+	} );
+
+	it( 'keeps the same slot size for fallback, emoji, wp, and image icons', async () => {
+		useEntityRecord.mockReturnValue( {
+			record: {
+				source_url: 'https://example.test/icon.jpg',
+			},
+		} );
+
+		const fallback = render( <PageIcon /> );
+		const fallbackIcon = renderedIcon( fallback.container );
+		expect( fallbackIcon ).toHaveClass( 'cortext-document-icon--fallback' );
+		expectStableSlot( fallbackIcon );
+		expect(
+			fallbackIcon.style.getPropertyValue(
+				'--cortext-page-icon-glyph-size'
+			)
+		).toBe( DEFAULT_GLYPH_SIZE );
+		expect( fallbackIcon.querySelector( 'svg' ) ).toHaveAttribute(
+			'width',
+			'22'
+		);
+		fallback.unmount();
+
+		const emoji = render(
+			<PageIcon
+				icon={ iconMeta( { type: 'emoji', value: '\u{1F600}' } ) }
+			/>
+		);
+		const emojiIcon = renderedIcon( emoji.container );
+		expect( emojiIcon ).toHaveClass( 'cortext-document-icon--emoji' );
+		expectStableSlot( emojiIcon );
+		expect( emojiIcon ).toHaveStyle( { fontSize: '14px' } );
+		emoji.unmount();
+
+		const wp = render(
+			<PageIcon icon={ iconMeta( { type: 'wp', name: 'bell' } ) } />
+		);
+		const wpIcon = renderedIcon( wp.container );
+		expect( wpIcon ).toHaveClass( 'cortext-document-icon--wp' );
+		expectStableSlot( wpIcon );
+		expect(
+			wpIcon.style.getPropertyValue( '--cortext-page-icon-glyph-size' )
+		).toBe( DEFAULT_GLYPH_SIZE );
+		await waitFor( () =>
+			expect(
+				wp.container.querySelector( '[data-testid="wp-glyph"]' )
+			).toBeInTheDocument()
+		);
+		wp.unmount();
+
+		const image = render(
+			<PageIcon icon={ iconMeta( { type: 'image', id: 42 } ) } />
+		);
+		const imageIcon = renderedIcon( image.container );
+		expect( imageIcon ).toHaveClass( 'cortext-document-icon--image-wrap' );
+		expectStableSlot( imageIcon );
+		expect( image.container.querySelector( 'img' ) ).toHaveAttribute(
+			'width',
+			'16'
+		);
+	} );
+
+	it( 'keeps glyph svgs from shrinking in flex containers', () => {
+		const stylesheet = readFileSync(
+			join( process.cwd(), 'src/components/PageIcon.scss' ),
+			'utf8'
+		);
+
+		expect( stylesheet ).toContain(
+			'min-width: var(--cortext-page-icon-glyph-size);'
+		);
+		expect( stylesheet ).toContain(
+			'flex: 0 0 var(--cortext-page-icon-glyph-size);'
+		);
+		expect( stylesheet ).toContain( 'max-width: none;' );
+	} );
+} );

--- a/tests/js/components/dataViewItemLookup.test.js
+++ b/tests/js/components/dataViewItemLookup.test.js
@@ -1,0 +1,80 @@
+import { findDataViewItemFromEvent } from '../../../src/components/dataViewItemLookup';
+
+function eventFrom( target ) {
+	return { target };
+}
+
+describe( 'findDataViewItemFromEvent', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'resolves a grid card to the matching rendered row', () => {
+		const wrapper = document.createElement( 'div' );
+		wrapper.innerHTML = `
+			<div class="dataviews-view-grid">
+				<div class="dataviews-view-grid__card"><span>Alpha</span></div>
+				<div class="dataviews-view-grid__card"><span>Beta</span></div>
+			</div>
+		`;
+		document.body.appendChild( wrapper );
+
+		const target = wrapper.querySelectorAll( 'span' )[ 1 ];
+		const rowInfo = findDataViewItemFromEvent(
+			eventFrom( target ),
+			wrapper,
+			'grid',
+			[ { id: 10 }, { id: 20 } ]
+		);
+
+		expect( rowInfo ).toEqual( {
+			id: '20',
+			row: { id: 20 },
+		} );
+	} );
+
+	it( 'resolves a list row to the matching rendered row', () => {
+		const wrapper = document.createElement( 'div' );
+		wrapper.innerHTML = `
+			<div class="dataviews-view-list">
+				<div role="row"><div class="dataviews-title-field">Alpha</div></div>
+				<div role="row"><div class="dataviews-title-field">Beta</div></div>
+			</div>
+		`;
+		document.body.appendChild( wrapper );
+
+		const target = wrapper.querySelectorAll(
+			'.dataviews-title-field'
+		)[ 1 ];
+		const rowInfo = findDataViewItemFromEvent(
+			eventFrom( target ),
+			wrapper,
+			'list',
+			[ { id: 10 }, { id: 20 } ]
+		);
+
+		expect( rowInfo ).toEqual( {
+			id: '20',
+			row: { id: 20 },
+		} );
+	} );
+
+	it( 'ignores list rows outside the current wrapper', () => {
+		const wrapper = document.createElement( 'div' );
+		const otherWrapper = document.createElement( 'div' );
+		otherWrapper.innerHTML = `
+			<div class="dataviews-view-list">
+				<div role="row"><div class="dataviews-title-field">Beta</div></div>
+			</div>
+		`;
+		document.body.append( wrapper, otherWrapper );
+
+		const target = otherWrapper.querySelector( '.dataviews-title-field' );
+
+		expect(
+			findDataViewItemFromEvent( eventFrom( target ), wrapper, 'list', [
+				{ id: 20 },
+			] )
+		).toBeNull();
+	} );
+} );


### PR DESCRIPTION
## What

Closes #103.

This finishes the list side of the collection browsing baseline. List rows now feel like rows: clicking the empty space opens the row, visible properties sit beside the title, empty values disappear, and "+ New" sits where the next row would be. The PR also keeps row reorder attached to the real list row and fixes document icon sizing so emoji, images, fallback icons, and WP icons line up across layouts.

## Why

After the grid pass, list was still the layout that felt unfinished. DataViews gives us a usable base, but its default list behavior did not match how Cortext rows should open, edit, and scan.

## How

- Keep the native DataViews list layout.
- Make blank space in a row open that row, while clicks on property values still edit the value.
- Add keyboard movement and row opening for list rows.
- Make visible property values editable from the list.

## Testing Instructions

1. Open a collection with several rows and visible properties, then switch to List.
2. Click the blank area of a row and confirm it opens on the first click.
3. Click a visible property value, chip, or URL and confirm it edits instead of opening the row.
4. Move through list rows with Arrow Up/Down, Home/End, then open one with Enter or Space.
5. Add a row from "+ New", reorder rows in List, and confirm the spacing stays compact.

## Screen recording

https://github.com/user-attachments/assets/34f519a9-a632-4db9-b66a-19934f5785c1

