### PR TITLE
Release: Add milestone and type label automation

### DIFF
--- a/.github/workflows/assign-release-milestone.yml
+++ b/.github/workflows/assign-release-milestone.yml
@@ -1,0 +1,69 @@
+name: Assign Release Milestone
+
+on:
+    pull_request:
+        types: [closed]
+
+permissions:
+    issues: write
+    pull-requests: read
+
+jobs:
+    assign:
+        if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/github-script@v8
+              with:
+                  script: |
+                      const owner = context.repo.owner;
+                      const repo = context.repo.repo;
+                      const pr = context.payload.pull_request;
+                      const labels = pr.labels.map( ( label ) => label.name );
+
+                      if ( labels.includes( 'release: skip' ) ) {
+                        core.info( 'Skipping release milestone assignment because release: skip is present.' );
+                        return;
+                      }
+
+                      const milestones = await github.paginate(
+                        github.rest.issues.listMilestones,
+                        { owner, repo, state: 'open', per_page: 100 }
+                      );
+
+                      if ( milestones.length !== 1 ) {
+                        const message = milestones.length === 0
+                          ? 'No open release milestone exists. Create the next release milestone, for example 0.1.0.'
+                          : `Expected exactly one open release milestone, found ${ milestones.length }: ${ milestones.map( ( milestone ) => milestone.title ).join( ', ' ) }.`;
+                        await github.rest.issues.createComment( {
+                          owner,
+                          repo,
+                          issue_number: pr.number,
+                          body: `Release automation could not assign a milestone. ${ message }`,
+                        } );
+                        core.setFailed( message );
+                        return;
+                      }
+
+                      const milestone = milestones[0];
+                      if ( pr.milestone ) {
+                        core.info( `PR already has milestone ${ pr.milestone.title }; leaving it unchanged.` );
+                      } else {
+                        await github.rest.issues.update( {
+                          owner,
+                          repo,
+                          issue_number: pr.number,
+                          milestone: milestone.number,
+                        } );
+                        core.info( `Assigned milestone ${ milestone.title }.` );
+                      }
+
+                      const typeLabels = labels.filter( ( label ) => label.startsWith( 'type:' ) );
+                      if ( typeLabels.length !== 1 ) {
+                        await github.rest.issues.createComment( {
+                          owner,
+                          repo,
+                          issue_number: pr.number,
+                          body: `This PR is assigned to the release milestone ${ milestone.title }, but release notes need exactly one \`type:*\` label. Found ${ typeLabels.length ? typeLabels.map( ( label ) => `\`${ label }\`` ).join( ', ' ) : 'none' }.`,
+                        } );
+                      }

--- a/.github/workflows/assign-release-milestone.yml
+++ b/.github/workflows/assign-release-milestone.yml
@@ -1,7 +1,7 @@
 name: Assign Release Milestone
 
 on:
-    pull_request:
+    pull_request_target:
         types: [closed]
 
 permissions:
@@ -20,6 +20,13 @@ jobs:
                       const repo = context.repo.repo;
                       const pr = context.payload.pull_request;
                       const labels = pr.labels.map( ( label ) => label.name );
+                      const allowedTypeLabels = [
+                        'type: enhancement',
+                        'type: bug',
+                        'type: docs',
+                        'type: tooling',
+                        'type: code quality',
+                      ];
 
                       if ( labels.includes( 'release: skip' ) ) {
                         core.info( 'Skipping release milestone assignment because release: skip is present.' );
@@ -45,7 +52,8 @@ jobs:
                         return;
                       }
 
-                      const milestone = milestones[0];
+                      const releaseMilestone = milestones[0];
+                      let assignedMilestone = pr.milestone;
                       if ( pr.milestone ) {
                         core.info( `PR already has milestone ${ pr.milestone.title }; leaving it unchanged.` );
                       } else {
@@ -53,17 +61,23 @@ jobs:
                           owner,
                           repo,
                           issue_number: pr.number,
-                          milestone: milestone.number,
+                          milestone: releaseMilestone.number,
                         } );
-                        core.info( `Assigned milestone ${ milestone.title }.` );
+                        assignedMilestone = releaseMilestone;
+                        core.info( `Assigned milestone ${ releaseMilestone.title }.` );
                       }
 
                       const typeLabels = labels.filter( ( label ) => label.startsWith( 'type:' ) );
-                      if ( typeLabels.length !== 1 ) {
+                      const validTypeLabels = typeLabels.filter( ( label ) => allowedTypeLabels.includes( label ) );
+                      if ( typeLabels.length !== 1 || validTypeLabels.length !== 1 ) {
+                        const foundTypeLabels = typeLabels.length
+                          ? typeLabels.map( ( label ) => `\`${ label }\`` ).join( ', ' )
+                          : 'none';
+                        const allowedTypeLabelList = allowedTypeLabels.map( ( label ) => `\`${ label }\`` ).join( ', ' );
                         await github.rest.issues.createComment( {
                           owner,
                           repo,
                           issue_number: pr.number,
-                          body: `This PR is assigned to the release milestone ${ milestone.title }, but release notes need exactly one \`type:*\` label. Found ${ typeLabels.length ? typeLabels.map( ( label ) => `\`${ label }\`` ).join( ', ' ) : 'none' }.`,
+                          body: `This PR is assigned to the release milestone ${ assignedMilestone.title }, but release notes need exactly one supported \`type:*\` label. Found ${ foundTypeLabels }. Use one of: ${ allowedTypeLabelList }.`,
                         } );
                       }

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -1,0 +1,35 @@
+name: Enforce PR labels
+
+on:
+    pull_request_target:
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - ready_for_review
+            - labeled
+            - unlabeled
+
+permissions: {}
+
+jobs:
+    type-label:
+        if: ${{ github.event.pull_request.state == 'open' && github.event.pull_request.draft == false }}
+        runs-on: ubuntu-24.04
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5.5.2
+              with:
+                  mode: exactly
+                  count: 1
+                  labels: '^type:'
+                  use_regex: true
+                  add_comment: true
+                  message: |
+                      **Missing PR type label**
+
+                      This PR needs exactly one `type:*` label before it can merge.
+
+                      Valid labels are `type: enhancement`, `type: bug`, `type: docs`, `type: tooling`, and `type: code quality`.
+                  exit_type: failure

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -27,9 +27,9 @@ jobs:
                   use_regex: true
                   add_comment: true
                   message: |
-                      **Missing PR type label**
+                      **Choose one PR type**
 
-                      This PR needs exactly one `type:*` label before it can merge.
+                      Add exactly one `type:*` label before merging this PR.
 
-                      Valid labels are `type: enhancement`, `type: bug`, `type: docs`, `type: tooling`, and `type: code quality`.
+                      Use one of: `type: enhancement`, `type: bug`, `type: docs`, `type: tooling`, `type: code quality`.
                   exit_type: failure

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -23,7 +23,7 @@ jobs:
               with:
                   mode: exactly
                   count: 1
-                  labels: '^type:'
+                  labels: '^(type: enhancement|type: bug|type: docs|type: tooling|type: code quality)$'
                   use_regex: true
                   add_comment: true
                   message: |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Cortext stores documents, collection definitions, fields, and collection rows as
 ## Docs
 
 -   [Getting started](docs/getting-started.md): install, run, day-to-day commands.
+-   [Release process](docs/release.md): milestones, labels, and changelog previews.
 -   [Vision and principles](docs/vision.md): what drives the design.
 -   [Architecture](docs/architecture.md): current storage and shell overview.
 -   [Shell architecture](docs/architecture/shell.md): React shell, mount point, editor setup.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,79 @@
+# Release process
+
+Cortext builds release notes from GitHub milestones. For now the release flow is
+small on purpose; we can add ceremony once there is a real cadence to protect.
+
+## Milestones
+
+-   Keep exactly one release milestone open at a time.
+-   Milestone titles are version numbers, starting with `0.1.0`.
+-   Git tags and GitHub Release names use the same version number, without a
+    leading `v`.
+-   Milestones do not need due dates.
+-   After publishing a release, close its milestone and create the next one.
+
+The first milestone is `0.1.0`.
+
+## Versioning
+
+Use the same version number for the plugin header, `readme.txt` stable tag,
+milestone, Git tag, and GitHub Release name.
+
+-   `0.1.0` is the first public beta.
+-   `0.1.1` is a patch release for the `0.1` beta line.
+-   `0.2.0` is the next beta with larger product changes.
+-   `1.0.0` is the first stable release.
+-   After `1.0.0`, use major releases such as `2.0.0` for incompatible changes.
+
+While Cortext is in `0.x`, treat minor releases as beta release lines and patch
+releases as fixes to the current beta.
+
+## PR labels
+
+Every PR included in a release needs exactly one `type:*` label:
+
+-   `type: enhancement` for product changes, including new features and
+    improvements to existing behavior
+-   `type: bug`
+-   `type: docs`
+-   `type: tooling` for CI, release, packaging, scripts, dependencies, and
+    repo automation
+-   `type: code quality` for refactors, cleanup, tests, and internal structure
+
+Use `release: skip` for PRs that should not be assigned to the active release
+milestone. A skipped PR does not need a `type:*` label.
+
+Area labels are optional and do not affect release automation. Add them when
+they make planning or filtering easier:
+
+-   `area: desktop`
+-   `area: performance`
+
+## Automatic assignment
+
+When a PR is merged into `main`, `.github/workflows/assign-release-milestone.yml`
+assigns it to the single open milestone unless:
+
+-   the PR already has a milestone, or
+-   the PR has `release: skip`.
+
+If there is no open milestone, or more than one, the workflow comments on the PR
+and fails. If the PR does not have exactly one `type:*` label, it leaves a
+comment so the changelog can be fixed before release time.
+
+## Changelog preview
+
+Preview the changelog locally:
+
+```bash
+pnpm run release:notes -- --milestone 0.1.0 --version 0.1.0 --strict
+```
+
+Save the changelog locally:
+
+```bash
+pnpm run release:notes -- --milestone 0.1.0 --version 0.1.0 --strict > .context/release-notes-0.1.0.md
+```
+
+Use `--strict` before drafting a release. It fails if any included PR is missing
+a `type:*` label or has more than one.

--- a/docs/release.md
+++ b/docs/release.md
@@ -74,6 +74,10 @@ fails if a ready PR has zero `type:*` labels or more than one.
 
 ## Changelog preview
 
+By default, release notes are the public changelog. They include user-facing
+enhancements and bug fixes, and leave docs, tooling, and code quality changes
+out of the published notes.
+
 Preview the changelog locally:
 
 ```bash
@@ -86,5 +90,11 @@ Save the changelog locally:
 pnpm run release:notes -- --milestone 0.1.0 --version 0.1.0 --strict > .context/release-notes-0.1.0.md
 ```
 
-Use `--strict` before drafting a release. It fails if any included PR is missing
-a `type:*` label or has more than one.
+Preview the full milestone changelog when you want an internal audit:
+
+```bash
+pnpm run release:notes -- --milestone 0.1.0 --version 0.1.0 --strict --full
+```
+
+Use `--strict` before drafting a release. It fails if any milestone PR is
+missing a `type:*` label or has more than one.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,7 +1,7 @@
 # Release process
 
-Cortext builds release notes from GitHub milestones. For now the release flow is
-small on purpose; we can add ceremony once there is a real cadence to protect.
+Cortext builds release notes from GitHub milestones. The process is intentionally
+small for now; we can add more steps once we have a regular release cadence.
 
 ## Milestones
 
@@ -47,14 +47,14 @@ label.
 Area labels are optional and do not affect release automation. Add them when
 they make planning or filtering easier:
 
--   `area: canvas` for the block editor canvas, blocks, inspector, covers,
-    icons, and document chrome
+-   `area: canvas` for the block editor canvas, blocks, inspector, covers, and
+    icons
 -   `area: collections` for fields, rows, views, DataViews, relations, rollups,
     formulas, and row properties
 -   `area: desktop`
 -   `area: performance` for budgets, profiling, benchmarks, and regressions
--   `area: publishing` for public rendering through WordPress, templates,
-    frontend block output, and theme-facing views
+-   `area: publishing` for public output through WordPress, templates, frontend
+    block rendering, and theme-facing views
 -   `area: shell` for the app shell, sidebar, routing, top bar, command palette,
     recents, favorites, trash, and layout
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -30,7 +30,7 @@ releases as fixes to the current beta.
 
 ## PR labels
 
-Every PR included in a release needs exactly one `type:*` label:
+Every PR needs exactly one `type:*` label:
 
 -   `type: enhancement` for product changes, including new features and
     improvements to existing behavior
@@ -41,7 +41,8 @@ Every PR included in a release needs exactly one `type:*` label:
 -   `type: code quality` for refactors, cleanup, tests, and internal structure
 
 Use `release: skip` for PRs that should not be assigned to the active release
-milestone. A skipped PR does not need a `type:*` label.
+milestone. It only skips milestone assignment; the PR still needs one `type:*`
+label.
 
 Area labels are optional and do not affect release automation. Add them when
 they make planning or filtering easier:
@@ -58,8 +59,10 @@ assigns it to the single open milestone unless:
 -   the PR has `release: skip`.
 
 If there is no open milestone, or more than one, the workflow comments on the PR
-and fails. If the PR does not have exactly one `type:*` label, it leaves a
-comment so the changelog can be fixed before release time.
+and fails.
+
+`.github/workflows/enforce-pr-labels.yml` also checks open PRs before merge. It
+fails if a ready PR has zero `type:*` labels or more than one.
 
 ## Changelog preview
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -47,8 +47,16 @@ label.
 Area labels are optional and do not affect release automation. Add them when
 they make planning or filtering easier:
 
+-   `area: canvas` for the block editor canvas, blocks, inspector, covers,
+    icons, and document chrome
+-   `area: collections` for fields, rows, views, DataViews, relations, rollups,
+    formulas, and row properties
 -   `area: desktop`
--   `area: performance`
+-   `area: performance` for budgets, profiling, benchmarks, and regressions
+-   `area: publishing` for public rendering through WordPress, templates,
+    frontend block output, and theme-facing views
+-   `area: shell` for the app shell, sidebar, routing, top bar, command palette,
+    recents, favorites, trash, and layout
 
 ## Automatic assignment
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"dev": "wp-scripts start",
 		"build": "wp-scripts build",
 		"build:zip": "./scripts/build-zip.sh",
+		"release:notes": "node scripts/release-notes.mjs",
 		"format": "wp-scripts format",
 		"format:check": "prettier --check '**/*.{js,jsx,json,ts,tsx,yml,yaml}' --config .prettierrc.js --ignore-path .prettierignore",
 		"lint:js": "wp-scripts lint-js src",

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const TYPE_LABELS = new Map( [
+	[ 'type: enhancement', 'Enhancements' ],
+	[ 'type: bug', 'Bug fixes' ],
+	[ 'type: docs', 'Documentation' ],
+	[ 'type: tooling', 'Tooling' ],
+	[ 'type: code quality', 'Code quality' ],
+] );
+
+const TYPE_ORDER = [
+	'Enhancements',
+	'Bug fixes',
+	'Documentation',
+	'Tooling',
+	'Code quality',
+];
+
+function parseArgs() {
+	const args = process.argv.slice( 2 );
+	const options = {
+		repo: process.env.GITHUB_REPOSITORY || 'Automattic/cortext',
+		milestone: '',
+		version: '',
+		strict: false,
+	};
+
+	for ( let i = 0; i < args.length; i++ ) {
+		const arg = args[ i ];
+		const next = args[ i + 1 ];
+		if ( arg === '--repo' && next ) {
+			options.repo = next;
+			i++;
+			continue;
+		}
+		if ( arg === '--milestone' && next ) {
+			options.milestone = next;
+			i++;
+			continue;
+		}
+		if ( arg === '--version' && next ) {
+			options.version = next;
+			i++;
+			continue;
+		}
+		if ( arg === '--strict' ) {
+			options.strict = true;
+			continue;
+		}
+		throw new Error( `Unknown or incomplete argument: ${ arg }` );
+	}
+
+	if ( ! options.milestone ) {
+		throw new Error( 'Missing required --milestone value.' );
+	}
+
+	return options;
+}
+
+function ghJson( args ) {
+	const result = spawnSync( 'gh', args, {
+		encoding: 'utf8',
+		maxBuffer: 1024 * 1024 * 16,
+		stdio: [ 'ignore', 'pipe', 'pipe' ],
+	} );
+
+	if ( result.error ) {
+		throw result.error;
+	}
+	if ( result.status !== 0 ) {
+		throw new Error(
+			result.stderr.trim() || `gh ${ args.join( ' ' ) } failed.`
+		);
+	}
+
+	return JSON.parse( result.stdout || '[]' );
+}
+
+function normalizeTitle( title ) {
+	const normalized = title
+		.replace(
+			/^(feat|feature|fix|bugfix|docs|build|chore|internal)(\([^)]+\))?!?:\s*/i,
+			''
+		)
+		.trim();
+	return normalized
+		? normalized[ 0 ].toUpperCase() + normalized.slice( 1 )
+		: title;
+}
+
+function sentence( text ) {
+	return /[.!?]$/.test( text ) ? text : `${ text }.`;
+}
+
+function getTypeLabels( pr ) {
+	return pr.labels
+		.map( ( label ) => label.name )
+		.filter( ( name ) => TYPE_LABELS.has( name.toLowerCase() ) );
+}
+
+function formatPr( pr ) {
+	const title = sentence( normalizeTitle( pr.title ) );
+	return `- ${ title } ([#${ pr.number }](${ pr.html_url || pr.url }))`;
+}
+
+async function main() {
+	const options = parseArgs();
+	const [ owner, repoName ] = options.repo.split( '/' );
+	if ( ! owner || ! repoName ) {
+		throw new Error( `Invalid --repo value: ${ options.repo }` );
+	}
+
+	const milestones = ghJson( [
+		'api',
+		`repos/${ owner }/${ repoName }/milestones`,
+		'--method',
+		'GET',
+		'--paginate',
+		'-f',
+		'state=all',
+	] );
+
+	const milestone = milestones.find(
+		( item ) => item.title === options.milestone
+	);
+	if ( ! milestone ) {
+		throw new Error(
+			`Cannot find milestone "${ options.milestone }" in ${ options.repo }.`
+		);
+	}
+
+	const items = ghJson( [
+		'api',
+		`repos/${ owner }/${ repoName }/issues`,
+		'--method',
+		'GET',
+		'--paginate',
+		'-f',
+		'state=closed',
+		'-f',
+		`milestone=${ milestone.number }`,
+	] );
+
+	const pullRequests = items
+		.filter( ( item ) => item.pull_request )
+		.sort( ( a, b ) => a.number - b.number );
+
+	const errors = [];
+	const grouped = new Map( TYPE_ORDER.map( ( type ) => [ type, [] ] ) );
+
+	for ( const pr of pullRequests ) {
+		const typeLabels = getTypeLabels( pr );
+		if ( typeLabels.length !== 1 ) {
+			errors.push(
+				`#${ pr.number } needs exactly one type:* label; found ${
+					typeLabels.length ? typeLabels.join( ', ' ) : 'none'
+				}.`
+			);
+			continue;
+		}
+
+		const section = TYPE_LABELS.get( typeLabels[ 0 ].toLowerCase() );
+		grouped.get( section ).push( pr );
+	}
+
+	if ( errors.length && options.strict ) {
+		throw new Error(
+			`Release note classification failed:\n${ errors.join( '\n' ) }`
+		);
+	}
+
+	const title = options.version
+		? `# Cortext ${ options.version }`
+		: `# ${ options.milestone }`;
+	let notes = `${ title }\n\n`;
+
+	if ( ! pullRequests.length ) {
+		notes += 'No pull requests were found for this milestone.\n';
+	} else {
+		for ( const section of TYPE_ORDER ) {
+			const prs = grouped.get( section );
+			if ( ! prs.length ) {
+				continue;
+			}
+			notes += `## ${ section }\n\n`;
+			notes += `${ prs.map( formatPr ).join( '\n' ) }\n\n`;
+		}
+	}
+
+	const contributors = [
+		...new Set(
+			pullRequests
+				.map( ( pr ) => pr.user?.login )
+				.filter( Boolean )
+				.filter( ( login ) => ! login.endsWith( '[bot]' ) )
+		),
+	].sort( ( a, b ) => a.localeCompare( b ) );
+
+	if ( contributors.length ) {
+		notes += '## Contributors\n\n';
+		notes += contributors.map( ( login ) => `@${ login }` ).join( ' ' );
+		notes += '\n\n';
+	}
+
+	if ( errors.length ) {
+		notes += '## Release note warnings\n\n';
+		notes += errors.map( ( error ) => `- ${ error }` ).join( '\n' );
+		notes += '\n';
+	}
+
+	process.stdout.write( notes );
+}
+
+main().catch( ( error ) => {
+	console.error( error.message );
+	process.exit( 1 );
+} );

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -143,7 +143,7 @@ async function main() {
 	] );
 
 	const pullRequests = items
-		.filter( ( item ) => item.pull_request )
+		.filter( ( item ) => item.pull_request?.merged_at )
 		.sort( ( a, b ) => a.number - b.number );
 
 	const errors = [];

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -9,6 +9,8 @@ const TYPE_LABELS = new Map( [
 	[ 'type: code quality', 'Code quality' ],
 ] );
 
+const PUBLIC_TYPE_LABELS = new Set( [ 'type: enhancement', 'type: bug' ] );
+
 const TYPE_ORDER = [
 	'Enhancements',
 	'Bug fixes',
@@ -24,6 +26,7 @@ function parseArgs() {
 		milestone: '',
 		version: '',
 		strict: false,
+		full: false,
 	};
 
 	for ( let i = 0; i < args.length; i++ ) {
@@ -46,6 +49,10 @@ function parseArgs() {
 		}
 		if ( arg === '--strict' ) {
 			options.strict = true;
+			continue;
+		}
+		if ( arg === '--full' ) {
+			options.full = true;
 			continue;
 		}
 		throw new Error( `Unknown or incomplete argument: ${ arg }` );
@@ -99,6 +106,21 @@ function getTypeLabels( pr ) {
 		.filter( ( name ) => TYPE_LABELS.has( name.toLowerCase() ) );
 }
 
+function getIncludedTypeLabels( options ) {
+	if ( options.full ) {
+		return new Set( TYPE_LABELS.keys() );
+	}
+	return PUBLIC_TYPE_LABELS;
+}
+
+function getTypeOrder( includedTypeLabels ) {
+	return TYPE_ORDER.filter( ( section ) =>
+		Array.from( includedTypeLabels ).some(
+			( typeLabel ) => TYPE_LABELS.get( typeLabel ) === section
+		)
+	);
+}
+
 function formatPr( pr ) {
 	const title = sentence( normalizeTitle( pr.title ) );
 	return `- ${ title } ([#${ pr.number }](${ pr.html_url || pr.url }))`;
@@ -147,7 +169,10 @@ async function main() {
 		.sort( ( a, b ) => a.number - b.number );
 
 	const errors = [];
-	const grouped = new Map( TYPE_ORDER.map( ( type ) => [ type, [] ] ) );
+	const includedTypeLabels = getIncludedTypeLabels( options );
+	const typeOrder = getTypeOrder( includedTypeLabels );
+	const grouped = new Map( typeOrder.map( ( type ) => [ type, [] ] ) );
+	const includedPullRequests = [];
 
 	for ( const pr of pullRequests ) {
 		const typeLabels = getTypeLabels( pr );
@@ -160,8 +185,14 @@ async function main() {
 			continue;
 		}
 
-		const section = TYPE_LABELS.get( typeLabels[ 0 ].toLowerCase() );
+		const typeLabel = typeLabels[ 0 ].toLowerCase();
+		if ( ! includedTypeLabels.has( typeLabel ) ) {
+			continue;
+		}
+
+		const section = TYPE_LABELS.get( typeLabel );
 		grouped.get( section ).push( pr );
+		includedPullRequests.push( pr );
 	}
 
 	if ( errors.length && options.strict ) {
@@ -177,8 +208,12 @@ async function main() {
 
 	if ( ! pullRequests.length ) {
 		notes += 'No pull requests were found for this milestone.\n';
+	} else if ( ! includedPullRequests.length ) {
+		notes += options.full
+			? 'No release note entries were found for this milestone.\n'
+			: 'No public changelog entries were found for this milestone.\n';
 	} else {
-		for ( const section of TYPE_ORDER ) {
+		for ( const section of typeOrder ) {
 			const prs = grouped.get( section );
 			if ( ! prs.length ) {
 				continue;
@@ -190,7 +225,7 @@ async function main() {
 
 	const contributors = [
 		...new Set(
-			pullRequests
+			includedPullRequests
 				.map( ( pr ) => pr.user?.login )
 				.filter( Boolean )
 				.filter( ( login ) => ! login.endsWith( '[bot]' ) )


### PR DESCRIPTION
## What

Part of #283

Adds the release setup for the first beta: release notes from GitHub milestones, a required `type:*` label check, automatic milestone assignment after merge, and a short release process doc. The default changelog stays public-facing; `--full` shows docs, tooling, and code quality changes when we want to audit the whole milestone.

## Why

Cortext already has a long pre-release history. Before the beta, we need a reliable way to know what shipped and what kind of change each PR made. Capturing that as PRs merge is much safer than reconstructing it at the end.

## How

- Builds public notes from enhancements and bug fixes by default.
- Adds `--full` for the internal milestone view.
- Assigns merged PRs to the one open release milestone, unless they have `release: skip`.
- Blocks ready PRs that have zero supported `type:*` labels or more than one.

## Testing Instructions

1. Check that this PR has exactly one `type:*` label.
2. Read `docs/release.md` and compare the documented labels with the labels available in GitHub.
