### PR TITLE
Fix: Match the canvas layout to theme support

### DIFF
--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -1126,7 +1126,32 @@ export default function EditorBody( {
 	const styles = extraStyles
 		? [ ...( baseStyles ?? [] ), ...extraStyles ]
 		: baseStyles;
-	const [ layout ] = useSettings( 'layout' );
+	const { themeSupportsLayout, hasRootPaddingAwareAlignments } = useSelect(
+		( select ) => {
+			const settings = select( blockEditorStore ).getSettings();
+			return {
+				themeSupportsLayout: settings.supportsLayout,
+				hasRootPaddingAwareAlignments:
+					settings.__experimentalFeatures
+						?.useRootPaddingAwareAlignments,
+			};
+		},
+		[]
+	);
+	const [ globalLayoutSettings ] = useSettings( 'layout' );
+	// Match @wordpress/editor's visual-editor fallback. Themes with layout
+	// support get the constrained post-content canvas; classic themes keep the
+	// default flow layout.
+	const canvasLayout = themeSupportsLayout
+		? { type: 'constrained', ...globalLayoutSettings }
+		: { type: 'default' };
+	const canvasClassName = [
+		'wp-block-post-content',
+		themeSupportsLayout ? 'is-layout-constrained' : 'is-layout-flow',
+		hasRootPaddingAwareAlignments ? 'has-global-padding' : '',
+	]
+		.filter( Boolean )
+		.join( ' ' );
 	const blockCanvasRef = useRef( null );
 	const isTrashed = useSelect(
 		( select ) =>
@@ -1178,8 +1203,8 @@ export default function EditorBody( {
 						.join( ' ' ) }
 				>
 					<BlockList
-						className="wp-block-post-content is-layout-constrained has-global-padding"
-						layout={ { type: 'constrained', ...layout } }
+						className={ canvasClassName }
+						layout={ canvasLayout }
 						renderAppender={ renderAppender }
 					/>
 				</div>


### PR DESCRIPTION
## What

Part of #85.

Cortext now matches the document canvas layout to the active theme. Themes with layout support keep the constrained canvas; classic themes use the normal flow layout.

## Why

Classic themes should not get constrained layout classes or global padding when they do not support that layout model.

## How

- Reading the editor layout settings before rendering the canvas.
- Applying constrained or flow classes based on theme support.
- Adding global padding only when the editor enables root-padding-aware alignments.

## Testing Instructions

1. Open a Cortext document with a theme that supports layout settings.
2. Confirm the canvas still uses the constrained content width.
3. Switch to a classic theme without layout support.
4. Confirm the same document uses the normal flow layout.
