### PR TITLE
Build: Add plugin ZIP packaging

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,6 +44,7 @@ This is not optional. wp-env runs detached and would leak containers if a worktr
 ```
 pnpm run dev          # JS watcher, when wp-env is already running
 pnpm run build        # production build
+pnpm run build:zip    # production build packaged as dist/cortext.zip
 pnpm run lint:js      # ESLint, scoped to src/
 pnpm run lint:php     # PHPCS via pnpm (same as composer phpcs)
 pnpm run lint:style   # stylelint for src/**/*.{css,pcss,scss}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ Cortext is an early prototype. There is no packaged release yet; to try it you r
 -   PHP 8.1+
 -   WordPress 6.9+ (provided by wp-env)
 -   Docker (recommended runtime for wp-env)
--   Node.js 24.15
+-   Node.js 24.15 or newer in the Node 24 line
 -   pnpm 11+
 -   Git
 
@@ -44,7 +44,7 @@ This is not optional. wp-env runs detached and would leak containers if a worktr
 ```
 pnpm run dev          # JS watcher, when wp-env is already running
 pnpm run build        # production build
-pnpm run build:zip    # production build packaged as dist/cortext.zip
+pnpm run build:zip    # build dist/cortext.zip
 pnpm run lint:js      # ESLint, scoped to src/
 pnpm run lint:php     # PHPCS via pnpm (same as composer phpcs)
 pnpm run lint:style   # stylelint for src/**/*.{css,pcss,scss}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"start:seed": "wp-env start && pnpm run env:seed && pnpm run dev",
 		"dev": "wp-scripts start",
 		"build": "wp-scripts build",
+		"build:zip": "./scripts/build-zip.sh",
 		"format": "wp-scripts format",
 		"format:check": "prettier --check '**/*.{js,jsx,json,ts,tsx,yml,yaml}' --config .prettierrc.js --ignore-path .prettierignore",
 		"lint:js": "wp-scripts lint-js src",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"description": "Knowledge base inside WordPress.",
 	"engines": {
-		"node": "~24.15",
+		"node": "^24.15",
 		"pnpm": ">=11"
 	},
 	"private": true,

--- a/scripts/build-zip.sh
+++ b/scripts/build-zip.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Build a distributable Cortext plugin ZIP.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+dist_dir="dist"
+stage_dir="${dist_dir}/cortext"
+zip_path="${dist_dir}/cortext.zip"
+
+command -v zip >/dev/null || {
+	echo "Missing required command: zip" >&2
+	exit 1
+}
+
+pnpm install --frozen-lockfile
+pnpm run build
+
+rm -rf "$stage_dir" "$zip_path"
+mkdir -p "$stage_dir"
+
+runtime_paths=(
+	cortext.php
+	readme.txt
+	LICENSE
+	cortext-banner.png
+	cortext-banner.svg
+	includes
+	templates
+	build
+	seed-assets
+	composer.json
+	composer.lock
+)
+
+cp -R "${runtime_paths[@]}" "$stage_dir"
+
+composer install \
+	--working-dir="$stage_dir" \
+	--no-dev \
+	--no-scripts \
+	--optimize-autoloader \
+	--no-interaction
+
+rm -f "${stage_dir}/composer.json" "${stage_dir}/composer.lock"
+
+(
+	cd "$dist_dir"
+	zip -qr cortext.zip cortext
+)
+
+echo "Built ${zip_path}"

--- a/scripts/build-zip.sh
+++ b/scripts/build-zip.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build a distributable Cortext plugin ZIP.
+# Build dist/cortext.zip without changing the local dev install.
 
 set -euo pipefail
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
## What

Part of #283.

Adds `pnpm run build:zip`, which builds `dist/cortext.zip` for releases and Playground. It also lets the repo use newer Node 24 releases instead of pinning development to the `24.15.x` patch line.

## Why

We need one repeatable way to package Cortext before the release and Playground PRs can use it. The ZIP should include built assets and production Composer dependencies, but it should not rewrite the local dev install in the process.

## How

- Stages the plugin files in `dist/cortext/` before zipping them.
- Runs Composer inside that staged copy with dev packages and scripts disabled.
- Keeps Node on the 24.x line while allowing newer Node 24 patch and minor releases.

## Testing Instructions

1. Run `pnpm run build:zip`.
2. Check that `dist/cortext.zip` contains `cortext/cortext.php`, `cortext/build/index.js`, and `cortext/vendor/autoload.php`.
3. Check that the ZIP does not contain `node_modules`, `src`, `tests`, `apps`, `.github`, `composer.json`, or `package.json`.
