### PR TITLE
Docs: Reshape `tech-debt.md`

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,106 +1,639 @@
 # Tech debt and upstream gaps
 
-A running log of the workarounds in this codebase. Most are here because a primitive is missing in WordPress core or Gutenberg rather than because we cut corners. The high-impact items live at the top; trivial ones at the bottom.
+A running log of the workarounds in this codebase. Most are here because a primitive is missing in WordPress core or Gutenberg rather than because we cut corners.
 
-Each entry is tagged `[upstream]` (we're waiting on Gutenberg or core) or `[internal]` (ours to schedule), and broken into **What** (the problem), **Where** (the code that's load-bearing), and **Solution** (how this gets cleaner). Numbers are stable cross-references: code that works around an entry tags itself with `tech-debt.md#N`, so `grep -r 'tech-debt.md#3' src/` lights up every spot affected.
+The doc has two sections. **Upstream opportunities** are gaps in Gutenberg, WordPress, or supporting libraries; if upstream fills them, the corresponding plugin code disappears. **Internal debt** is work we own to schedule.
+
+Each entry has a stable slug anchor (`td-…`). Code that works around an entry tags itself with `tech-debt.md#td-slug`, so `grep -r 'tech-debt.md#td-row-sort-split' src/` lights up every spot affected. Entries follow **What** (the problem), **Where** (the load-bearing code), and **Solution** (how this gets cleaner).
 
 Pair with [decisions.md](decisions.md) for choices we've made peace with and [roadmap.md](roadmap.md) for net-new product work.
 
-## 1. DataViews has no inline cell editing `[upstream]`
+---
+
+## Upstream opportunities
+
+### DataViews and field views
+
+<a id="td-dataviews-inline-editing"></a>
+
+**DataViews has no inline cell editing.**
 
 **What.** DataViews v6 can render values and edit them through a separate `DataForm`, but it cannot turn a rendered value into an inline editor. Cortext mounts its own editor from `field.render` (documented as a display renderer, but the only hook available), keeps edit state per cell, and sends saves through `RowMutationContext` because `field.render` only receives `{ item }`. Tab and Shift+Tab live in the same layer: editors catch Tab, ask the parent for the next editable cell through `requestNext`, and the target cell opens through the same `editRequest` channel used to focus the title cell in a fresh row. Table, grid, and list use that surface when a visible field supports it.
 
-**Where.** `src/components/EditableCell.js`, `RowMutationContext` and `requestNext` in `src/components/CollectionDataViews.js`, plus a sliver of `src/components/CollectionDataViews.scss`.
+DataViews renders an actual `<table>`; Cortext switches it to `table-layout: fixed` so resize widths behave as real column constraints, renders the display shell, and overlays the editor on top via `position: absolute` so the table only sees the display state while the editor is open. The shell's `min-height` is pinned to 40px to match `__next40pxDefaultSize`, the height of TextControl/NumberControl/SelectControl with the modern WP size flag. DataViews paints row height via the td's `padding-block`, varied per density; the shell zeroes that padding and replicates the per-density row heights via `min-height` overrides so the hover/edit highlight covers the row edge to edge. Balanced and comfortable mirror DataViews v6 (12 / 16); compact is intentionally tighter than upstream (4 → 0) to match the 40px editor floor, and compact is the default in `createDefaultView` and `DEFAULT_LAYOUTS`.
 
-**Solution.** Upstream would need an `editable` mode on DataViews layouts that uses each field's `Edit` per value, an `onSaveItem(item, changes)` prop on `<DataViews>`, native cell-to-cell keyboard navigation where the layout supports it, and a documented path for controls rendered inline. That would remove `RowMutationContext`, `requestNext`, most of `EditableCell`, and the layout couplings tracked in #5. This is still the largest workaround on the page: roughly 530 lines of `EditableCell`, plus context wiring and the navigation walker. File a Gutenberg issue with the use case and proposed API; `docs/roadmap.md` lists upstream issues as a stretch success metric.
+**Where.** `src/components/EditableCell.js`, `RowMutationContext` and `requestNext` in `src/components/CollectionDataViews.js`, plus the `.cortext-editable-cell`, `.cortext-cell-checkbox`, and `.cortext-data-view .dataviews-view-table` rules in `src/components/CollectionDataViews.scss`.
 
-## 2. Rows aren't in `core-data`'s entity store `[internal]`
+**Solution.** An `editable` mode on DataViews layouts that uses each field's `Edit` per value, an `onSaveItem(item, changes)` prop on `<DataViews>`, native cell-to-cell keyboard navigation where the layout supports it, and a documented path for controls rendered inline. That would remove `RowMutationContext`, `requestNext`, most of `EditableCell`, and the overlay / height pin / density mirror.
 
-Updated by [#80](https://github.com/priethor/cortext/pull/80), #179, #118, and the relation-picker search pass.
+<a id="td-dataviews-multiselect-control"></a>
 
-**What.** Rows still sit outside `core-data`. `useCollectionRows` owns fetch state, the `requestId` race guard, the manual `refresh()` counter, and the choice between server and client mode. #80 moved the normal table path to paged REST requests, then changed the fallback from one `per_page=-1` request to pages of 100 fetched with a small concurrency cap. #179 exposed the same gap from another angle: trashing or restoring a row can change relation chips and rollups in other open collections. Since there is no shared row store, the client fires small row and document-trash events, then lets open row queries and the sidebar Trash list refetch.
+**DataViews has no multiselect form control.**
 
-The dynamic `crtxt_{slug}` post types already use `show_in_rest`, so `core-data` can probably discover them lazily. We have not wired rows through it yet. Mutations still POST directly with `apiFetch`, then ask the hook to refetch. Relation chips now add a second small read path: when a saved relation only has IDs, `useCollectionRowsByIds` calls `/cortext/v1/rows?include[]=...` so the picker can show labels without walking the whole target collection.
+**What.** DataViews v6 ships `text`, `integer`, `email`, `datetime`, `radio`, `select`, `toggleGroup`, `boolean`, and `checkbox` controls but no multiselect. Cortext used to bridge that with `FormTokenField`, but option editing outgrew it: multiselect now opens the same option picker as Select so users can create, recolor, rename, delete, and migrate options from the cell. That gives one option-management surface, but every multiselect cell still carries a custom editor instead of a DataViews-native control.
 
-Full-page collection creation hit the same schema-cache edge. A new collection registers a dynamic row CPT on the server, but `core-data` may already have cached `/wp/v2/types`. The sidebar and DataView block creator invalidate `getEntitiesConfig( 'postType' )` after creation so the next row `useEntityRecord` can see the new entity instead of waiting on a type it does not know about.
+**Where.** `src/components/MultiselectEdit.js`.
+
+**Solution.** A `multiselect` dataform-control upstream that DataForm and a future inline-edit mode resolve from `Edit: 'multiselect'`. It needs hooks for custom option rendering and option management, not just a token input, otherwise Cortext still needs the picker.
+
+<a id="td-dataviews-layout-slots"></a>
+
+**DataViews has no layout extension slots (append rows or footer).**
+
+**What.** DataViews owns layout markup but exposes no place to add content. Cortext needs two slots.
+
+The first is an append row at the bottom of a layout for the "+ New" affordance. Table and list use a Cortext footer mounted just outside `<DataViews>`, with a CSS layer that works around DataViews' default `height: 100%`. Grid is trickier: the button needs to sit with the cards, so Cortext finds the rendered `.dataviews-view-grid` node and portals `DataViewNewRowButton` into it. Empty grid views fall back to a local grid shell until DataViews renders a real grid node.
+
+The second is a footer row for column summaries and table-level bulk actions. The calculation footer has to find the rendered `.dataviews-view-table`, watch for it with a `MutationObserver`, and portal a `<tfoot>` into the table after DataViews renders. Table bulk-action controls share that footer row so selected-row controls and column summaries sit on one line. Calculations also need rows after search/filter but before pagination, which DataViews does not hand back; Cortext runs DataViews' `filterSortAndPaginate` helper a second time with `page` and `perPage` removed.
+
+**Where.** `DataViewNewRowButton` in `src/components/DataViewNewRowButton.js`, `GridNewRowPortal` in `src/components/GridNewRowPortal.js`, `TableCalculationsFooter` in `src/components/TableCalculationsFooter.js`, the footer mount and second filtering pass in `src/components/CollectionDataViews.js`, and the footer / new-row-card / footer-row rules in `src/components/CollectionDataViews.scss`, `src/components/CollectionDataViews.grid.scss`, and `src/components/CollectionDataViews.list.scss`.
+
+**Solution.** Upstream needs an append-item slot per layout (covers "+ New"), a table `renderFooter` / `renderSummaryRow` slot (covers calculations and table-level bulk actions), and a helper that returns filtered rows before pagination (covers summary computation). The internal `view.calculations` storage concern is separate; see [td-table-calculations-schema](#td-table-calculations-schema).
+
+<a id="td-dataviews-fieldtype-union"></a>
+
+**DataViews `FieldType` union has no decimal `number` or `url`.**
+
+**What.** DataViews v6's `FieldType` union is `'text' | 'integer' | 'datetime' | 'date' | 'media' | 'boolean' | 'email' | 'array'`. Cortext has `number` (decimals allowed) and `url`, neither of which has an exact match. Numbers map to `'integer'` so the filter UI offers numeric operators, then Cortext disables DataViews' integer-only validator, attaches a decimal-aware sort comparator, and provides a decimal-safe number filter control because the built-in integer `between` control applies whole-number min/max bounds. URLs still map to `'text'`, which is close enough for contains/starts-with filters but not an exact semantic type.
+
+**Where.** `mapField` in `src/hooks/fieldMapping.js`.
+
+**Solution.** A decimal-friendly `'number'` type and a `'url'` type, or a cleaner way for consumers to supply custom field controls / operator sets without borrowing the nearest built-in type.
+
+<a id="td-dataviews-option-color"></a>
+
+**DataViews `Option` type has no `color`.**
+
+**What.** DataViews's `Option` shape is `{ value, label, description? }`. Cortext's select / multiselect options can carry a `color` for chip rendering, so `color` is attached as an extra key on each element. DataViews ignores unknown keys today, but a stricter validator upstream would strip it, breaking colored chips silently.
+
+**Where.** `elementsFromOptions` in `src/hooks/fieldMapping.js`. Read by `Chip` (`src/components/fields/Chip.js`) via `formatDisplay` in `src/components/EditableCell.js`.
+
+**Solution.** Add `color` (or a generic decoration slot) to DataViews's `Option` type upstream.
+
+<a id="td-dataviews-column-interactions"></a>
+
+**DataViews table columns lack interaction extension points.**
+
+**What.** DataViews persists table column order in `view.fields` and widths in `view.layout.styles`, but exposes no table-column interaction layer: no resize handles, min/max width contract, double-click autofit, reorder callback, drag preview, stable header/cell refs, or supported way to opt into `table-layout: fixed`. Cortext therefore portals resize and dnd-kit drag handles into DataViews-rendered `<th>` elements, snapshots header geometry during drag, mutates inline widths during resize for immediate feedback, and overrides internal table/cell wrapper CSS so narrow columns behave as hard constraints rather than intrinsic-size hints. Double-click autofit is the trickiest piece because there is no measurement hook upstream; the workaround clones the cell into a hidden subtree that recreates every ancestor affecting layout. See the comment block in `DataViewColumnInteractions.js` for the measurement details.
+
+**Where.** `src/components/DataViewColumnInteractions.js`, `src/components/dataViewColumns.js`, the `DataViewColumnInteractions` mount in `src/components/CollectionDataViews.js`, and the column affordance / table wrapper rules in `src/components/DataViewColumnInteractions.scss` and `src/components/CollectionDataViews.scss`.
+
+**Solution.** DataViews table-column APIs that cover `onChangeFields`, `onChangeColumnStyle`, resize handle rendering, per-field min/max widths, double-click autofit, drag overlay/insertion affordances, and stable header/cell slots or refs. If DataViews owned that layer, Cortext could drop the portal/DOM-query adapter, the wrapper min-width overrides, most of the dnd-kit column glue, the cloned-measurement gymnastics, and the direct DOM mutation used for live resize feedback.
+
+<a id="td-dataviews-header-extension-slots"></a>
+
+**DataViews has no per-column header extension slots.**
+
+**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list: no `field.menuItems` hook for Rename / Duplicate / Delete or Calculate, and no header accessory slot for the field-description help icon. To keep one dropdown per column, Cortext hides DataViews' built-in trigger on custom-field `<th>`s via CSS and portals its own combined trigger in (Sort / Move / Hide _plus_ field management and table calculations). Custom field descriptions add a small help trigger next to that replacement header trigger. Title and system fields keep the built-in trigger. The drag-handle click-forward (`DataViewColumnInteractions`) iterates header buttons and skips `display: none` ones via `offsetParent`, so it lands on whichever trigger is visible. Filter is intentionally absent: Cortext doesn't surface column-level filters in the header.
+
+**Where.** `src/components/fields/ColumnHeaderActions.js` (table-only items and the header portal), `src/components/fields/FieldActionsMenu.js` (shared field actions and description help trigger), `src/components/fields/ColumnHeaderActions.scss` (custom header layout and help-trigger z-index), `src/components/CollectionDataViews.scss` (`.dataviews-view-table th:has(.cortext-column-header-marker) > .dataviews-view-table-header-button { display: none }`), and `src/components/DataViewColumnInteractions.js` (visible-button click forward).
+
+**Solution.** Two header extension points: a `field.menuItems` array or render prop appended to the built-in dropdown, plus a header accessory/help slot rendered next to the label. Other consumers (Pattern Manager, Pages, Site Editor) would benefit too.
+
+<a id="td-dataviews-actions-column-piggyback"></a>
+
+**Add-field header piggybacks on the DataViews actions column.**
+
+**What.** The table's `+ add field` button sits in DataViews' row-actions column header. `ColumnHeaderActions` finds `th.dataviews-view-table__actions-column` and portals the button there; CSS hides the built-in "Actions" label and keeps the header cell sticky on the right. This is cleaner than the old synthetic `__add_field` column because it no longer leaks into `view.fields`, but it still leans on DataViews internals. The create-field flow also reveals the new trailing column itself: it carries the created field ID back to `CollectionDataViews`, waits until the field marker exists in the rendered header, then scrolls `.dataviews-wrapper` to the right edge.
+
+**Where.** `src/components/fields/ColumnHeaderActions.js` (actions-column lookup and portal), `src/components/CollectionDataViews.js` and `src/components/dataViewScroll.js` (created-field reveal and `.dataviews-wrapper` scroll), `src/components/CollectionDataViews.scss` (`.dataviews-view-table__actions-column` overrides), and the legacy `__add_field` cleanup in `src/components/CollectionDataViews.js`.
+
+**Solution.** A trailing table-header slot, an add-column slot, or a header action area separate from per-row actions, plus refs for the table scroll wrapper and rendered headers. Then the portal targets a real extension point, the reveal code stops querying DataViews DOM, and the sticky/header-label CSS disappears.
+
+<a id="td-dataviews-table-layout-overrides"></a>
+
+**Table layout overrides couple to DataViews internals.**
+
+**What.** DataViews ships `table-layout: auto; width: 100%` plus per-cell padding rules. Cortext flips to `table-layout: fixed; width: max-content` with explicit per-cell widths so adding or removing a field doesn't reflow every other column. The actions-column header override keeps the add-field button pinned beside the row kebabs. The table sizes to its content and scrolls horizontally on overflow. Depends on DataViews' class names and selector specificity staying put.
+
+**Where.** `src/components/CollectionDataViews.scss`, around the `.dataviews-view-table` block.
+
+**Solution.** A `tableLayout` (or similar) prop on DataViews so consumers can pick between "auto with redistribution" and "fixed with content-sized columns", plus per-field `width` hints so columns can be pinned without overriding DataViews CSS.
+
+<a id="td-dataviews-query-capability-contract"></a>
+
+**DataViews has no query-capability contract for custom field types.**
+
+**What.** Each Cortext field type advertises its sortable / filterable / text-like / storage-type / supported-operators contract via `FieldTypeRegistry`, a local stand-in. WordPress post meta and DataViews each know part of that story, but neither exposes the whole contract for custom field types today. The client uses the registry to decide whether a sort or filter can go to the server; PHP validates the same contract from the collection schema. Mirroring the contract in both places is fragile and falls back to client mode whenever the answer is "no" (see [td-row-sort-split](#td-row-sort-split) and [td-row-filter-split](#td-row-filter-split) for the consequences).
+
+**Where.** `FieldTypeRegistry` in `src/hooks/`, `serverFilterNode` / `buildQueryPlan` in `src/hooks/useCollectionRows.js`, and `RowsFilterQuery::validate_sort()` / `validate_filter_fields` in `includes/Rest/RowsFilterQuery.php`.
+
+**Solution.** A first-class query-capability contract for custom fields, either on DataViews directly or on WordPress post meta. Custom types would declare sortable / filterable operators once; consumers (DataViews, REST) would consume that declaration without each consumer re-mirroring the contract.
+
+<a id="td-dataviews-relation-primitive"></a>
+
+**DataViews has no relation/reference field primitive.**
+
+**What.** Relation fields store row post IDs, but the UI behaves like a reference field: search rows in another collection, pick one or many, create a missing row, show row chips, and open the row from the chip. DataViews has no `relation` / `reference` field type and DataForm has no async record picker that accepts a target entity/query and cardinality. Cortext maps relations to the closest DataViews metadata type, carries relation-specific metadata on the field object, renders relation chips from `field.render`, ships a custom picker that pages and searches `/cortext/v1/rows`, and routes chip clicks through its own peek state. The picker also asks REST to put exact title matches on the first page, so "Create row" does not offer a duplicate just because the match would otherwise sit later in the results.
+
+**Where.** `mapField` / `buildRender` in `src/hooks/fieldMapping.js`, `src/components/relations/RelationEditor.js`, `src/components/RowProperties.js`, `src/hooks/useCollectionRowsByIds.js`, `RowsController`'s `include` handling, `RowsFilterQuery::apply_search_order_clauses()`, `src/components/relations/RelationReferences.js`, `src/components/relations/relationUtils.js`, `src/components/DocumentPeekProvider.js`, `src/components/DocumentPeekHost.js`, `src/components/CurrentViewModeContext.js`, relation setup in `src/components/fields/AddFieldPopover.js`, and the `.cortext-relation-*` rules in `src/components/CollectionDataViews.scss` and `src/components/RowDetailView.scss`.
+
+**Solution.** A generic reference field/control in DataViews/DataForm: target entity config, single vs multi cardinality, async search with a selected-record resolver, optional create-new button, token/chip rendering hooks, and a supported action slot for opening or navigating to referenced records. Cortext would still own the backend relation sync and reverse-field semantics, but could drop most of the custom picker, chip, search-order guard, and open-action code.
+
+<a id="td-dataviews-row-reorder"></a>
+
+**DataViews has no row reorder API.**
+
+**What.** Manual order lives on the row posts, but DataViews doesn't give row refs, drag handles, drop targets, or an `onReorder` hook. Cortext decorates the layouts after DataViews renders them: finds rows by internal class selectors, matches them to `rows` by visible index, portals dnd-kit handles into the first data cell, places fixed drop targets over row gaps, clones a few cells for the drag preview, and holds CSS transforms while the REST request and refetch finish.
+
+That makes row reorder sensitive to DataViews DOM changes: density classes, bulk-selection cells, fullscreen mode, block embedding, and scroll containers all matter. Grid still uses before/after card targets because a linear row gap doesn't map cleanly to a two-dimensional card layout.
+
+**Where.** `src/components/DataViewRowReorder.js`, `src/components/RowDragHandle.js`, the mount in `src/components/CollectionDataViews.js`, and the row-reorder rules in `src/components/DataViewRowReorder.scss`.
+
+**Solution.** Stable row ids/refs, a row-handle render prop, keyboard-aware reorder callbacks, a table/list gap model, and row preview/drop indicator hooks. Cortext would keep the REST/manual-order policy and drop the selectors, MutationObserver, portals, and transform bookkeeping.
+
+<a id="td-dataviews-selection-page-local"></a>
+
+**DataViews selection is page-local.**
+
+**What.** DataViews accepts a controlled `selection`, but layouts only receive the IDs for rows in the current `data` array. Its built-in clicks are page-local too: table rows handle plain and modifier clicks, grid cards handle modifier clicks, and neither layout gives consumers shift-range selection across the rendered page. Cortext needs selected row IDs to survive pagination and needs the selected row objects later for bulk Trash actions and partial-failure cleanup. `CollectionDataViews` keeps the real selection state: selected IDs, a cache of selected row objects seen on previous pages, a shift-click anchor, and a capture-phase click-intent layer that translates DataViews' visible-page selection changes into Cortext's persistent selection.
+
+**Where.** Selection state and `captureSelectionIntent` in `src/components/CollectionDataViews.js`, helper functions in `src/components/dataViewSelection.js`, and coverage in `tests/js/components/dataViewSelection.test.js` plus `tests/e2e/specs/data-view-block.spec.js`.
+
+**Solution.** DataViews treats selection as a persistent ID set, with range selection and consistent modifier behavior across table and grid, and does not filter hidden IDs out of the controlled value before handing it to layouts. Bulk actions also need either all selected items, or an item resolver for selected IDs that are not on the current page.
+
+<a id="td-dataviews-loading-skeletons"></a>
+
+**Loading skeletons track DataViews layouts by hand.**
+
+**What.** DataViews has no loading slot for individual layouts. Cortext renders `CollectionRowsSkeleton` beside `<DataViews>` while the first page loads; without it, the collection pane collapses and jumps when rows arrive. The placeholder has table/list row variants and a grid card variant, so switching layouts does not briefly show the wrong shape. The brittle part is sizing: the table/list skeleton copies DataViews row heights for compact, balanced, and comfortable density. The grid skeleton copies Cortext's card min size and spacing, which sit on top of DataViews' grid classes. The two match in the current build, but a DataViews density or markup change could make the placeholder drift from the real view.
+
+**Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/components/Skeleton.scss` and `src/components/CollectionDataViews.scss`.
+
+**Solution.** A loading slot per layout, or at least row/card size CSS variables. Cortext could then follow the active layout instead of copying its constants.
+
+<a id="td-dataviews-view-state-shape"></a>
+
+**DataViews view state has one active layout shape.**
+
+**What.** DataViews emits one active `view` shape: one `type`, one `fields` array, and one `layout` object. Cortext needs layout switches to preserve table columns, grid/list display fields, density, card media settings, and query state without one layout overwriting another. The adapter stores Cortext-owned buckets (`layoutByType` and `fieldsByType`) beside the DataViews view, hydrates the active layout before render, and merges DataViews changes back into the canonical view after each change. Block attributes and public DataViews state now carry keys upstream does not know about. When a new layout setting is added, the adapter, normalizer, and public renderer all need to move together.
+
+**Where.** `src/components/dataViewAdapter.js`, `src/components/dataViewViewState.js`, `normalizeView` in `src/components/dataViewColumns.js`, the DataViews mounts in `src/components/CollectionDataViews.js` and `src/components/PublicDataView.js`, and the data-view block attributes in `src/blocks/data-view/block.json`.
+
+**Solution.** Native per-layout settings on DataViews would let Cortext map to upstream's shape instead of carrying separate buckets.
+
+<a id="td-dataviews-list-row-hooks"></a>
+
+**DataViews list lacks row-open and compact metadata hooks.**
+
+**What.** DataViews list is close enough to use, but it does not expose the pieces Cortext needs for the list it wants: opening a row from the blank part of the row, keeping focus without a selected-row state, showing metadata as a compact inline run, and placing "+ New" as the last row. Cortext keeps the native layout and fills those gaps locally: empty controlled selection, capture-phase pointer and keyboard handlers for row open, CSS that reshapes DataViews' title/media/field/action DOM, and a footer button styled like a row. The parts to watch are the `.dataviews-view-list > [role="row"]` lookup, `.dataviews-view-list__item` as the focus/open target, and the CSS grid/contents overrides that put title, metadata, media, and actions on one row.
+
+**Where.** List open/focus handling in `src/components/CollectionDataViews.js`, list row lookup in `src/components/dataViewItemLookup.js`, list reorder decoration in `src/components/DataViewRowReorder.js`, `DataViewNewRowButton`'s `list-row` presentation, and the list rules in `src/components/CollectionDataViews.list.scss`.
+
+**Solution.** Row activation/focus hooks, a way to disable selected-row state without losing focus, a compact metadata list variant, and an append-row/item slot. If the native list never grows that shape, write a small Cortext list layout instead of piling more CSS on DataViews internals.
+
+### WordPress components
+
+<a id="td-checkboxcontrol-hide-label"></a>
+
+**`CheckboxControl` ignores `hideLabelFromVision`.**
+
+**What.** `CheckboxControl` always renders its `label` prop as a visible `<label>` next to the input regardless of `hideLabelFromVision` (verified against `node_modules/@wordpress/components/build-module/checkbox-control/index.mjs`). DataViews columns already show the field label in the header, so passing `label={ label }` echoed it next to every checkbox. Cortext passes `aria-label={ label }` instead, which the component forwards to the underlying input. Screen readers still get a label; sighted users no longer see it twice. Risk: the next contributor reaches for `label` (the documented prop) and the duplicate quietly returns.
+
+**Where.** Checkbox cell in `src/components/EditableCell.js`.
+
+**Solution.** Honor `hideLabelFromVision` on `CheckboxControl`. The `tech-debt.md#td-checkboxcontrol-hide-label` comment next to `aria-label` is the signal until then.
+
+<a id="td-textcontrol-row-height"></a>
+
+**Sidebar rename input pinned via WP component internals.**
+
+**What.** The page-row rename uses `<TextControl size="compact" __next40pxDefaultSize>`, which should produce a 32px input matching the 32px row. It doesn't, on its own: the wrapping `BaseControl > field > InputControl > container` chain still contributes vertical space, so opening rename used to bump the row a few pixels. The fix pins `height` / `min-height` / `max-height` to `$grid-unit-40` and zeroes `padding-block` on every layer in that chain (`.components-base-control`, `.components-base-control__field`, `.components-input-control`, `.components-input-control__container`, `.components-input-control__input`). It works, but it couples Cortext to WP component-internal class names. If WP refactors `TextControl` (renames a class, drops a wrapper, restructures the DOM), the input loses its height pin and the row starts bumping again, silently.
+
+**Where.** The `&__rename` block in `src/components/Sidebar.scss`. The e2e test `keeps the rename input inside the page row height` in `tests/e2e/specs/sidebar-layout.spec.js` is the tripwire: it asserts the input never overflows the row's bounding rect, so a WP-internals refactor would surface there before reaching production.
+
+**Solution.** Either a "fit-the-row" size for `TextControl` (or a CSS variable hook for input height), or replace the rename `TextControl` with a plain `<input>` styled to match the row. The plain input is the more reliable path: drops the WP-internals coupling, but adds a small amount of styling and accessibility plumbing that comes free today.
+
+<a id="td-wp-menu-popover-limitations"></a>
+
+**`@wordpress/components` Menu and Popover are missing primitives.**
+
+**What.** Several gaps in `Menu` (privateApis, Ariakit underneath) and `Popover` push policy into consumers.
+
+- `Menu`'s outside-click is scoped to one document. The `cortext/data-view` block and row properties render inside Gutenberg's editor iframe, so clicks on the editor sidebar or top toolbar never reach Ariakit. Cortext adds a `mousedown` listener on `window.parent.document` while the menu is open.
+- `Menu.Item` has no destructive variant. The legacy `MenuItem` accepted `isDestructive` and rendered the row in red; the new privateApis `Menu.Item` dropped that prop without a replacement (verified in `node_modules/@wordpress/components/build-types/menu/types.d.ts` against `ItemProps`). Cortext paints the red itself with a className and one CSS rule, scoped to inactive rows so focus/hover overrides it.
+- `Menu.Popover` does not portal by default. Inside a `<th>` with `text-transform: uppercase`, that cascades into the menu items. Cortext passes `portal` explicitly everywhere.
+- Submenus only accept menu primitives. `Menu.SubmenuTriggerItem` opens a `Menu.Popover` that only accepts `Menu.Item` / `Menu.Group` / `Menu.Separator` children. Cortext's Edit field and Calculate submenus have tile previews, labelled value rows, and nested popovers, so they stay as sibling popovers with a manual hover bridge. The parent menu ignores outside-clicks that land in `.cortext-format-submenu`, `.cortext-format-submenu__flyout`, or `.cortext-table-calculation-submenu`.
+- Nested `Popover` outside-clicks do not close the host. `Popover` handles outside clicks one popover at a time. In the option editor, after a color edit the first click outside both popovers only closed the small option menu; the main picker stayed open. Cortext listens for `pointerdown` while the option menu is open and asks the host to close when the click lands outside both popovers.
+- Cascading `Popover` has no fallback placement. `Popover` can shift a submenu along the cross axis but does not try a left-side fallback when a `right-start` cascade runs past the viewport edge. Cortext measures the outer menu and the portaled submenu and switches between `right-start`, `left-start`, and `bottom-start` based on clip detection.
+
+**Where.** `src/components/fields/FieldActionsMenu.js` (outside-click document listener, portal opt-in, hover bridge), `src/components/fields/ColumnHeaderActions.js` and `src/components/fields/ColumnHeaderActions.scss` (destructive item class and rule), `FieldFormatPopover` and `TableCalculationMenu` (sibling submenus and outside-click guards), `useSubmenuPlacement` in `src/hooks/useSubmenuPlacement.js`, and `EditOptionsPopover` in `src/components/fields/EditOptionsPopover.js` (nested popover dismiss).
+
+**Solution.** Each of these is a small PR on its own: register extra documents for outside-click detection (or have the WP wrapper do it), add `isDestructive` (or `variant: 'destructive'`) to `Menu.Item`, flip the `Menu.Popover` portal default, allow arbitrary content in submenu popovers, expose a parent/child dismissal story on `Popover`, and pass enough Floating UI middleware through `Popover` for consumers to declare placement fallbacks.
+
+<a id="td-wp-meta-query-compares"></a>
+
+**`WP_Meta_Query` is missing compares row filtering needs.**
+
+**What.** `RowsMetaQuery` keeps row filters on WordPress's native meta-query tree instead of building a parallel SQL compiler, but core's compares do not cover every operator Cortext needs. `LIKE` always wraps both sides, so starts-with and ends-with need one-sided patterns. Multi-value fields need "no meta row has this value" for `isNone` / `notContains`, which is not the same as a plain `!=` join. Title filters also live on `wp_posts.post_title`, outside post meta, so they ride through a sentinel clause.
+
+**Where.** `RowsMetaQuery` in `includes/Rest/RowsMetaQuery.php`, called from `RowsFilterQuery::meta_query_sql()`.
+
+**Solution.** `WP_Meta_Query` grows one-sided `LIKE` compares and value-bearing negative `NOT EXISTS` compares. A structured title-query helper in `WP_Query` would cover the title sentinel separately. `RowsMetaQuery` then shrinks back toward a thin adapter or disappears.
+
+### Block editor and Gutenberg shell
+
+<a id="td-gutenberg-scrollbar-select"></a>
+
+**Block editor selects on scrollbar drag.**
+
+**What.** Gutenberg selects a block on any `mousedown` that bubbles up to the block wrapper. Inside the data-view block, dragging the dataviews scrollbar fires a mousedown on the scrolling element and pulls a bounding box around the whole block. Gutenberg has no primitive for "this region scrolls, don't select on click." Cortext listens for `mousedown` on `.cortext-data-view` in capture phase, sniffs scrollbar-gutter clicks by geometry (target's computed `overflow-x/y` is `auto`/`scroll`, the element actually overflows, and the click landed past `clientWidth` or `clientHeight`), then `stopPropagation` so the event never reaches Gutenberg. Cell, row, and header clicks keep bubbling and select normally.
+
+**Where.** The mousedown effect on `tableWrapperRef` in `src/components/CollectionDataViews.js`.
+
+**Solution.** A Gutenberg API for declaring interactive scroll regions on a block (or a way to opt mousedowns out of selection per descendant). The brittleness is in browser scrollbar pseudo-element behavior; the day someone introduces an overlay-scrollbar shim or a custom scroll library, this needs rethinking.
+
+<a id="td-workspace-notices-prefix-filter"></a>
+
+**Workspace notices filtered by id prefix.**
+
+**What.** Gutenberg's editor store fires off its own "Page updated" snackbar on every successful save. Autosave runs constantly here, so that toast would never stop popping up. The workaround is a custom `SnackbarList` that only shows notices whose id starts with `cortext-`; everything else gets dropped on the floor, including any third-party plugin notice or a future first-party one we'd actually want to surface.
+
+**Where.** `CortextSnackbars` in `src/components/Canvas.js`, paired with the `id: 'cortext-autosave-error'` we set on the autosave error notice in `src/hooks/useAutosave.js`.
+
+**Solution.** A way to suppress the editor's default save notice, or scope notices per surface so we don't have to share a global stream. Until then, anything Cortext wants visible has to opt in with a `cortext-` id.
+
+<a id="td-gutenberg-block-chrome-slot"></a>
+
+**Block editor has no non-serialized before/after block chrome slot.**
+
+**What.** Document identity actions ("Add icon" / "Add cover") are editor chrome, but the ideal visual placement is immediately before the document title inside the block canvas. Persisting an actions block put UI into post content, while portalling controls into the iframe coupled Cortext to BlockList DOM and block hover/selection behavior. The current compromise renders editor-only actions from the canvas shell, outside the persisted `BlockList`, and inserts only the real dynamic blocks (`cortext/document-icon`, `cortext/document-cover`) into content.
+
+**Where.** `DocumentIdentityActions` and `EnsureHeaderBlocks` in `src/components/EditorBody.js`.
+
+**Solution.** A non-serialized block chrome slot/fill, e.g. "before/after this block" keyed by `clientId`, block name, and root list. Fills would participate in editor layout and focus order but stay out of block order, list view, serialization, copy/paste, movers, undo history as content, and frontend rendering. Cortext could then render the identity actions before the root `core/post-title` without storing a fake block or querying iframe DOM.
+
+<a id="td-command-palette-host-glue"></a>
+
+**Command palette embedding needs host glue.**
+
+**What.** Cortext uses `@wordpress/commands` for command registration and palette state, but the stock menu is built for wp-admin. On the Cortext screen the palette needs to be scoped to the app: keep Core's commands out, avoid a second cmd+K menu, return focus to the workspace after a command runs, and put workspace recents in their own section instead of mixing them into suggestions. That leaves some glue in Cortext: a local data registry, a `wp-core-commands` dequeue, a bundled stylesheet import, a canvas ref for focus return, and a local command-menu renderer.
+
+The awkward bit is `CortextCommandMenu`. `@wordpress/commands` has a built-in "Recent" group, but that means recently used commands, not Cortext workspace history, and there is no public way to add a custom group. So Cortext renders the menu itself while still reading from the upstream command store. That is better than patching `node_modules` or poking the DOM after render, but upgrades need a close look at the upstream menu markup, CSS classes, keyboard behavior, and `cmdk` wiring. The user-facing placeholder is still Core's generic "Search commands and settings" string too.
+
+**Where.** `src/components/CommandPalette.js`, `src/components/CortextCommandMenu.js`, the `canvasRef` passed from `src/router.js`, `dequeue_core_command_palette` in `includes/Admin/Screen.php`, the `@wordpress/commands` stylesheet import in `src/index.scss`, and Cortext command-menu overrides in `src/styles/global/_command-palette.scss`.
+
+**Solution.** Make app-owned palettes less ad hoc: a scoped command registry or namespace API, a supported way for full-screen admin apps to opt out of Core's admin palette, a custom input label, an explicit focus-return target or after-close callback, and a group/section API for registered commands or command loaders. With those, Cortext keeps registering commands through `@wordpress/commands`, renders workspace recents through an upstream extension point, and drops the local menu renderer plus most of this shell-specific wiring.
+
+<a id="td-autosave-save-completion"></a>
+
+**Autosave has to infer save completion.**
+
+**What.** `savePost()` gives a promise when Cortext starts the save. If a save is already running, though, Gutenberg only tells us about it through selectors like `isSavingPost()` and `didPostSaveRequestFail()`. There is no promise to await. `flushNow()` has to keep its own small list of waiters and release them when `isSaving` flips back to false.
+
+The same selector shape affects user-visible save side effects. `didPostSaveRequestSucceed()` and `didPostSaveRequestFail()` are level signals, not one-shot events. They can stay true after the save that set them, so mounting autosave on a different row or changing `recentTarget` can otherwise replay an old success into status and Recents. The hook tracks the previous `isSaving` value and only treats success as current when this hook observed the save finish.
+
+**Where.** `savePromiseRef`, `savingWaitersRef`, `prevIsSavingRef`, `flushNow`, and the save-status effect in `src/hooks/useAutosave.js`.
+
+**Solution.** Gutenberg exposes the current save promise, makes `savePost()` return the in-flight promise when one already exists, or exposes per-save completion events/state keyed to a request. Then Cortext drops the waiter bookkeeping and the local `isSaving` edge detection.
+
+<a id="td-gutenberg-header-boundary"></a>
+
+**Block editor controls do not understand Cortext's header boundary.**
+
+**What.** Gutenberg block locks keep cover, icon, title, and row properties from moving, but the root list still has no idea that Cortext's body starts after those blocks. Cortext repairs bad order with block-editor store actions and hides protected insertion points, but two bits of Gutenberg UI still leak through. First, the first body block gets a live "move up" button even though moving it above the title would be wrong; Cortext waits for the toolbar, finds `.block-editor-block-mover-button.is-up-button`, and sets `disabled` / `aria-disabled` itself. Second, Gutenberg only shows the default empty-body appender when the whole root list is empty. A row with title/properties and no body is not empty by that test, so Cortext supplies its own first-block prompt after the header. If Gutenberg renames mover classes or changes the appender contract, this code needs another pass.
+
+**Where.** `HeaderPrefixToolbarGuard`, `syncHeaderBoundaryMoveUpButtons`, `HeaderAwareRootAppender`, and the header-prefix correction in `src/components/EditorBody.js`, with coverage in `tests/e2e/specs/editor-header-blocks.spec.js` and `tests/e2e/specs/data-view-block.spec.js`.
+
+**Solution.** A block-list boundary policy for root lists: a minimum insertion index, a minimum move target, empty-body detection that ignores locked chrome, and mover/appender state from that same boundary. Then Cortext declares "body blocks start after the title/properties prefix" once and drops the toolbar DOM query, the mutation observer, the local button-state restoration, and the custom root appender.
+
+<a id="td-row-detail-toolbar-isolation"></a>
+
+**Row detail toolbars rely on local editor-surface isolation.**
+
+**What.** Row peek and modal now keep their toolbars separate from the parent page editor. The fix is local and covered by e2e: each row editor gets its own `SlotFillProvider`, the row surface says it has no block inspector, and the parent page toolbar is hidden while peek/modal owns the screen. The plumbing stays in the debt log because Gutenberg's toolbar path still runs through `BlockControls`, SlotFill, and portaled popovers, and there is no clean public primitive for saying "this nested editor owns its toolbar and inspector." Cortext avoids the unsafe inspector entrypoint instead of building a row-scoped inspector in this pass.
+
+**Where.** `src/components/RowEditor.js` (`SlotFillProvider` and `EditorSurfaceProvider`), `src/components/EditorSurfaceContext.js`, `src/blocks/data-view/edit.js` (`hasBlockInspector` around the DataView toolbar button), `src/components/RowDetailView.js` (body class while side/modal is open), and `src/styles/global/_shell-root.scss` (parent canvas toolbar hiding).
+
+**Solution.** Editor-instance-scoped `BlockControls`, toolbar popovers, and `InspectorControls`. Cortext then drops the local `SlotFillProvider`, the `hasBlockInspector` context, and the parent-toolbar body class. If row peek/modal needs block settings before that exists upstream, build a row-scoped inspector deliberately rather than routing those actions to the parent inspector.
+
+<a id="td-page-transitions-snapshot"></a>
+
+**Page transitions hold a browser snapshot by hand.**
+
+**What.** Page-to-page navigation rebuilds the editor provider inside the same workspace pane. A normal View Transition cross-fade can expose the empty editor frame while Gutenberg, cover media, and the editor iframe catch up. Cortext keeps the old `cortext-canvas` snapshot above the new one until the new editor says it has painted, then fades the old snapshot away. That requires a `data-cortext-view-transition` mode on `:root`, custom `::view-transition-*` CSS, a long-running hold animation, and promise plumbing around `startViewTransition()` because the browser update callback may run after `withViewTransition()` has already returned.
+
+**Where.** `withViewTransition` in `src/hooks/viewTransition.js`, the `hold-old-canvas` / `reveal-old-canvas` rules in `src/index.scss`, document switching in `src/components/Canvas.js`, editor readiness in `src/components/EditorBody.js`, and the navigation lifecycle coverage in `tests/e2e/specs/navigation-lifecycle.spec.js`.
+
+**Solution.** A first-class hold/release hook in the View Transitions API, or a reliable editor-surface "painted" signal from Gutenberg for document swaps. Replace the mode flag and long CSS hold animation with that primitive when it exists.
+
+<a id="td-collection-owner-block-template"></a>
+
+**Full-page collections need a dynamic block-template hook.**
+
+**What.** A full-page collection needs a locked `cortext/data-view` block whose `collectionId` is the collection post's own ID. WordPress and Gutenberg can give a CPT a static template, but not one that fills attributes from the just-created post and then treats that block as the body. See [td-collection-owner-body-contract](#td-collection-owner-body-contract) for the local workarounds this gap produces.
+
+**Where.** No code on the upstream side; the workarounds live in the internal entry linked above.
+
+**Solution.** A dynamic block-template registration that reads attributes from the current post at insert time. Either an option on `register_post_type` (`template_callback`) or a `block-templates`-style API that supports per-post resolved attributes. With that, the post-insert seed, backfill, and editor fallback go away.
+
+### Other libraries
+
+<a id="td-dnd-kit-inert"></a>
+
+**dnd-kit does not observe `inert`.**
+
+**What.** Collapsed branches of the page tree stay mounted so the expand/collapse animation can run. The wrapper gets `inert` so focus, screen readers, and click events skip the subtree, but dnd-kit doesn't pay attention to that. It walks its registered droppables in JavaScript, asks each one for its bounding rect, and treats them as live drop targets whether anything visible is there or not. Without intervention, a drag can land on a row you cannot see. The workaround is to thread an `isHidden` prop down through `PageRow` and pass `disabled: isHidden` to every `useDroppable`. Anything else that wants this animation pattern has to do the same drilling.
+
+**Where.** The `isHidden` prop chain through `src/components/PageRow.js`, plus the wrapper's `inert` attribute in the same file.
+
+**Solution.** dnd-kit honors `inert` (or computed `pointer-events: none`) on an ancestor, letting consumers drop the prop-drilling. Any tree-shaped surface that uses a CSS-clipped collapse animation has to thread `disabled` through its rows itself until then.
+
+---
+
+## Internal debt
+
+### Rows and storage
+
+<a id="td-rows-not-in-core-data"></a>
+
+**Rows aren't in `core-data`'s entity store.**
+
+**What.** Rows still sit outside `core-data`. `useCollectionRows` owns fetch state, the `requestId` race guard, the manual `refresh()` counter, and the choice between server and client mode (paged REST when the table can express the query; a fallback that fetches pages of 100 with a small concurrency cap otherwise). Mutations still POST directly with `apiFetch`, then ask the hook to refetch. Since there is no shared row store, trash and restore fire small row / document-trash events that open row queries and the sidebar Trash list refetch. Relation chips add a second read path: `useCollectionRowsByIds` calls `/cortext/v1/rows?include[]=…` so the picker can show labels without walking the target collection.
+
+Full-page collection creation hits a related edge: `core-data` may have cached `/wp/v2/types` before a new collection's row CPT was registered. The sidebar and DataView block creator invalidate `getEntitiesConfig('postType')` after creation so the next row `useEntityRecord` can see the new entity.
 
 **Where.** `src/hooks/useCollectionRows.js`, `src/hooks/useCollectionRowsByIds.js`, `src/hooks/rowInvalidation.js`, `src/hooks/documentTrashInvalidation.js`, and `src/hooks/useTrashedDocuments.js`, with call sites in `src/components/CollectionDataViews.js` (`saveRowField`, `onCreated`, row trash), `src/components/SidebarTrash.js`, `src/router/EntityRoute.js`, `src/blocks/data-view/edit.js`, `src/components/Sidebar.js` (post-type entity-config invalidation after collection creation), and `src/components/relations/RelationEditor.js` (paged target-row search and selected-row label lookup).
 
 **Solution.** Switch to `useEntityRecords('postType', \`crtxt_${slug}\`, query)` plus `saveEntityRecord` for writes once the remaining query shapes can be expressed there. `core-data` would then own caching, race protection, and post-mutation invalidation. Knock-on workarounds it deletes:
 
 - The `refresh()` handles and invalidation events exist only because rows aren't reactive.
-- Half of `RowMutationContext` (also driven by #1) exists because cells can't reach a `core-data` store that isn't there.
-- `onCreated` still runs optimistic `lastPage = ceil((totalItems+1)/perPage)` arithmetic for unconstrained views. With reactive pagination we'd watch `totalPages` instead of guessing.
+- Half of `RowMutationContext` (also driven by [td-dataviews-inline-editing](#td-dataviews-inline-editing)) exists because cells can't reach a `core-data` store that isn't there.
+- `onCreated` still runs optimistic `lastPage = ceil((totalItems+1)/perPage)` arithmetic for unconstrained views. With reactive pagination Cortext could watch `totalPages` instead of guessing.
 - The server/client planner becomes normal resolver queries instead of a local fetch policy.
 - Relation label lookup becomes a normal entity-record resolver instead of a one-off include query.
 
-Worth a small spike before committing. Dynamic post-type discovery also needs a real answer: either `core-data` learns about new row CPTs after collection creation, or each collection-creation path keeps the post-type entity-config invalidation nearby.
+Worth a small spike before committing. Dynamic post-type discovery also needs a real answer: either `core-data` learns about new row CPTs after collection creation, or each collection-creation path keeps the post-type entity-config invalidation nearby. That does not mean every document-shaped query belongs in `core-data`: single records and mutations should use the entity store when WordPress can model them, while cross-type product views like Trash can stay behind `/cortext/v1/documents/*` endpoints.
 
-That does not mean every document-shaped query belongs in `core-data`. Single records and mutations should use the entity store when WordPress can model them. Cross-type product views, like Trash, can stay behind `/cortext/v1/documents/*` endpoints.
+<a id="td-modified-by-plugin-stored"></a>
 
-## 3. Sorting support is split between REST and client mode `[internal]`
+**`_modified_by` is plugin-stored, not native.**
 
-Updated by [#80](https://github.com/priethor/cortext/pull/80) and RSM-1459.
+**What.** WordPress core stores `post_modified` (timestamp) but not who last edited the post. The "Last edited by" system column needs that information, so a `save_post` hook on entry CPTs records `_modified_by` post meta with the current user ID on every save. Skipped when no user is signed in (CLI imports, cron, seeds, unauthenticated REST) so background writes don't clobber the last real editor with `0`. Risk: third-party plugins that bypass `save_post` (direct DB writes) won't update `_modified_by`. Acceptable for the block's scope; entries created before this hook fall back to the post author when the meta is absent.
 
-**What.** #80 fixed the old bad state where the sort UI changed but REST ignored it. RSM-1459 moved the supported scalar collection sorts into `/cortext/v1/rows`: title, timestamps, text-like fields, number, date/datetime, select, checkbox, email, and URL. With no explicit sort, REST still uses oldest-first ordering so new rows land at the bottom of the table.
+**Where.** `record_modified_by` in `includes/PostType/CollectionEntries.php`, read by `format_row` in `includes/Rest/RowsController.php`.
 
-The debt is the split brain. The client has an allow-list for server-safe sorts, and `FieldTypeRegistry` / `RowsFilterQuery` own the PHP version of the same story. Unsupported display-value sorts fall back to client mode: fetch all pages, then let DataViews sort locally. That keeps the result honest, but it is not where we want sorting to live long-term.
+**Solution.** Either core grows native "last editor" tracking (unlikely; long-standing wishlist), or accept the hook as the canonical answer. No upstream issue to file; this is plugin-managed state.
 
-The hard cases are still display-value sorts: users, relations, list-style rollups, files, and any field where the value users see is not the value stored in meta. That broader choice is tracked in #14.
+<a id="td-field-meta-global-delete"></a>
+
+**Field-meta cleanup uses a global delete.**
+
+**What.** `cleanup_after_field_delete` calls `delete_post_meta_by_key( "field-<id>" )`, which wipes that key from every post, not just Cortext entry CPTs. The collision risk is theoretical (`<id>` is a globally unique `crtxt_field` post ID, so any postmeta keyed that way belongs to a Cortext entry by construction), but the code doesn't enforce that. A scoped `DELETE pm … INNER JOIN wp_posts p … WHERE p.post_type IN (…)` would prove the scope, but WorDBless (see [td-wordbless-row-coverage](#td-wordbless-row-coverage)) can't run JOINs and its in-memory `$wpdb->posts` isn't exposed via SQL; `WP_Query`/`get_posts` against dynamic entry CPTs returns empty in the mock, so the per-post fallback also can't be unit-tested here.
+
+**Where.** `cleanup_after_field_delete` in `includes/PostType/CollectionEntries.php`.
+
+**Solution.** Stand up an integration environment with a real `wpdb` (`wp-env` + WP_PHPUnit), move the cleanup to a scoped JOIN, and keep WorDBless for the parts that don't need a real database.
+
+### Row query capabilities
+
+<a id="td-row-sort-split"></a>
+
+**Sorting support is split between REST and client mode.**
+
+**What.** Server sort supports scalar collection fields: title, timestamps, text-like fields, number, date/datetime, select, checkbox, email, and URL. With no explicit sort, REST uses oldest-first ordering so new rows land at the bottom of the table.
+
+The debt is the split brain. The client has an allow-list for server-safe sorts, and `FieldTypeRegistry` / `RowsFilterQuery` own the PHP version of the same story (see [td-dataviews-query-capability-contract](#td-dataviews-query-capability-contract)). Unsupported display-value sorts fall back to client mode: fetch all pages, then let DataViews sort locally. That keeps the result honest, but it is not where sorting should live long-term.
+
+The hard cases are still display-value sorts: users, relations, list-style rollups, files, and any field where the value users see is not the value stored in meta. That broader choice is tracked in [td-display-value-sort](#td-display-value-sort).
 
 **Where.** The query planner and sort allow-lists in `src/hooks/useCollectionRows.js`, the `onCreated` no-sort branch in `src/components/CollectionDataViews.js`, `FieldTypeRegistry`, and `RowsFilterQuery::validate_sort()`.
 
-**Solution.** Make REST the source of truth for sortable fields and expose that capability to the client instead of mirroring it by hand. Resolve #14 for display-value sorts, then remove the client fallback for sorting except where DataViews really needs a local-only view state.
+**Solution.** Make REST the source of truth for sortable fields and expose that capability to the client instead of mirroring it by hand. Resolve [td-display-value-sort](#td-display-value-sort) for display-value sorts, then remove the client fallback for sorting except where DataViews really needs a local-only view state.
 
-## 4. Filtering support is split between REST and client mode `[upstream, internal]`
+<a id="td-row-filter-split"></a>
 
-Updated by [#80](https://github.com/priethor/cortext/pull/80) and RSM-1459.
+**Filtering support is split between REST and client mode.**
 
-**What.** #80 made simple field filters real on the server. RSM-1459 expanded that to the supported Notion-style operators, title filters, split-term search, and nested `AND` / `OR` groups through `RowsFilterQuery` and `RowsMetaQuery`. When the server cannot handle a filter, the hook falls back to client mode, fetches all pages, applies grouped filters in a small Cortext wrapper, and lets DataViews handle the remaining flat search/sort/pagination work.
+**What.** Server-side filtering supports the documented operator set, title filters, split-term search, and nested `AND` / `OR` groups through `RowsFilterQuery` and `RowsMetaQuery`. When the server cannot handle a filter, the hook falls back to client mode, fetches all pages, applies grouped filters in a small Cortext wrapper, and lets DataViews handle the remaining flat search/sort/pagination work.
 
-The cost is another split support matrix. The client checks field type, operator, grouping, and value shape before choosing server mode. PHP validates the same contract from the collection schema. `FieldTypeRegistry` is Cortext's local stand-in for an upstream field-query capability contract: sortable, filterable, text-like, storage type, and supported operators. WordPress post meta and DataViews each know part of that story, but neither exposes the whole contract for custom field types today. System fields are still deferred (#13), display-value fields are still client-only, and grouped filters only go server-side when every descendant is supported.
+The cost is another split support matrix. The client checks field type, operator, grouping, and value shape before choosing server mode. PHP validates the same contract from the collection schema. System fields are still deferred (see [td-system-field-filtering](#td-system-field-filtering)), display-value fields are still client-only, and grouped filters only go server-side when every descendant is supported. The root cause is the missing capability contract tracked in [td-dataviews-query-capability-contract](#td-dataviews-query-capability-contract); this entry covers the internal consolidation work that follows once that lands.
 
-**Where.** `FieldTypeRegistry`, `serverFilterNode` / `buildQueryPlan` in `src/hooks/useCollectionRows.js`, `filterSortAndPaginateWithGroups` in `src/components/groupedFilters.js`, `RowsFilterQuery`, `RowsMetaQuery`, and `prefillFromFilters` in `src/components/CollectionDataViews.js`.
+**Where.** `serverFilterNode` / `buildQueryPlan` in `src/hooks/useCollectionRows.js`, `filterSortAndPaginateWithGroups` in `src/components/groupedFilters.js`, `RowsFilterQuery`, `RowsMetaQuery`, and `prefillFromFilters` in `src/components/CollectionDataViews.js`.
 
-**Solution.** Make the server-owned capability map the only local source of truth, then shrink it if DataViews or WordPress grows a first-class query-capability contract for custom fields. System fields need the date/user handling from #13, and display-value fields need dedicated query semantics instead of pretending stored meta is the UI value.
+**Solution.** Make the server-owned capability map the only local source of truth, then shrink it if DataViews or WordPress grows a first-class query-capability contract for custom fields. System fields need the date/user handling from [td-system-field-filtering](#td-system-field-filtering), and display-value fields need dedicated query semantics instead of pretending stored meta is the UI value.
 
-## 5. Inline-edit layout couplings `[internal]`
+<a id="td-system-field-filtering"></a>
 
-**What.** Three small but real internal mechanisms exist because DataViews doesn't have an inline-edit contract (#1):
+**System field filtering is deferred.**
 
--   **Column anchoring via overlay.** DataViews renders an actual `<table>`; Cortext switches it to `table-layout: fixed` so resize widths behave as real column constraints instead of intrinsic-size hints. Mounting an editor inline would still change the column's content sizing and row geometry. We always render the display shell and overlay the editor on top via `position: absolute`, so the table only sees the display state while the editor is open.
--   **Row height pin.** The shell's `min-height` is hardcoded to 40px to match `__next40pxDefaultSize`, the height of TextControl/NumberControl/SelectControl with the modern WP size flag. If WP changes the default control height, the pin desyncs and rows jitter again.
--   **Density mirror.** DataViews paints row height via the td's `padding-block`, varied per density (`has-compact-density` / `has-comfortable-density`). The shell's hover/edit highlight lives on the shell itself, so the gray floated inside the larger row instead of covering it. We zero the td's `padding-block` so the shell becomes the row, then replicate DataViews's per-density row heights via `min-height` overrides on the shell (and `.cortext-cell-checkbox`, which shares the shell's dimensions). Balanced and comfortable mirror DataViews v6 exactly (12 / 16); compact is intentionally tighter than the upstream default (4 -> 0) so the row matches the 40px editor floor, and that's the density we set as the project default in `createDefaultView` and `DEFAULT_LAYOUTS`. If upstream bumps the balanced/comfortable paddings, those two row heights silently desync until we update the numbers.
+**What.** Filters route through `meta_query`, but system fields (`created_at`, `modified_at`, `created_by`, `modified_by`) live on the post table or in user data, not in post meta. The filter validator rejects all four with a clean 400 rather than silently no-op'ing through the meta_query branch. Users can sort by `created_at` and `modified_at` (free WP_Query orderby) but can't filter on any system field today.
 
-**Where.** `src/components/EditableCell.js` and the `.cortext-editable-cell`, `.cortext-cell-checkbox`, and `.cortext-data-view .dataviews-view-table` rules in `src/components/CollectionDataViews.scss`.
+**Where.** `validate_filter_fields` and `build_query_args` in `includes/Rest/RowsController.php`.
 
-**Solution.** All three go away if DataViews lands inline editing (#1) and exposes a layout contract for cells (or a CSS variable for cell padding the shell can hook into). Until then the overlay is a clean enough pattern to keep, the height pin is one CSS line worth maintaining, and the density mirror is the price of painting hover/edit highlights edge to edge. Worth tracking separately so the next person editing the cell layout knows the constraints rather than re-deriving them.
+**Solution.** Add date-range filter operators with native `date_query` for `created_at` / `modified_at`, and JOIN-to-users filtering for `created_by` / `modified_by` (paired with [td-display-value-sort](#td-display-value-sort), since the JOIN cost is shared with display-value sorting).
 
-## 6. DataViews has no multiselect form control `[upstream]`
+<a id="td-display-value-sort"></a>
 
-**What.** DataViews v6 ships `text`, `integer`, `email`, `datetime`, `radio`, `select`, `toggleGroup`, `boolean`, and `checkbox` controls but no multiselect. Cortext used to bridge that with `FormTokenField`, but option editing outgrew it: multiselect now opens the same option picker as Select so users can create, recolor, rename, delete, and migrate options from the cell. That gives us one option-management surface, but it also means every multiselect cell still carries a custom editor instead of a DataViews-native control.
+**Sort on display-value properties is an open architectural decision.**
 
-**Where.** `src/components/MultiselectEdit.js`.
+**What.** `created_by`, `modified_by`, Person-style fields, Relations, relation-backed Rollups, and Files all share the same problem: the stored value is an internal handle, while the useful sort is the displayed value. Sorting by user ID, row ID, or attachment ID is not what users mean. Sorting by display name, related-row title, filename, or a computed rollup value needs either JOINs, denormalized display values, or an in-memory pass.
 
-**Solution.** A `multiselect` dataform-control upstream that DataForm and a future inline-edit mode (#1) resolve from `Edit: 'multiselect'`. It would need hooks for custom option rendering and option management, not just a token input, otherwise Cortext would still need the picker.
+Relations and list-style rollups now keep sorting disabled. Scalar rollups can sort in the client while the table has all rows loaded, but the REST query path still cannot order by computed rollup values because they are not stored as row meta. `build_query_args` falls back to the default date ordering if a rollup sort reaches the server.
 
-## 7. DataViews has no footer or layout append slot `[upstream, soft]`
+**Where.** `validate_sort_field` and `build_query_args` in `includes/Rest/RowsController.php`; `enableSorting: false` for display-value fields in `systemFields` and `mapField` (`src/hooks/fieldMapping.js`).
 
-**What.** DataViews has nowhere to put "+ New" at the bottom of a layout. Table and list use a Cortext footer just outside `<DataViews>`, with a small CSS layer to keep the wrapper working around DataViews' default `height: 100%`. Grid is trickier: the button needs to sit with the cards, so Cortext finds the rendered `.dataviews-view-grid` node and portals `DataViewNewRowButton` into it. Empty grid views use a local grid shell until DataViews renders a real grid node.
+**Solution.** Pick one model for display-value sorting: JOIN-and-sort in `build_query_args`, denormalize sortable display values into row meta, or keep fetching all rows and sort in memory. The answer should cover system user fields, Relations, Rollups, Person, and Files at the same time.
 
-**Where.** `DataViewNewRowButton` in `src/components/DataViewNewRowButton.js`, `GridNewRowPortal` in `src/components/GridNewRowPortal.js`, the footer mount in `src/components/CollectionDataViews.js`, and the `.cortext-data-view__footer` / `.cortext-data-view__new-row-card` rules in `src/components/CollectionDataViews.scss` and `src/components/CollectionDataViews.grid.scss`.
+<a id="td-select-server-sort-stored"></a>
 
-**Solution.** For table and list, switch fully to DataViews free composition (already supported through `children`) and lay out `<DataViews.Layout />` and `<DataViews.Pagination />` ourselves. For grid, DataViews needs an append-item or empty-item slot, or a layout hook that can place a card after the data items without a DOM lookup. This is separate from table footer rows for calculations; see #36 for that harder gap.
+**Select server sort uses stored values, not option order.**
 
-## 8. `CheckboxControl` ignores `hideLabelFromVision` `[upstream]`
+**What.** Server-side row sorting treats select fields as scalar stored values. That keeps `GET /cortext/v1/rows` sortable without joining or decoding option metadata, but it differs from curated option ordering.
 
-**What.** `CheckboxControl` always renders its `label` prop as a visible `<label>` next to the input regardless of `hideLabelFromVision` (verified against `node_modules/@wordpress/components/build-module/checkbox-control/index.mjs`). DataViews columns already show the field label in the header, so passing `label={ label }` echoed it next to every checkbox. We pass `aria-label={ label }` instead, which the component forwards to the underlying input. Screen readers still get a label; sighted users no longer see it twice. Risk: the next contributor reaches for `label` (the documented prop) and the duplicate quietly returns.
+**Where.** `RowsFilterQuery::apply_sort_clauses()` in `includes/Rest/RowsFilterQuery.php`.
 
-**Where.** Checkbox cell in `src/components/EditableCell.js`.
+**Solution.** If users expect select order to follow the field's configured options, compile select sorts into an option-order `CASE` expression generated from the field schema. Until then, document stored-value sorting as the v1 behavior.
 
-**Solution.** File a Gutenberg bug or PR. In the meantime, the `tech-debt.md#8` comment next to `aria-label` is the signal.
+### Public document rendering
 
-## 9. WorDBless can't integration-test the rows endpoint `[internal]`
+<a id="td-public-title-double-render"></a>
+
+**Public pages render the title twice.**
+
+**What.** `DocumentIdentity::prepend_header_blocks` slips a locked `core/post-title` block into `post_content` on insert, so the editor canvas can show the title inline as part of the BlockList. The public template still calls `the_title()` immediately before `the_content()`, and `core/post-title` resolves to the same `post_title` again, so every page created after this filter landed renders its title twice publicly. Older pages (no title block in their content) are fine until the editor next persists them.
+
+**Where.** `prepend_header_blocks` in `includes/PostType/DocumentIdentity.php`, paired with `the_title()` in `templates/single-crtxt_page.php`.
+
+**Solution.** Stop baking `core/post-title` into `post_content` and mount the editor's title input as canvas chrome above `BlockCanvas`, the way Gutenberg itself does it. The template keeps `the_title()` as the single source of truth; the editor keeps an inline-editable title; pages already saved with the block get a small migration that strips it.
+
+<a id="td-frontend-cover-icon-styles"></a>
+
+**Frontend stylesheet doesn't carry the cover/icon rules.**
+
+**What.** The PHP `render_callback`s emit `.cortext-document-cover-block`, `.cortext-document-icon-block`, and `.cortext-document-icon` markup on public pages, but their CSS still doesn't load there. Since the shell-style split, the admin/editor rules live in block edit partials and `PageIcon.scss`; `src/frontend.scss` still has none. On a public `crtxt_page`, the cover image renders at intrinsic size and the icon block falls back to inline layout.
+
+**Where.** `src/blocks/document-cover/edit.scss`, `src/blocks/document-icon/edit.scss`, and `src/components/PageIcon.scss` versus `src/frontend.scss`, plus the PHP render callbacks in `includes/Editor/DocumentCoverBlock.php` and `includes/Editor/DocumentIconBlock.php`.
+
+**Solution.** Extract the persisted cover/icon markup rules into a shared partial that both admin/editor and frontend stylesheets `@use`. Keep editor-only chrome, such as hover replace/remove controls and picker popovers, in the block edit partials.
+
+<a id="td-wp-icon-public-blank"></a>
+
+**WP-icon variant renders blank on the public frontend.**
+
+**What.** `DocumentIconBlock::render` emits a marker span (`<span class="cortext-document-icon--wp" data-icon="…">`) for the `wp` icon variant and relies on a frontend hydration step to fill in the SVG. `frontend.js` is CSS-only, so nothing fills it and the icon disappears on the public page; the saved color is also dropped. Emoji and image variants render server-side and are fine.
+
+**Where.** Case `'wp'` in `includes/Editor/DocumentIconBlock.php`, paired with `src/frontend.js` (no hydration).
+
+**Solution.** Either ship the SVG inline server-side (a small build-time generator that reads `@wordpress/icons` and emits a name-to-markup PHP map, refreshed on install) or hydrate from `data-icon` markers in `frontend.js` (smaller PHP surface, adds a public script). The inline-color is a one-line fix in either path. Until then, surface the limitation in the picker copy or restrict the saved variant to emoji + image for public-rendered pages.
+
+<a id="td-row-properties-public-render"></a>
+
+**Row properties have no public render.**
+
+**What.** Row properties live inside the block-editor iframe, between the title and body. They are a locked `cortext/document-properties` block, and `EnsureHeaderBlocks` keeps that block in place when the row's collection has fields. In the editor, the block renders `<RowProperties>` and reads `fields` from `DocumentPropertiesProvider`. The editor also owns inline layout editing, relation saves, hidden-property ordering, and the collapsed/visible state. On the PHP side the block is registered, but its `render_callback` still returns an empty string. Published rows rendered through `the_content()` therefore show body blocks only, without their schema fields.
+
+The row-detail layout setting means public rendering cannot just print every field in schema order. PHP has to follow the same cleanup as the editor: drop stale entries, append new fields as visible, keep hidden properties hidden, and leave `title` to `core/post-title`.
+
+**Where.** `src/blocks/document-properties/{block.json,edit.js,index.js}` defines the editor block. `includes/Editor/DocumentPropertiesBlock.php` registers it on the server with the placeholder `render_callback`. `src/components/DocumentPropertiesContext.js` passes `fields`, `allFields`, `detailLayoutEntries`, `fallbackRecord`, `rowId`, visibility state, and layout-edit requests from Canvas or RowEditor. `src/components/RowProperties.js` renders the editor-only property surface and relation controls. `src/components/EditorBody.js` (`EnsureHeaderBlocks`) inserts the block after the title when schema exists and removes it when schema disappears. `detail_layout` is registered in `includes/PostType/Collection.php`; the editor normalizes it in `src/hooks/detailLayout.js` and threads it through `src/hooks/useCollectionFields.js`. The schema accessor is `Cortext\Rest\RowsFilterQuery::field_schema_for( $collection_id )`; field values are formatted by `RowsController::format_typed_value()`.
+
+**Solution.** Fill in `DocumentPropertiesBlock::render()` so `the_content()` emits `<div class="cortext-document-properties">...</div>` with formatted values for rows whose collection has fields. Reuse `RowsController::format_typed_value()`, and add a small PHP normalizer for `detail_layout` so public markup follows the editor's field order and visibility. Share the same SCSS through `src/frontend.scss` so public markup matches the editor. This pass also needs a decision on row CPTs: today they are not `publicly_queryable`.
+
+### Editor and workspace UX
+
+<a id="td-data-view-block-height"></a>
+
+**Embedded data-view block has no width/height controls.**
+
+**What.** The `cortext/data-view` block exposes `align` (default / wide / full) for width but nothing for height. The block sizes to its content: short tables fit their rows, long tables grow with the page, and empty blocks fall back to DataViews' no-results state. That default is easy to understand, but authors still can't say "show 10 rows and scroll the rest." A long table stretches the document.
+
+**Where.** `src/blocks/data-view/block.json` (no `height` attribute today). The block-mode size rule lives in `src/components/CollectionDataViews.scss` next to the `.wp-block-cortext-data-view .cortext-data-view > .dataviews-wrapper` override.
+
+**Solution.** Add a `height` (or "rows visible") attribute to the block with an inspector control, and clamp the shell to that value when set. A density-aware default would help, but the per-block control is the part that matters.
+
+<a id="td-table-calculations-schema"></a>
+
+**Table calculations live on the DataViews view shape.**
+
+**What.** Calculation state stays in Cortext but is attached to the DataViews view object: `view.calculations` rides along on the saved view because embedded data-view blocks already persist that object, and named saved views do not exist yet. `normalizeView` prunes stale calculation entries when fields disappear or their type changes. That keeps the saved shape honest, but it is Cortext state attached to a DataViews object that upstream knows nothing about. The upstream side of the workaround (table footer slot) is tracked in [td-dataviews-layout-slots](#td-dataviews-layout-slots); this entry covers the internal storage concern that exists independently.
+
+**Where.** `src/components/tableCalculations.js`, calculation persistence in `src/components/dataViewColumns.js`, and the view shape declared in `src/blocks/data-view/block.json`.
+
+**Solution.** Saved named views become their own Cortext schema, and `calculations` lives there instead of being smuggled onto `view`. Until then, keep the calculation key in `view` clearly documented as Cortext-owned so DataViews upgrades don't strip it.
+
+<a id="td-row-properties-dnd"></a>
+
+**Row properties editing has its own dnd layer.**
+
+**What.** Row properties edit their layout inline. The UI has drag handles beside labels, a `Hidden properties` divider, an empty drop target for hiding properties, and a drag overlay sized to the row so relation chips wrap the same way while dragging. This cannot reuse the DataViews row reorder adapter ([td-dataviews-row-reorder](#td-dataviews-row-reorder)): it writes `detail_layout`, not table row order.
+
+Keep this local for now, but treat it as custom drag-and-drop code. It measures the dragged row, stops stale dnd-kit state from showing on the source row, blurs the handle after drop, and special-cases the empty hidden section. Before changing row-property spacing, chip wrapping, or dnd-kit overlays, check this path instead of assuming the table behavior applies.
+
+**Where.** `src/components/RowProperties.js` owns the `DndContext`, `DragOverlay`, hidden-property target, and layout reorder callbacks. `src/components/RowDetailView.scss` handles the drag handle, source-row hiding, overlay sizing, and hidden-drop-zone visuals. `src/blocks/document-properties/edit.js` maps the drag events into `detail_layout` saves.
+
+**Solution.** If another surface needs the same visible/hidden property list, extract a small shared primitive. Otherwise keep the code here until Gutenberg or DataViews exposes a field-list reorder primitive with hidden items and drop zones. Then RowProperties can shrink to the `detail_layout` save policy.
+
+<a id="td-favorites-row-shape"></a>
+
+**Favorite rows have their own sidebar-row shape.**
+
+**What.** Favorites look like sidebar rows, but they are not normal page-tree rows. They are shortcuts, they should never show the active selection state, and they are sortable only inside the Favorites section. Sharing the whole row as both a navigation button and a dnd-kit sortable handle made clicks repaint the hover state and feel like a flash. The current row splits those jobs: the icon is the drag handle, the title is a plain navigation button, and the star is the remove action. It works, but Favorites carry a small custom row shape alongside `PageRow` and `CollectionRow`.
+
+**Where.** `src/components/SidebarFavorites.js`, plus the `.cortext-sidebar__favorite-*` rules in `src/components/Sidebar.scss` and `src/styles/global/_shell-root.scss`.
+
+**Solution.** Extract a shared sidebar-row primitive with explicit slots for title navigation, drag handle, menu/actions, selected state, and shortcut-only rows. Then `PageRow`, `CollectionRow`, and `SidebarFavorites` can share the same interaction contract without reusing the wrong DOM shape for Favorites.
+
+<a id="td-recents-call-site-wired"></a>
+
+**Recents tracking is wired at each call site.**
+
+**What.** There is no workspace activity layer. Each surface that counts as a visit or edit calls `touchRecent` itself: route resolution, page autosave, sidebar rename, row field save, row creation, and relation-created rows. That makes the behavior easy to understand, but future write paths can forget to update recents unless the reviewer knows to look for it.
+
+**Where.** `src/router/EntityRoute.js`, `src/hooks/useAutosave.js`, `src/components/Sidebar.js`, `src/components/CollectionDataViews.js`, and `src/components/relations/RelationEditor.js`.
+
+**Solution.** If more activity surfaces appear, move this behind a small workspace activity helper or event. Route visits can stay in the router, but writes should eventually report through the same mutation path instead of each component remembering to call `touchRecent`. If rows move into `core-data` ([td-rows-not-in-core-data](#td-rows-not-in-core-data)), that would be a natural time to centralize row touches too.
+
+<a id="td-document-layer-thin"></a>
+
+**Cortext document layer is still thin.**
+
+**What.** Pages, full-page collections, and rows all opt into `cortext-document`. The shared reader (`Cortext\Documents`, `GET /cortext/v1/documents`, `useDocuments`) now gives trash, document lists, and recents the same shape instead of making each screen rebuild its own version. The layer is still thin: pages use the page tree and `core-data`; full-page collections mount in Canvas, but keep `collection/` URLs and collection-shaped recents; rows still use `useCollectionRows`. Restore/delete still fan out through page-tree refresh, row invalidation, collection context refresh, and Trash refresh. Favorites and recents use the document service for row paths, but routing, URL targets, and activity tracking still ask "page, collection, or row?" where they should only need "document." Relation chips open row documents, but still depend on local row URL helpers (`rowRoute` / `rowHref`) and `slug` in relation responses.
+
+**Where.** `includes/Documents.php`, `includes/PostType/Collection.php`, `includes/Rest/DocumentsController.php`, `includes/Rest/RecentsController.php`, relation slug hydration and row `kind` output in `includes/Rest/RowsController.php`, `src/components/Canvas.js`, `src/documents/favorites.js`, `useFavoriteToggle` in `src/documents/hooks.js`, `src/hooks/useDocuments.js`, `src/hooks/useTrashedDocuments.js`, `src/components/SidebarTrash.js`, `src/router/useResolveEntity.js`, `src/router/EntityRoute.js`, `src/router/entityRouteReducer.js`, `rowRoute` / `rowHref` in `src/components/relations/relationUtils.js`, `src/hooks/documentTrashInvalidation.js`, and `src/hooks/rowInvalidation.js`.
+
+**Solution.** Keep `Cortext\Documents` as the cross-type reader, then move shared document behavior behind it one piece at a time: URL targets, invalidation, activity/recents, and trash refresh. Individual records can still use `core-data` or row endpoints where WordPress models them well. Cross-type views can stay under `/cortext/v1/documents`; shared document features should not rebuild the same page/row branching every time.
+
+<a id="td-frontend-bundle-split"></a>
+
+**DataView block shares a frontend bundle with page chrome.**
+
+**What.** The `cortext-frontend` script and style handle serves double duty: it hydrates the DataView block (React, DataViews, field renderers) and provides general page chrome (body font, content column, title styles). Both `Assets.php` and the render callback in `DataView.php` enqueue the same handle, creating a registration race where the first caller's dependency list wins and the second is silently ignored. The DataView block should provision its own script and style (e.g. `cortext-data-view-view`) via `viewScript`/`viewStyle` in `block.json` or its own dedicated handles in the render callback, so its dependencies (`wp-components`, `wp-api-fetch`, etc.) are self-contained. `cortext-frontend`, if it makes sense to exist, should only cover general concerns: page chrome, light/dark mode toggle, etc.
+
+**Where.** `includes/Block/DataView.php` (render callback enqueue), `includes/Frontend/Assets.php` (page-level enqueue), `src/frontend.js` (single entry point for both concerns).
+
+**Solution.** Split `src/frontend.js` into two entry points: one for page chrome (`cortext-frontend`) and one for the DataView block (`cortext-data-view-view`). The block entry handles hydration and declares its own dependencies. The page entry stays minimal. Update `webpack.config.js` with the new entry point, and update `DataView.php` to enqueue the block-specific handle.
+
+<a id="td-bulk-row-trash-fanout"></a>
+
+**Bulk row trash fans out through per-row REST calls.**
+
+**What.** Bulk row trash still calls the same row REST delete endpoint as the single-row action. The client sends one `DELETE /wp/v2/<row post type>/<id>` request per selected row, capped at four concurrent requests by `allSettledWithConcurrency`. That cap keeps a large selection from flooding the server, and the `Promise.allSettled`-style result list keeps partial failures easy to handle. It is acceptable for the current DataView scale, but not a real bulk operation: moving 100 rows to Trash still means 100 REST writes, just in a small queue. There is no atomic all-or-nothing behavior, no server-side progress state, and no way to resume if the browser goes away mid-run.
+
+**Where.** `requestDeleteRows` in `src/components/CollectionDataViews.js`, the queue helper in `src/components/allSettledWithConcurrency.js`, and coverage in `tests/js/components/allSettledWithConcurrency.test.js`.
+
+**Solution.** If collections start moving large row sets to Trash, add a collection-row bulk trash endpoint or an async job endpoint with progress polling. That endpoint should own permission checks, trash order, partial-failure reporting, and cleanup. Then the DataView action can send selected IDs once instead of managing a client-side queue.
+
+<a id="td-workspace-tree-no-unified-model"></a>
+
+**Workspace tree has no unified node model.**
+
+**What.** The sidebar builds its workspace tree from two REST lists: active pages (`crtxt_page`) and full-page collections (`crtxt_collection`). The shell joins them client-side by reading `post_parent`. That works for collections under loaded pages, but row-owned collections and collections whose parent page is outside the loaded window fall back to the flat Collections section because there is no parent record to attach to. There is still no "workspace node" shape with `kind`, so every tree consumer has to branch on pages versus collections.
+
+Drag/drop and `menu_order` accounting look at both pages and collections through `treeRecords`, a single `DndContext` now wraps both sections, and the cycle guard walks the merged node graph. The model gap that remains is shape, not wiring: every tree consumer still branches on pages versus collections to derive a `kind`, and the Collections section's contents are a UX choice on top of that. Today it shows only top-level full-page collections (`parent = 0`); nested ones live solely in the Pages tree. The unified model would let this be configurable per workspace: top-level only, all collections grouped, or per-parent sub-headers.
+
+**Where.** `ACTIVE_PAGES_QUERY` in `src/components/page-queries.js`, `FULL_PAGE_COLLECTION_QUERY` in `src/collections.js`, `nestedCollections` / `topLevelCollections`, `treeRecords`, `handleDragOver`, and the shared `DndContext` in `src/components/Sidebar.js`, the `renderCollectionRow` bridge in `src/components/PageRow.js`, `CollectionRow`'s drag/drop zones, `computeDropTarget` in `src/components/pages-tree.js`, and the `Collection::hierarchical` / `Collection::validate_parent_document` setup on the PHP side.
+
+**Solution.** Add a workspace-tree REST endpoint that returns navigable nodes with `kind`, `id`, `parent`, `menu_order`, and visibility in one shape. Row-owned collections could then appear under their row, missing parents would not look top-level by accident, and page/collection branching would move out of every consumer. The Collections section then becomes a view over the same model with the user's chosen filter, instead of a separate flat list.
+
+<a id="td-collection-owner-body-contract"></a>
+
+**Collection canvases use a self-referencing owner block.**
+
+**What.** A full-page collection needs a locked `cortext/data-view` block whose `collectionId` is the collection post's own ID. WordPress and Gutenberg can give a CPT a static template, but not one that fills attributes from the just-created post and then treats that block as the body. Cortext works around that in a few places: PHP seeds the serialized block after insert, a one-shot backfill catches older collections, the editor adds the block if content is still empty, CSS hides body appenders and owner-block chrome, a SlotFill moves the data-view panels into the Collection tab, and the block hides "Change collection" so the owner cannot point away from itself. See [td-collection-owner-block-template](#td-collection-owner-block-template) for the upstream alternative.
+
+**Where.** `Collection::build_data_view_block_markup()` and `Collection::maybe_seed_data_view_block()` in `includes/PostType/Collection.php`, `includes/PostType/CollectionContentBackfill.php`, `src/components/CanvasOwnerInspector.js`, owner-block handling in `src/components/EditorBody.js`, `src/blocks/data-view/edit.js`, `src/components/PageInspectorSidebar.js`, and the owner rules in `src/styles/global/_shell-root.scss`.
+
+**Solution.** Build a single internal body-owner contract: a Cortext primitive that takes a post and a block name, locks the body to that block, owns inserter/chrome/inspector policy, and keeps public serialization predictable. Then the post-insert seed, backfill, editor fallback, SlotFill routing, and owner CSS shrink or disappear, independently of whether upstream ever lands a dynamic block-template hook.
+
+### Field management UX
+
+<a id="td-field-management-panel"></a>
+
+**Field management still needs a panel outside the table.**
+
+**What.** Field actions live in one shared menu, but there is still no collection-level field manager. Table users get the menu from column headers. Row-detail users get it from clickable property labels. Grid and list users can manage fields only after opening a row; those layouts still have no direct "Manage fields" entry point.
+
+**Where.** `src/components/fields/FieldActionsMenu.js` (shared field actions), `src/components/fields/ColumnHeaderActions.js` (table-header trigger), `src/components/RowProperties.js` and `src/blocks/document-properties/edit.js` (row-property labels and field snapshot context). `ColumnHeaderActions` still mounts only when `view.type === 'table'` (`src/components/CollectionDataViews.js`).
+
+**Solution.** A toolbar "Manage fields" panel listing every custom field with per-row rename / duplicate / delete, available in every layout.
+
+<a id="td-select-no-options-on-create"></a>
+
+**Select / multi-select fields ship with no options.**
+
+**What.** Add field creates the field as soon as you click a type; there is no second step for type-specific setup. For select / multi-select, the column starts with no options. Users can add options from the shared field menu, but the create flow still leaves them with an empty property first.
+
+**Where.** `src/components/fields/AddFieldPopover.js` (no options input), plus the after-creation path in `src/components/fields/FieldActionsMenu.js` and `src/components/fields/EditOptionsPopover.js`. The REST route already accepts an `options` array; the create UI just doesn't expose it.
+
+**Solution.** Add a setup step during field creation, or open the options editor immediately after creating a select / multi-select field. Until then, users fix empty select fields through the shared field menu.
+
+### Schema migrations
+
+<a id="td-collection-duplication-relations"></a>
+
+**Collection duplication cannot clone relation schema.**
+
+**What.** Duplicating a full-page collection creates the new collection, registers its row CPT, and copies field posts that stand on their own. It skips relations because a relation is really a pair: the forward field plus the reverse field on another collection. A safe copy has to create or update both sides, keep the cardinality, and remap ids without touching the original relation. Until that exists, the REST response lists skipped fields and the sidebar tells the user the copy is missing columns. Rollups that read through a skipped relation belong in the same bucket; they are not useful until the copied schema has its own relation target.
+
+**Where.** `CollectionDuplicator::duplicate()`, `clone_fields()`, and `remap_rollup_references()` in `includes/Documents/CollectionDuplicator.php`, plus the skipped-field notice in `src/components/Sidebar.js` and duplicate coverage in `tests/php/test-rest-collections.php`.
+
+**Solution.** Add a relation-aware schema copy step. It should clone and remap the forward and reverse fields together, or skip every dependent field, including rollups that point at skipped relations. The duplicate should never carry references back to the source collection's fields. Once that exists, the sidebar notice can name the exact skipped field types instead of treating them all as generic missing columns.
+
+### Testing infrastructure
+
+<a id="td-wordbless-row-coverage"></a>
+
+**WorDBless can't integration-test the rows endpoint.**
 
 **What.** WorDBless uses `Db_Less_Wpdb`, an in-memory store where `wp_insert_post` and `get_post` work via the object cache but `WP_Query` SQL returns zero results. `InMemoryPostsQuery` now covers the simple query shapes used by document listing and page-trash cascade tests: post type, status, parent, `meta_key` / `meta_value`, search, ordering, and pagination. That keeps those tests useful, but it is still an approximation of WordPress queries, not a real database.
 
@@ -109,457 +642,3 @@ The rows endpoint is still the hard case. `RowsController` unit tests cover rout
 **Where.** `tests/php/InMemoryPostsQuery.php`, `tests/php/test-documents.php`, `tests/php/test-rest-documents-controller.php`, `tests/php/test-page-trash-cascade.php`, `tests/php/test-rest-document-trash-controller.php`, and `tests/php/test-rest-recents-controller.php`, plus the still-limited row coverage in `tests/php/test-rest-rows-controller.php` and `tests/php/test-field-value-read-query.php`.
 
 **Solution.** Keep the in-memory shim for simple document queries, but test the row endpoint against a real `wpdb` before treating sort/filter/pagination as covered. Either add a `wp-env` + `WP_UnitTestCase` suite for rows, or rely on targeted e2e coverage in `tests/e2e/specs/data-view-block.spec.js` until that suite exists. Once real database coverage exists, the shim should stay limited to tests that only need cheap post lookup behavior.
-
-## 10. DataViews `FieldType` union has no decimal `number` or `url` `[upstream]`
-
-**What.** DataViews v6's `FieldType` union is `'text' | 'integer' | 'datetime' | 'date' | 'media' | 'boolean' | 'email' | 'array'`. Cortext has `number` (decimals allowed) and `url`, neither of which has an exact match. We map numbers to `'integer'` so the filter UI can offer numeric operators, then disable DataViews' integer-only validator, attach a decimal-aware sort comparator, and provide a decimal-safe number filter control because the built-in integer `between` control applies whole-number min/max bounds. URLs still map to `'text'`, which is close enough for contains/starts-with filters but not an exact semantic type.
-
-**Where.** `mapField` in `src/hooks/fieldMapping.js`.
-
-**Solution.** DataViews adds a decimal-friendly `'number'` type and a `'url'` type, or exposes a cleaner way for consumers to supply custom field controls/operator sets without borrowing the nearest built-in type. Filing a Gutenberg issue is the cheaper play.
-
-## 11. DataViews `Option` type has no `color` `[upstream]`
-
-**What.** DataViews's `Option` shape is `{ value, label, description? }`. Cortext's select / multiselect options can carry a `color` for chip rendering, so we attach `color` as an extra key on each element. DataViews ignores unknown keys today, but a stricter validator upstream would strip it, breaking colored chips silently.
-
-**Where.** `elementsFromOptions` in `src/hooks/fieldMapping.js`. Read by `Chip` (`src/components/fields/Chip.js`) via `formatDisplay` in `src/components/EditableCell.js`.
-
-**Solution.** Add `color` (or a generic decoration slot) to DataViews's `Option` type upstream, then drop the piggyback. File a Gutenberg issue with the chip-render use case.
-
-## 12. `_modified_by` is plugin-stored, not native `[internal]`
-
-**What.** WordPress core stores `post_modified` (timestamp) but not who last edited the post. The "Last edited by" system column needs that information, so a `save_post` hook on entry CPTs records `_modified_by` post meta with the current user ID on every save. Skipped when no user is signed in (CLI imports, cron, seeds, unauthenticated REST) so background writes don't clobber the last real editor with `0`. Risk: third-party plugins that bypass `save_post` (direct DB writes) won't update `_modified_by`. Acceptable for the block's scope; entries created before this PR fall back to the post author when the meta is absent.
-
-**Where.** `record_modified_by` in `includes/PostType/CollectionEntries.php`, read by `format_row` in `includes/Rest/RowsController.php`.
-
-**Solution.** Either core grows native "last editor" tracking (unlikely; long-standing wishlist), or we accept the hook as the canonical answer. No upstream issue to file — this is just a small piece of plugin-managed state.
-
-## 13. System field filtering is deferred `[internal]`
-
-**What.** Filters route through `meta_query`, but system fields (`created_at`, `modified_at`, `created_by`, `modified_by`) live on the post table or in user data, not in post meta. The filter validator rejects all four with a clean 400 rather than silently no-op'ing through the meta_query branch. Users can sort by `created_at` and `modified_at` (free WP_Query orderby) but can't filter on any system field today.
-
-**Where.** `validate_filter_fields` and `build_query_args` in `includes/Rest/RowsController.php`.
-
-**Solution.** Add date-range filter operators with native `date_query` for `created_at` / `modified_at`, and JOIN-to-users filtering for `created_by` / `modified_by` (paired with #14, since the JOIN cost is shared with display-value sorting).
-
-## 14. Sort on display-value properties is an open architectural decision `[internal]`
-
-**What.** `created_by`, `modified_by`, Person-style fields, Relations, relation-backed Rollups, and Files all share the same problem: the stored value is an internal handle, while the useful sort is the displayed value. Sorting by user ID, row ID, or attachment ID is not what users mean. Sorting by display name, related-row title, filename, or a computed rollup value needs either JOINs, denormalized display values, or an in-memory pass.
-
-Relations and list-style rollups now keep sorting disabled. Scalar rollups can sort in the client while the table has all rows loaded, but the REST query path still cannot order by computed rollup values because they are not stored as row meta. `build_query_args` falls back to the default date ordering if a rollup sort reaches the server.
-
-**Where.** `validate_sort_field` and `build_query_args` in `includes/Rest/RowsController.php`; `enableSorting: false` for display-value fields in `systemFields` and `mapField` (`src/hooks/fieldMapping.js`).
-
-**Solution.** Pick one model for display-value sorting: JOIN-and-sort in `build_query_args`, denormalize sortable display values into row meta, or keep fetching all rows and sort in memory. The answer should cover system user fields, Relations, Rollups, Person, and Files at the same time. Tracked in RSM-1793.
-
-## 15. DataViews table columns lack interaction extension points `[upstream]`
-
-**What.** DataViews persists table column order in `view.fields` and widths in `view.layout.styles`, but it doesn't expose a table-column interaction layer: no resize handles, min/max width contract, double-click autofit, reorder callback, drag preview, stable header/cell refs, or supported way to opt into `table-layout: fixed`. Cortext therefore portals resize and dnd-kit drag handles into DataViews-rendered `<th>` elements, snapshots header geometry during drag, mutates inline widths during resize for immediate feedback, and overrides internal table/cell wrapper CSS so narrow columns behave as hard constraints rather than intrinsic-size hints.
-
-Double-click autofit is the trickiest piece. With no measurement hook upstream, we clone the cell into a hidden subtree that has to recreate every ancestor that affects layout: a `.cortext-data-view` wrapper for our scoped overrides, a real `<tbody>` or `<thead>` for upstream's tbody-scoped rules, an append next to the live `.dataviews-wrapper` for font inheritance, and `display: block` on the wrapper so flex sizing on the parent doesn't push the measurement around. Then the persisted width subtracts the cell's own padding and border (we read border-box, write content-box), and a 2px buffer absorbs proportional-digit rounding so `2007` doesn't clip where `1939` fits. Each ancestor and constant is a place the live DOM can drift away from us.
-
-**Where.** `src/components/DataViewColumnInteractions.js`, `src/components/dataViewColumns.js`, the `DataViewColumnInteractions` mount in `src/components/CollectionDataViews.js`, and the column affordance / table wrapper rules in `src/components/DataViewColumnInteractions.scss` and `src/components/CollectionDataViews.scss`.
-
-**Solution.** Upstream DataViews could expose table-column APIs that cover `onChangeFields`, `onChangeColumnStyle`, resize handle rendering, per-field min/max widths, double-click autofit, drag overlay/insertion affordances, and stable header/cell slots or refs. If DataViews owned that layer, Cortext could drop the portal/DOM-query adapter, the wrapper min-width overrides, most of the dnd-kit column glue, the cloned-measurement gymnastics, and the direct DOM mutation used for live resize feedback.
-
-## 16. DataViews has no per-column header extension slots `[upstream, soft]`
-
-**What.** DataViews' column-header dropdown (Sort / Add filter / Move / Hide) is a closed list: it has no `field.menuItems` hook for Rename / Duplicate / Delete or Calculate, and no header accessory slot for the field-description help icon. To keep one dropdown per column, we hide DataViews' built-in trigger on custom-field `<th>`s via CSS and portal our own combined trigger in (Sort / Move / Hide _plus_ field management and table calculations). Custom field descriptions add a small help trigger next to that replacement header trigger. Title and system fields keep the built-in trigger. Main's drag-handle click-forward (`DataViewColumnInteractions`) iterates header buttons and skips `display: none` ones via `offsetParent`, so it lands on whichever trigger is visible. Filter is intentionally absent: Cortext doesn't surface column-level filters in the header.
-
-**Where.** `src/components/fields/ColumnHeaderActions.js` (table-only items and the header portal), `src/components/fields/FieldActionsMenu.js` (shared field actions and description help trigger), `src/components/fields/ColumnHeaderActions.scss` (custom header layout and help-trigger z-index), `src/components/CollectionDataViews.scss` (`.dataviews-view-table th:has(.cortext-column-header-marker) > .dataviews-view-table-header-button { display: none }`), and `src/components/DataViewColumnInteractions.js` (visible-button click forward).
-
-**Risk.** Re-implementing Sort / Move / Hide ourselves means new DataViews items in those menus won't show up here automatically. Calculations and description help both depend on this custom header path staying in sync with DataViews. The help icon also has to sit above Cortext's transparent column drag handle; if that overlay changes, the icon can become visible but not hoverable. If main's drag handle stops calling `.click()` on the header trigger, column-name clicks would need another way to open the menu.
-
-**Solution.** DataViews should expose two header extension points: a `field.menuItems` array or render prop appended to the built-in dropdown, plus a header accessory/help slot rendered next to the label. Other consumers (Pattern Manager, Pages, Site Editor) would benefit too. File as a Gutenberg feature request.
-
-## 17. Add-field header piggybacks on the DataViews actions column `[upstream, soft]`
-
-**What.** The table's `+ add field` button now sits in DataViews' row-actions column header. `ColumnHeaderActions` finds `th.dataviews-view-table__actions-column` and portals the button there; CSS hides the built-in "Actions" label and keeps the header cell sticky on the right. This is cleaner than the old synthetic `__add_field` column because it no longer leaks into `view.fields`, but it still leans on DataViews internals. If the class name, header rendering, or sticky-column markup changes, the button can disappear or stop lining up with the row kebabs.
-
-The create-field flow also has to reveal the new trailing column itself. It carries the created field ID back to `CollectionDataViews`, waits until the field marker exists in the rendered header, then scrolls `.dataviews-wrapper` to the right edge. The interaction feels right, but it still depends on DataViews' DOM shape.
-
-**Where.** `src/components/fields/ColumnHeaderActions.js` (actions-column lookup and portal), `src/components/CollectionDataViews.js` and `src/components/dataViewScroll.js` (created-field reveal and `.dataviews-wrapper` scroll), `src/components/CollectionDataViews.scss` (`.dataviews-view-table__actions-column` overrides), and the legacy `__add_field` cleanup in `src/components/CollectionDataViews.js`.
-
-**Solution.** DataViews exposes a trailing table-header slot, an add-column slot, or a header action area separate from per-row actions, plus refs for the table scroll wrapper and rendered headers. Then the portal targets a real extension point, the reveal code stops querying DataViews DOM, the sticky/header-label CSS disappears, and `__add_field` stays only as migration cleanup for old saved views.
-
-## 18. Field management still needs a panel outside the table `[internal]`
-
-**What.** Field actions now live in one shared menu, but there is still no collection-level field manager. Table users get the menu from column headers. Row-detail users get it from clickable property labels. Grid and list users can manage fields only after opening a row; those layouts still have no direct "Manage fields" entry point.
-
-**Where.** `src/components/fields/FieldActionsMenu.js` (shared field actions), `src/components/fields/ColumnHeaderActions.js` (table-header trigger), `src/components/RowProperties.js` and `src/blocks/document-properties/edit.js` (row-property labels and field snapshot context). `ColumnHeaderActions` still mounts only when `view.type === 'table'` (`src/components/CollectionDataViews.js`).
-
-**Solution.** A toolbar "Manage fields" panel listing every custom field with per-row rename / duplicate / delete, available in every layout.
-
-## 19. Select / multi-select fields ship with no options `[internal]`
-
-**What.** Add field creates the field as soon as you click a type; there is no second step for type-specific setup. For select / multi-select, the column starts with no options. Users can add options from the shared field menu, but the create flow still leaves them with an empty property first.
-
-**Where.** `src/components/fields/AddFieldPopover.js` (no options input), plus the after-creation path in `src/components/fields/FieldActionsMenu.js` and `src/components/fields/EditOptionsPopover.js`. The REST route already accepts an `options` array; the create UI just doesn't expose it.
-
-**Solution.** Add a setup step during field creation, or open the options editor immediately after creating a select / multi-select field. Until then, users fix empty select fields through the shared field menu.
-
-## 20. Table layout overrides couple to DataViews internals `[upstream, soft]`
-
-**What.** DataViews ships `table-layout: auto; width: 100%` plus per-cell padding rules. We flip to `table-layout: fixed; width: max-content` with explicit per-cell widths so adding or removing a field doesn't reflow every other column. We also override the actions-column header so the add-field button stays pinned beside the row kebabs. The table sizes to its content and scrolls horizontally on overflow. Depends on DataViews' class names and selector specificity staying put.
-
-**Where.** `src/components/CollectionDataViews.scss`, around the `.dataviews-view-table` block.
-
-**Solution.** A `tableLayout` (or similar) prop on DataViews so consumers can pick between "auto with redistribution" and "fixed with content-sized columns", plus per-field `width` hints so columns can be pinned without overriding DataViews CSS.
-
-## 21. Field-meta cleanup uses a global delete `[internal]`
-
-**What.** `cleanup_after_field_delete` calls `delete_post_meta_by_key( "field-<id>" )`, which wipes that key from every post — not just Cortext entry CPTs. The collision risk is theoretical (`<id>` is a globally unique `crtxt_field` post ID, so any postmeta keyed that way belongs to a Cortext entry by construction), but the code doesn't enforce that. A scoped `DELETE pm … INNER JOIN wp_posts p … WHERE p.post_type IN (…)` would prove the scope, but WorDBless (#9) can't run JOINs and its in-memory `$wpdb->posts` isn't exposed via SQL — `WP_Query`/`get_posts` against dynamic entry CPTs returns empty in the mock, so the per-post fallback also can't be unit-tested here.
-
-**Where.** `cleanup_after_field_delete` in `includes/PostType/CollectionEntries.php`.
-
-**Solution.** Stand up an integration environment with a real `wpdb` (`wp-env` + WP_PHPUnit), move the cleanup to a scoped JOIN, and keep WorDBless for the parts that don't need a real database.
-
-## 22. Block editor selects on scrollbar drag `[upstream]`
-
-**What.** Gutenberg selects a block on any `mousedown` that bubbles up to the block wrapper. Inside the data-view block, dragging the dataviews scrollbar fires a mousedown on the scrolling element and pulls a bounding box around the whole block. Gutenberg has no primitive for "this region scrolls, don't select on click." We listen for `mousedown` on `.cortext-data-view` in capture phase, sniff scrollbar-gutter clicks by geometry (target's computed `overflow-x/y` is `auto`/`scroll`, the element actually overflows, and the click landed past `clientWidth` or `clientHeight`), then `stopPropagation` so the event never reaches Gutenberg. Cell, row, and header clicks keep bubbling and select normally.
-
-**Where.** The mousedown effect on `tableWrapperRef` in `src/components/CollectionDataViews.js`.
-
-**Solution.** A Gutenberg API for declaring interactive scroll regions on a block (or a way to opt mousedowns out of selection per descendant) would let us drop the heuristic. Until then the geometry sniff is the cleanest signal we have. The brittleness is in browser scrollbar pseudo-element behavior; the day someone introduces an overlay-scrollbar shim or a custom scroll library, this would need rethinking.
-
-## 23. Embedded data-view block has no width/height controls `[internal]`
-
-**What.** The `cortext/data-view` block exposes `align` (default / wide / full) for width but nothing for height. For now the block sizes to its content: short tables fit their rows, long tables grow with the page, and empty blocks fall back to DataViews' no-results state. That default is easy to understand, but authors still can't say "show 10 rows and scroll the rest." A long table stretches the document.
-
-**Where.** `src/blocks/data-view/block.json` (no `height` attribute today). The block-mode size rule lives in `src/components/CollectionDataViews.scss` next to the `.wp-block-cortext-data-view .cortext-data-view > .dataviews-wrapper` override.
-
-**Solution.** Add a `height` (or "rows visible") attribute to the block with an inspector control, and clamp the shell to that value when set. A density-aware default would help, but the per-block control is the part that matters.
-
-## 24. Workspace notices filtered by id prefix `[upstream, soft]`
-
-**What.** Gutenberg's editor store fires off its own "Page updated" snackbar on every successful save. Autosave runs constantly here, so that toast would never stop popping up. Our workaround is a custom `SnackbarList` that only shows notices whose id starts with `cortext-`; everything else gets dropped on the floor, including any third-party plugin notice or a future first-party one we'd actually want to surface.
-
-**Where.** `CortextSnackbars` in `src/components/Canvas.js`, paired with the `id: 'cortext-autosave-error'` we set on the autosave error notice in `src/hooks/useAutosave.js`.
-
-**Solution.** Upstream could expose a way to suppress the editor's default save notice, or scope notices per surface so we don't have to share a global stream. Until then, anything Cortext wants visible has to opt in with a `cortext-` id.
-
-## 25. dnd-kit doesn't observe `inert` `[upstream, soft]`
-
-**What.** Collapsed branches of the page tree stay mounted so the expand/collapse animation can run. The wrapper gets `inert` so focus, screen readers, and click events skip the subtree, but dnd-kit doesn't pay attention to that. It walks its registered droppables in JavaScript, asks each one for its bounding rect, and treats them as live drop targets whether anything visible is there or not. Without intervention, a drag can land on a row you can't see. The workaround is to thread an `isHidden` prop down through `PageRow` and pass `disabled: isHidden` to every `useDroppable`. Anything else that wants this animation pattern has to do the same drilling.
-
-**Where.** The `isHidden` prop chain through `src/components/PageRow.js`, plus the wrapper's `inert` attribute in the same file.
-
-**Solution.** dnd-kit honoring `inert` (or computed `pointer-events: none`) on an ancestor would let us drop the prop-drilling. Until then, any tree-shaped surface that uses a CSS-clipped collapse animation has to thread `disabled` through its rows itself.
-
-## 26. Sidebar rename input pinned via WP component internals `[upstream]`
-
-**What.** The page-row rename uses `<TextControl size="compact" __next40pxDefaultSize>`, which should produce a 32px input matching the 32px row. It doesn't, on its own: the wrapping `BaseControl > field > InputControl > container` chain still contributes vertical space, so opening rename used to bump the row a few pixels. The fix pins `height` / `min-height` / `max-height` to `$grid-unit-40` and zeroes `padding-block` on every layer in that chain (`.components-base-control`, `.components-base-control__field`, `.components-input-control`, `.components-input-control__container`, `.components-input-control__input`). It works, but it couples Cortext to WP component-internal class names. If WP refactors `TextControl` (renames a class, drops a wrapper, restructures the DOM), the input loses its height pin and the row starts bumping again, silently.
-
-**Where.** The `&__rename` block in `src/components/Sidebar.scss`. The e2e test `keeps the rename input inside the page row height` in `tests/e2e/specs/sidebar-layout.spec.js` is the tripwire: it asserts the input never overflows the row's bounding rect, so a WP-internals refactor would surface there before reaching production.
-
-**Solution.** Either WP exposes a "fit-the-row" size for `TextControl` (or a CSS variable hook for input height), or we replace the rename `TextControl` with a plain `<input>` styled to match the row. The plain input is the more reliable path: drops the WP-internals coupling, but adds a small amount of styling and accessibility plumbing we currently get for free. Worth doing the day this test fails on a WP bump.
-
-## 27. `Menu` outside-click only watches one document `[upstream]`
-
-**What.** WP's `Menu` (privateApis, Ariakit underneath) only sees clicks on the document where the popover renders. The `cortext/data-view` block and row properties render inside Gutenberg's editor iframe, so clicks on the editor sidebar or top toolbar never reach Ariakit. Without a fallback, the field menu stays open until the user clicks back into the canvas. We add a `mousedown` listener on `window.parent.document` while the menu is open and skip it when there is no parent document (the Cortext admin is not in an iframe).
-
-**Where.** The `useEffect` block in `src/components/fields/FieldActionsMenu.js`, used by table column headers and row-property label menus.
-
-**Solution.** Either Ariakit grows a way to register extra documents for outside-click detection, or WP's wrapper does it for us. We drop the listener once that ships.
-
-## 28. `Menu.Item` has no destructive variant `[upstream]`
-
-**What.** The legacy `MenuItem` from `@wordpress/components` accepted `isDestructive` and rendered the row in red. The new privateApis `Menu.Item` dropped that prop without a replacement (verified in `node_modules/@wordpress/components/build-types/menu/types.d.ts` against `ItemProps`). For the Delete field action we paint the red ourselves with a className and one CSS rule, scoped to inactive rows so the focus/hover highlight overrides it.
-
-**Where.** The Delete `Menu.Item` in `src/components/fields/FieldActionsMenu.js` and `.cortext-column-header-actions__destructive-item` in `src/components/fields/ColumnHeaderActions.scss`.
-
-**Solution.** Add `isDestructive` (or a `variant: 'destructive'`) to `Menu.Item` upstream. One-line change here once it ships.
-
-## 29. `Menu.Popover` doesn't portal by default `[upstream]`
-
-**What.** Without `portal`, `Menu.Popover` renders inline at its mount point. The table-header trigger lives inside a `<th>` whose `text-transform: uppercase` cascades into the menu items and turns every label into ALL CAPS. The shared field menu passes `portal` explicitly, so table headers and row-property labels use the same code. Most popovers in the system portal by default; this one doesn't.
-
-**Where.** The `<Menu.Popover portal …>` in `src/components/fields/FieldActionsMenu.js`.
-
-**Solution.** Flip the default upstream. Trivial PR.
-
-## 30. `Menu` submenus only accept menu primitives `[upstream]`
-
-**What.** `Menu.SubmenuTriggerItem` opens a nested `Menu.Popover`, but that popover only accepts `Menu.Item` / `Menu.Group` / `Menu.Separator` children. Our "Edit field" submenu has tile previews (Number / Bar / Ring), labelled rows with right-anchored values, and three more popovers for format, color, and time choices. The Calculate submenu is simpler, but it still needs the same hover bridge so it feels like the adjacent Edit field menu. These panels do not fit the menu primitive cleanly, so they stay as sibling popovers. We run the hover bridge ourselves, and the parent menu ignores outside-clicks that land in `.cortext-format-submenu`, `.cortext-format-submenu__flyout`, or `.cortext-table-calculation-submenu`.
-
-**Where.** `openFormat`, `scheduleClose`, and `hideMenuOnInteractOutside` in `src/components/fields/FieldActionsMenu.js`; `openCalculation` / `scheduleClose` in `src/components/fields/ColumnHeaderActions.js`; `FieldFormatPopover` and its flyouts in `src/components/fields/FieldFormatPopover.js`; `TableCalculationMenu` and its flyouts in `src/components/TableCalculationMenu.js`.
-
-**Solution.** A WP `Menu` submenu that accepts arbitrary content would let these panels mount as real submenus, with outside-click and focus management owned by the library. Until then the manual bridge stays.
-
-## 31. Block editor has no non-serialized before/after block chrome slot `[upstream]`
-
-**What.** Document identity actions ("Add icon" / "Add cover") are editor chrome, but the ideal visual placement is immediately before the document title inside the block canvas. Persisting an actions block put UI into post content, while portalling controls into the iframe coupled us to BlockList DOM and block hover/selection behavior. The current compromise renders editor-only actions from the canvas shell, outside the persisted `BlockList`, and inserts only the real dynamic blocks (`cortext/document-icon`, `cortext/document-cover`) into content.
-
-**Where.** `DocumentIdentityActions` and `EnsureHeaderBlocks` in `src/components/EditorBody.js`.
-
-**Solution.** Gutenberg could expose a non-serialized block chrome slot/fill, e.g. "before/after this block" keyed by `clientId`, block name, and root list. Fills would participate in editor layout and focus order but stay out of block order, list view, serialization, copy/paste, movers, undo history as content, and frontend rendering. Cortext could then render the identity actions before the root `core/post-title` without storing a fake block or querying iframe DOM.
-
-## 32. Public pages render the title twice `[internal]`
-
-**What.** `DocumentIdentity::prepend_header_blocks` slips a locked `core/post-title` block into `post_content` on insert, so the editor canvas can show the title inline as part of the BlockList. The public template still calls `the_title()` immediately before `the_content()`, and `core/post-title` resolves to the same `post_title` again, so every page created after this filter landed renders its title twice publicly. Older pages (no title block in their content) are fine until the editor next persists them.
-
-**Where.** `prepend_header_blocks` in `includes/PostType/DocumentIdentity.php`, paired with `the_title()` in `templates/single-crtxt_page.php`.
-
-**Solution.** Stop baking `core/post-title` into `post_content` and mount the editor's title input as canvas chrome above `BlockCanvas`, the way Gutenberg itself does it. The template keeps `the_title()` as the single source of truth; the editor keeps an inline-editable title; pages already saved with the block get a small migration that strips it. Until then `the_title()` is the authoritative render and the duplication is the cost of the canvas-as-blocklist shape.
-
-## 33. Frontend stylesheet doesn't carry the cover/icon rules `[internal]`
-
-**What.** The PHP `render_callback`s emit `.cortext-document-cover-block`, `.cortext-document-icon-block`, and `.cortext-document-icon` markup on public pages, but their CSS still doesn't load there. Since the shell-style split, the admin/editor rules live in block edit partials and `PageIcon.scss`; `src/frontend.scss` still has none. On a public `crtxt_page`, the cover image renders at intrinsic size and the icon block falls back to inline layout.
-
-**Where.** `src/blocks/document-cover/edit.scss`, `src/blocks/document-icon/edit.scss`, and `src/components/PageIcon.scss` versus `src/frontend.scss`, plus the PHP render callbacks in `includes/Editor/DocumentCoverBlock.php` and `includes/Editor/DocumentIconBlock.php`.
-
-**Solution.** Extract the persisted cover/icon markup rules into a shared partial that both admin/editor and frontend stylesheets `@use`. Keep editor-only chrome, such as hover replace/remove controls and picker popovers, in the block edit partials.
-
-## 34. WP-icon variant renders blank on the public frontend `[internal]`
-
-**What.** `DocumentIconBlock::render` emits a marker span (`<span class="cortext-document-icon--wp" data-icon="…">`) for the `wp` icon variant and relies on a frontend hydration step to fill in the SVG. `frontend.js` is CSS-only, so nothing fills it and the icon disappears on the public page; the saved color is also dropped. Emoji and image variants render server-side and are fine.
-
-**Where.** Case `'wp'` in `includes/Editor/DocumentIconBlock.php`, paired with `src/frontend.js` (no hydration).
-
-**Solution.** Either ship the SVG inline server-side (a small build-time generator that reads `@wordpress/icons` and emits a name-to-markup PHP map, refreshed on install) or hydrate from `data-icon` markers in `frontend.js` (smaller PHP surface, adds a public script). The inline-color is a one-line fix in either path. Until then, surface the limitation in the picker copy or restrict the saved variant to emoji + image for public-rendered pages.
-
-## 35. Nested `Popover` outside clicks do not close the host `[upstream]`
-
-**What.** `Popover` handles outside clicks one popover at a time. In the option editor, the main picker opens a second popover for an individual option's color/menu controls. After a color edit, the first click outside both popovers closed only the small option menu; the main picker stayed open because the host never saw that same outside click. We now listen for `pointerdown` while the option menu is open and ask the host to close when the click lands outside both popovers.
-
-**Where.** The pointer listener in `EditOptionsPopover` (`src/components/fields/EditOptionsPopover.js`) and the `onRequestClose` plumbing through `EditableCell`, `MultiselectEdit`, and `ColumnHeaderActions`.
-
-**Solution.** `Popover` needs a parent/child dismissal story: either close the whole stack when a click lands outside all related popovers, or expose enough event detail for a host popover to opt into that behavior without a document-level listener.
-
-## 36. Table footer content lives outside DataViews' table contract `[upstream, internal]`
-
-**What.** DataViews owns the table markup, but it has no place for footer content: no footer-row slot, no per-column summary cell, no table-aligned bulk-action area, and no "filtered rows before pagination" result. The calculation footer has to find the rendered `.dataviews-view-table`, watch for it with a `MutationObserver`, and portal a `<tfoot>` into the table after DataViews renders.
-
-In table layout, bulk row actions use that same footer row. Selected-row controls and column summaries sit on one line, which is the right layout, but the plumbing is awkward. `CollectionDataViews` passes the table bulk controls into the portaled footer, and `CollectionDataViews.scss` manages the checkbox-width spacer, overflow, and stacking so the buttons stay clickable without painting over the block selection outline. Grid still uses the composed DataViews footer because there is no table summary row to align with.
-
-For calculations, we also need rows after search/filter but before pagination. DataViews does not hand that list back to consumers, so `CollectionDataViews` runs DataViews' `filterSortAndPaginate` helper a second time with `page` and `perPage` removed.
-
-Calculation state also stays in Cortext. `view.calculations` lives on the DataViews view object because embedded data-view blocks already persist that object, and named saved views do not exist yet. `normalizeView` prunes stale calculation entries when fields disappear or their type changes. That keeps the saved shape honest, but it is still Cortext state attached to a DataViews object that upstream knows nothing about.
-
-**Where.** `src/components/TableCalculationsFooter.js` (table lookup, observer, `<tfoot>` portal), `src/components/CollectionDataViews.js` (second filtering pass, table bulk controls, and footer mount), `src/components/CollectionDataViews.scss` (footer-row alignment and overflow rules), `src/components/tableCalculations.js` (operation matrix and result formatting), and `src/components/dataViewColumns.js` (view cleanup).
-
-**Solution.** DataViews needs either a table `renderFooter` / `renderSummaryRow` slot, or a column-level summary API that gets the filtered, unpaginated rows and leaves space for table-level selection controls. Then we can drop the DOM lookup and portal. A helper that returns filtered rows before pagination would remove the second `filterSortAndPaginate` pass. Internally, saved named views should eventually make `calculations` part of Cortext's own saved view schema instead of just an extra key on embedded block state.
-
-## 37. DataViews has no relation/reference field primitive `[upstream]`
-
-**What.** Relation fields store row post IDs, but the UI behaves like a reference field: search rows in another collection, pick one or many, create a missing row, show row chips, and open the row from the chip. DataViews has no `relation` / `reference` field type and DataForm has no async record picker that accepts a target entity/query and cardinality. Cortext maps relations to the closest DataViews metadata type, carries relation-specific metadata on the field object, renders relation chips from `field.render`, ships a custom picker that pages and searches `/cortext/v1/rows`, and routes chip clicks through its own peek state. The picker also asks REST to put exact title matches on the first page, so "Create row" does not offer a duplicate just because the match would otherwise sit later in the results. The picker, chip rendering, and open action are still local Cortext code.
-
-**Where.** `mapField` / `buildRender` in `src/hooks/fieldMapping.js`, `src/components/relations/RelationEditor.js`, `src/components/RowProperties.js`, `src/hooks/useCollectionRowsByIds.js`, `RowsController`'s `include` handling, `RowsFilterQuery::apply_search_order_clauses()`, `src/components/relations/RelationReferences.js`, `src/components/relations/relationUtils.js`, `src/components/DocumentPeekProvider.js`, `src/components/DocumentPeekHost.js`, `src/components/CurrentViewModeContext.js`, relation setup in `src/components/fields/AddFieldPopover.js`, and the `.cortext-relation-*` rules in `src/components/CollectionDataViews.scss` and `src/components/RowDetailView.scss`.
-
-**Solution.** Upstream DataViews/DataForm (or shared WP components) could expose a generic reference field/control: target entity config, single vs multi cardinality, async search with a selected-record resolver, optional create-new button, token/chip rendering hooks, and a supported action slot for opening or navigating to referenced records. Cortext would still own the backend relation sync and reverse-field semantics, but could drop most of the custom picker, chip, search-order guard, and open-action code and stop smuggling relation metadata through DataViews field objects.
-
-## 38. Command palette embedding needs host glue `[upstream, soft]`
-
-**What.** Cortext uses `@wordpress/commands` for command registration and palette state, but the stock menu is built for wp-admin. On the Cortext screen we need a scoped app palette: keep Core's commands out, avoid a second cmd+K menu, return focus to the workspace after a command runs, and put workspace recents in their own section instead of mixing them into suggestions. That leaves some glue in Cortext: a local data registry, a `wp-core-commands` dequeue, a bundled stylesheet import, a canvas ref for focus return, and a local command-menu renderer.
-
-The awkward bit is `CortextCommandMenu`. `@wordpress/commands` has a built-in "Recent" group, but that means recently used commands, not Cortext workspace history, and there is no public way to add a custom group. So Cortext renders the menu itself while still reading from the upstream command store. That is better than patching `node_modules` or poking the DOM after render, but upgrades need a close look at the upstream menu markup, CSS classes, keyboard behavior, and `cmdk` wiring.
-
-The user-facing placeholder is still Core's generic "Search commands and settings" string too. Fine for this slice, but it will feel off once the palette grows into actual Cortext search.
-
-**Where.** `src/components/CommandPalette.js`, `src/components/CortextCommandMenu.js`, the `canvasRef` passed from `src/router.js`, `dequeue_core_command_palette` in `includes/Admin/Screen.php`, the `@wordpress/commands` stylesheet import in `src/index.scss`, and Cortext command-menu overrides in `src/styles/global/_command-palette.scss`.
-
-**Solution.** Upstream could make app-owned palettes less ad hoc: a scoped command registry or namespace API, a supported way for full-screen admin apps to opt out of Core's admin palette, a custom input label, an explicit focus-return target or after-close callback, and a group/section API for registered commands or command loaders. With those, Cortext could keep registering commands through `@wordpress/commands`, render workspace recents through an upstream extension point, and drop the local menu renderer plus most of this shell-specific wiring.
-
-## 39. Row properties editing has its own dnd layer `[internal, soft]`
-
-**What.** Row properties now edit their layout inline. The UI has drag handles beside labels, a `Hidden properties` divider, an empty drop target for hiding properties, and a drag overlay sized to the row so relation chips wrap the same way while dragging. This cannot reuse the DataViews row reorder adapter (#49): it writes `detail_layout`, not table row order.
-
-Keep this local for now, but treat it as custom drag-and-drop code. It measures the dragged row, stops stale dnd-kit state from showing on the source row, blurs the handle after drop, and special-cases the empty hidden section. Before changing row-property spacing, chip wrapping, or dnd-kit overlays, check this path instead of assuming the table behavior applies.
-
-**Where.** `src/components/RowProperties.js` owns the `DndContext`, `DragOverlay`, hidden-property target, and layout reorder callbacks. `src/components/RowDetailView.scss` handles the drag handle, source-row hiding, overlay sizing, and hidden-drop-zone visuals. `src/blocks/document-properties/edit.js` maps the drag events into `detail_layout` saves.
-
-**Solution.** If another surface needs the same visible/hidden property list, extract a small shared primitive. Otherwise keep the code here until Gutenberg or DataViews exposes a field-list reorder primitive with hidden items and drop zones. Then RowProperties can shrink to the `detail_layout` save policy.
-
-## 40. Autosave has to infer save completion `[upstream, soft]`
-
-**What.** `savePost()` gives us a promise when Cortext starts the save. If a save is already running, though, Gutenberg only tells us about it through selectors like `isSavingPost()` and `didPostSaveRequestFail()`. There is no promise to await. `flushNow()` has to keep its own small list of waiters and release them when `isSaving` flips back to false.
-
-The same selector shape affects user-visible save side effects. `didPostSaveRequestSucceed()` and `didPostSaveRequestFail()` are level signals, not one-shot events. They can stay true after the save that set them, so mounting autosave on a different row or changing `recentTarget` can otherwise replay an old success into status and Recents. The hook tracks the previous `isSaving` value and only treats success as current when this hook observed the save finish.
-
-**Where.** `savePromiseRef`, `savingWaitersRef`, `prevIsSavingRef`, `flushNow`, and the save-status effect in `src/hooks/useAutosave.js`.
-
-**Solution.** Gutenberg could expose the current save promise, make `savePost()` return the in-flight promise when one already exists, or expose per-save completion events/state keyed to a request. Then Cortext could drop the waiter bookkeeping and the local `isSaving` edge detection.
-
-## 41. Favorite rows have their own sidebar-row shape `[internal, soft]`
-
-**What.** Favorites look like sidebar rows, but they are not normal page-tree rows. They are shortcuts, they should never show the active selection state, and they are sortable only inside the Favorites section. Sharing the whole row as both a navigation button and a dnd-kit sortable handle made clicks repaint the hover state and feel like a flash. The current row splits those jobs: the icon is the drag handle, the title is a plain navigation button, and the star is the remove action. It works, but it means Favorites carry a small custom row shape alongside `PageRow` and `CollectionRow`.
-
-**Where.** `src/components/SidebarFavorites.js`, plus the `.cortext-sidebar__favorite-*` rules in `src/components/Sidebar.scss` and `src/styles/global/_shell-root.scss`.
-
-**Solution.** Extract a shared sidebar-row primitive with explicit slots for title navigation, drag handle, menu/actions, selected state, and shortcut-only rows. Then `PageRow`, `CollectionRow`, and `SidebarFavorites` can share the same interaction contract without reusing the wrong DOM shape for Favorites.
-
-## 42. Public render for in-document row properties `[internal, important]`
-
-Updated by #119 and this PR.
-
-**What.** Row properties now live inside the block-editor iframe, between the title and body. They are a locked `cortext/document-properties` block, and `EnsureHeaderBlocks` keeps that block in place when the row's collection has fields. In the editor, the block renders `<RowProperties>` and reads `fields` from `DocumentPropertiesProvider`. This PR also puts inline layout editing, relation saves, hidden-property ordering, and the collapsed/visible state on the editor side. On the PHP side the block is registered, but its `render_callback` still returns an empty string. Published rows rendered through `the_content()` therefore show body blocks only, without their schema fields.
-
-The row-detail layout setting means public rendering cannot just print every field in schema order. PHP has to follow the same cleanup as the editor: drop stale entries, append new fields as visible, keep hidden properties hidden, and leave `title` to `core/post-title`.
-
-**Where.** `src/blocks/document-properties/{block.json,edit.js,index.js}` defines the editor block. `includes/Editor/DocumentPropertiesBlock.php` registers it on the server with the placeholder `render_callback`. `src/components/DocumentPropertiesContext.js` passes `fields`, `allFields`, `detailLayoutEntries`, `fallbackRecord`, `rowId`, visibility state, and layout-edit requests from Canvas or RowEditor. `src/components/RowProperties.js` renders the editor-only property surface and relation controls. `src/components/EditorBody.js` (`EnsureHeaderBlocks`) inserts the block after the title when schema exists and removes it when schema disappears. `detail_layout` is registered in `includes/PostType/Collection.php`; the editor normalizes it in `src/hooks/detailLayout.js` and threads it through `src/hooks/useCollectionFields.js`. The schema accessor is `Cortext\Rest\RowsFilterQuery::field_schema_for( $collection_id )`; field values are formatted by `RowsController::format_typed_value()`.
-
-**Solution.** Fill in `DocumentPropertiesBlock::render()` so `the_content()` emits `<div class="cortext-document-properties">...</div>` with formatted values for rows whose collection has fields. Reuse `RowsController::format_typed_value()`, and add a small PHP normalizer for `detail_layout` so public markup follows the editor's field order and visibility. Share the same SCSS through `src/frontend.scss` so public markup matches the editor. This pass also needs a decision on row CPTs: today they are not `publicly_queryable`.
-
-## 44. Recents tracking is wired at each call site `[internal]`
-
-**What.** There is no workspace activity layer. Each surface that counts as a visit or edit calls `touchRecent` itself: route resolution, page autosave, sidebar rename, row field save, row creation, and relation-created rows. That makes the behavior easy to understand right now, but future write paths can forget to update recents unless the reviewer knows to look for it.
-
-**Where.** `src/router/EntityRoute.js`, `src/hooks/useAutosave.js`, `src/components/Sidebar.js`, `src/components/CollectionDataViews.js`, and `src/components/relations/RelationEditor.js`.
-
-**Solution.** If more activity surfaces appear, move this behind a small workspace activity helper or event. Route visits can stay in the router, but writes should eventually report through the same mutation path instead of each component remembering to call `touchRecent`. If rows move into `core-data` (#2), that would be a natural time to centralize row touches too.
-
-## 45. Select server sort uses stored values, not option order `[internal]`
-
-**What.** Server-side row sorting treats select fields as scalar stored values. That keeps `GET /cortext/v1/rows` sortable without joining or decoding option metadata, but it differs from Notion-style curated option ordering.
-
-**Where.** `RowsFilterQuery::apply_sort_clauses()` in `includes/Rest/RowsFilterQuery.php`.
-
-**Solution.** If users expect select order to follow the field's configured options, compile select sorts into an option-order `CASE` expression generated from the field schema. Until then, document stored-value sorting as the v1 behavior.
-
-## 46. Row filters extend `WP_Meta_Query` with custom compares `[upstream, soft]`
-
-**What.** `RowsMetaQuery` keeps row filters on WordPress's native meta-query tree instead of building a parallel SQL compiler, but core's compares do not cover every database-style operator Cortext needs. `LIKE` always wraps both sides, so starts-with and ends-with need one-sided patterns. Multi-value fields need "no meta row has this value" for `isNone` / `notContains`, which is not the same as a plain `!=` join. Title filters also live on `wp_posts.post_title`, outside post meta, so they ride through a sentinel clause.
-
-**Where.** `RowsMetaQuery` in `includes/Rest/RowsMetaQuery.php`, called from `RowsFilterQuery::meta_query_sql()`.
-
-**Solution.** Upstream `WP_Meta_Query` could grow one-sided `LIKE` compares and value-bearing negative `NOT EXISTS` compares. A structured title-query helper in `WP_Query` would cover the title sentinel separately. If those land, `RowsMetaQuery` shrinks back toward a thin adapter or disappears.
-
-## 47. Cascading Popovers need manual fallback placement `[upstream, soft]`
-
-**What.** `@wordpress/components` `Popover` can shift a submenu along the cross axis, but it does not try a left-side fallback when a `right-start` cascading submenu runs past the viewport edge. Cortext now measures the outer menu and the portaled submenu, starts on the side that keeps the submenu away from the column dropdown, then switches to `left-start` or `bottom-start` if the first placement clips. This keeps Format and Calculate submenus usable near the right side of the table, but it is still a local placement policy layered on top of Popover.
-
-**Where.** `useSubmenuPlacement` in `src/hooks/useSubmenuPlacement.js`, wired into `src/components/fields/FieldFormatPopover.js` and `src/components/TableCalculationMenu.js`.
-
-**Solution.** WordPress Popover could expose fallback placements, or pass enough Floating UI middleware through for consumers to say "try right, then left, then bottom" without measuring after render. If that lands, Cortext can drop `useSubmenuPlacement` and let the Popover own cascading-menu collision handling.
-
-## 48. Cortext document layer is still thin `[internal]`
-
-**What.** Pages, full-page collections, and rows all opt into `cortext-document`. The shared reader (`Cortext\Documents`, `GET /cortext/v1/documents`, `useDocuments`) now gives trash, document lists, and recents the same shape instead of making each screen rebuild its own version.
-
-The layer is still thin. Pages use the page tree and `core-data`. Full-page collections mount in Canvas, but still keep `collection/` URLs and collection-shaped recents. Rows still use `useCollectionRows`. Restore/delete still fan out through page-tree refresh, row invalidation, collection context refresh, and Trash refresh. Favorites and recents use the document service for row paths, but routing, URL targets, and activity tracking still ask "page, collection, or row?" where they should only need "document." Relation chips open row documents, but still depend on local row URL helpers (`rowRoute` / `rowHref`) and `slug` in relation responses.
-
-**Where.** `includes/Documents.php`, `includes/PostType/Collection.php`, `includes/Rest/DocumentsController.php`, `includes/Rest/RecentsController.php`, relation slug hydration and row `kind` output in `includes/Rest/RowsController.php`, `src/components/Canvas.js`, `src/documents/favorites.js`, `useFavoriteToggle` in `src/documents/hooks.js`, `src/hooks/useDocuments.js`, `src/hooks/useTrashedDocuments.js`, `src/components/SidebarTrash.js`, `src/router/useResolveEntity.js`, `src/router/EntityRoute.js`, `src/router/entityRouteReducer.js`, `rowRoute` / `rowHref` in `src/components/relations/relationUtils.js`, `src/hooks/documentTrashInvalidation.js`, and `src/hooks/rowInvalidation.js`.
-
-**Solution.** Keep `Cortext\Documents` as the cross-type reader, then move shared document behavior behind it one piece at a time: URL targets, invalidation, activity/recents, and trash refresh. Individual records can still use `core-data` or row endpoints where WordPress models them well. Cross-type views can stay under `/cortext/v1/documents`; shared document features should not rebuild the same page/row branching every time.
-
-## 49. DataViews has no row reorder API `[upstream]`
-
-**What.** Manual order lives on the row posts, but DataViews doesn't give us row refs, drag handles, drop targets, or an `onReorder` hook. Cortext has to decorate the layouts after DataViews renders them: find rows by internal class selectors, match them to `rows` by visible index, portal dnd-kit handles into the first data cell, place fixed drop targets over row gaps, clone a few cells for the drag preview, and hold CSS transforms while the REST request and refetch finish.
-
-That makes row reorder sensitive to DataViews DOM changes: density classes, bulk-selection cells, fullscreen mode, block embedding, and scroll containers all matter. Grid still uses before/after card targets because a linear row gap doesn't map cleanly to a two-dimensional card layout. Fine for v1, but it is one more reason this belongs in a DataViews API instead of a DOM adapter.
-
-**Where.** `src/components/DataViewRowReorder.js`, `src/components/RowDragHandle.js`, the mount in `src/components/CollectionDataViews.js`, and the row-reorder rules in `src/components/DataViewRowReorder.scss`.
-
-**Solution.** DataViews could expose stable row ids/refs, a row-handle render prop, keyboard-aware reorder callbacks, a table/list gap model, and row preview/drop indicator hooks. Cortext would keep the REST/manual-order policy and drop the selectors, MutationObserver, portals, and transform bookkeeping.
-
-## 50. DataView block shares a frontend bundle with page chrome `[internal]`
-
-**What.** The `cortext-frontend` script and style handle serves double duty: it hydrates the DataView block (React, DataViews, field renderers) and provides general page chrome (body font, content column, title styles). Both `Assets.php` and the render callback in `DataView.php` enqueue the same handle, creating a registration race where the first caller's dependency list wins and the second is silently ignored. The DataView block should provision its own script and style (e.g. `cortext-data-view-view`) via `viewScript`/`viewStyle` in `block.json` or its own dedicated handles in the render callback, so its dependencies (`wp-components`, `wp-api-fetch`, etc.) are self-contained. `cortext-frontend`, if it makes sense to exist, should only cover general concerns: page chrome, light/dark mode toggle, etc.
-
-**Where.** `includes/Block/DataView.php` (render callback enqueue), `includes/Frontend/Assets.php` (page-level enqueue), `src/frontend.js` (single entry point for both concerns).
-
-**Solution.** Split `src/frontend.js` into two entry points: one for page chrome (`cortext-frontend`) and one for the DataView block (`cortext-data-view-view`). The block entry handles hydration and declares its own dependencies. The page entry stays minimal. Update `webpack.config.js` with the new entry point, and update `DataView.php` to enqueue the block-specific handle.
-
-## 51. DataViews selection is page-local `[upstream, internal]`
-
-**What.** DataViews accepts a controlled `selection`, but layouts only receive the IDs for rows in the current `data` array. Its built-in clicks are page-local too: table rows handle plain and modifier clicks, grid cards handle modifier clicks, and neither layout gives us shift-range selection across the rendered page. Cortext needs selected row IDs to survive pagination. It also needs the selected row objects later for bulk Trash actions and partial-failure cleanup.
-
-`CollectionDataViews` keeps the real selection state: selected IDs, a cache of selected row objects seen on previous pages, a shift-click anchor, and a capture-phase click-intent layer. That layer translates DataViews' visible-page selection changes into Cortext's persistent selection. The pure helpers in `dataViewSelection.js` keep the merge behavior testable. This works, but it is tied to DataViews layout class names and event order.
-
-**Where.** Selection state and `captureSelectionIntent` in `src/components/CollectionDataViews.js`, helper functions in `src/components/dataViewSelection.js`, and coverage in `tests/js/components/dataViewSelection.test.js` plus `tests/e2e/specs/data-view-block.spec.js`.
-
-**Solution.** DataViews could treat selection as a persistent ID set, with range selection and consistent modifier behavior across table and grid. It should not filter hidden IDs out of the controlled value before handing it to layouts. Bulk actions also need either all selected items, or an item resolver for selected IDs that are not on the current page. With that, Cortext can drop the row cache, click-intent capture, and most of `dataViewSelection.js`.
-
-## 52. Bulk row trash fans out through per-row REST calls `[internal, soft]`
-
-**What.** Bulk row trash still calls the same row REST delete endpoint as the single-row action. The client sends one `DELETE /wp/v2/<row post type>/<id>` request per selected row, capped at four concurrent requests by `allSettledWithConcurrency`. That cap keeps a large selection from flooding the server, and the `Promise.allSettled`-style result list keeps partial failures easy to handle.
-
-That is acceptable for the current DataView scale. It is not a real bulk operation, though. Moving 100 rows to Trash still means 100 REST writes, just in a small queue. There is no atomic all-or-nothing behavior, no server-side progress state, and no way to resume if the browser goes away mid-run.
-
-**Where.** `requestDeleteRows` in `src/components/CollectionDataViews.js`, the queue helper in `src/components/allSettledWithConcurrency.js`, and coverage in `tests/js/components/allSettledWithConcurrency.test.js`.
-
-**Solution.** If collections start moving large row sets to Trash, add a collection-row bulk trash endpoint or an async job endpoint with progress polling. That endpoint should own permission checks, trash order, partial-failure reporting, and cleanup. Then the DataView action can send selected IDs once instead of managing a client-side queue.
-
-## 53. Workspace tree has no unified node model `[internal]`
-
-**What.** The sidebar builds its workspace tree from two REST lists: active pages (`crtxt_page`) and full-page collections (`crtxt_collection`). The shell joins them client-side by reading `post_parent`. That works for collections under loaded pages, but row-owned collections and collections whose parent page is outside the loaded window fall back to the flat Collections section because there is no parent record to attach to. There is still no "workspace node" shape with `kind`, so every tree consumer has to branch on pages versus collections.
-
-Drag/drop and `menu_order` accounting look at both pages and collections through `treeRecords`, a single `DndContext` now wraps both sections, and the cycle guard walks the merged node graph. The model gap that remains is shape, not wiring: every tree consumer still branches on pages versus collections to derive a `kind`, and the Collections section's contents are a UX choice on top of that. Today it shows only top-level full-page collections (`parent = 0`); nested ones live solely in the Pages tree. That follows Notion's "one thing, one place" rule, but once collections nest there is no surface for "see every collection at a glance". The unified model would let this be configurable per workspace: top-level only, all collections grouped, or per-parent sub-headers. Lazy loading lives in RSM-1848.
-
-**Where.** `ACTIVE_PAGES_QUERY` in `src/components/page-queries.js`, `FULL_PAGE_COLLECTION_QUERY` in `src/collections.js`, `nestedCollections` / `topLevelCollections`, `treeRecords`, `handleDragOver`, and the shared `DndContext` in `src/components/Sidebar.js`, the `renderCollectionRow` bridge in `src/components/PageRow.js`, `CollectionRow`'s drag/drop zones, `computeDropTarget` in `src/components/pages-tree.js`, and the `Collection::hierarchical` / `Collection::validate_parent_document` setup on the PHP side.
-
-**Solution.** Add a workspace-tree REST endpoint that returns navigable nodes with `kind`, `id`, `parent`, `menu_order`, and visibility in one shape. Row-owned collections could then appear under their row, missing parents would not look top-level by accident, and page/collection branching would move out of every consumer. The Collections section then becomes a view over the same model with the user's chosen filter, instead of a separate flat list.
-
-## 54. Collection duplication cannot clone relation schema `[internal]`
-
-**What.** Duplicating a full-page collection creates the new collection, registers its row CPT, and copies field posts that stand on their own. It skips relations because a relation is really a pair: the forward field plus the reverse field on another collection. A safe copy has to create or update both sides, keep the cardinality, and remap ids without touching the original relation. Until that exists, the REST response lists skipped fields and the sidebar tells the user the copy is missing columns. Rollups that read through a skipped relation belong in the same bucket; they are not useful until the copied schema has its own relation target.
-
-**Where.** `CollectionDuplicator::duplicate()`, `clone_fields()`, and `remap_rollup_references()` in `includes/Documents/CollectionDuplicator.php`, plus the skipped-field notice in `src/components/Sidebar.js` and duplicate coverage in `tests/php/test-rest-collections.php`.
-
-**Solution.** Add a relation-aware schema copy step. It should clone and remap the forward and reverse fields together, or skip every dependent field, including rollups that point at skipped relations. The duplicate should never carry references back to the source collection's fields. Once that exists, the sidebar notice can name the exact skipped field types instead of treating them all as generic missing columns.
-
-## 55. Loading collection skeletons track DataViews layouts `[upstream, soft]`
-
-**What.** DataViews has no loading slot for individual layouts. Cortext renders `CollectionRowsSkeleton` beside `<DataViews>` while the first page loads; without it, the collection pane collapses and jumps when rows arrive. The placeholder now has table/list row variants and a grid card variant, so switching layouts does not briefly show the wrong shape.
-
-The brittle part is sizing. The table/list skeleton copies DataViews row heights for compact, balanced, and comfortable density. The grid skeleton copies Cortext's card min size and spacing, which sit on top of DataViews' grid classes. The two match in the current build, but a DataViews density or markup change could make the placeholder drift from the real view.
-
-**Where.** `CollectionRowsSkeleton` in `src/components/Skeleton.js`, the rows-skeleton mount in `src/components/CollectionDataViews.js`, and the `.cortext-collection-skeleton` / `.cortext-data-view__rows-skeleton` rules in `src/components/Skeleton.scss` and `src/components/CollectionDataViews.scss`.
-
-**Solution.** DataViews exposes a loading slot per layout, or at least row/card size CSS variables. Cortext could then follow the active layout instead of copying its constants. Until then, keep the skeleton rules next to the DataViews layout rules and check for visual drift after DataViews upgrades.
-
-## 56. Block editor controls do not understand Cortext's header boundary `[upstream]`
-
-**What.** Gutenberg block locks keep cover, icon, title, and row properties from moving, but the root list still has no idea that Cortext's body starts after those blocks. Cortext repairs bad order with block-editor store actions and hides protected insertion points, but two bits of Gutenberg UI still leak through. First, the first body block gets a live "move up" button even though moving it above the title would be wrong; Cortext waits for the toolbar, finds `.block-editor-block-mover-button.is-up-button`, and sets `disabled` / `aria-disabled` itself. Second, Gutenberg only shows the default empty-body appender when the whole root list is empty. A row with title/properties and no body is not empty by that test, so Cortext supplies its own first-block prompt after the header. If Gutenberg renames mover classes or changes the appender contract, this code needs another pass.
-
-**Where.** `HeaderPrefixToolbarGuard`, `syncHeaderBoundaryMoveUpButtons`, `HeaderAwareRootAppender`, and the header-prefix correction in `src/components/EditorBody.js`, with coverage in `tests/e2e/specs/editor-header-blocks.spec.js` and `tests/e2e/specs/data-view-block.spec.js`.
-
-**Solution.** Gutenberg exposes a block-list boundary policy for root lists: a minimum insertion index, a minimum move target, empty-body detection that ignores locked chrome, and mover/appender state from that same boundary. Then Cortext can declare "body blocks start after the title/properties prefix" once and drop the toolbar DOM query, the mutation observer, the local button-state restoration, and the custom root appender.
-
-## 57. Row detail toolbars rely on local editor-surface isolation `[upstream, soft]`
-
-**What.** Row peek and modal now keep their toolbars separate from the parent page editor. The fix is local and covered by e2e: each row editor gets its own `SlotFillProvider`, the row surface says it has no block inspector, and the parent page toolbar is hidden while peek/modal owns the screen.
-
-The only reason this stays in the debt log is the plumbing. Gutenberg's toolbar path still runs through `BlockControls`, SlotFill, and portaled popovers, and there is no clean public primitive for saying "this nested editor owns its toolbar and inspector." Cortext avoids the unsafe inspector entrypoint instead of building a row-scoped inspector in this pass. Normal row block toolbar actions still work.
-
-**Where.** `src/components/RowEditor.js` (`SlotFillProvider` and `EditorSurfaceProvider`), `src/components/EditorSurfaceContext.js`, `src/blocks/data-view/edit.js` (`hasBlockInspector` around the DataView toolbar button), `src/components/RowDetailView.js` (body class while side/modal is open), and `src/styles/global/_shell-root.scss` (parent canvas toolbar hiding).
-
-**Solution.** If Gutenberg grows editor-instance-scoped `BlockControls`, toolbar popovers, and `InspectorControls`, Cortext can drop the local `SlotFillProvider`, the `hasBlockInspector` context, and the parent-toolbar body class. If row peek/modal needs block settings before that exists upstream, build a row-scoped inspector deliberately rather than routing those actions to the parent inspector.
-
-## 58. Page transitions hold a browser snapshot by hand `[upstream, internal, soft]`
-
-**What.** Page-to-page navigation rebuilds the editor provider inside the same workspace pane. A normal View Transition cross-fade can expose the empty editor frame while Gutenberg, cover media, and the editor iframe catch up. Cortext now keeps the old `cortext-canvas` snapshot above the new one until the new editor says it has painted, then fades the old snapshot away. That requires a `data-cortext-view-transition` mode on `:root`, custom `::view-transition-*` CSS, a long-running hold animation, and promise plumbing around `startViewTransition()` because the browser update callback may run after `withViewTransition()` has already returned.
-
-This is acceptable for now and covered by e2e, but it is still a timing bridge between React state, Gutenberg editor readiness, iframe image decode, and the browser's View Transitions lifecycle. Any future transition refactor should preserve the "old canvas stays visible until the new canvas has painted" contract before touching this code.
-
-**Where.** `withViewTransition` in `src/hooks/viewTransition.js`, the `hold-old-canvas` / `reveal-old-canvas` rules in `src/index.scss`, document switching in `src/components/Canvas.js`, editor readiness in `src/components/EditorBody.js`, and the navigation lifecycle coverage in `tests/e2e/specs/navigation-lifecycle.spec.js`.
-
-**Solution.** If the View Transitions API gets a first-class hold/release hook, or Gutenberg exposes a reliable editor-surface "painted" signal for document swaps, replace the mode flag and long CSS hold animation with that primitive. Until then, keep the hold/reveal logic small, keep page-to-page swaps inside `Canvas`, and keep the cover/image readiness test as the tripwire.
-
-## 59. Collection canvases use a self-referencing owner block `[upstream, internal]`
-
-**What.** A full-page collection needs a locked `cortext/data-view` block whose `collectionId` is the collection post's own ID. WordPress and Gutenberg can give a CPT a static template, but not one that fills attributes from the just-created post and then treats that block as the body. Cortext works around that in a few places: PHP seeds the serialized block after insert, a one-shot backfill catches older collections, the editor adds the block if content is still empty, CSS hides body appenders and owner-block chrome, a SlotFill moves the data-view panels into the Collection tab, and the block hides "Change collection" so the owner cannot point away from itself.
-
-**Where.** `Collection::build_data_view_block_markup()` and `Collection::maybe_seed_data_view_block()` in `includes/PostType/Collection.php`, `includes/PostType/CollectionContentBackfill.php`, `src/components/CanvasOwnerInspector.js`, owner-block handling in `src/components/EditorBody.js`, `src/blocks/data-view/edit.js`, `src/components/PageInspectorSidebar.js`, and the owner rules in `src/styles/global/_shell-root.scss`.
-
-**Solution.** Replace this with a direct owner-block path: either an upstream dynamic block-template hook or a local body-owner contract. It should read attributes from the current post, lock the body to that block, own inserter/chrome/inspector policy, and keep public serialization predictable. Then the post-insert seed, backfill, editor fallback, SlotFill routing, and owner CSS can shrink or disappear.
-
-## 60. DataViews view state has one active layout shape `[internal, soft]`
-
-**What.** DataViews emits one active `view` shape: one `type`, one `fields` array, and one `layout` object. Cortext needs layout switches to preserve table columns, grid/list display fields, density, card media settings, and query state without one layout overwriting another. The adapter stores Cortext-owned buckets (`layoutByType` and `fieldsByType`) beside the DataViews view, hydrates the active layout before render, and merges DataViews changes back into the canonical view after each change.
-
-This is fine for the baseline, but block attributes and public DataViews state now carry keys upstream does not know about. When a new layout setting is added, the adapter, normalizer, and public renderer all need to move together.
-
-**Where.** `src/components/dataViewAdapter.js`, `src/components/dataViewViewState.js`, `normalizeView` in `src/components/dataViewColumns.js`, the DataViews mounts in `src/components/CollectionDataViews.js` and `src/components/PublicDataView.js`, and the data-view block attributes in `src/blocks/data-view/block.json`.
-
-**Solution.** If DataViews adds native per-layout settings, map to those instead of carrying separate buckets. If Cortext saved views become their own schema, move `layoutByType` / `fieldsByType` there and treat DataViews' `view` as a render adapter only. Until one of those exists, keep this adapter small and covered by round-trip tests.
-
-## 61. DataViews list lacks row-open and compact metadata hooks `[upstream, soft]`
-
-**What.** DataViews list is close enough to use, but it does not expose the pieces Cortext needs for the list we want: opening a row from the blank part of the row, keeping focus without a selected-row state, showing metadata as a compact inline run, and placing "+ New" as the last row. Cortext keeps the native layout and fills those gaps locally. The list gets an empty controlled selection, capture-phase pointer and keyboard handlers for row open, CSS that reshapes DataViews' title/media/field/action DOM, and a footer button styled like a row.
-
-That keeps us out of a custom React layout for now, but it depends on DataViews markup and event timing. The parts to watch are the `.dataviews-view-list > [role="row"]` lookup, `.dataviews-view-list__item` as the focus/open target, and the CSS grid/contents overrides that put title, metadata, media, and actions on one row.
-
-**Where.** List open/focus handling in `src/components/CollectionDataViews.js`, list row lookup in `src/components/dataViewItemLookup.js`, list reorder decoration in `src/components/DataViewRowReorder.js`, `DataViewNewRowButton`'s `list-row` presentation, and the list rules in `src/components/CollectionDataViews.list.scss`.
-
-**Solution.** DataViews could make this cleaner with row activation/focus hooks, a way to disable selected-row state without losing focus, a compact metadata list variant, and an append-row/item slot. With those, Cortext could drop the capture-phase list handlers, the empty-selection shim, most list DOM selectors, and the CSS reshaping. If the native list never grows that shape, write a small Cortext list layout instead of piling more CSS on DataViews internals.

--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -28,7 +28,7 @@ final class Screen {
 	public function register(): void {
 		add_action( 'admin_menu', array( $this, 'register_menu' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
-		// tech-debt.md#38: core adds this late; run after it so this
+		// tech-debt.md#td-command-palette-host-glue: core adds this late; run after it so this
 		// screen only has one palette.
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_core_command_palette' ), 100 );
 		add_filter( 'admin_body_class', array( $this, 'add_body_class' ) );
@@ -167,7 +167,7 @@ final class Screen {
 			return;
 		}
 
-		// tech-debt.md#38: Cortext has its own palette here, so drop core's
+		// tech-debt.md#td-command-palette-host-glue: Cortext has its own palette here, so drop core's
 		// wp-admin palette before global commands leak into the app.
 		wp_dequeue_script( 'wp-core-commands' );
 	}

--- a/includes/Documents/CollectionDuplicator.php
+++ b/includes/Documents/CollectionDuplicator.php
@@ -2,7 +2,7 @@
 /**
  * Duplicates a full-page collection's schema into a new collection. Rows are
  * not copied. Fields with local metadata are copied; relation fields are
- * reported in `skipped_fields` until tech-debt.md#54 handles reverse-field
+ * reported in `skipped_fields` until tech-debt.md#td-collection-duplication-relations handles reverse-field
  * copies.
  *
  * Internal to the Documents layer. `Documents::duplicate()` is the public
@@ -153,7 +153,7 @@ final class CollectionDuplicator {
 			}
 
 			$source_type = (string) get_post_meta( $source_field_id, 'type', true );
-			// tech-debt.md#54: skip relations until duplication can copy and
+			// tech-debt.md#td-collection-duplication-relations: skip relations until duplication can copy and
 			// remap the forward and reverse fields together.
 			if ( 'relation' === $source_type ) {
 				$skipped_fields[] = array(
@@ -204,7 +204,7 @@ final class CollectionDuplicator {
 	/**
 	 * Rewrites rollup meta when the referenced field was copied too. If a
 	 * rollup points to a skipped relation, the old reference stays for now;
-	 * tech-debt.md#54 tracks the remaining skip/remap work.
+	 * tech-debt.md#td-collection-duplication-relations tracks the remaining skip/remap work.
 	 *
 	 * @param array<string, int> $field_id_map Source field id (string) => new field id.
 	 */

--- a/includes/Editor/DocumentIconBlock.php
+++ b/includes/Editor/DocumentIconBlock.php
@@ -100,7 +100,7 @@ final class DocumentIconBlock {
 				//
 				// frontend.js is CSS-only today, so the marker stays empty
 				// on the public page and the saved color is dropped. See
-				// tech-debt.md#34 for the build-time SVG map vs. hydration
+				// tech-debt.md#td-wp-icon-public-blank for the build-time SVG map vs. hydration
 				// trade-off.
 				$name = isset( $decoded['name'] ) ? (string) $decoded['name'] : '';
 				if ( '' === $name ) {

--- a/includes/Editor/DocumentPropertiesBlock.php
+++ b/includes/Editor/DocumentPropertiesBlock.php
@@ -2,7 +2,7 @@
 /**
  * Server-side registration for the `cortext/document-properties` block.
  *
- * The render callback is intentionally empty for now. tech-debt.md#42 tracks
+ * The render callback is intentionally empty for now. tech-debt.md#td-row-properties-public-render tracks
  * the public row markup, including how row CPTs should be reached on the
  * frontend. Register the block now so rows already store it in `post_content`;
  * the server render can come later without changing editor wiring.
@@ -44,7 +44,7 @@ final class DocumentPropertiesBlock {
 
 	/**
 	 * Frontend render placeholder. Rows keep this block in `post_content`;
-	 * tech-debt.md#42 tracks the public markup.
+	 * tech-debt.md#td-row-properties-public-render tracks the public markup.
 	 *
 	 * @param array  $attributes Block attributes (unused).
 	 * @param string $content    Inner HTML (none; block is dynamic).

--- a/includes/PostType/Collection.php
+++ b/includes/PostType/Collection.php
@@ -30,7 +30,7 @@ final class Collection {
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_filters' ) );
 		// The owner data-view needs the new post ID, so seed it after insert.
-		// EditorBody still repairs old or empty content. See tech-debt.md#59.
+		// EditorBody still repairs old or empty content. See tech-debt.md#td-collection-owner-body-contract.
 		add_action( 'wp_after_insert_post', array( $this, 'maybe_seed_data_view_block' ), 10, 3 );
 	}
 

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -164,8 +164,8 @@ final class CollectionEntries {
 		// ID for a `crtxt_field` post, so any postmeta row keyed
 		// `field-<that-id>` belongs to a Cortext entry by construction.
 		// A scoped SQL JOIN would tighten the scope on paper but
-		// WorDBless (the test mock — see tech-debt.md#9) can't simulate
-		// it; tracked as tech-debt.md#21.
+		// WorDBless (the test mock — see tech-debt.md#td-wordbless-row-coverage) can't simulate
+		// it; tracked as tech-debt.md#td-field-meta-global-delete.
 		delete_post_meta_by_key( "field-{$post_id}" );
 
 		// Defensive: remove the field's string ID from any collection's

--- a/includes/PostType/DocumentIdentity.php
+++ b/includes/PostType/DocumentIdentity.php
@@ -68,7 +68,7 @@ final class DocumentIdentity {
 	 *
 	 * Note: prepending `core/post-title` to `post_content` makes the
 	 * public template render the title twice (the_title + the block's
-	 * own resolution of `post_title`). See tech-debt.md#32 for the
+	 * own resolution of `post_title`). See tech-debt.md#td-public-title-double-render for the
 	 * architectural fix that drops the block from content entirely.
 	 */
 	public static function header_blocks_markup(): string {

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -200,7 +200,7 @@ function CollectionCreator( { onCreate } ) {
 					FULL_PAGE_COLLECTION_QUERY,
 				] );
 			}
-			// tech-debt.md#2: core-data may have cached `/wp/v2/types` before
+			// tech-debt.md#td-rows-not-in-core-data: core-data may have cached `/wp/v2/types` before
 			// this collection registered its row CPT. Refresh the entity config
 			// so the next row detail lookup can find the new post type.
 			invalidateResolution( 'getEntitiesConfig', [ 'postType' ] );
@@ -315,7 +315,7 @@ function CollectionToolbarControl( {
 					) }
 				/>
 			) }
-			{ /* tech-debt.md#57: peek/modal hide the parent inspector
+			{ /* tech-debt.md#td-row-detail-toolbar-isolation: peek/modal hide the parent inspector
 			     button until there is a row-scoped one. Owner blocks open
 			     the document tab, where their panels are slotted. */ }
 			{ ( hasBlockInspector || isOwner ) && (

--- a/src/components/CanvasOwnerInspector.js
+++ b/src/components/CanvasOwnerInspector.js
@@ -4,7 +4,7 @@ import { useSelect } from '@wordpress/data';
 
 // Maps a Canvas post type to its one allowed body block. Owner blocks join the
 // header set, hide the Block tab, fill the document tab, and drop the usual
-// block chrome. See tech-debt.md#59.
+// block chrome. See tech-debt.md#td-collection-owner-body-contract.
 //
 // `matches` lets the data-view block disambiguate the owned instance from any
 // inline data-view that happens to point at this collection.

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -92,7 +92,7 @@ function hasActiveCalculations( view ) {
 }
 
 const BULK_DELETE_CONCURRENCY = 4;
-// tech-debt.md#61: DataViews ties list focus to its own selection. Cortext
+// tech-debt.md#td-dataviews-list-row-hooks: DataViews ties list focus to its own selection. Cortext
 // uses blank-row clicks and keyboard activation to open the row instead.
 const EMPTY_DATA_VIEW_SELECTION = [];
 const LIST_ROW_EMPTY_CLICK_TARGET_SELECTOR = '.dataviews-view-list__item';
@@ -252,7 +252,7 @@ export default function CollectionDataViews( {
 
 	// Editable, currently-visible columns in the order DataViews renders
 	// them. Drives Tab/Shift+Tab cell-to-cell navigation. See
-	// tech-debt.md#1: DataViews would own this if inline editing were
+	// tech-debt.md#td-dataviews-inline-editing: DataViews would own this if inline editing were
 	// upstream, and this walker would go away.
 	const editableVisibleFields = useMemo( () => {
 		const order = dataViewsView?.fields ?? [];
@@ -287,7 +287,7 @@ export default function CollectionDataViews( {
 			return { data };
 		}
 		const calculationView = { ...( view ?? {} ) };
-		// tech-debt.md#36: summaries need the filtered row set before
+		// tech-debt.md#td-dataviews-layout-slots: summaries need the filtered row set before
 		// pagination, which DataViews does not expose as a separate result.
 		delete calculationView.page;
 		delete calculationView.perPage;
@@ -324,7 +324,7 @@ export default function CollectionDataViews( {
 	const [ selectedRowIds, setSelectedRowIds ] = useState( [] );
 	const [ selectedRowsById, setSelectedRowsById ] = useState( {} );
 	const [ selectionAnchorId, setSelectionAnchorId ] = useState( null );
-	// tech-debt.md#48: DataViews only gives layouts the current-page
+	// tech-debt.md#td-document-layer-thin: DataViews only gives layouts the current-page
 	// selection, so Cortext owns off-page ids and click-intent merging.
 	const selectionInteractionRef = useRef( null );
 
@@ -625,7 +625,7 @@ export default function CollectionDataViews( {
 			// new row belongs on the last page. Search, filters, and explicit
 			// sorts make that guess unsafe; refresh in place instead.
 			//
-			// tech-debt.md#2: lastPage arithmetic is optimistic against
+			// tech-debt.md#td-rows-not-in-core-data: lastPage arithmetic is optimistic against
 			// possibly stale paginationInfo. With rows in core-data this
 			// becomes a useEffect on totalPages.
 			const nextView = nextViewAfterRowCreated(
@@ -1383,7 +1383,7 @@ export default function CollectionDataViews( {
 		};
 	}, [ collectionId, isResolving, onReady, rowError, rowsResolved ] );
 
-	// tech-debt.md#22: Gutenberg selects on any mousedown that bubbles up.
+	// tech-debt.md#td-gutenberg-scrollbar-select: Gutenberg selects on any mousedown that bubbles up.
 	// Dragging the dataviews scrollbar lands in the gutter (offset past the
 	// scrollable element's clientWidth/Height); stop propagation there so
 	// the scroll drag doesn't also pull a bounding box around the block.
@@ -1461,7 +1461,7 @@ export default function CollectionDataViews( {
 
 	const hasSelectionColumn = isTableLayout && dataFiltered.length > 0;
 	const hasVisibleRows = visibleRowIds.length > 0;
-	// tech-debt.md#36: DataViews has no table footer slot, so table bulk
+	// tech-debt.md#td-dataviews-layout-slots: DataViews has no table footer slot, so table bulk
 	// controls share the same portaled footer row as calculations.
 	const tableBulkActions =
 		isTableLayout && hasVisibleRows && selectedRowIds.length > 0 ? (
@@ -1641,7 +1641,7 @@ export default function CollectionDataViews( {
 											onRowsChanged={ refresh }
 										/>
 									) }
-									{ /* tech-debt.md#7: table/list render New just
+									{ /* tech-debt.md#td-dataviews-layout-slots: table/list render New just
 									   outside DataViews because there is no append
 									   slot in the layout chrome. */ }
 									{ ! isGridLayout && (

--- a/src/components/CollectionDataViews.list.scss
+++ b/src/components/CollectionDataViews.list.scss
@@ -5,8 +5,9 @@ $list-row-hover-background: #f8f8f8;
 $list-row-open-background: #f3f3f3;
 
 .cortext-data-view {
-	// tech-debt.md#61: DataViews has no compact metadata list variant, so this
-	// file reshapes its current list DOM for Cortext's baseline.
+	// tech-debt.md#td-dataviews-list-row-hooks: DataViews has no compact
+	// metadata list variant, so this file reshapes its current list DOM
+	// for Cortext's baseline.
 
 	&__footer--list {
 		padding: 0 $grid-unit-20 $grid-unit-20;

--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -168,7 +168,8 @@ th.dataviews-view-table__checkbox-column {
 // those <th>s and replace it with a single combined dropdown (Sort /
 // Move / Hide / Rename / Duplicate / Delete). Title and system fields
 // don't have a marker, so their built-in triggers stay visible.
-// `tech-debt.md#16` covers the upstream gap that forces this takeover.
+// `tech-debt.md#td-dataviews-header-extension-slots` covers the upstream
+// gap that forces this takeover.
 .dataviews-view-table
 th:has(.cortext-column-header-marker)
 .dataviews-view-table-header-button:not(.cortext-column-header-trigger) {
@@ -223,7 +224,8 @@ tbody > tr > td:not(:first-child) {
 	width: 100%;
 }
 
-// tech-debt.md#5: DataViews uses a real <table>. Cortext switches it to
+// tech-debt.md#td-dataviews-inline-editing: DataViews uses a real
+// <table>. Cortext switches it to
 // `table-layout: fixed` for predictable resizing, but the display shell
 // still anchors cell layout while editors mount. To keep the column from
 // reflowing when an editor mounts, we always render the display shell and
@@ -887,7 +889,8 @@ tr:has(.cortext-title-cell--is-opening)
 	width: 100%;
 	min-width: 0;
 
-	// tech-debt.md#55: hold the layout area while rows load, so search,
+	// tech-debt.md#td-dataviews-loading-skeletons: hold the layout area
+	// while rows load, so search,
 	// filters, header, and rows/cards appear together.
 	&__rows-skeleton {
 		position: absolute;
@@ -937,7 +940,7 @@ tr:has(.cortext-title-cell--is-opening)
 	// DataViews v6's td `padding-block` (12 and 16); compact is
 	// intentionally tighter than DataViews's default (4 -> 0) so the row
 	// matches the 40px editor floor and gets closer to a compact
-	// density. See tech-debt.md#5.
+	// density. See tech-debt.md#td-dataviews-inline-editing.
 	.dataviews-view-table {
 		table-layout: fixed;
 
@@ -1136,7 +1139,8 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 }
 
-// tech-debt.md#15: The resizer and dnd-kit drag handle are portaled into each
+// tech-debt.md#td-dataviews-column-interactions: The resizer and dnd-kit
+// drag handle are portaled into each
 // `<th>` rendered by `@wordpress/dataviews`, so the th needs a position anchor.
 /* stylelint-disable-next-line no-descending-specificity */
 .cortext-data-view .dataviews-view-table thead > tr > th {

--- a/src/components/CommandPalette.js
+++ b/src/components/CommandPalette.js
@@ -1,4 +1,4 @@
-// tech-debt.md#38: use WordPress' palette UI, but keep it on a local
+// tech-debt.md#td-command-palette-host-glue: use WordPress' palette UI, but keep it on a local
 // registry so core/wp-admin commands do not show up in Cortext.
 
 import { store as commandsStore, useCommand } from '@wordpress/commands';

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -23,7 +23,7 @@ import { store as commandsStore } from '@wordpress/commands';
 const EMPTY_DESCRIPTIONS = new Map();
 export const CommandDescriptionContext = createContext( EMPTY_DESCRIPTIONS );
 
-// tech-debt.md#38: @wordpress/commands has no custom group API. Keep the
+// tech-debt.md#td-command-palette-host-glue: @wordpress/commands has no custom group API. Keep the
 // upstream store/hooks, but render the menu locally so workspace recents
 // can live in their own section.
 const ITEM_ID_PREFIX = 'command-palette-item-';

--- a/src/components/DataViewColumnInteractions.js
+++ b/src/components/DataViewColumnInteractions.js
@@ -31,7 +31,7 @@ import {
 
 const TABLE_SELECTOR = '.dataviews-view-table';
 const HEADER_CELLS_SELECTOR = '.dataviews-view-table thead > tr > th';
-// tech-debt.md#15: DataViews doesn't expose stable table-column refs. This
+// tech-debt.md#td-dataviews-column-interactions: DataViews doesn't expose stable table-column refs. This
 // adapter maps `view.fields` onto rendered `<th>` elements and filters out
 // library-owned utility columns so resize/reorder controls stay aligned.
 const SKIP_HEADER_CLASSES = [
@@ -448,7 +448,7 @@ function ColumnDragHandle( { cell } ) {
 			// columns, Cortext hides DataViews' built-in trigger and
 			// portals its own combined dropdown trigger in (same class,
 			// later in DOM order); `offsetParent` rules out the hidden
-			// one. tech-debt.md#16.
+			// one. tech-debt.md#td-dataviews-header-extension-slots.
 			const buttons = cell.el.querySelectorAll( HEADER_BUTTON_SELECTOR );
 			for ( const btn of buttons ) {
 				if ( btn.offsetParent !== null ) {
@@ -523,7 +523,7 @@ function ColumnResizer( { fieldId, fieldType, headerEl, view, onChangeView } ) {
 			headerEl.classList.add( 'cortext-column-resizing' );
 			document.body.classList.add( 'cortext-column-resizing' );
 
-			// tech-debt.md#15: DataViews doesn't provide a live resize hook, so
+			// tech-debt.md#td-dataviews-column-interactions: DataViews doesn't provide a live resize hook, so
 			// we mutate the rendered cells during pointer movement and commit
 			// the same width into `view.layout.styles` on pointerup.
 			// Find every cell in this column so the live drag mutates body

--- a/src/components/DataViewRowReorder.js
+++ b/src/components/DataViewRowReorder.js
@@ -53,7 +53,7 @@ const ROW_ACTIONS_CHROME_RESERVE = 48;
 const ROW_DROP_ZONE_MAX_SIDE = 40;
 const HOVER_SUPPRESSION_RELEASE_DELAY = 120;
 
-// tech-debt.md#49: DataViews doesn't expose row refs or reorder hooks.
+// tech-debt.md#td-dataviews-row-reorder: DataViews doesn't expose row refs or reorder hooks.
 // Keep the DOM selectors for this adapter in one place. Grid stays out for now;
 // card-to-card drops need a separate 2D design.
 const ROW_SELECTORS = {

--- a/src/components/EditableCell.js
+++ b/src/components/EditableCell.js
@@ -42,10 +42,10 @@ function siteLocale() {
 	return wpLocale.replace( '_', '-' );
 }
 
-// tech-debt.md#1: DataViews v6 has no inline cell editing in any layout,
+// tech-debt.md#td-dataviews-inline-editing: DataViews v6 has no inline cell editing in any layout,
 // so we mount this component from `field.render` (a display renderer in
 // the docs) and treat the click-to-edit + commit/cancel state as our own.
-// tech-debt.md#2: the save callback comes through context because
+// tech-debt.md#td-rows-not-in-core-data: the save callback comes through context because
 // `field.render` only receives `{ item }`. Once rows live in core-data
 // the cell could call `saveEntityRecord` directly.
 export const RowMutationContext = createContext( {
@@ -971,7 +971,7 @@ export default function EditableCell( {
 					checked={ Boolean( value ) }
 					onChange={ ( next ) => commit( next ) }
 					disabled={ isSaving }
-					// tech-debt.md#8: CheckboxControl renders its `label`
+					// tech-debt.md#td-checkboxcontrol-hide-label: CheckboxControl renders its `label`
 					// prop visibly regardless of hideLabelFromVision, so we
 					// pass aria-label to keep screen readers labelled
 					// without doubling the column header text.

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -105,7 +105,7 @@ function getHeaderBoundaryMoveUpScopes( root ) {
 }
 
 function syncHeaderBoundaryMoveUpButtons( root, shouldDisable ) {
-	// tech-debt.md#56: Gutenberg does not expose boundary-aware mover state.
+	// tech-debt.md#td-gutenberg-header-boundary: Gutenberg does not expose boundary-aware mover state.
 	const ownerWindow = root?.ownerDocument?.defaultView ?? window;
 	getHeaderBoundaryMoveUpScopes( root ).forEach( ( scope ) => {
 		scope
@@ -814,7 +814,7 @@ function HideHeaderBlockKebab( { postType } ) {
 }
 
 function HeaderAwareRootAppender( { postType } ) {
-	// tech-debt.md#56: Gutenberg's root appender only treats a fully empty
+	// tech-debt.md#td-gutenberg-header-boundary: Gutenberg's root appender only treats a fully empty
 	// root list as empty. Cortext's locked header blocks are chrome, so the
 	// body still needs a first-block prompt after them.
 	const { bodyEmpty, insertionIndex } = useSelect(

--- a/src/components/GridNewRowPortal.js
+++ b/src/components/GridNewRowPortal.js
@@ -4,7 +4,7 @@ import DataViewNewRowButton from './DataViewNewRowButton';
 
 const GRID_VIEW_SELECTOR = '.dataviews-view-grid';
 
-// tech-debt.md#7: DataViews has no grid append-card slot, so rows with data use
+// tech-debt.md#td-dataviews-layout-slots: DataViews has no grid append-card slot, so rows with data use
 // a portal into the rendered grid.
 export default function GridNewRowPortal( {
 	wrapperRef,

--- a/src/components/MultiselectEdit.js
+++ b/src/components/MultiselectEdit.js
@@ -14,7 +14,7 @@ import EditOptionsPopover from './fields/EditOptionsPopover';
 // happens via the Popover's outside-click which fires `onCancel`.
 //
 // Replaces the previous `FormTokenField` implementation
-// (tech-debt.md#6) so the cell picker matches the column-header "Edit
+// (tech-debt.md#td-dataviews-multiselect-control) so the cell picker matches the column-header "Edit
 // options" surface: same chips, same per-option submenu, same
 // search-or-create input. Uses a controlled Popover (instead of
 // `Dropdown`) so the editor isn't torn down by Dropdown's outside-click

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -347,7 +347,7 @@ export default function RowDetailView( {
 			return undefined;
 		}
 
-		// tech-debt.md#57: while row detail owns the surface, keep the
+		// tech-debt.md#td-row-detail-toolbar-isolation: while row detail owns the surface, keep the
 		// still-selected page block toolbar out of sight.
 		document.body.classList.add( HIDE_PARENT_BLOCK_TOOLBAR_CLASS );
 		return () => {

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -206,7 +206,7 @@ export default function RowEditor( {
 			settings={ getEditorSettings() }
 			useSubRegistry
 		>
-			{ /* tech-debt.md#57: row detail owns these SlotFills while
+			{ /* tech-debt.md#td-row-detail-toolbar-isolation: row detail owns these SlotFills while
 			     peek/modal are open. */ }
 			<SlotFillProvider>
 				<EditorSurfaceProvider hasBlockInspector={ false }>

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -1,7 +1,7 @@
 /**
  * Property panel for a row document. It renders one row per collection field
  * with the edit control that matches the field type. Row detail chrome and the
- * locked document-properties editor block both mount this; see tech-debt.md#42
+ * locked document-properties editor block both mount this; see tech-debt.md#td-row-properties-public-render
  * for the remaining public-rendering work.
  *
  * Reads the post's edited title and meta from `editorStore` so the live
@@ -917,7 +917,7 @@ function SortableRowProperty( props ) {
 /*
  * Renders the row's collection-field properties as document chrome above the
  * block editor. This is intentionally not serialized yet; see
- * tech-debt.md#42 for the frontend rendering work.
+ * tech-debt.md#td-row-properties-public-render for the frontend rendering work.
  *
  * @param {Object}   props
  * @param {number}   props.collectionId The row's parent collection ID.

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -120,7 +120,7 @@ export default function Sidebar( {
 	onToggleCollapsed,
 	onWidthChange,
 } ) {
-	// tech-debt.md#53: this tree still comes from flat REST lists capped at
+	// tech-debt.md#td-workspace-tree-no-unified-model: this tree still comes from flat REST lists capped at
 	// `per_page: 100`. The follow-up is lazy loading or a paged tree endpoint.
 	const { records: collections, isResolving: isResolvingCollections } =
 		useEntityRecords(
@@ -313,7 +313,7 @@ export default function Sidebar( {
 			'crtxt_collection',
 			FULL_PAGE_COLLECTION_QUERY,
 		] );
-		// tech-debt.md#2: core-data may have cached `/wp/v2/types` before this
+		// tech-debt.md#td-rows-not-in-core-data: core-data may have cached `/wp/v2/types` before this
 		// collection registered its row CPT. Refresh the entity config so row
 		// lookups can find the new post type.
 		invalidateResolution( 'getEntitiesConfig', [ 'postType' ] );

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -96,7 +96,7 @@ export function SidebarListSkeleton( { itemCount = 5 } ) {
 	);
 }
 
-// tech-debt.md#55: keep loading placeholders close to the real row/card shapes.
+// tech-debt.md#td-dataviews-loading-skeletons: keep loading placeholders close to the real row/card shapes.
 // Cap the count so perPage=25 does not paint an oversized skeleton.
 const COLLECTION_SKELETON_ROW_CAP = 15;
 

--- a/src/components/Skeleton.scss
+++ b/src/components/Skeleton.scss
@@ -53,7 +53,8 @@
 	}
 }
 
-// tech-debt.md#55: placeholder shaped like the active layout while
+// tech-debt.md#td-dataviews-loading-skeletons: placeholder shaped like
+// the active layout while
 // useCollectionRows fetches. It sits beside <DataViews>; the wrapper handles
 // placement. Heights track DataViews v6 closely enough to keep the page steady.
 .cortext-collection-skeleton {

--- a/src/components/TableCalculationsFooter.js
+++ b/src/components/TableCalculationsFooter.js
@@ -21,7 +21,7 @@ function useDataViewsTable( wrapperRef ) {
 		}
 
 		const sync = () => {
-			// tech-debt.md#36: DataViews has no table footer slot, so the
+			// tech-debt.md#td-dataviews-layout-slots: DataViews has no table footer slot, so the
 			// calculation row has to attach to the table after it renders.
 			setTable( wrapper.querySelector( '.dataviews-view-table' ) );
 		};

--- a/src/components/dataViewAdapter.js
+++ b/src/components/dataViewAdapter.js
@@ -1,6 +1,6 @@
 import { COVER_FIELD_ID, TITLE_FIELD_ID } from './dataViewColumns';
 
-// tech-debt.md#60: DataViews only carries the active layout shape. Cortext keeps
+// tech-debt.md#td-dataviews-view-state-shape: DataViews only carries the active layout shape. Cortext keeps
 // per-layout buckets and hydrates the active shape before rendering.
 export const DATA_VIEW_LAYOUT_TYPES = [ 'table', 'grid', 'list' ];
 export const DATA_VIEW_FIELD_LAYOUT_TYPES = [ 'grid', 'list' ];

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -466,7 +466,7 @@ export default function AddFieldPopover( { collectionId, onCreate } ) {
 			// Select / multi-select fields are created without
 			// pre-defined options. Options can be edited via wp-admin
 			// today; a future field-edit dialog will bring it inline
-			// (tech-debt.md#18).
+			// (tech-debt.md#td-field-management-panel).
 			const created = await run( {
 				title: trimmed || fallback,
 				type: chosenType,

--- a/src/components/fields/ColumnHeaderActions.js
+++ b/src/components/fields/ColumnHeaderActions.js
@@ -32,13 +32,13 @@ import { withColumnCalculation } from '../tableCalculations';
 // Projects Cortext controls into DataViews' table header:
 //
 // - `[data-cortext-field-marker="<recordId>"]` marks custom fields. We hide
-//   DataViews' trigger (see `tech-debt.md#16`) and portal in one menu with
+//   DataViews' trigger (see `tech-debt.md#td-dataviews-header-extension-slots`) and portal in one menu with
 //   Sort / Move / Hide plus Rename / Duplicate / Delete. The marker is only
 //   the anchor; the real button is a sibling so the column drag handle can
 //   still forward clicks to it.
 // - `th.dataviews-view-table__actions-column` — `+` button in the
 //   row-actions column header that opens the same `AddFieldPopover`
-//   as the toolbar Add field trigger. See `tech-debt.md#17`.
+//   as the toolbar Add field trigger. See `tech-debt.md#td-dataviews-actions-column-piggyback`.
 //
 // The invisible anchor lets this component find its wrapper. A
 // MutationObserver re-syncs portals after DataViews rewrites the header.
@@ -88,7 +88,7 @@ export default function ColumnHeaderActions( {
 				} );
 			// The add-field button lives in DataViews' actions column header.
 			// Row actions keep that column rendered, so we no longer need a
-			// synthetic table column for it. See `tech-debt.md#17`.
+			// synthetic table column for it. See `tech-debt.md#td-dataviews-actions-column-piggyback`.
 			const actionsTh = wrapper.querySelector(
 				'th.dataviews-view-table__actions-column'
 			);

--- a/src/components/fields/ColumnHeaderActions.scss
+++ b/src/components/fields/ColumnHeaderActions.scss
@@ -37,7 +37,8 @@
 	}
 
 	.cortext-infotip__trigger {
-		// tech-debt.md#16: this help affordance is portaled beside our
+		// tech-debt.md#td-dataviews-header-extension-slots: this help
+		// affordance is portaled beside our
 		// replacement header trigger. It must sit above the transparent
 		// drag handle until DataViews exposes a header accessory slot.
 		position: relative;

--- a/src/components/fields/EditOptionsPopover.js
+++ b/src/components/fields/EditOptionsPopover.js
@@ -225,7 +225,7 @@ export default function EditOptionsPopover( {
 		if ( ! openMenuValue || typeof onRequestClose !== 'function' ) {
 			return undefined;
 		}
-		// tech-debt.md#35: nested Popovers do not close the host picker
+		// tech-debt.md#td-wp-menu-popover-limitations: nested Popovers do not close the host picker
 		// when the first outside click is consumed by the child menu.
 		const onPointerDown = ( event ) => {
 			const target = event.target;

--- a/src/components/fields/FieldActionsMenu.js
+++ b/src/components/fields/FieldActionsMenu.js
@@ -201,7 +201,7 @@ export default function FieldActionsMenu( {
 		[ closeMenu ]
 	);
 
-	// tech-debt.md#30: Format lives here; Calculate is injected by table
+	// tech-debt.md#td-wp-menu-popover-limitations: Format lives here; Calculate is injected by table
 	// headers. Both are sibling popovers that act like submenus.
 	const hideMenuOnInteractOutside = useCallback( ( event ) => {
 		const target = event.target;
@@ -217,7 +217,7 @@ export default function FieldActionsMenu( {
 		return true;
 	}, [] );
 
-	// tech-debt.md#27: Ariakit only sees clicks in this iframe. Editor chrome
+	// tech-debt.md#td-wp-menu-popover-limitations: Ariakit only sees clicks in this iframe. Editor chrome
 	// clicks land in the parent document, so listen there too.
 	useEffect( () => {
 		if ( ! isMenuOpen ) {
@@ -317,7 +317,7 @@ export default function FieldActionsMenu( {
 						placement="bottom"
 					/>
 				) : null }
-				{ /* tech-debt.md#29: portal avoids table-header text
+				{ /* tech-debt.md#td-wp-menu-popover-limitations: portal avoids table-header text
 				     transform leaking into the menu. */ }
 				<Menu.Popover
 					className="cortext-field-actions-popover"
@@ -397,7 +397,7 @@ export default function FieldActionsMenu( {
 								{ __( 'Duplicate', 'cortext' ) }
 							</Menu.ItemLabel>
 						</Menu.Item>
-						{ /* tech-debt.md#28: Menu.Item has no destructive
+						{ /* tech-debt.md#td-wp-menu-popover-limitations: Menu.Item has no destructive
 						     variant, so style Delete with a class. */ }
 						<Menu.Item
 							className="cortext-column-header-actions__destructive-item"

--- a/src/components/sidebar/useSidebarTree.js
+++ b/src/components/sidebar/useSidebarTree.js
@@ -5,7 +5,7 @@ import { buildTree, collectAncestorIds } from '../pages-tree';
 // Pages and full-page collections share one tree. Collections with a loaded
 // page parent appear under that page. Collections without a loaded page
 // parent stay in the Collections section, including row-owned collections
-// for now (tech-debt.md#53).
+// for now (tech-debt.md#td-workspace-tree-no-unified-model).
 //
 // Sort top-level collections here. Otherwise `useEntityRecords` returns
 // whatever order core-data emits, which can shift after a rename and reorder

--- a/src/frontend.scss
+++ b/src/frontend.scss
@@ -6,7 +6,7 @@
  *
  * Heads-up: cover and icon styles still only load in admin/editor
  * bundles, so the PHP-rendered cover/icon markup is unstyled here.
- * See tech-debt.md#33.
+ * See tech-debt.md#td-frontend-cover-icon-styles.
  */
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;

--- a/src/hooks/fieldMapping.js
+++ b/src/hooks/fieldMapping.js
@@ -363,7 +363,7 @@ function checkboxFieldValue( item, id ) {
 // default-hidden, addable like any other field. Sort is enabled only on
 // the timestamps — sort on display-value
 // properties (Person, Relation, Rollup) is an open architectural
-// decision shared with relations and rollups (tech-debt.md#14).
+// decision shared with relations and rollups (tech-debt.md#td-display-value-sort).
 export function systemFields() {
 	const formatDate = ( value ) =>
 		value ? dateI18n( 'M j, Y g:i a', value ) : '';
@@ -517,7 +517,7 @@ export function mapField( field ) {
 		// `ColumnHeaderActions` queries the DOM for it and portals our
 		// combined-dropdown trigger into the owning <th>; DataViews'
 		// built-in trigger is hidden via CSS on marker-bearing columns
-		// (tech-debt.md#16). Skipping the label here avoids leaking
+		// (tech-debt.md#td-dataviews-header-extension-slots). Skipping the label here avoids leaking
 		// duplicate text into the th's accessible/text content.
 		header: (
 			<HeaderLabel>
@@ -546,7 +546,7 @@ export function mapField( field ) {
 	// UI). We pick the closest honest type rather than the prettiest one:
 	// decimals go through 'integer' with DataViews' integer-only
 	// validator disabled because there's no exact number type
-	// (tech-debt.md#10), url goes through 'text', and multiselect goes
+	// (tech-debt.md#td-dataviews-fieldtype-union), url goes through 'text', and multiselect goes
 	// through 'array' so DataViews understands the value cardinality.
 	switch ( type ) {
 		case 'number':

--- a/src/hooks/optionElements.js
+++ b/src/hooks/optionElements.js
@@ -1,7 +1,7 @@
 // Parses stored option records into the DataViews `elements` shape.
 // Accepts a string shorthand (`'red'` becomes `{ value: 'red', label: 'red' }`)
 // or `{ value, label, color? }`. `color` is an optional palette name (or
-// legacy CSS color) the chip renderer reads -- tech-debt.md#11: DataViews's
+// legacy CSS color) the chip renderer reads -- tech-debt.md#td-dataviews-option-color: DataViews's
 // `Option` type doesn't declare `color`, but it tolerates extra keys on
 // element entries.
 //

--- a/src/hooks/rowInvalidation.js
+++ b/src/hooks/rowInvalidation.js
@@ -1,6 +1,6 @@
 import { useEffect } from '@wordpress/element';
 
-// tech-debt.md#2: rows do not have a core-data store yet. Use this small
+// tech-debt.md#td-rows-not-in-core-data: rows do not have a core-data store yet. Use this small
 // event until row caching and dependent refreshes live there.
 export const COLLECTION_ROWS_CHANGED_EVENT = 'cortext:collection-rows-changed';
 

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -210,7 +210,7 @@ export default function useAutosave( options = {} ) {
 	] );
 
 	useEffect( () => {
-		// tech-debt.md#40: the editor store keeps didSucceed/didFail as level signals, but
+		// tech-debt.md#td-autosave-save-completion: the editor store keeps didSucceed/didFail as level signals, but
 		// the user-visible side effects below (status flip, Recents touch)
 		// are edges: they should fire once per save that *this hook ran*.
 		// Re-running the effect because recentTarget changed (the user opened

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -4,7 +4,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 import { useCollectionRowsInvalidation } from './rowInvalidation';
 
-// tech-debt.md#2: rows live outside core-data, so this hook manages
+// tech-debt.md#td-rows-not-in-core-data: rows live outside core-data, so this hook manages
 // its own fetch state and exposes a manual refresh() handle.
 
 const CLIENT_PER_PAGE = 100;
@@ -482,7 +482,7 @@ export default function useCollectionRows(
 		  } )
 		: null;
 
-	// tech-debt.md#2: callers POST via apiFetch and bump refresh() to
+	// tech-debt.md#td-rows-not-in-core-data: callers POST via apiFetch and bump refresh() to
 	// re-read. With rows in core-data this whole counter goes away.
 	const refresh = useCallback( () => {
 		setRefreshKey( ( key ) => key + 1 );

--- a/src/hooks/useSubmenuPlacement.js
+++ b/src/hooks/useSubmenuPlacement.js
@@ -7,7 +7,7 @@ import {
 
 // Picks a `Popover` placement for a row submenu inside a cascading menu,
 // adjusting after render if the chosen side overflows the viewport.
-// See docs/tech-debt.md#47.
+// See docs/tech-debt.md#td-wp-menu-popover-limitations.
 // `@wordpress/components` `Popover` only flips on the main axis and shifts
 // on the cross axis, so a `right-start` submenu that overflows past the
 // viewport's right edge wouldn't be pulled back into view on its own.

--- a/src/hooks/viewTransition.js
+++ b/src/hooks/viewTransition.js
@@ -64,7 +64,7 @@ export function withViewTransition( updater, options = {} ) {
 	}
 	activeTransition = tx;
 	if ( options.mode === HOLD_OLD_CANVAS_MODE ) {
-		// tech-debt.md#58: the View Transition callback can run after this
+		// tech-debt.md#td-page-transitions-snapshot: the View Transition callback can run after this
 		// function returns, so wait for the updater result before revealing.
 		const reveal = () => {
 			if ( activeTransition === tx ) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -7,8 +7,8 @@
 // emits them into the editor chunk's CSS file and skip the initial CSS
 // bundle on home and collection views.
 
-// tech-debt.md#38: wp-admin does not expose this handle on our screen, so
-// bundle the palette styles here.
+// tech-debt.md#td-command-palette-host-glue: wp-admin does not expose this
+// handle on our screen, so bundle the palette styles here.
 @use "../node_modules/@wordpress/commands/build-style/style.css" as commands;
 
 // Same deal for @wordpress/dataviews. Importing via JS would be tree-shaken

--- a/src/styles/global/_shell-root.scss
+++ b/src/styles/global/_shell-root.scss
@@ -335,7 +335,8 @@ body.cortext-hide-block-settings-menu .block-editor-block-switcher {
 	display: none;
 }
 
-// tech-debt.md#59: owner canvases lock the body to one block. Hide the normal
+// tech-debt.md#td-collection-owner-body-contract: owner canvases lock
+// the body to one block. Hide the normal
 // appender; cover and icon insertion still goes through
 // DocumentIdentityActions.
 .cortext-canvas__editor--owner .block-editor-default-block-appender,
@@ -370,7 +371,8 @@ body.cortext-hide-block-settings-menu .block-editor-block-switcher {
 	display: none;
 }
 
-// tech-debt.md#57: while row peek/modal owns the surface, keep the page
+// tech-debt.md#td-row-detail-toolbar-isolation: while row peek/modal
+// owns the surface, keep the page
 // canvas toolbar out of sight so only row toolbar actions are reachable.
 body.cortext-hide-parent-block-toolbar
 .cortext-shell__canvas

--- a/src/styles/global/_view-transitions.scss
+++ b/src/styles/global/_view-transitions.scss
@@ -53,7 +53,8 @@
 	}
 }
 
-// tech-debt.md#58: Page-to-page swaps rebuild the editor while the route
+// tech-debt.md#td-page-transitions-snapshot: Page-to-page swaps rebuild
+// the editor while the route
 // stays on the same pane. Keep the old snapshot above the new one until the
 // new editor has painted, then fade it away.
 :root[data-cortext-view-transition="hold-old-canvas"]::view-transition-old(cortext-canvas),

--- a/templates/single-crtxt_page.php
+++ b/templates/single-crtxt_page.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 			// resolves a second time inside `the_content()` for any page
 			// whose `post_content` carries the locked `core/post-title`
 			// block prepended by `DocumentIdentity::prepend_header_blocks`.
-			// See tech-debt.md#32.
+			// See tech-debt.md#td-public-title-double-render.
 			?>
 			<h1 class="cortext-public-page__title"><?php the_title(); ?></h1>
 			<div class="cortext-public-page__body is-layout-constrained">

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -4224,7 +4224,7 @@ test.describe( 'Collection view block', () => {
 
 			// 2. Rename "Notes" → "Description" via the column-header
 			//    dropdown (combined Sort/Move/Hide + Rename/Duplicate/
-			//    Delete menu — see docs/tech-debt.md#16).
+			//    Delete menu — see docs/tech-debt.md#td-dataviews-header-extension-slots).
 			await openColumnDropdown( notesHeader, 'Notes' );
 			await columnMenuItem( 'Rename' ).click();
 

--- a/tests/php/InMemoryPostsQuery.php
+++ b/tests/php/InMemoryPostsQuery.php
@@ -9,7 +9,7 @@
  * `posts_pre_query` filter that answers from the in-memory store and keeps
  * pagination totals available.
  *
- * Tracked in docs/tech-debt.md#9. Use by `use InMemoryPostsQuery;` in a test
+ * Tracked in docs/tech-debt.md#td-wordbless-row-coverage. Use by `use InMemoryPostsQuery;` in a test
  * class and call `install_in_memory_posts_query()` from `set_up()` and
  * `uninstall_in_memory_posts_query()` from `tear_down()`.
  *

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -1374,7 +1374,7 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 
 	// Multi-author flow through the REST endpoint isn't testable in
 	// WorDBless: `wp_insert_post` works via the object cache but
-	// `WP_Query` SQL returns zero results (tech-debt.md#9). The
+	// `WP_Query` SQL returns zero results (tech-debt.md#td-wordbless-row-coverage). The
 	// `test_format_row_resolves_distinct_modified_by` test above
 	// already covers display-name resolution for distinct users at the
 	// `format_row` layer; the full REST flow is exercised in e2e.
@@ -1483,7 +1483,7 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertNull( $args['fields']['default'] );
 	}
 
-	// tech-debt.md#9: WorDBless cannot run the full rows query, so these
+	// tech-debt.md#td-wordbless-row-coverage: WorDBless cannot run the full rows query, so these
 	// projection checks stay at the route/schema and formatter layers.
 	public function test_filter_requested_field_ids_keeps_collection_field_keys(): void {
 		$result = $this->invoke_filter_requested_field_ids(


### PR DESCRIPTION
## What

Reshape `docs/tech-debt.md` into two sections (Upstream opportunities, Internal debt) with area subgroups, and replace numbered entries with stable slug anchors (`td-…`). A few entries get merged where they were facets of one upstream gap (e.g. all the `Menu` / `Popover` items become one), and a couple get split where they bundled two independent fixes. Style scrubs along the way: em dashes, Linear IDs, "Notion-style" phrasings, and the `[soft]` / `[important]` tag axis nobody used.

The 66 in-source comments move with the doc: `tech-debt.md#15` becomes `tech-debt.md#td-dataviews-column-interactions`. A comment in code now says what the workaround is about without opening the doc.

## Why

The doc had become unmanageable. With 60 flat numbered entries, any PR that added or moved one fought for the next free number, and 66 cross-references in code made renumbering expensive. Slug anchors and the section split take that pressure off; entries can be added or moved without touching anyone else's anchor.

## Testing Instructions

1. Open the doc and confirm the two top-level sections (Upstream opportunities, Internal debt) render with their area subheadings.
2. Click a couple of in-doc cross-links (e.g. `td-row-filter-split` → `td-dataviews-query-capability-contract`) and confirm they land on the right entry.
3. From the branch, run `grep -rn 'tech-debt.md#[0-9]' src/ includes/ tests/ templates/` and confirm no results.