### PR TITLE
Fix: Handle autosave failure snackbars

### DIFF
--- a/src/components/CortextSnackbars.js
+++ b/src/components/CortextSnackbars.js
@@ -2,9 +2,10 @@ import { SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
-// Renders only Cortext-owned snackbars. The editor store also dispatches its
-// own "Post updated" success notice on every save; in an autosave-silent UI
-// those would fire constantly, so we filter to notices we tagged ourselves.
+import './CortextSnackbars.scss';
+
+// Show only snackbars created by Cortext. Core also emits its own "Post updated"
+// notice after saves, which would be noisy here, so we keep notices with our ids.
 export default function CortextSnackbars() {
 	const notices = useSelect(
 		( select ) =>
@@ -20,5 +21,9 @@ export default function CortextSnackbars() {
 	);
 	const { removeNotice } = useDispatch( noticesStore );
 
-	return <SnackbarList notices={ notices } onRemove={ removeNotice } />;
+	return (
+		<div className="cortext-snackbars">
+			<SnackbarList notices={ notices } onRemove={ removeNotice } />
+		</div>
+	);
 }

--- a/src/components/CortextSnackbars.scss
+++ b/src/components/CortextSnackbars.scss
@@ -1,0 +1,23 @@
+// SnackbarList is absolute-positioned but has no offsets, so it would sit over
+// the top-bar breadcrumbs here. This wrapper lives in the canvas column, which
+// lets us anchor notices below the top bar and away from the sidebar.
+// Keep the left edge fixed so the snackbar does not jump when the message
+// changes from failure to success.
+.cortext-snackbars {
+	position: absolute;
+	bottom: 24px;
+	left: 24px;
+	z-index: 100000;
+	pointer-events: none;
+
+	.components-snackbar-list {
+		position: static;
+		width: auto;
+	}
+
+	// Let the snackbar controls receive clicks while the wrapper stays
+	// click-through over the canvas.
+	.components-snackbar {
+		pointer-events: auto;
+	}
+}

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -56,6 +56,10 @@ export default function useAutosave( options = {} ) {
 	const savingWaitersRef = useRef( [] );
 	const prevIsSavingRef = useRef( isSaving );
 	const savingTargetRef = useRef( null );
+	// Show the failure snackbar once per failed-save streak. Background retries
+	// can cycle through saving and error repeatedly; the next successful save
+	// resets the latch.
+	const errorNoticeShownRef = useRef( false );
 
 	const stateRef = useRef( {
 		isDirty,
@@ -239,19 +243,28 @@ export default function useAutosave( options = {} ) {
 		} else if ( didFail ) {
 			savingTargetRef.current = null;
 			setStatus( 'error' );
-			// The toolbar no longer carries a save status, so a failed
-			// autosave needs its own way of reaching the user. Snackbar
-			// is dismissable and stays out of the way when things work.
-			createErrorNotice( __( 'Failed to save changes.', 'cortext' ), {
-				id: AUTOSAVE_ERROR_NOTICE_ID,
-				type: 'snackbar',
-			} );
+			// Successful autosaves stay quiet, so failures need a clear notice.
+			// Show it once when saving first fails; background retries would
+			// otherwise open it every few seconds. `explicitDismiss` keeps it
+			// around until the user closes it or the save recovers.
+			if ( ! errorNoticeShownRef.current ) {
+				createErrorNotice(
+					__( "Couldn't save your changes.", 'cortext' ),
+					{
+						id: AUTOSAVE_ERROR_NOTICE_ID,
+						type: 'snackbar',
+						explicitDismiss: true,
+					}
+				);
+				errorNoticeShownRef.current = true;
+			}
 		} else if ( didSucceed && wasSaving ) {
 			const latchedTarget = savingTargetRef.current;
 			savingTargetRef.current = null;
 			setStatus( 'saved' );
 			setLastSavedAt( Date.now() );
 			removeNotice( AUTOSAVE_ERROR_NOTICE_ID );
+			errorNoticeShownRef.current = false;
 			if ( latchedTarget ) {
 				touchRecent( latchedTarget );
 			}

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -18,7 +18,8 @@ export default function useAutosave( options = {} ) {
 	const recentId = options.recentTarget?.id ?? null;
 	const recentCollectionId = options.recentTarget?.collectionId ?? null;
 	const { savePost, editPost } = useDispatch( editorStore );
-	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
 	const { touchRecent } = useRecents();
 
 	const {
@@ -263,8 +264,16 @@ export default function useAutosave( options = {} ) {
 			savingTargetRef.current = null;
 			setStatus( 'saved' );
 			setLastSavedAt( Date.now() );
-			removeNotice( AUTOSAVE_ERROR_NOTICE_ID );
-			errorNoticeShownRef.current = false;
+			if ( errorNoticeShownRef.current ) {
+				// Replace the failure notice with a short success message.
+				// Reusing the notice id swaps it in place, and without
+				// `explicitDismiss` SnackbarList fades it out.
+				createSuccessNotice( __( 'All changes saved.', 'cortext' ), {
+					id: AUTOSAVE_ERROR_NOTICE_ID,
+					type: 'snackbar',
+				} );
+				errorNoticeShownRef.current = false;
+			}
 			if ( latchedTarget ) {
 				touchRecent( latchedTarget );
 			}
@@ -274,7 +283,7 @@ export default function useAutosave( options = {} ) {
 		didSucceed,
 		didFail,
 		createErrorNotice,
-		removeNotice,
+		createSuccessNotice,
 		recentKind,
 		recentId,
 		recentCollectionId,

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -92,7 +92,7 @@ beforeEach( () => {
 		savePost: jest.fn(),
 		editPost: jest.fn(),
 		createErrorNotice: jest.fn(),
-		removeNotice: jest.fn(),
+		createSuccessNotice: jest.fn(),
 	} );
 	mockTouchRecent.mockReset();
 } );
@@ -605,7 +605,7 @@ describe( 'useAutosave: status', () => {
 			savePost: jest.fn(),
 			editPost: jest.fn(),
 			createErrorNotice,
-			removeNotice: jest.fn(),
+			createSuccessNotice: jest.fn(),
 		} );
 		setStoreState( { didFail: true } );
 
@@ -627,7 +627,7 @@ describe( 'useAutosave: status', () => {
 			savePost: jest.fn(),
 			editPost: jest.fn(),
 			createErrorNotice,
-			removeNotice: jest.fn(),
+			createSuccessNotice: jest.fn(),
 		} );
 		setStoreState( { didFail: true } );
 
@@ -648,13 +648,13 @@ describe( 'useAutosave: status', () => {
 		expect( createErrorNotice ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'removes the autosave error notice after a successful save', () => {
-		const removeNotice = jest.fn();
+	it( 'swaps the failure snackbar for a short success snackbar after recovery', () => {
+		const createSuccessNotice = jest.fn();
 		useDispatch.mockReturnValue( {
 			savePost: jest.fn(),
 			editPost: jest.fn(),
 			createErrorNotice: jest.fn(),
-			removeNotice,
+			createSuccessNotice,
 		} );
 		setStoreState( { didFail: true } );
 
@@ -669,7 +669,38 @@ describe( 'useAutosave: status', () => {
 			rerender();
 		} );
 
-		expect( removeNotice ).toHaveBeenCalledWith( 'cortext-autosave-error' );
+		// Reusing the failure notice id swaps it in place. Omitting
+		// explicitDismiss lets SnackbarList fade out the success message.
+		expect( createSuccessNotice ).toHaveBeenCalledWith(
+			expect.any( String ),
+			expect.objectContaining( {
+				id: 'cortext-autosave-error',
+				type: 'snackbar',
+			} )
+		);
+		expect(
+			createSuccessNotice.mock.calls[ 0 ][ 1 ].explicitDismiss
+		).toBeUndefined();
+	} );
+
+	it( 'does not announce success on a normal save with no prior failure', () => {
+		const createSuccessNotice = jest.fn();
+		useDispatch.mockReturnValue( {
+			savePost: jest.fn(),
+			editPost: jest.fn(),
+			createErrorNotice: jest.fn(),
+			createSuccessNotice,
+		} );
+		setStoreState( { isSaving: true } );
+
+		const { rerender } = renderHook( () => useAutosave() );
+
+		act( () => {
+			setStoreState( { isSaving: false, didSucceed: true } );
+			rerender();
+		} );
+
+		expect( createSuccessNotice ).not.toHaveBeenCalled();
 	} );
 
 	it( 'resets status when the current post id changes', () => {

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -581,7 +581,25 @@ describe( 'useAutosave: status', () => {
 		expect( result.current.status ).toBe( 'error' );
 	} );
 
-	it( 'surfaces a snackbar notice when a save fails', () => {
+	it( 'recovers to saved when a later save succeeds', () => {
+		setStoreState( { didFail: true } );
+
+		const { result, rerender } = renderHook( () => useAutosave() );
+		expect( result.current.status ).toBe( 'error' );
+
+		act( () => {
+			setStoreState( { isSaving: true, didFail: false } );
+			rerender();
+		} );
+		act( () => {
+			setStoreState( { isSaving: false, didSucceed: true } );
+			rerender();
+		} );
+
+		expect( result.current.status ).toBe( 'saved' );
+	} );
+
+	it( 'shows a dismissible snackbar when a save fails', () => {
 		const createErrorNotice = jest.fn();
 		useDispatch.mockReturnValue( {
 			savePost: jest.fn(),
@@ -598,8 +616,36 @@ describe( 'useAutosave: status', () => {
 			expect.objectContaining( {
 				type: 'snackbar',
 				id: 'cortext-autosave-error',
+				explicitDismiss: true,
 			} )
 		);
+	} );
+
+	it( 'does not reopen the snackbar while retries keep failing', () => {
+		const createErrorNotice = jest.fn();
+		useDispatch.mockReturnValue( {
+			savePost: jest.fn(),
+			editPost: jest.fn(),
+			createErrorNotice,
+			removeNotice: jest.fn(),
+		} );
+		setStoreState( { didFail: true } );
+
+		const { rerender } = renderHook( () => useAutosave() );
+		expect( createErrorNotice ).toHaveBeenCalledTimes( 1 );
+
+		// A background retry starts and fails again. Without the latch, the
+		// snackbar would open again on every cycle.
+		act( () => {
+			setStoreState( { isSaving: true, didFail: false } );
+			rerender();
+		} );
+		act( () => {
+			setStoreState( { isSaving: false, didFail: true } );
+			rerender();
+		} );
+
+		expect( createErrorNotice ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'removes the autosave error notice after a successful save', () => {


### PR DESCRIPTION
## What

Part of #85.

When autosave fails, Cortext now shows one dismissible snackbar instead of opening a new notice on every retry. When saving recovers, that snackbar changes to `All changes saved.` and fades out.

## Why

Autosave failures should be visible without interrupting the user every time the background retry loop runs.

## How

- Showing the failure snackbar once per failure streak.
- Keeping the failure snackbar dismissible.
- Replacing the failure snackbar with a short success message when saving recovers.

## Testing Instructions

1. Open a Cortext document and make an edit.
2. Force an autosave failure, for example by blocking the save request in dev tools.
3. Confirm a dismissible `Couldn't save your changes.` snackbar appears.
4. Dismiss the snackbar.
5. Keep the save request blocked and wait for another retry. Confirm the snackbar does not reopen.
6. Restore the save request.
7. Confirm the snackbar changes to `All changes saved.` and then fades out.

## Screen recording

https://github.com/user-attachments/assets/86e0aa64-21b8-40b1-989f-765a2043e29c

