### PR TITLE
Release: Fix milestone workflow permissions

### DIFF
--- a/.github/workflows/assign-release-milestone.yml
+++ b/.github/workflows/assign-release-milestone.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
     issues: write
-    pull-requests: read
+    pull-requests: write
 
 jobs:
     assign:


### PR DESCRIPTION
## What

Part of #283.

Fixes the permissions for the release milestone workflow. It was running after merges, but it could not write the milestone back to the merged PR.

## Why

#276 and #281 both hit GitHub's `Resource not accessible by integration` error when the workflow tried to set `0.1.0`. GitHub treats PRs as issues for milestones, but this endpoint still needs `pull-requests: write`, not just `issues: write`.

## Testing Instructions

1. Merge a labeled PR into `main` after this lands.
2. Confirm the Assign Release Milestone workflow passes.
3. Confirm the merged PR is assigned to the open release milestone.
