### PR TITLE
Release: Set the plugin version to 0.1.0

### DIFF
--- a/cortext.php
+++ b/cortext.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Cortext
  * Plugin URI:        https://github.com/priethor/cortext
  * Description:       Build a WordPress-native knowledge base with nested pages, typed collections, flexible views, and publishing through your own site.
- * Version:           0.0.1
+ * Version:           0.1.0
  * Requires at least: 6.9
  * Requires PHP:      8.1
  * Author:            Héctor Prieto, Miguel Fonseca
@@ -16,7 +16,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CORTEXT_VERSION', '0.0.1' );
+define( 'CORTEXT_VERSION', '0.1.0' );
 define( 'CORTEXT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CORTEXT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/PostType/CollectionEntries.php
+++ b/includes/PostType/CollectionEntries.php
@@ -468,7 +468,7 @@ final class CollectionEntries {
 						$slug
 					)
 				),
-				'0.0.1'
+				'0.1.0'
 			);
 			return;
 		}
@@ -484,7 +484,7 @@ final class CollectionEntries {
 						self::MAX_CPT_LEN - strlen( self::CPT_PREFIX )
 					)
 				),
-				'0.0.1'
+				'0.1.0'
 			);
 			return;
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cortext",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"description": "Knowledge base inside WordPress.",
 	"engines": {
 		"node": "^24.15",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: knowledge-base, collections, dataviews, block-editor, workspace
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable tag: 0.0.1
+Stable tag: 0.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,5 +18,5 @@ Cortext creates a knowledge base inside WordPress. You get nested pages, typed c
 
 == Changelog ==
 
-= 0.0.1 =
-* Initial scaffolding.
+= 0.1.0 =
+* Initial public beta.


### PR DESCRIPTION
## What

Part of #283.

Updates the plugin-facing version metadata to `0.1.0`, so the release ZIP does not still carry `0.0.1` in public plugin files. This covers the plugin header, `CORTEXT_VERSION`, `readme.txt`, the root package version, and the existing `_doing_it_wrong` version markers.

## Why

After the release workflow creates the `0.1.0` ZIP, the plugin inside it should agree with the release it came from.

## Testing Instructions

1. Build the plugin ZIP locally.
2. Inspect `cortext/cortext.php` inside the ZIP and confirm it reports `0.1.0`.
3. Inspect `cortext/readme.txt` inside the ZIP and confirm the stable tag is `0.1.0`.
