### PR TITLE
Fix: Flush edits when leaving the browser and prompt on dirty state

### DIFF
--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -57,6 +57,11 @@ export default function useAutosave( options = {} ) {
 	const savingWaitersRef = useRef( [] );
 	const prevIsSavingRef = useRef( isSaving );
 	const savingTargetRef = useRef( null );
+	// Track the one beforeunload case worth interrupting: the document still
+	// has edits and the last save failed. Healthy saves still get a final flush
+	// and leave without a prompt.
+	const unsavedRiskRef = useRef( false );
+	unsavedRiskRef.current = isDirty && status === 'error';
 	// Show the failure snackbar once per failed-save streak. Background retries
 	// can cycle through saving and error repeatedly; the next successful save
 	// resets the latch.
@@ -313,8 +318,15 @@ export default function useAutosave( options = {} ) {
 		const onBlur = () => {
 			flushNow();
 		};
-		const onBeforeUnload = () => {
+		const onBeforeUnload = ( event ) => {
 			flushNow();
+			if ( unsavedRiskRef.current ) {
+				// Save is already failing, and the browser may unload before
+				// flushNow finishes. Ask it to show the native leave-site
+				// prompt so the user can stay put.
+				event.preventDefault();
+				event.returnValue = '';
+			}
 		};
 
 		document.addEventListener( 'visibilitychange', onVisibilityChange );

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -301,6 +301,45 @@ describe( 'useAutosave: flush triggers', () => {
 		expect( savePost ).not.toHaveBeenCalled();
 	} );
 
+	it( 'prompts before unload when failed saves leave edits unsaved', () => {
+		setStoreState( { isDirty: true, didFail: true } );
+
+		renderHook( () => useAutosave() );
+
+		const event = new Event( 'beforeunload', { cancelable: true } );
+		act( () => {
+			window.dispatchEvent( event );
+		} );
+
+		expect( event.defaultPrevented ).toBe( true );
+	} );
+
+	it( 'does not prompt before unload while saves are healthy', () => {
+		setStoreState( { isDirty: true } );
+
+		renderHook( () => useAutosave() );
+
+		const event = new Event( 'beforeunload', { cancelable: true } );
+		act( () => {
+			window.dispatchEvent( event );
+		} );
+
+		expect( event.defaultPrevented ).toBe( false );
+	} );
+
+	it( 'does not prompt before unload without unsaved edits', () => {
+		setStoreState( { isDirty: false, didFail: true } );
+
+		renderHook( () => useAutosave() );
+
+		const event = new Event( 'beforeunload', { cancelable: true } );
+		act( () => {
+			window.dispatchEvent( event );
+		} );
+
+		expect( event.defaultPrevented ).toBe( false );
+	} );
+
 	it( 'waits for an in-flight autosave instead of reporting failure', async () => {
 		let resolveSave;
 		const savePost = jest.fn(


### PR DESCRIPTION
## What

Part of #85.

When autosave has failed, and the document still has unsaved edits, Cortext now marks the page unload as unsafe so the browser can show its native leave-site prompt.

## Why

The unload handler still tries to flush pending edits, but that async save may not finish before the tab goes away. If saving is already failing, we should not let the page close quietly.

## How

- Tracking the failed-save plus unsaved-edits case before the page unloads.
- Letting the normal close flow continue when saves are healthy or there is nothing unsaved.

## Testing Instructions

1. Open a Cortext document and make an edit.
2. Make the save fail: in DevTools, block the save request (Network → right-click the `wp/v2` request → Block request URL), or switch to Offline.
3. Edit again and wait for the "Couldn't save your changes." snackbar. That snackbar is the signal that the save has actually failed.
4. With the snackbar showing, close or reload the tab. Confirm the browser shows its native leave-site prompt.
5. Stop blocking the request (or go back online) so autosave recovers, or open a document with no unsaved edits.
6. Close or reload. Confirm there is no prompt.

## Screen recording
Leaving the page flushes the changes immediately:

https://github.com/user-attachments/assets/4a39de1c-6aa8-4bc7-a18e-197031433b34

But if edits can't be saved and the editor is in a dirty state, we get a prompt:

https://github.com/user-attachments/assets/75102696-8df5-4cbd-9395-d41ac95f4591

