### PR TITLE
Fix: ensure Cortext-owned editor blocks behave as app, not content

### DIFF
--- a/src/blocks/document-cover/edit.js
+++ b/src/blocks/document-cover/edit.js
@@ -86,7 +86,7 @@ export default function Edit( { context, clientId } ) {
 		}
 		insertBlocks(
 			createBlock( 'cortext/document-icon', {
-				lock: { move: true },
+				lock: { move: true, remove: true },
 			} ),
 			coverIndex + 1,
 			undefined,

--- a/src/components/DataViewRowReorder.js
+++ b/src/components/DataViewRowReorder.js
@@ -1132,6 +1132,7 @@ export default function DataViewRowReorder( {
 	dataRef.current = data;
 	const mutateRowsRef = useRef( mutateRows );
 	mutateRowsRef.current = mutateRows;
+	const pendingRefreshAfterSortClearRef = useRef( false );
 	const hoverSuppressionTimeoutRef = useRef( null );
 	const noTransitionFrameRef = useRef( null );
 	const onChangeViewRef = useRef( onChangeView );
@@ -1207,6 +1208,29 @@ export default function DataViewRowReorder( {
 		[ releaseRowHover, suppressRowTransitionsOnce ]
 	);
 
+	const flushRefreshAfterSortClear = useCallback( () => {
+		if ( ! pendingRefreshAfterSortClearRef.current ) {
+			return;
+		}
+		const currentSort = viewRef.current?.sort ?? null;
+		const hasExplicitSort =
+			Boolean( currentSort?.field ) &&
+			currentSort.field !== MANUAL_SORT_ID;
+		if ( hasExplicitSort ) {
+			return;
+		}
+		pendingRefreshAfterSortClearRef.current = false;
+		onReorderedRef.current?.();
+	}, [] );
+
+	useEffect( () => {
+		flushRefreshAfterSortClear();
+	}, [
+		flushRefreshAfterSortClear,
+		view?.sort?.direction,
+		view?.sort?.field,
+	] );
+
 	// Posts the reorder to the server. On failure restores `data` from the
 	// snapshot taken before the optimistic mutation, and (if we cleared a
 	// non-manual sort to make the move visible) restores that sort too.
@@ -1229,7 +1253,12 @@ export default function DataViewRowReorder( {
 						current_sort: request.currentSort ?? null,
 					},
 				} );
-				onReorderedRef.current?.();
+				if ( request.refreshAfterSortClear ) {
+					pendingRefreshAfterSortClearRef.current = true;
+					flushRefreshAfterSortClear();
+				} else {
+					onReorderedRef.current?.();
+				}
 			} catch {
 				if ( request.previousData && mutateRowsRef.current ) {
 					mutateRowsRef.current( request.previousData );
@@ -1251,7 +1280,12 @@ export default function DataViewRowReorder( {
 				setIsPosting( false );
 			}
 		},
-		[ collectionId, createErrorNotice, isPosting ]
+		[
+			collectionId,
+			createErrorNotice,
+			flushRefreshAfterSortClear,
+			isPosting,
+		]
 	);
 
 	const onDragStart = useCallback(
@@ -1309,7 +1343,9 @@ export default function DataViewRowReorder( {
 			performReorder( {
 				...request,
 				previousData,
-				...( clearSort ? { previousSort } : {} ),
+				...( clearSort
+					? { previousSort, refreshAfterSortClear: true }
+					: {} ),
 			} );
 		},
 		[ clearDragState, performReorder ]

--- a/src/components/DocumentInspectorSidebar.js
+++ b/src/components/DocumentInspectorSidebar.js
@@ -187,7 +187,7 @@ function DocumentIconInspectorControls( { postId, postType } ) {
 			const insertIndex = hasCoverBlock ? coverIndex + 1 : 0;
 			insertBlocks(
 				createBlock( 'cortext/document-icon', {
-					lock: { move: true },
+					lock: { move: true, remove: true },
 				} ),
 				insertIndex,
 				undefined,
@@ -299,7 +299,7 @@ function PageFeaturedImageInspectorControls( { postId, postType } ) {
 		insertBlocks(
 			createBlock( 'cortext/document-cover', {
 				align: 'full',
-				lock: { move: true },
+				lock: { move: true, remove: true },
 			} ),
 			0,
 			undefined,

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -23,7 +23,7 @@ import { useEntityProp, useEntityRecord } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import { ENTER, SPACE } from '@wordpress/keycodes';
+import { ENTER, SPACE, isKeyboardEvent } from '@wordpress/keycodes';
 import {
 	useEffect,
 	useLayoutEffect,
@@ -64,6 +64,8 @@ const DEFAULT_HEADER_BLOCK_NAMES = new Set( [
 	POST_TITLE_BLOCK,
 	DOCUMENT_PROPERTIES_BLOCK,
 ] );
+const PROTECTED_HEADER_LOCK = { move: true, remove: true };
+const COLLECTION_LEGACY_BLOCK_LOCK = { move: true, remove: true, edit: true };
 const CANVAS_READY_IMAGE_TIMEOUT = 8000;
 
 // Schema-bearing documents add an owner block to the reserved header/body
@@ -75,8 +77,24 @@ function getHeaderBlockNames( ownerBlockName ) {
 	return new Set( [ ...DEFAULT_HEADER_BLOCK_NAMES, ownerBlockName ] );
 }
 
-function isHeaderBlock( block, ownerBlockName ) {
-	return getHeaderBlockNames( ownerBlockName ).has( block?.name );
+function isCanvasOwnerBlock( block, record, postId ) {
+	if ( ! block || ! getCanvasOwnerBlockNameForRecord( record ) ) {
+		return false;
+	}
+	return !! findCanvasOwnerBlock( [ block ], record, postId );
+}
+
+function isHeaderBlock( block, ownerBlockName, record = null, postId = null ) {
+	if ( ! getHeaderBlockNames( ownerBlockName ).has( block?.name ) ) {
+		return false;
+	}
+	if ( block?.name !== ownerBlockName ) {
+		return true;
+	}
+	if ( ! record || ! postId ) {
+		return true;
+	}
+	return isCanvasOwnerBlock( block, record, postId );
 }
 
 // Returns clientIds of header blocks that should be removed by the next
@@ -138,8 +156,36 @@ function useDocumentRecord( postType, postId ) {
 	return record;
 }
 
-function isHeaderChromeBlock( block, ownerBlockName ) {
-	return isHeaderBlock( block, ownerBlockName );
+function isHeaderChromeBlock( block, ownerBlockName, record, postId ) {
+	return isHeaderBlock( block, ownerBlockName, record, postId );
+}
+
+function isCollectionBodyBlock( block, ownerBlockName, record, postId ) {
+	return (
+		!! ownerBlockName &&
+		!! block &&
+		! isHeaderBlock( block, ownerBlockName, record, postId )
+	);
+}
+
+function lockNeedsRepair( lock, desiredLock ) {
+	return (
+		lock?.move !== desiredLock.move ||
+		lock?.remove !== desiredLock.remove ||
+		( desiredLock.edit === true
+			? lock?.edit !== true
+			: lock?.edit === true )
+	);
+}
+
+function selectedClientIdFromEvent( event ) {
+	const target = event.target;
+	if ( ! target || typeof target.closest !== 'function' ) {
+		return null;
+	}
+	return (
+		target.closest( '[data-block]' )?.getAttribute( 'data-block' ) ?? null
+	);
 }
 
 function syncHeaderBoundaryMoveUpClass() {
@@ -263,7 +309,7 @@ function HeaderPrefixToolbarGuard( {
 			const firstBodyIndex = blocks.findIndex(
 				( block, index ) =>
 					index > titleIndex &&
-					! isHeaderBlock( block, ownerBlockName )
+					! isHeaderBlock( block, ownerBlockName, record, postId )
 			);
 			if ( firstBodyIndex < 0 ) {
 				return false;
@@ -281,7 +327,7 @@ function HeaderPrefixToolbarGuard( {
 
 			return Math.min( ...selectedRootIndexes ) === firstBodyIndex;
 		},
-		[ isActive, isLocked, ownerBlockName ]
+		[ isActive, isLocked, ownerBlockName, postId, record ]
 	);
 
 	useEffect( () => {
@@ -407,7 +453,7 @@ function DocumentIdentityActions( { isLocked = false, postId, postType } ) {
 			return;
 		}
 		const block = createBlock( DOCUMENT_ICON_BLOCK, {
-			lock: { move: true },
+			lock: PROTECTED_HEADER_LOCK,
 		} );
 		insertBlocks( block, 0, undefined, false );
 	};
@@ -419,7 +465,7 @@ function DocumentIdentityActions( { isLocked = false, postId, postType } ) {
 		isInsertingCoverRef.current = true;
 		const block = createBlock( DOCUMENT_COVER_BLOCK, {
 			align: 'full',
-			lock: { move: true },
+			lock: PROTECTED_HEADER_LOCK,
 		} );
 		insertBlocks( block, 0, undefined, false );
 		try {
@@ -479,6 +525,11 @@ function DocumentIdentityActions( { isLocked = false, postId, postType } ) {
 }
 
 function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
+	const collectionBodySnapshotRef = useRef( {
+		key: null,
+		initialized: false,
+		clientIds: new Set(),
+	} );
 	const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId );
 	const [ featuredId ] = useEntityProp(
 		'postType',
@@ -511,6 +562,10 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 		bodyBlockBeforeTitleId,
 		shouldHideHeaderInsertionPoint,
 		duplicateHeaderIds,
+		shouldSeedEmptyBodyBlock,
+		emptyBodyInsertionIndex,
+		protectedLockRepairs,
+		collectionBodyClientIds,
 		isTrashed,
 	} = useSelect(
 		( select ) => {
@@ -521,8 +576,13 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 			const currentPropertiesIndex = names.indexOf(
 				DOCUMENT_PROPERTIES_BLOCK
 			);
-			const currentOwnerIndex = ownerBlockName
-				? names.indexOf( ownerBlockName )
+			const ownerBlock = ownerBlockName
+				? findCanvasOwnerBlock( blocks, record, postId )
+				: null;
+			const currentOwnerIndex = ownerBlock
+				? blocks.findIndex(
+						( block ) => block.clientId === ownerBlock.clientId
+				  )
 				: -1;
 			// The protected prefix ends at the last installed header block:
 			// cover, icon, title, properties, or the owner block. max() keeps
@@ -540,7 +600,9 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 					index--
 				) {
 					const block = blocks[ index ];
-					if ( isHeaderBlock( block, ownerBlockName ) ) {
+					if (
+						isHeaderBlock( block, ownerBlockName, record, postId )
+					) {
 						continue;
 					}
 					currentBodyBlockBeforeTitleId = block.clientId;
@@ -557,6 +619,36 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 				ownerBlockName,
 				postId
 			);
+			const lockRepairs = [];
+			const bodyClientIds = [];
+			blocks.forEach( ( block ) => {
+				let desiredLock = null;
+				if (
+					DEFAULT_HEADER_BLOCK_NAMES.has( block.name ) ||
+					isCanvasOwnerBlock( block, record, postId )
+				) {
+					desiredLock = PROTECTED_HEADER_LOCK;
+				} else if (
+					isCollectionBodyBlock(
+						block,
+						ownerBlockName,
+						record,
+						postId
+					)
+				) {
+					bodyClientIds.push( block.clientId );
+					desiredLock = COLLECTION_LEGACY_BLOCK_LOCK;
+				}
+				if (
+					desiredLock &&
+					lockNeedsRepair( block.attributes?.lock, desiredLock )
+				) {
+					lockRepairs.push( {
+						clientId: block.clientId,
+						lock: desiredLock,
+					} );
+				}
+			} );
 			const propertiesBlock = blocks.find(
 				( block ) => block.name === DOCUMENT_PROPERTIES_BLOCK
 			);
@@ -567,12 +659,22 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 				hasIcon: names.includes( DOCUMENT_ICON_BLOCK ),
 				hasTitle: names.includes( POST_TITLE_BLOCK ),
 				hasProperties: !! propertiesBlock,
-				hasOwner: ownerBlockName
-					? !! findCanvasOwnerBlock( blocks, record, postId )
-					: true,
+				hasOwner: ownerBlockName ? !! ownerBlock : true,
 				propertiesClientId: propertiesBlock?.clientId ?? null,
 				headerEndIndex: currentHeaderEndIndex,
 				bodyBlockBeforeTitleId: currentBodyBlockBeforeTitleId,
+				shouldSeedEmptyBodyBlock:
+					! ownerBlockName &&
+					blocks.length > 0 &&
+					blocks.every( ( block ) =>
+						isHeaderChromeBlock(
+							block,
+							ownerBlockName,
+							record,
+							postId
+						)
+					),
+				emptyBodyInsertionIndex: currentHeaderEndIndex + 1,
 				shouldHideHeaderInsertionPoint:
 					store.isBlockInsertionPointVisible() &&
 					currentHeaderEndIndex > -1 &&
@@ -583,6 +685,8 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 					select( editorStore ).getCurrentPostAttribute(
 						'status'
 					) === 'trash',
+				protectedLockRepairs: lockRepairs,
+				collectionBodyClientIds: bodyClientIds,
 			};
 		},
 		[ ownerBlockName, postId, record ]
@@ -598,13 +702,52 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 	} = useDispatch( blockEditorStore );
 
 	useLayoutEffect( () => {
+		collectionBodySnapshotRef.current = {
+			key: `${ postType }:${ postId }`,
+			initialized: false,
+			clientIds: new Set(),
+		};
+	}, [ postId, postType ] );
+
+	useLayoutEffect( () => {
 		if ( isTrashed || isLocked ) {
 			return;
 		}
 
+		const removedClientIds = new Set();
 		duplicateHeaderIds.forEach( ( clientId ) => {
+			removedClientIds.add( clientId );
 			updateBlockAttributes( clientId, { lock: {} } );
 			removeBlock( clientId, false );
+		} );
+
+		const snapshot = collectionBodySnapshotRef.current;
+		if (
+			ownerBlockName &&
+			hasOwner &&
+			hasTitle &&
+			! snapshot.initialized
+		) {
+			snapshot.key = `${ postType }:${ postId }`;
+			snapshot.clientIds = new Set( collectionBodyClientIds );
+			snapshot.initialized = true;
+		}
+
+		if ( ownerBlockName && hasOwner && snapshot.initialized ) {
+			collectionBodyClientIds
+				.filter( ( clientId ) => ! snapshot.clientIds.has( clientId ) )
+				.forEach( ( clientId ) => {
+					removedClientIds.add( clientId );
+					updateBlockAttributes( clientId, { lock: {} } );
+					removeBlock( clientId, false );
+				} );
+		}
+
+		protectedLockRepairs.forEach( ( { clientId, lock } ) => {
+			if ( removedClientIds.has( clientId ) ) {
+				return;
+			}
+			updateBlockAttributes( clientId, { lock } );
 		} );
 
 		// Keep the properties block only on rows whose collection has fields.
@@ -621,12 +764,19 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 		}
 	}, [
 		duplicateHeaderIds,
+		collectionBodyClientIds,
 		hasProperties,
 		hasSchema,
+		hasOwner,
+		hasTitle,
 		isLocked,
 		isTrashed,
+		ownerBlockName,
 		propertiesClientId,
 		propertiesContextStable,
+		postId,
+		postType,
+		protectedLockRepairs,
 		removeBlock,
 		updateBlockAttributes,
 	] );
@@ -641,6 +791,42 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 		isLocked,
 		isTrashed,
 		shouldHideHeaderInsertionPoint,
+	] );
+
+	useLayoutEffect( () => {
+		if (
+			isTrashed ||
+			ownerBlockName ||
+			! shouldSeedEmptyBodyBlock ||
+			duplicateHeaderIds.length > 0 ||
+			( featuredId > 0 && ! hasCover ) ||
+			( iconMeta && ! hasIcon ) ||
+			! hasTitle ||
+			( hasSchema && ! hasProperties )
+		) {
+			return;
+		}
+
+		insertBlocks(
+			createBlock( 'core/paragraph' ),
+			emptyBodyInsertionIndex,
+			undefined,
+			false
+		);
+	}, [
+		duplicateHeaderIds.length,
+		emptyBodyInsertionIndex,
+		featuredId,
+		hasCover,
+		hasIcon,
+		hasProperties,
+		hasSchema,
+		hasTitle,
+		iconMeta,
+		insertBlocks,
+		isTrashed,
+		ownerBlockName,
+		shouldSeedEmptyBodyBlock,
 	] );
 
 	// useLayoutEffect rather than useEffect: we want the insertion to
@@ -680,7 +866,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 			insertBlocks(
 				createBlock( DOCUMENT_COVER_BLOCK, {
 					align: 'full',
-					lock: { move: true },
+					lock: PROTECTED_HEADER_LOCK,
 				} ),
 				0,
 				undefined,
@@ -696,7 +882,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 			}
 			insertBlocks(
 				createBlock( DOCUMENT_ICON_BLOCK, {
-					lock: { move: true },
+					lock: PROTECTED_HEADER_LOCK,
 				} ),
 				iconIndex,
 				undefined,
@@ -708,7 +894,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 		if ( needsTitle ) {
 			insertBlocks(
 				createBlock( POST_TITLE_BLOCK, {
-					lock: { move: true, remove: true },
+					lock: PROTECTED_HEADER_LOCK,
 				} ),
 				computedTitleIndex,
 				undefined,
@@ -727,7 +913,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 				: titleIndex + ( needsCover ? 1 : 0 ) + ( needsIcon ? 1 : 0 );
 			insertBlocks(
 				createBlock( DOCUMENT_PROPERTIES_BLOCK, {
-					lock: { move: true, remove: true },
+					lock: PROTECTED_HEADER_LOCK,
 				} ),
 				anchorTitleIndex + 1,
 				undefined,
@@ -820,41 +1006,147 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 	return null;
 }
 
-// Hide core's block settings menu while a locked header block is selected.
-// Those menu items do not fit fixed singleton blocks, and core does not expose
-// a per-block filter. The toolbar and iframe live in separate documents, so a
-// body class is the simplest hook for CSS. Mounting this here keeps Canvas and
-// RowEditor on the same path.
+// Hide Core block actions while a protected Cortext block is selected.
+// Duplicate, move, lock, and add actions do not make sense for fixed headers
+// or locked collection body content. The toolbar and iframe live in separate
+// documents, so a body class is the simplest hook.
 function HideHeaderBlockKebab( { postId, postType } ) {
 	const record = useDocumentRecord( postType, postId );
 	const ownerBlockName = getCanvasOwnerBlockNameForRecord( record );
-	const selectedName = useSelect( ( select ) => {
-		const store = select( blockEditorStore );
-		const clientId = store.getSelectedBlockClientId();
-		return clientId ? store.getBlockName( clientId ) : null;
-	}, [] );
+	const isSelectedProtected = useSelect(
+		( select ) => {
+			const store = select( blockEditorStore );
+			const clientId = store.getSelectedBlockClientId();
+			if ( ! clientId ) {
+				return false;
+			}
+			const block = store.getBlock( clientId );
+			return (
+				isHeaderBlock( block, ownerBlockName, record, postId ) ||
+				isCollectionBodyBlock( block, ownerBlockName, record, postId )
+			);
+		},
+		[ ownerBlockName, postId, record ]
+	);
 
 	useEffect( () => {
-		const isHeader =
-			selectedName === DOCUMENT_COVER_BLOCK ||
-			selectedName === DOCUMENT_ICON_BLOCK ||
-			selectedName === DOCUMENT_PROPERTIES_BLOCK ||
-			( !! ownerBlockName && selectedName === ownerBlockName );
 		document.body.classList.toggle(
 			'cortext-hide-block-settings-menu',
-			isHeader
+			isSelectedProtected
 		);
 		return () => {
 			document.body.classList.remove(
 				'cortext-hide-block-settings-menu'
 			);
 		};
-	}, [ ownerBlockName, selectedName ] );
+	}, [ isSelectedProtected ] );
 
 	return null;
 }
 
-function HeaderAwareRootAppender( { ownerBlockName } ) {
+function ProtectedBlockShortcutGuard( { postId, postType, canvasRootRef } ) {
+	const record = useDocumentRecord( postType, postId );
+	const ownerBlockName = getCanvasOwnerBlockNameForRecord( record );
+	const { protectedClientIds, selectedClientIds } = useSelect(
+		( select ) => {
+			const store = select( blockEditorStore );
+			const blocks = store.getBlocks();
+			const protectedIds = [];
+			const selectedIds = store.getSelectedBlockClientIds();
+
+			blocks.forEach( ( block ) => {
+				const isProtected =
+					isHeaderBlock( block, ownerBlockName, record, postId ) ||
+					isCollectionBodyBlock(
+						block,
+						ownerBlockName,
+						record,
+						postId
+					);
+				if ( isProtected ) {
+					protectedIds.push( block.clientId );
+				}
+			} );
+
+			return {
+				protectedClientIds: protectedIds,
+				selectedClientIds: selectedIds,
+			};
+		},
+		[ ownerBlockName, postId, record ]
+	);
+
+	useEffect( () => {
+		const protectedSet = new Set( protectedClientIds );
+		if ( protectedSet.size === 0 ) {
+			return undefined;
+		}
+
+		const getCandidateClientIds = ( event, fallbackClientIds ) => {
+			const eventClientId = selectedClientIdFromEvent( event );
+			return eventClientId ? [ eventClientId ] : fallbackClientIds;
+		};
+		const includesProtected = ( clientIds ) =>
+			clientIds.some( ( clientId ) => protectedSet.has( clientId ) );
+		const stopProtectedShortcut = ( event ) => {
+			event.preventDefault();
+			event.stopPropagation();
+			event.stopImmediatePropagation?.();
+		};
+		const onKeyDown = ( event ) => {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+			if ( isKeyboardEvent.primaryShift( event, 'd' ) ) {
+				const clientIds = getCandidateClientIds(
+					event,
+					selectedClientIds
+				);
+				if ( includesProtected( clientIds ) ) {
+					stopProtectedShortcut( event );
+				}
+				return;
+			}
+			if ( isKeyboardEvent.primaryAlt( event, 't' ) ) {
+				const clientIds = getCandidateClientIds(
+					event,
+					selectedClientIds.slice( 0, 1 )
+				);
+				if ( includesProtected( clientIds ) ) {
+					stopProtectedShortcut( event );
+				}
+				return;
+			}
+			if ( isKeyboardEvent.primaryAlt( event, 'y' ) ) {
+				const clientIds = getCandidateClientIds(
+					event,
+					selectedClientIds.slice( -1 )
+				);
+				if ( includesProtected( clientIds ) ) {
+					stopProtectedShortcut( event );
+				}
+			}
+		};
+
+		const ownerDocument = canvasRootRef?.current?.ownerDocument ?? document;
+		const iframeDocument =
+			canvasRootRef?.current?.querySelector( 'iframe' )
+				?.contentDocument ?? null;
+		const documents = [ ownerDocument, iframeDocument ].filter( Boolean );
+		documents.forEach( ( doc ) =>
+			doc.addEventListener( 'keydown', onKeyDown, true )
+		);
+		return () => {
+			documents.forEach( ( doc ) =>
+				doc.removeEventListener( 'keydown', onKeyDown, true )
+			);
+		};
+	}, [ canvasRootRef, protectedClientIds, selectedClientIds ] );
+
+	return null;
+}
+
+function HeaderAwareRootAppender( { ownerBlockName, postId, record } ) {
 	// tech-debt.md#td-gutenberg-header-boundary: Gutenberg's root appender only treats a fully empty
 	// root list as empty. Cortext's locked header blocks are chrome, so the
 	// body still needs a first-block prompt after them.
@@ -863,7 +1155,7 @@ function HeaderAwareRootAppender( { ownerBlockName } ) {
 			const blocks = select( blockEditorStore ).getBlocks();
 			const headerEndIndex = blocks.reduce(
 				( lastIndex, block, index ) =>
-					isHeaderChromeBlock( block, ownerBlockName )
+					isHeaderChromeBlock( block, ownerBlockName, record, postId )
 						? index
 						: lastIndex,
 				-1
@@ -872,12 +1164,17 @@ function HeaderAwareRootAppender( { ownerBlockName } ) {
 				bodyEmpty:
 					blocks.length > 0 &&
 					blocks.every( ( block ) =>
-						isHeaderChromeBlock( block, ownerBlockName )
+						isHeaderChromeBlock(
+							block,
+							ownerBlockName,
+							record,
+							postId
+						)
 					),
 				insertionIndex: headerEndIndex + 1,
 			};
 		},
-		[ ownerBlockName ]
+		[ ownerBlockName, postId, record ]
 	);
 	const { insertDefaultBlock, startTyping } = useDispatch( blockEditorStore );
 
@@ -1217,11 +1514,11 @@ export default function EditorBody( {
 			return (
 				blocks.length > 0 &&
 				blocks.every( ( block ) =>
-					isHeaderChromeBlock( block, ownerBlockName )
+					isHeaderChromeBlock( block, ownerBlockName, record, postId )
 				)
 			);
 		},
-		[ ownerBlockName ]
+		[ ownerBlockName, postId, record ]
 	);
 	const isReadOnly = isTrashed || isLocked;
 	const renderAppender =
@@ -1229,6 +1526,8 @@ export default function EditorBody( {
 			? () => (
 					<HeaderAwareRootAppender
 						ownerBlockName={ ownerBlockName }
+						postId={ postId }
+						record={ record }
 					/>
 			  )
 			: undefined;
@@ -1247,6 +1546,11 @@ export default function EditorBody( {
 					postType={ postType }
 				/>
 				<HideHeaderBlockKebab postId={ postId } postType={ postType } />
+				<ProtectedBlockShortcutGuard
+					postId={ postId }
+					postType={ postType }
+					canvasRootRef={ blockCanvasRef }
+				/>
 				<HeaderPrefixToolbarGuard
 					isActive={ isActive }
 					isLocked={ isReadOnly }

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -566,6 +566,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 		emptyBodyInsertionIndex,
 		protectedLockRepairs,
 		collectionBodyClientIds,
+		lockedCollectionBodyClientIds,
 		isTrashed,
 	} = useSelect(
 		( select ) => {
@@ -621,6 +622,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 			);
 			const lockRepairs = [];
 			const bodyClientIds = [];
+			const lockedBodyClientIds = [];
 			blocks.forEach( ( block ) => {
 				let desiredLock = null;
 				if (
@@ -638,6 +640,14 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 				) {
 					bodyClientIds.push( block.clientId );
 					desiredLock = COLLECTION_LEGACY_BLOCK_LOCK;
+					if (
+						! lockNeedsRepair(
+							block.attributes?.lock,
+							COLLECTION_LEGACY_BLOCK_LOCK
+						)
+					) {
+						lockedBodyClientIds.push( block.clientId );
+					}
 				}
 				if (
 					desiredLock &&
@@ -687,6 +697,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 					) === 'trash',
 				protectedLockRepairs: lockRepairs,
 				collectionBodyClientIds: bodyClientIds,
+				lockedCollectionBodyClientIds: lockedBodyClientIds,
 			};
 		},
 		[ ownerBlockName, postId, record ]
@@ -710,7 +721,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 	}, [ postId, postType ] );
 
 	useLayoutEffect( () => {
-		if ( isTrashed || isLocked ) {
+		if ( isTrashed ) {
 			return;
 		}
 
@@ -729,7 +740,11 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 			! snapshot.initialized
 		) {
 			snapshot.key = `${ postType }:${ postId }`;
-			snapshot.clientIds = new Set( collectionBodyClientIds );
+			snapshot.clientIds = new Set(
+				lockedCollectionBodyClientIds.length > 0
+					? lockedCollectionBodyClientIds
+					: collectionBodyClientIds
+			);
 			snapshot.initialized = true;
 		}
 
@@ -741,6 +756,10 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 					updateBlockAttributes( clientId, { lock: {} } );
 					removeBlock( clientId, false );
 				} );
+		}
+
+		if ( isLocked ) {
+			return;
 		}
 
 		protectedLockRepairs.forEach( ( { clientId, lock } ) => {
@@ -771,6 +790,7 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 		hasTitle,
 		isLocked,
 		isTrashed,
+		lockedCollectionBodyClientIds,
 		ownerBlockName,
 		propertiesClientId,
 		propertiesContextStable,

--- a/src/components/initEditor.js
+++ b/src/components/initEditor.js
@@ -24,9 +24,10 @@ import './initInserterMediaCategories';
 // Side-effect import: float Cortext blocks to the top of the slash inserter.
 import './prioritizeCortextInserterBlocks';
 
-// `core/post-title` is insertable by default. Cortext owns title placement
-// through EnsureHeaderBlocks, so users should not see the block in the
-// inserter. Flip the support before `registerCoreBlocks` reads it.
+// Core exposes `core/post-title` in the inserter and block actions by default.
+// Cortext owns title placement through EnsureHeaderBlocks, so users shouldn't
+// insert another title, duplicate it, or unlock its fixed position. Adjust the
+// supports before `registerCoreBlocks` reads them.
 // Keep it in `ALLOWED_BLOCK_TYPES`: `insertBlocks` checks that list before it
 // inserts the locked header. The `cortext/document-*` blocks use the same
 // hidden-from-inserter pattern in block.json.
@@ -42,6 +43,8 @@ addFilter(
 			supports: {
 				...settings.supports,
 				inserter: false,
+				lock: false,
+				multiple: false,
 			},
 		};
 	}

--- a/src/styles/global/_shell-root.scss
+++ b/src/styles/global/_shell-root.scss
@@ -303,16 +303,16 @@ body:has(.cortext-canvas__identity-actions:hover) .cortext-canvas__identity-acti
 }
 /* stylelint-enable no-descending-specificity */
 
-// Hide the block kebab (more options) while a Cortext header block is
-// selected. The body class is toggled by HideHeaderBlockKebab in
-// Canvas.js. The long comment there explains why a JS hook beats CSS
-// :has() here. We hide several adjacent wrappers because core's toolbar
-// keeps a placeholder slot around the kebab even when it's empty.
+// Hide Core actions while a protected Cortext block is selected. Hide adjacent
+// wrappers too, because Core leaves empty toolbar slots around missing
+// controls.
 body.cortext-hide-block-settings-menu .block-editor-block-settings-menu,
 body.cortext-hide-block-settings-menu .block-editor-block-toolbar > .block-editor-block-settings-menu,
 body.cortext-hide-block-settings-menu .components-toolbar-group:has(> .block-editor-block-settings-menu),
 body.cortext-hide-block-settings-menu .block-editor-block-toolbar__group-collapsible-toolbar,
-body.cortext-hide-block-settings-menu .block-editor-block-switcher {
+body.cortext-hide-block-settings-menu .block-editor-block-switcher,
+body.cortext-hide-block-settings-menu .block-editor-block-lock-toolbar,
+body.cortext-hide-block-settings-menu .block-editor-block-mover {
 	display: none;
 }
 

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -45,25 +45,70 @@ function markAlphaNoticeSeen( storageStatePath, origin ) {
 	);
 }
 
-function runWpCli( args, options = {} ) {
-	const projectRoot = path.resolve( __dirname, '../..' );
+const projectRoot = path.resolve( __dirname, '../..' );
+
+function readWpEnvPort( configPath ) {
+	try {
+		const resolvedPath = path.resolve( projectRoot, configPath );
+		const config = JSON.parse( fs.readFileSync( resolvedPath, 'utf8' ) );
+		return config.port ? Number( config.port ) : null;
+	} catch {
+		return null;
+	}
+}
+
+function baseUrlPort( baseURL ) {
+	try {
+		const { port, protocol } = new URL( baseURL );
+		if ( port ) {
+			return Number( port );
+		}
+		return protocol === 'https:' ? 443 : 80;
+	} catch {
+		return null;
+	}
+}
+
+function resolveWpEnvConfig( baseURL ) {
+	if ( process.env.WP_ENV_CONFIG ) {
+		return process.env.WP_ENV_CONFIG;
+	}
+
+	const port = baseUrlPort( baseURL );
+	if ( port && port === readWpEnvPort( '.wp-env.test.json' ) ) {
+		return '.wp-env.test.json';
+	}
+
+	if ( port && port === readWpEnvPort( '.wp-env.override.json' ) ) {
+		return null;
+	}
+
+	if ( port && port === readWpEnvPort( '.wp-env.json' ) ) {
+		return null;
+	}
+
+	return false;
+}
+
+function runWpCli( args, wpEnvConfig, options = {} ) {
 	const wpEnvBin = path.join(
 		projectRoot,
 		'node_modules',
 		'.bin',
 		process.platform === 'win32' ? 'wp-env.cmd' : 'wp-env'
 	);
+	const configArgs = wpEnvConfig ? [ '--config', wpEnvConfig ] : [];
 
-	execFileSync( wpEnvBin, [ 'run', 'cli', 'wp', ...args ], {
+	execFileSync( wpEnvBin, [ ...configArgs, 'run', 'cli', 'wp', ...args ], {
 		cwd: projectRoot,
 		stdio: 'inherit',
 		...options,
 	} );
 }
 
-function deactivateLocalAutologin() {
+function deactivateLocalAutologin( wpEnvConfig ) {
 	try {
-		runWpCli( [ 'plugin', 'deactivate', 'dev-autologin' ], {
+		runWpCli( [ 'plugin', 'deactivate', 'dev-autologin' ], wpEnvConfig, {
 			stdio: 'ignore',
 		} );
 	} catch {
@@ -71,8 +116,8 @@ function deactivateLocalAutologin() {
 	}
 }
 
-function flushRewriteRules() {
-	runWpCli( [ 'rewrite', 'flush' ] );
+function flushRewriteRules( wpEnvConfig ) {
+	runWpCli( [ 'rewrite', 'flush' ], wpEnvConfig );
 }
 
 /**
@@ -81,10 +126,14 @@ function flushRewriteRules() {
  */
 async function globalSetup( config ) {
 	await baseGlobalSetup( config );
-	deactivateLocalAutologin();
-	flushRewriteRules();
-
 	const { storageState, baseURL } = config.projects[ 0 ].use;
+
+	const wpEnvConfig = resolveWpEnvConfig( baseURL );
+	if ( wpEnvConfig !== false ) {
+		deactivateLocalAutologin( wpEnvConfig );
+		flushRewriteRules( wpEnvConfig );
+	}
+
 	if ( typeof storageState !== 'string' || ! baseURL ) {
 		return;
 	}

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,4 +1,6 @@
 const fs = require( 'fs' );
+const path = require( 'path' );
+const { execFileSync } = require( 'child_process' );
 
 const baseGlobalSetup = require( '@wordpress/scripts/config/playwright/global-setup.js' );
 
@@ -43,12 +45,44 @@ function markAlphaNoticeSeen( storageStatePath, origin ) {
 	);
 }
 
+function runWpCli( args, options = {} ) {
+	const projectRoot = path.resolve( __dirname, '../..' );
+	const wpEnvBin = path.join(
+		projectRoot,
+		'node_modules',
+		'.bin',
+		process.platform === 'win32' ? 'wp-env.cmd' : 'wp-env'
+	);
+
+	execFileSync( wpEnvBin, [ 'run', 'cli', 'wp', ...args ], {
+		cwd: projectRoot,
+		stdio: 'inherit',
+		...options,
+	} );
+}
+
+function deactivateLocalAutologin() {
+	try {
+		runWpCli( [ 'plugin', 'deactivate', 'dev-autologin' ], {
+			stdio: 'ignore',
+		} );
+	} catch {
+		// The local dev-autologin plugin only exists in some wp-env overrides.
+	}
+}
+
+function flushRewriteRules() {
+	runWpCli( [ 'rewrite', 'flush' ] );
+}
+
 /**
  * @param {import('@playwright/test').FullConfig} config
  * @return {Promise<void>}
  */
 async function globalSetup( config ) {
 	await baseGlobalSetup( config );
+	deactivateLocalAutologin();
+	flushRewriteRules();
 
 	const { storageState, baseURL } = config.projects[ 0 ].use;
 	if ( typeof storageState !== 'string' || ! baseURL ) {

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -62,83 +62,6 @@ function tableFooterDataCells( footer ) {
 	return footer.locator( TABLE_FOOTER_DATA_CELL_SELECTOR );
 }
 
-async function expectSidePeekCoversPageInspector( page ) {
-	await expect
-		.poll( async () =>
-			page.evaluate( () => {
-				const inspector = document.querySelector(
-					'.cortext-shell__canvas .cortext-workspace__pane[data-active="true"] .interface-interface-skeleton__sidebar'
-				);
-				const peek = document.querySelector(
-					'.cortext-row-detail-sidebar-shell:not(.cortext-row-detail-sidebar-shell--closing)'
-				);
-
-				if ( ! inspector || ! peek ) {
-					return false;
-				}
-
-				const inspectorRect = inspector.getBoundingClientRect();
-				const peekRect = peek.getBoundingClientRect();
-				const overlapLeft = Math.max(
-					inspectorRect.left,
-					peekRect.left
-				);
-				const overlapRight = Math.min(
-					inspectorRect.right,
-					peekRect.right
-				);
-				const overlapTop = Math.max( inspectorRect.top, peekRect.top );
-				const overlapBottom = Math.min(
-					inspectorRect.bottom,
-					peekRect.bottom
-				);
-
-				if (
-					overlapRight <= overlapLeft ||
-					overlapBottom <= overlapTop
-				) {
-					return false;
-				}
-
-				const topElement = document.elementFromPoint(
-					( overlapLeft + overlapRight ) / 2,
-					( overlapTop + overlapBottom ) / 2
-				);
-				return Boolean(
-					topElement?.closest( '.cortext-row-detail-sidebar-shell' )
-				);
-			} )
-		)
-		.toBe( true );
-}
-
-async function expectPageInspectorIsTopmost( page ) {
-	await expect
-		.poll( async () =>
-			page.evaluate( () => {
-				const inspector = document.querySelector(
-					'.cortext-shell__canvas .cortext-workspace__pane[data-active="true"] .interface-interface-skeleton__sidebar'
-				);
-
-				if ( ! inspector ) {
-					return false;
-				}
-
-				const rect = inspector.getBoundingClientRect();
-				const topElement = document.elementFromPoint(
-					( rect.left + rect.right ) / 2,
-					( rect.top + rect.bottom ) / 2
-				);
-				return Boolean(
-					topElement?.closest(
-						'.interface-interface-skeleton__sidebar'
-					)
-				);
-			} )
-		)
-		.toBe( true );
-}
-
 async function startSidePeekShellStabilityLog( page ) {
 	await page.evaluate( () => {
 		window.__cortextSidePeekShellEvents = [];
@@ -698,7 +621,7 @@ test.describe( 'Collection view block', () => {
 								type: layout,
 								fields: [ 'title' ],
 								sort: {
-									field: 'created_at',
+									field: 'title',
 									direction: 'asc',
 								},
 							}
@@ -813,7 +736,7 @@ test.describe( 'Collection view block', () => {
 								view: {
 									...block.attributes.view,
 									sort: {
-										field: 'created_at',
+										field: 'title',
 										direction: 'asc',
 									},
 								},
@@ -831,8 +754,8 @@ test.describe( 'Collection view block', () => {
 						.toEqual( [
 							expect.stringContaining( 'Alpha Manual' ),
 							expect.stringContaining( 'Beta Manual' ),
-							expect.stringContaining( 'Gamma Manual' ),
 							expect.stringContaining( 'Delta Manual' ),
+							expect.stringContaining( 'Gamma Manual' ),
 						] );
 
 					await dragRenderedRow(
@@ -874,8 +797,8 @@ test.describe( 'Collection view block', () => {
 						.toEqual( [
 							expect.stringContaining( 'Alpha Manual' ),
 							expect.stringContaining( 'Beta Manual' ),
-							expect.stringContaining( 'Gamma Manual' ),
 							expect.stringContaining( 'Delta Manual' ),
+							expect.stringContaining( 'Gamma Manual' ),
 						] );
 				}
 			} finally {
@@ -2347,7 +2270,7 @@ test.describe( 'Collection view block', () => {
 		}
 	} );
 
-	test( 'shows the default body prompt below row properties when the row body is empty', async ( {
+	test( 'seeds the first empty row body block below row properties', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -2405,29 +2328,33 @@ test.describe( 'Collection view block', () => {
 			const propertiesSlot = detailCanvas.locator(
 				'.cortext-document-properties'
 			);
-			const prompt = detailCanvas.locator(
-				'.block-editor-default-block-appender.has-visible-prompt .block-editor-default-block-appender__content'
+			const bodyParagraph = detailCanvas
+				.locator( '[data-type="core/paragraph"]' )
+				.first();
+			const appender = detailCanvas.locator(
+				'.block-editor-default-block-appender.has-visible-prompt'
 			);
 
 			await expect( propertiesSlot ).toBeVisible();
-			await expect( prompt ).toContainText( 'Type / to choose a block' );
+			await expect( bodyParagraph ).toBeVisible();
+			await expect( appender ).toHaveCount( 0 );
 			await expect
 				.poll( async () => {
-					const [ propertiesBox, promptBox ] = await Promise.all( [
+					const [ propertiesBox, paragraphBox ] = await Promise.all( [
 						propertiesSlot.boundingBox(),
-						prompt.boundingBox(),
+						bodyParagraph.boundingBox(),
 					] );
-					if ( ! propertiesBox || ! promptBox ) {
+					if ( ! propertiesBox || ! paragraphBox ) {
 						return false;
 					}
 					return (
-						promptBox.y >=
+						paragraphBox.y >=
 						propertiesBox.y + propertiesBox.height - 2
 					);
 				} )
 				.toBe( true );
 
-			await prompt.click();
+			await bodyParagraph.click();
 			await expect(
 				detailCanvas.locator( '[data-type="core/paragraph"]' )
 			).toHaveCount( 1 );

--- a/tests/e2e/specs/editor-header-blocks.spec.js
+++ b/tests/e2e/specs/editor-header-blocks.spec.js
@@ -18,6 +18,8 @@ const EXPECTED_HEADER_PREFIX = [ DOCUMENT_ICON_BLOCK, POST_TITLE_BLOCK ];
 const BODY_A = 'Header guard body A';
 const BODY_B = 'Header guard body B';
 const INSERTED_BODY = 'Header guard inserted at zero';
+const COLLECTION_LEGACY_BODY = 'Collection legacy body block';
+const COLLECTION_BLOCKED_BODY = 'Collection blocked new body';
 const DOCUMENT_ICON_META = JSON.stringify( { type: 'emoji', value: 'P' } );
 const DISABLE_HEADER_BOUNDARY_MOVE_UP_CLASS =
 	'cortext-disable-header-boundary-move-up';
@@ -52,6 +54,10 @@ function bodyMarkup() {
 		`<!-- wp:paragraph --><p>${ BODY_A }</p><!-- /wp:paragraph -->`,
 		`<!-- wp:paragraph --><p>${ BODY_B }</p><!-- /wp:paragraph -->`,
 	].join( '\n\n' );
+}
+
+function paragraphMarkup( text ) {
+	return `<!-- wp:paragraph --><p>${ text }</p><!-- /wp:paragraph -->`;
 }
 
 async function readHeaderState( page ) {
@@ -214,6 +220,98 @@ async function selectParagraph( page, content ) {
 	}, content );
 }
 
+async function selectFirstBlockByName( page, blockName ) {
+	await page.evaluate( ( name ) => {
+		const block = window.wp.data
+			.select( 'core/block-editor' )
+			.getBlocks()
+			.find( ( candidate ) => candidate.name === name );
+		if ( ! block ) {
+			throw new Error( `Block not found: ${ name }` );
+		}
+		window.wp.data
+			.dispatch( 'core/block-editor' )
+			.selectBlock( block.clientId );
+	}, blockName );
+}
+
+async function readCollectionBodyState( page, collectionId ) {
+	return page.evaluate(
+		( { blockedText, legacyText, postId } ) => {
+			const getParagraphText = ( block ) => {
+				const content = block.attributes?.content ?? '';
+				if ( typeof content?.text === 'string' ) {
+					return content.text;
+				}
+				const element = document.createElement( 'div' );
+				element.innerHTML = String( content );
+				return element.textContent || String( content );
+			};
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+			const ownerBlocks = blocks.filter(
+				( block ) =>
+					block.name === 'cortext/data-view' &&
+					Number( block.attributes?.collectionId ) ===
+						Number( postId )
+			);
+			const legacyBlock = blocks.find(
+				( block ) =>
+					block.name === 'core/paragraph' &&
+					getParagraphText( block ) === legacyText
+			);
+			return {
+				blockedCount: blocks.filter(
+					( block ) =>
+						block.name === 'core/paragraph' &&
+						getParagraphText( block ) === blockedText
+				).length,
+				legacyLock: legacyBlock?.attributes?.lock ?? null,
+				legacyPresent: Boolean( legacyBlock ),
+				ownerCount: ownerBlocks.length,
+			};
+		},
+		{
+			blockedText: COLLECTION_BLOCKED_BODY,
+			legacyText: COLLECTION_LEGACY_BODY,
+			postId: collectionId,
+		}
+	);
+}
+
+async function attemptCollectionBodyMutations( page, collectionId ) {
+	await page.evaluate(
+		( { blockedText, postId } ) => {
+			const select = window.wp.data.select( 'core/block-editor' );
+			const dispatch = window.wp.data.dispatch( 'core/block-editor' );
+			const blocks = select.getBlocks();
+			const ownerBlock = blocks.find(
+				( block ) =>
+					block.name === 'cortext/data-view' &&
+					Number( block.attributes?.collectionId ) ===
+						Number( postId )
+			);
+			if ( ! ownerBlock ) {
+				throw new Error( 'Owner data-view block not found.' );
+			}
+			dispatch.selectBlock( ownerBlock.clientId );
+			dispatch.duplicateBlocks( [ ownerBlock.clientId ], false );
+			dispatch.insertBeforeBlock( ownerBlock.clientId );
+			dispatch.insertAfterBlock( ownerBlock.clientId );
+			dispatch.insertBlocks(
+				window.wp.blocks.createBlock( 'core/paragraph', {
+					content: blockedText,
+				} ),
+				blocks.length,
+				undefined,
+				false
+			);
+		},
+		{ blockedText: COLLECTION_BLOCKED_BODY, postId: collectionId }
+	);
+}
+
 async function expectMoveUpToolbarState( page, content, shouldBeEnabled ) {
 	await selectParagraph( page, content );
 	await expect
@@ -329,7 +427,10 @@ async function exerciseHeaderGuard( page ) {
 	await expectInsertionPointAllowedAfterHeader( page );
 }
 
-async function createRowFixture( requestUtils ) {
+async function createRowFixture(
+	requestUtils,
+	{ content = bodyMarkup(), withField = false } = {}
+) {
 	const suffix = Date.now().toString( 36 ).slice( -4 );
 	const collection = await requestUtils.rest( {
 		method: 'POST',
@@ -337,8 +438,28 @@ async function createRowFixture( requestUtils ) {
 		data: {
 			title: `E2E Header Collection ${ suffix }`,
 			status: 'private',
+			cortext_collection: true,
 		},
 	} );
+	let field = null;
+	if ( withField ) {
+		field = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/crtxt_fields',
+			data: {
+				title: `E2E Header Field ${ suffix }`,
+				status: 'private',
+				meta: { type: 'text' },
+			},
+		} );
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/crtxt_documents/${ collection.id }`,
+			data: {
+				meta: { cortext_fields: [ String( field.id ) ] },
+			},
+		} );
+	}
 	const row = await requestUtils.rest( {
 		method: 'POST',
 		path: '/wp/v2/crtxt_documents',
@@ -346,11 +467,11 @@ async function createRowFixture( requestUtils ) {
 			title: `E2E Header Row ${ suffix }`,
 			status: 'private',
 			cortext_trait: collection.id,
-			content: bodyMarkup(),
+			content,
 			meta: { cortext_document_icon: DOCUMENT_ICON_META },
 		},
 	} );
-	return { collection, row };
+	return { collection, field, row };
 }
 
 test.describe( 'editor header blocks', () => {
@@ -386,6 +507,86 @@ test.describe( 'editor header blocks', () => {
 		}
 	} );
 
+	test( 'adds the first empty body block after page and row headers', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let createdPage;
+		let fixture;
+		try {
+			createdPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: 'E2E Empty Body Page',
+					status: 'private',
+					content: '',
+					meta: { cortext_document_icon: DOCUMENT_ICON_META },
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ createdPage.id }`
+			);
+			await waitForEditorPost( page, createdPage.id );
+			await expectHeaderPrefix( page );
+			const editorCanvas = page.frameLocator(
+				'iframe[name="editor-canvas"]'
+			);
+
+			await selectFirstBlockByName( page, DOCUMENT_ICON_BLOCK );
+			await expect(
+				editorCanvas.getByRole( 'button', {
+					name: 'Add block after',
+				} )
+			).toHaveCount( 0 );
+
+			await selectFirstBlockByName( page, POST_TITLE_BLOCK );
+			await expect(
+				editorCanvas.getByRole( 'button', {
+					name: 'Add block after',
+				} )
+			).toHaveCount( 0 );
+			await expectParagraphsAfterTitle( page, [ '' ] );
+
+			fixture = await createRowFixture( requestUtils, {
+				content: '',
+				withField: true,
+			} );
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ fixture.row.id }`
+			);
+			await waitForEditorPost( page, fixture.row.id );
+			await expectParagraphsAfterTitle( page, [ '' ] );
+			await selectFirstBlockByName( page, DOCUMENT_PROPERTIES_BLOCK );
+			await expect(
+				editorCanvas.getByRole( 'button', {
+					name: 'Add block after',
+				} )
+			).toHaveCount( 0 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				createdPage && `/wp/v2/crtxt_documents/${ createdPage.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture && `/wp/v2/crtxt_documents/${ fixture.row.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture && `/wp/v2/crtxt_documents/${ fixture.collection.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture?.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+		}
+	} );
+
 	test( 'keeps row body blocks below the locked header prefix', async ( {
 		admin,
 		page,
@@ -409,6 +610,72 @@ test.describe( 'editor header blocks', () => {
 			await deleteIfCreated(
 				requestUtils,
 				fixture && `/wp/v2/crtxt_documents/${ fixture.collection.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture?.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+		}
+	} );
+
+	test( 'keeps legacy collection body blocks locked and removes new ones', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let collection;
+		try {
+			collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: 'E2E Collection With Legacy Body',
+					status: 'private',
+					cortext_collection: true,
+					content: paragraphMarkup( COLLECTION_LEGACY_BODY ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ collection.id }`
+			);
+			await waitForEditorPost( page, collection.id );
+			const editorCanvas = page.frameLocator(
+				'iframe[name="editor-canvas"]'
+			);
+			await expect
+				.poll( () => readCollectionBodyState( page, collection.id ) )
+				.toMatchObject( {
+					blockedCount: 0,
+					legacyLock: {
+						edit: true,
+						move: true,
+						remove: true,
+					},
+					legacyPresent: true,
+					ownerCount: 1,
+				} );
+
+			await attemptCollectionBodyMutations( page, collection.id );
+
+			await expect
+				.poll( () => readCollectionBodyState( page, collection.id ) )
+				.toMatchObject( {
+					blockedCount: 0,
+					legacyPresent: true,
+					ownerCount: 1,
+				} );
+			await selectFirstBlockByName( page, POST_TITLE_BLOCK );
+			await expect(
+				editorCanvas.getByRole( 'button', {
+					name: 'Add block after',
+				} )
+			).toHaveCount( 0 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				collection && `/wp/v2/crtxt_documents/${ collection.id }`
 			);
 		}
 	} );

--- a/tests/e2e/specs/editor-header-blocks.spec.js
+++ b/tests/e2e/specs/editor-header-blocks.spec.js
@@ -280,6 +280,14 @@ async function readCollectionBodyState( page, collectionId ) {
 	);
 }
 
+async function expectCollectionBodyState( page, collectionId, expected ) {
+	await expect
+		.poll( () => readCollectionBodyState( page, collectionId ), {
+			timeout: 15_000,
+		} )
+		.toMatchObject( expected );
+}
+
 async function attemptCollectionBodyMutations( page, collectionId ) {
 	await page.evaluate(
 		( { blockedText, postId } ) => {
@@ -644,28 +652,24 @@ test.describe( 'editor header blocks', () => {
 			const editorCanvas = page.frameLocator(
 				'iframe[name="editor-canvas"]'
 			);
-			await expect
-				.poll( () => readCollectionBodyState( page, collection.id ) )
-				.toMatchObject( {
-					blockedCount: 0,
-					legacyLock: {
-						edit: true,
-						move: true,
-						remove: true,
-					},
-					legacyPresent: true,
-					ownerCount: 1,
-				} );
+			await expectCollectionBodyState( page, collection.id, {
+				blockedCount: 0,
+				legacyLock: {
+					edit: true,
+					move: true,
+					remove: true,
+				},
+				legacyPresent: true,
+				ownerCount: 1,
+			} );
 
 			await attemptCollectionBodyMutations( page, collection.id );
 
-			await expect
-				.poll( () => readCollectionBodyState( page, collection.id ) )
-				.toMatchObject( {
-					blockedCount: 0,
-					legacyPresent: true,
-					ownerCount: 1,
-				} );
+			await expectCollectionBodyState( page, collection.id, {
+				blockedCount: 0,
+				legacyPresent: true,
+				ownerCount: 1,
+			} );
 			await selectFirstBlockByName( page, POST_TITLE_BLOCK );
 			await expect(
 				editorCanvas.getByRole( 'button', {
@@ -673,6 +677,74 @@ test.describe( 'editor header blocks', () => {
 				} )
 			).toHaveCount( 0 );
 		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				collection && `/wp/v2/crtxt_documents/${ collection.id }`
+			);
+		}
+	} );
+
+	test( 'preserves legacy collection body blocks after switching documents', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const sourceTitle = `E2E Switch Source ${ suffix }`;
+		const collectionTitle = `E2E Switch Collection ${ suffix }`;
+		let sourcePage;
+		let collection;
+		try {
+			sourcePage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: sourceTitle,
+					status: 'private',
+					content: bodyMarkup(),
+				},
+			} );
+			collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: collectionTitle,
+					status: 'private',
+					cortext_collection: true,
+					content: paragraphMarkup( COLLECTION_LEGACY_BODY ),
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ sourcePage.id }`
+			);
+			await waitForEditorPost( page, sourcePage.id );
+			await expectParagraphsAfterTitle( page, [ BODY_A, BODY_B ] );
+
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: collectionTitle,
+					exact: true,
+				} )
+				.click();
+			await waitForEditorPost( page, collection.id );
+			await expectCollectionBodyState( page, collection.id, {
+				blockedCount: 0,
+				legacyLock: {
+					edit: true,
+					move: true,
+					remove: true,
+				},
+				legacyPresent: true,
+				ownerCount: 1,
+			} );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				sourcePage && `/wp/v2/crtxt_documents/${ sourcePage.id }`
+			);
 			await deleteIfCreated(
 				requestUtils,
 				collection && `/wp/v2/crtxt_documents/${ collection.id }`

--- a/tests/e2e/specs/public-page.spec.js
+++ b/tests/e2e/specs/public-page.spec.js
@@ -7,7 +7,10 @@
 
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-const { withExpectedConsoleError } = require( '../utils' );
+const {
+	clearWordPressAuthCookies,
+	withExpectedConsoleError,
+} = require( '../utils' );
 
 async function deleteIfCreated( requestUtils, path ) {
 	if ( ! path ) {
@@ -157,8 +160,7 @@ test.describe( 'Public page rendering', () => {
 				},
 			} );
 
-			await page.context().clearCookies( { name: /^wordpress_/ } );
-
+			await clearWordPressAuthCookies( page.context() );
 			const response = await page.goto(
 				`/cortext/${ createdPage.slug }/`
 			);
@@ -412,10 +414,7 @@ test.describe( 'Public page rendering', () => {
 						},
 					} );
 
-					await page
-						.context()
-						.clearCookies( { name: /^wordpress_/ } );
-
+					await clearWordPressAuthCookies( page.context() );
 					const response = await page.goto(
 						`/cortext/${ createdPage.slug }/`
 					);

--- a/tests/e2e/specs/shell.spec.js
+++ b/tests/e2e/specs/shell.spec.js
@@ -10,7 +10,10 @@
 
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-const { withExpectedConsoleError } = require( '../utils' );
+const {
+	clearWordPressAuthCookies,
+	withExpectedConsoleError,
+} = require( '../utils' );
 
 const SHELL_PATH = '/wp-admin/admin.php?page=cortext';
 
@@ -34,10 +37,7 @@ test.describe( 'Cortext shell', () => {
 	} );
 
 	test( 'anonymous visitor is redirected to login', async ( { page } ) => {
-		// Keep Playground's `playground_auto_login_already_happened` cookie
-		// intact so the `--login` mu-plugin doesn't silently log us back in
-		// as admin when WP auth cookies are cleared.
-		await page.context().clearCookies( { name: /^wordpress_/ } );
+		await clearWordPressAuthCookies( page.context() );
 
 		await page.goto( SHELL_PATH );
 
@@ -48,9 +48,11 @@ test.describe( 'Cortext shell', () => {
 		page,
 		requestUtils,
 	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -5 );
+		const username = `cortext-subscriber-${ suffix }`;
 		const user = await requestUtils.createUser( {
-			username: 'cortext-subscriber',
-			email: 'cortext-subscriber@example.test',
+			username,
+			email: `${ username }@example.test`,
 			password: 'cortext-sub-password',
 			roles: [ 'subscriber' ],
 		} );
@@ -59,17 +61,11 @@ test.describe( 'Cortext shell', () => {
 			/the server responded with a status of 403/,
 			async () => {
 				try {
-					// Keep Playground's `playground_auto_login_already_happened` cookie
-					// intact so the `--login` mu-plugin doesn't silently log us back in
-					// as admin when WP auth cookies are cleared.
-					await page
-						.context()
-						.clearCookies( { name: /^wordpress_/ } );
-
+					await clearWordPressAuthCookies( page.context() );
 					await page.request.post( '/wp-login.php', {
 						failOnStatusCode: true,
 						form: {
-							log: 'cortext-subscriber',
+							log: username,
 							pwd: 'cortext-sub-password',
 						},
 					} );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -26,4 +26,16 @@ async function withExpectedConsoleError( expectedPattern, testFn ) {
 	}
 }
 
-module.exports = { withExpectedConsoleError };
+async function clearWordPressAuthCookies( context ) {
+	const cookies = await context.cookies();
+	const preserved = cookies.filter(
+		( cookie ) => ! cookie.name.startsWith( 'wordpress_' )
+	);
+
+	await context.clearCookies();
+	if ( preserved.length > 0 ) {
+		await context.addCookies( preserved );
+	}
+}
+
+module.exports = { clearWordPressAuthCookies, withExpectedConsoleError };

--- a/tests/js/components/DataViewRowReorder.test.js
+++ b/tests/js/components/DataViewRowReorder.test.js
@@ -1133,7 +1133,10 @@ describe( 'DataViewRowReorder', () => {
 			type: 'table',
 			sort: { field: 'title', direction: 'asc' },
 		};
-		const { onChangeView, mutateRows } = await renderReorder( { view } );
+		const { onChangeView, mutateRows, onReordered, rerender } =
+			await renderReorder( {
+				view,
+			} );
 
 		dragEnd( 3, gapDrop( 0, 1, null ) );
 
@@ -1172,9 +1175,13 @@ describe( 'DataViewRowReorder', () => {
 			request.resolve( { reseeded: false } );
 			await request.promise;
 		} );
-		// Server confirms; we don't need a second `onChangeView` because the
-		// sort was already cleared at commit time.
+		// Server confirms before the parent has applied the cleared sort, so
+		// the rows are not refreshed under the stale title sort.
 		expect( onChangeView ).toHaveBeenCalledTimes( 1 );
+		expect( onReordered ).not.toHaveBeenCalled();
+
+		rerender( { view: { type: 'table', sort: null } } );
+		await waitFor( () => expect( onReordered ).toHaveBeenCalledTimes( 1 ) );
 	} );
 
 	it( 'skips confirmation when there is no current sort', async () => {

--- a/tests/js/initEditor.test.js
+++ b/tests/js/initEditor.test.js
@@ -29,6 +29,7 @@ import {
 	COLLECTIONS_BLOCK_CATEGORY,
 	getEditorSettings,
 } from '../../src/components/initEditor';
+import { applyFilters } from '@wordpress/hooks';
 
 beforeEach( () => {
 	delete window.cortextEditorSettings;
@@ -171,6 +172,33 @@ describe( 'ALLOWED_BLOCK_TYPES', () => {
 		expect( new Set( ALLOWED_BLOCK_TYPES ).size ).toBe(
 			ALLOWED_BLOCK_TYPES.length
 		);
+	} );
+} );
+
+describe( 'core/post-title registration filter', () => {
+	it( 'keeps the title available to Cortext but out of user actions', () => {
+		const settings = applyFilters(
+			'blocks.registerBlockType',
+			{ supports: { html: false } },
+			'core/post-title'
+		);
+
+		expect( settings.supports ).toMatchObject( {
+			html: false,
+			inserter: false,
+			lock: false,
+			multiple: false,
+		} );
+	} );
+
+	it( 'leaves other block supports alone', () => {
+		const settings = applyFilters(
+			'blocks.registerBlockType',
+			{ supports: { multiple: true } },
+			'core/paragraph'
+		);
+
+		expect( settings.supports ).toEqual( { multiple: true } );
 	} );
 } );
 

--- a/tests/php/test-document-identity.php
+++ b/tests/php/test-document-identity.php
@@ -29,6 +29,20 @@ final class Test_Document_Identity extends BaseTestCase {
 		$this->assertSame( 1, substr_count( $markup, '<!-- wp:post-title' ) );
 	}
 
+	public function test_header_blocks_markup_locks_title_move_and_remove(): void {
+		$blocks = parse_blocks( DocumentIdentity::header_blocks_markup() );
+
+		$this->assertCount( 1, $blocks );
+		$this->assertSame( 'core/post-title', $blocks[0]['blockName'] );
+		$this->assertSame(
+			array(
+				'move'   => true,
+				'remove' => true,
+			),
+			$blocks[0]['attrs']['lock'] ?? null
+		);
+	}
+
 	public function test_prepend_header_blocks_leaves_updates_untouched(): void {
 		$identity = new DocumentIdentity();
 		$content  = '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->';

--- a/tests/php/test-post-type-document.php
+++ b/tests/php/test-post-type-document.php
@@ -382,6 +382,21 @@ final class Test_Post_Type_Document extends BaseTestCase {
 		$this->assertStringContainsString( '"collectionId":' . $collection_id, wp_unslash( (string) $collection->post_content ) );
 	}
 
+	public function test_data_view_owner_markup_locks_move_and_remove(): void {
+		$blocks = parse_blocks( Document::build_data_view_block_markup( 123 ) );
+
+		$this->assertCount( 1, $blocks );
+		$this->assertSame( 'cortext/data-view', $blocks[0]['blockName'] );
+		$this->assertSame( 123, $blocks[0]['attrs']['collectionId'] ?? null );
+		$this->assertSame(
+			array(
+				'move'   => true,
+				'remove' => true,
+			),
+			$blocks[0]['attrs']['lock'] ?? null
+		);
+	}
+
 	public function test_seed_data_view_block_is_idempotent(): void {
 		// Pre-stamp the canvas with the canonical (unslashed) markup so the
 		// idempotency check matches even under WorDBless's storage quirk


### PR DESCRIPTION
## What

Related to #85.

Cortext-owned blocks now behave like document chrome instead of regular content. Users cannot duplicate, move, unlock, delete, or insert around the title, icon, cover, properties block, or collection owner view through Core block actions.

Full-page collections cannot get new body blocks anymore. If a collection already had body blocks saved from before, we leave them visible so we do not lose content, but they are read-only. Empty pages and rows still get a normal blank paragraph after the header, so writing starts in the right place without showing a stray `+` under the title or properties.

## Why

These blocks define the shape of the document. If Core actions can move or duplicate them, the editor can end up with broken headers or unsupported content inside collection pages.

## How

- Repair old lock attributes on load.
- Keep existing collection body blocks visible but locked.
- Remove new collection body blocks created through add, duplicate, shortcuts, or programmatic inserts.
- Add a blank paragraph after page and row headers when there is no body content yet.

## Testing Instructions

1. Open an empty page with a title and icon. Confirm a blank paragraph appears after the title and there is no standalone `+` under the header.
2. Select the title, icon, cover, and properties blocks. Confirm duplicate, add before, add after, move, lock, and delete are not available.
3. Open an empty row with properties. Confirm the blank body block appears after properties, with no standalone `+`.
4. Open a full-page collection with existing body content. Confirm that content renders but cannot be edited, moved, deleted, or duplicated.
5. Try adding or duplicating blocks in that collection from toolbar, list view, and keyboard shortcuts. Confirm no new body block remains.

## Screen recording

https://github.com/user-attachments/assets/d24e9ffa-10b0-4273-9cb9-a423b220afc3


