### PR TITLE
Hide publishing and WordPress controls in desktop mode

### DIFF
--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -16,6 +16,7 @@ declare( strict_types=1 );
 namespace Cortext\Admin;
 
 use Cortext\PostType\Document;
+use Cortext\Runtime\Features;
 use Cortext\Theming\Preferences;
 
 final class Screen {
@@ -97,6 +98,7 @@ final class Screen {
 			'window.cortextSettings = ' . wp_json_encode(
 				array(
 					'adminUrl'        => admin_url(),
+					'features'        => ( new Features() )->to_client_settings(),
 					'menuSlug'        => self::MENU_SLUG,
 					'userDisplayName' => wp_get_current_user()->display_name,
 				)

--- a/includes/Runtime/Features.php
+++ b/includes/Runtime/Features.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Feature defaults for each Cortext runtime.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Runtime;
+
+final class Features {
+
+	public function is_desktop(): bool {
+		return defined( 'CORTEXT_DESKTOP' ) && (bool) CORTEXT_DESKTOP;
+	}
+
+	public function public_web_affordances_enabled(): bool {
+		$enabled = ! $this->is_desktop();
+
+		/**
+		 * Filters whether Cortext should show public-web controls.
+		 *
+		 * This covers the publish toggles, their copy-link buttons, and the
+		 * Published documents surface. Desktop leaves them off by default.
+		 *
+		 * @param bool $enabled Whether public-web controls are enabled.
+		 */
+		return (bool) apply_filters( 'cortext_public_web_affordances_enabled', $enabled );
+	}
+
+	public function wordpress_affordances_enabled(): bool {
+		$enabled = ! $this->is_desktop();
+
+		/**
+		 * Filters whether Cortext should show links back to WordPress.
+		 *
+		 * Desktop hides these because the app should feel like Cortext, not
+		 * wp-admin with a shortcut out.
+		 *
+		 * @param bool $enabled Whether WordPress links are enabled.
+		 */
+		return (bool) apply_filters( 'cortext_wordpress_affordances_enabled', $enabled );
+	}
+
+	/**
+	 * Returns the flags consumed by the React shell.
+	 *
+	 * @return array{publicWebAffordances: bool, wordpressAffordances: bool}
+	 */
+	public function to_client_settings(): array {
+		return array(
+			'publicWebAffordances' => $this->public_web_affordances_enabled(),
+			'wordpressAffordances' => $this->wordpress_affordances_enabled(),
+		);
+	}
+}

--- a/src/components/DocumentPublishToggle.js
+++ b/src/components/DocumentPublishToggle.js
@@ -13,6 +13,7 @@ import { useCallback, useState } from '@wordpress/element';
 import PublishToggle from './PublishToggle';
 import useCollectionDependentPages from '../hooks/useCollectionDependentPages';
 import { definesTrait } from '../documents/capabilities';
+import { isPublicWebAffordancesEnabled } from '../settings';
 
 const CASCADE_PUBLISH_ERROR_NOTICE_ID = 'cortext-document-publish-error';
 
@@ -35,6 +36,7 @@ function referencedCollectionIds( blocks ) {
 }
 
 export default function DocumentPublishToggle( { postId } ) {
+	const publicWebAffordances = isPublicWebAffordancesEnabled();
 	const { editPost, savePost } = useDispatch( editorStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
@@ -119,7 +121,7 @@ export default function DocumentPublishToggle( { postId } ) {
 		togglePublishStatus();
 	}, [ togglePublishStatus ] );
 
-	if ( status === 'draft' ) {
+	if ( ! publicWebAffordances || status === 'draft' ) {
 		return null;
 	}
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -113,6 +113,10 @@ import useSidebarDnd from './sidebar/useSidebarDnd';
 import useSidebarNavigation from './sidebar/useSidebarNavigation';
 import useSidebarTree from './sidebar/useSidebarTree';
 import DocumentRow from './sidebar/DocumentRow';
+import {
+	isPublicWebAffordancesEnabled,
+	isWordPressAffordancesEnabled,
+} from '../settings';
 
 export default function Sidebar( {
 	collapsed = false,
@@ -161,6 +165,8 @@ export default function Sidebar( {
 		useDocumentSelection( { selectedId, selectedCollectionId } );
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
 	const userName = window.cortextSettings?.userDisplayName ?? '';
+	const publicWebAffordances = isPublicWebAffordancesEnabled();
+	const wordpressAffordances = isWordPressAffordancesEnabled();
 	const commandPaletteShortcut = displayShortcut.primary( 'k' );
 	const brandLabel = userName
 		? sprintf(
@@ -184,7 +190,8 @@ export default function Sidebar( {
 			params: { _splat: PUBLISHED_DOCUMENTS_URI },
 		} );
 	}, [ navigate ] );
-	const isPublishedActive = activeUri === PUBLISHED_DOCUMENTS_URI;
+	const isPublishedActive =
+		publicWebAffordances && activeUri === PUBLISHED_DOCUMENTS_URI;
 	const goImport = useCallback( () => {
 		navigate( {
 			to: '/$',
@@ -433,17 +440,21 @@ export default function Sidebar( {
 					<Icon icon={ homeIcon } size={ 16 } />
 					{ ! collapsed && <span>{ __( 'Home', 'cortext' ) }</span> }
 				</Button>
-				<Button
-					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--published"
-					label={ __( 'Published documents', 'cortext' ) }
-					isPressed={ isPublishedActive }
-					onClick={ goPublished }
-				>
-					<Icon icon={ globe } size={ 16 } />
-					{ ! collapsed && (
-						<span>{ __( 'Published documents', 'cortext' ) }</span>
-					) }
-				</Button>
+				{ publicWebAffordances ? (
+					<Button
+						className="cortext-sidebar__quick-action cortext-sidebar__quick-action--published"
+						label={ __( 'Published documents', 'cortext' ) }
+						isPressed={ isPublishedActive }
+						onClick={ goPublished }
+					>
+						<Icon icon={ globe } size={ 16 } />
+						{ ! collapsed && (
+							<span>
+								{ __( 'Published documents', 'cortext' ) }
+							</span>
+						) }
+					</Button>
+				) : null }
 				<Button
 					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--import"
 					label={ __( 'Import', 'cortext' ) }
@@ -612,12 +623,14 @@ export default function Sidebar( {
 				/>
 				<div className="cortext-sidebar__footer-group cortext-sidebar__footer-group--preferences">
 					<ThemeToggle />
-					<Button
-						className="cortext-sidebar__back"
-						label={ __( 'Go to WordPress', 'cortext' ) }
-						href={ adminUrl }
-						icon={ <Icon icon={ wordpress } size={ 24 } /> }
-					/>
+					{ wordpressAffordances ? (
+						<Button
+							className="cortext-sidebar__back"
+							label={ __( 'Go to WordPress', 'cortext' ) }
+							href={ adminUrl }
+							icon={ <Icon icon={ wordpress } size={ 24 } /> }
+						/>
+					) : null }
 				</div>
 			</div>
 			{ ! collapsed && (

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -41,6 +41,7 @@ import {
 	TRASHED_PAGES_QUERY,
 } from '../components/page-queries';
 import { firstDocumentInTree } from '../components/document-tree';
+import { isPublicWebAffordancesEnabled } from '../settings';
 import { withViewTransition } from '../hooks/viewTransition';
 import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
@@ -103,7 +104,11 @@ export default function EntityRoute( { history } ) {
 	const params = useParams( { strict: false } );
 	const navigate = useNavigate();
 	const splat = params._splat ?? '';
-	const target = useMemo( () => parseTarget( splat ), [ splat ] );
+	const publicWebAffordances = isPublicWebAffordancesEnabled();
+	const target = useMemo(
+		() => parseTarget( splat, { publicWebAffordances } ),
+		[ splat, publicWebAffordances ]
+	);
 	const { home, isResolving: isResolvingHome } = useWorkspaceHome();
 	const { touchRecent } = useRecents();
 	const { records: pages, isResolving: isResolvingPages } = useEntityRecords(
@@ -402,9 +407,11 @@ export default function EntityRoute( { history } ) {
 						) }
 					</WorkspacePane>
 				) }
-				<WorkspacePane active={ active.kind === 'published' }>
-					<PublishedDocumentsPane />
-				</WorkspacePane>
+				{ publicWebAffordances ? (
+					<WorkspacePane active={ active.kind === 'published' }>
+						<PublishedDocumentsPane />
+					</WorkspacePane>
+				) : null }
 				<WorkspacePane active={ active.kind === 'import' }>
 					<ImportPane />
 				</WorkspacePane>

--- a/src/router/entityRouteReducer.js
+++ b/src/router/entityRouteReducer.js
@@ -11,8 +11,12 @@ import {
 //   - `document`:  anything else with an id. Collections, pages, and rows all
 //                  fall here; the resolver discovers each document's
 //                  capabilities via the locator endpoint.
-export function parseTarget( splat ) {
+export function parseTarget( splat, options = {} ) {
+	const { publicWebAffordances = true } = options;
 	if ( splat === PUBLISHED_DOCUMENTS_URI ) {
+		if ( ! publicWebAffordances ) {
+			return { kind: 'empty', tail: '' };
+		}
 		return { kind: 'published', tail: '' };
 	}
 	if ( splat === IMPORT_URI ) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,29 @@
+const DEFAULT_FEATURES = {
+	publicWebAffordances: true,
+	wordpressAffordances: true,
+};
+
+function rawFeatureValue( key ) {
+	const settings =
+		typeof window === 'undefined' ? undefined : window.cortextSettings;
+	return settings?.features?.[ key ];
+}
+
+export function getCortextFeatures() {
+	return {
+		publicWebAffordances:
+			rawFeatureValue( 'publicWebAffordances' ) ??
+			DEFAULT_FEATURES.publicWebAffordances,
+		wordpressAffordances:
+			rawFeatureValue( 'wordpressAffordances' ) ??
+			DEFAULT_FEATURES.wordpressAffordances,
+	};
+}
+
+export function isPublicWebAffordancesEnabled() {
+	return getCortextFeatures().publicWebAffordances !== false;
+}
+
+export function isWordPressAffordancesEnabled() {
+	return getCortextFeatures().wordpressAffordances !== false;
+}

--- a/tests/js/entityRouteReducer.test.js
+++ b/tests/js/entityRouteReducer.test.js
@@ -31,6 +31,15 @@ describe( 'EntityRoute reducer', () => {
 			} );
 		} );
 
+		it( 'treats `published` as empty when public web affordances are off', () => {
+			expect(
+				parseTarget( 'published', { publicWebAffordances: false } )
+			).toEqual( {
+				kind: 'empty',
+				tail: '',
+			} );
+		} );
+
 		it( 'does not match `published/<anything>` (falls through to document)', () => {
 			expect( parseTarget( 'published/foo' ).kind ).toBe( 'document' );
 		} );

--- a/tests/js/settings.test.js
+++ b/tests/js/settings.test.js
@@ -1,0 +1,50 @@
+import {
+	getCortextFeatures,
+	isPublicWebAffordancesEnabled,
+	isWordPressAffordancesEnabled,
+} from '../../src/settings';
+
+describe( 'settings', () => {
+	afterEach( () => {
+		delete window.cortextSettings;
+	} );
+
+	it( 'keeps feature flags enabled when settings are missing', () => {
+		expect( getCortextFeatures() ).toEqual( {
+			publicWebAffordances: true,
+			wordpressAffordances: true,
+		} );
+		expect( isPublicWebAffordancesEnabled() ).toBe( true );
+		expect( isWordPressAffordancesEnabled() ).toBe( true );
+	} );
+
+	it( 'reads disabled flags from cortextSettings', () => {
+		window.cortextSettings = {
+			features: {
+				publicWebAffordances: false,
+				wordpressAffordances: false,
+			},
+		};
+
+		expect( getCortextFeatures() ).toEqual( {
+			publicWebAffordances: false,
+			wordpressAffordances: false,
+		} );
+		expect( isPublicWebAffordancesEnabled() ).toBe( false );
+		expect( isWordPressAffordancesEnabled() ).toBe( false );
+	} );
+
+	it( 'keeps individual missing flags enabled', () => {
+		window.cortextSettings = {
+			features: {
+				publicWebAffordances: false,
+			},
+		};
+
+		expect( getCortextFeatures() ).toEqual( {
+			publicWebAffordances: false,
+			wordpressAffordances: true,
+		} );
+		expect( isWordPressAffordancesEnabled() ).toBe( true );
+	} );
+} );

--- a/tests/php/test-runtime-features.php
+++ b/tests/php/test-runtime-features.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Tests for Cortext runtime feature flags.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Runtime\Features;
+use WorDBless\BaseTestCase;
+
+final class Test_Runtime_Features extends BaseTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'cortext_public_web_affordances_enabled' );
+		remove_all_filters( 'cortext_wordpress_affordances_enabled' );
+		parent::tear_down();
+	}
+
+	public function test_regular_wordpress_installs_keep_affordances_enabled(): void {
+		$features = new Features();
+
+		$this->assertFalse( $features->is_desktop() );
+		$this->assertTrue( $features->public_web_affordances_enabled() );
+		$this->assertTrue( $features->wordpress_affordances_enabled() );
+		$this->assertSame(
+			array(
+				'publicWebAffordances' => true,
+				'wordpressAffordances' => true,
+			),
+			$features->to_client_settings()
+		);
+	}
+
+	public function test_regular_wordpress_installs_can_turn_affordances_off_with_filters(): void {
+		add_filter( 'cortext_public_web_affordances_enabled', '__return_false' );
+		add_filter( 'cortext_wordpress_affordances_enabled', '__return_false' );
+
+		$features = new Features();
+
+		$this->assertFalse( $features->public_web_affordances_enabled() );
+		$this->assertFalse( $features->wordpress_affordances_enabled() );
+	}
+
+	/**
+	 * Desktop starts with these controls hidden.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_desktop_installs_hide_affordances_by_default(): void {
+		define( 'CORTEXT_DESKTOP', true );
+
+		$features = new Features();
+
+		$this->assertTrue( $features->is_desktop() );
+		$this->assertFalse( $features->public_web_affordances_enabled() );
+		$this->assertFalse( $features->wordpress_affordances_enabled() );
+		$this->assertSame(
+			array(
+				'publicWebAffordances' => false,
+				'wordpressAffordances' => false,
+			),
+			$features->to_client_settings()
+		);
+	}
+
+	/**
+	 * Filters can still opt a desktop build back in.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_desktop_installs_can_turn_affordances_back_on_with_filters(): void {
+		define( 'CORTEXT_DESKTOP', true );
+		add_filter( 'cortext_public_web_affordances_enabled', '__return_true' );
+		add_filter( 'cortext_wordpress_affordances_enabled', '__return_true' );
+
+		$features = new Features();
+
+		$this->assertTrue( $features->public_web_affordances_enabled() );
+		$this->assertTrue( $features->wordpress_affordances_enabled() );
+	}
+}


### PR DESCRIPTION
## What

Part of #196.

When Cortext runs as the desktop app, it now hides the bits of UI that assume there is a public WordPress site or a wp-admin surface to return to: publishing controls, copy-link controls, Published documents, and the Go to WordPress button.

Regular WordPress installs keep the current UI by default. The new flags are still filterable, so installs can opt in or out without changing the desktop defaults.

## Why

The desktop app should feel like Cortext. There is no public site to publish to, and sending people back to wp-admin does not fit the standalone app.

## How

- Resolves the affordance flags in PHP from `CORTEXT_DESKTOP`.
- Keeps each flag filterable for WordPress installs and desktop overrides.
- Routes direct `/published` visits through the normal empty/home flow when public-web affordances are off.

## Testing Instructions

1. In a desktop-configured install, open Cortext and confirm page and collection editors do not show Publish, Public, or Copy link controls.
2. Confirm the sidebar does not show Published documents or Go to WordPress.
3. Visit `wp-admin/admin.php?page=cortext&p=/published` and confirm Cortext lands on the normal empty/home behavior.
4. In a normal WordPress install, confirm those controls are still visible.
5. Disable `cortext_public_web_affordances_enabled` on a normal install and confirm the public-web controls disappear.

## Screnshots
Default mode:
<img width="1720" height="855" alt="image" src="https://github.com/user-attachments/assets/979bb73b-a987-4c19-a193-8062f3b804c6" />

With desktop mode active, there is no publishing UI:
<img width="1724" height="860" alt="image" src="https://github.com/user-attachments/assets/d07a3599-8f45-4132-a1ee-ec1b0c773520" />
