### PR TITLE
Fix the collection table blink after editing a cell

### DIFF
--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -301,6 +301,9 @@ export default function CollectionDataViews( {
 	const activePaginationInfo = isServerPaginated
 		? serverPaginationInfo
 		: clientPaginationInfo;
+	// DataViews changes its scroll wrapper while loading. For a background row
+	// refresh, keep the painted rows steady; our shell covers the empty load.
+	const showDataViewsLoading = isLoading && dataFiltered.length === 0;
 
 	const dataFilteredInRenderOrder = useMemo(
 		() =>
@@ -1586,7 +1589,7 @@ export default function CollectionDataViews( {
 										getItemId={ ( item ) =>
 											String( item.id )
 										}
-										isLoading={ isLoading }
+										isLoading={ showDataViewsLoading }
 										empty={ empty }
 										actions={ dataViewActions }
 										{ ...dataViewsSelectionProps }

--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -1052,7 +1052,7 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 
 	.dataviews-no-results,
-	.dataviews-loading {
+	.dataviews-loading:not(:empty) {
 		display: grid;
 		align-content: center;
 		min-height: 160px;
@@ -1063,6 +1063,13 @@ tr:has(.cortext-title-cell--is-opening)
 		p {
 			margin: 0;
 		}
+	}
+
+	// During a row refresh, DataViews can leave behind an empty loading notice
+	// even though the table is still painted. Hide it so inline saves do not add
+	// a blank strip below the rows.
+	.dataviews-loading:empty {
+		display: none;
 	}
 
 	// Loading shell hides DataViews chrome and the new-row footer so the rows

--- a/tests/js/components/CollectionDataViews.test.js
+++ b/tests/js/components/CollectionDataViews.test.js
@@ -1,4 +1,131 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { render } from '@testing-library/react';
+import { DataViews as mockDataViews } from '@wordpress/dataviews';
+
+jest.mock( '@wordpress/dataviews', () => {
+	const MockDataViews = jest.fn( ( { children } ) => (
+		<div data-testid="dataviews">{ children }</div>
+	) );
+	MockDataViews.Search = () => null;
+	MockDataViews.FiltersToggle = () => null;
+	MockDataViews.LayoutSwitcher = () => null;
+	MockDataViews.ViewConfig = () => null;
+	MockDataViews.Filters = () => null;
+	MockDataViews.Layout = () => null;
+	MockDataViews.Pagination = () => null;
+	return { DataViews: MockDataViews };
+} );
+
+jest.mock( '../../../src/components/CollectionFieldsContext', () => ( {
+	useCollectionFieldsContext: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/hooks/useCollectionRows', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/hooks/useRecents', () => ( {
+	useRecents: jest.fn( () => ( { touchRecent: jest.fn() } ) ),
+} ) );
+
+jest.mock( '../../../src/hooks/useFavorites', () => ( {
+	useFavorites: jest.fn( () => ( { setFavorites: jest.fn() } ) ),
+} ) );
+
+jest.mock( '../../../src/documents', () => ( {
+	filterFavoritesByDeletedIds: jest.fn( ( favorites ) => favorites ),
+	useFavoriteToggle: jest.fn( () => ( {
+		isFavorite: jest.fn( () => false ),
+		toggle: jest.fn(),
+		disabled: false,
+	} ) ),
+} ) );
+
+jest.mock( '../../../src/components/DocumentPeekProvider', () => ( {
+	useDocumentPeekActions: jest.fn( () => ( {
+		openDocument: jest.fn(),
+		closeDocument: jest.fn(),
+	} ) ),
+	useDocumentPeekState: jest.fn( () => ( { peek: null } ) ),
+} ) );
+
+jest.mock( '../../../src/components/RowDetailView', () => ( {
+	ROW_DETAIL_MODE_ICONS: { side: null, modal: null, full: null },
+	ROW_DETAIL_MODE_LABELS: {
+		side: 'Side peek',
+		modal: 'Center modal',
+		full: 'Full page',
+	},
+} ) );
+
+jest.mock(
+	'../../../src/components/DataViewColumnInteractions',
+	() => () => null
+);
+jest.mock( '../../../src/components/DataViewRowReorder', () => () => null );
+jest.mock( '../../../src/components/GridNewRowPortal', () => () => null );
+jest.mock(
+	'../../../src/components/TableCalculationsFooter',
+	() => () => null
+);
+jest.mock(
+	'../../../src/components/fields/ColumnHeaderActions',
+	() => () => null
+);
+jest.mock( '../../../src/components/DataViewNewRowButton', () => () => null );
+jest.mock( '../../../src/components/Skeleton', () => ( {
+	CollectionRowsSkeleton: () => <div data-testid="rows-skeleton" />,
+} ) );
+jest.mock( '../../../src/hooks/afterNextPaint', () => ( {
+	__esModule: true,
+	default: jest.fn( () => Promise.resolve() ),
+} ) );
+
+import { useCollectionFieldsContext } from '../../../src/components/CollectionFieldsContext';
+import CollectionDataViews from '../../../src/components/CollectionDataViews';
 import { scrollToEndQuickly } from '../../../src/components/dataViewScroll';
+import useCollectionRows from '../../../src/hooks/useCollectionRows';
+
+const tableView = {
+	type: 'table',
+	fields: [ 'title', 'field-11' ],
+	page: 1,
+	perPage: 10,
+	layout: { density: 'compact' },
+};
+
+const collectionFieldState = {
+	fields: [
+		{
+			id: 'field-11',
+			label: 'Priority',
+			header: 'Priority',
+			editable: true,
+			type: 'text',
+		},
+	],
+	collection: { id: 7, meta: { slug: 'projects' } },
+	slug: 'projects',
+	isResolving: false,
+	fieldsResolved: true,
+};
+
+function collectionRowsState( overrides = {} ) {
+	return {
+		data: [],
+		paginationInfo: { totalItems: 0, totalPages: 1 },
+		isLoading: false,
+		hasResolved: true,
+		error: null,
+		refresh: jest.fn(),
+		mutateRows: jest.fn(),
+		queryMode: 'server',
+		...overrides,
+	};
+}
 
 function makeScroller( {
 	direction = 'ltr',
@@ -20,6 +147,83 @@ function makeScroller( {
 	document.body.appendChild( wrapper );
 	return wrapper;
 }
+
+describe( 'CollectionDataViews loading state', () => {
+	beforeEach( () => {
+		mockDataViews.mockClear();
+		useCollectionFieldsContext.mockReturnValue( collectionFieldState );
+	} );
+
+	it( 'keeps DataViews out of loading mode during row refreshes with visible rows', () => {
+		useCollectionRows.mockReturnValue(
+			collectionRowsState( {
+				data: [
+					{
+						id: 1,
+						title: { raw: 'Row detail editing' },
+						meta: { 'field-11': 'Urgent' },
+					},
+				],
+				paginationInfo: { totalItems: 1, totalPages: 1 },
+				isLoading: true,
+			} )
+		);
+
+		render(
+			<CollectionDataViews
+				collectionId={ 7 }
+				view={ tableView }
+				onChangeView={ jest.fn() }
+			/>
+		);
+
+		expect( mockDataViews ).toHaveBeenCalled();
+		expect( mockDataViews.mock.calls.at( -1 )[ 0 ].isLoading ).toBe(
+			false
+		);
+	} );
+
+	it( 'passes loading through to DataViews before rows are available', () => {
+		useCollectionRows.mockReturnValue(
+			collectionRowsState( {
+				isLoading: true,
+				hasResolved: false,
+			} )
+		);
+
+		render(
+			<CollectionDataViews
+				collectionId={ 7 }
+				view={ tableView }
+				onChangeView={ jest.fn() }
+			/>
+		);
+
+		expect( mockDataViews ).toHaveBeenCalled();
+		expect( mockDataViews.mock.calls.at( -1 )[ 0 ].isLoading ).toBe( true );
+	} );
+} );
+
+describe( 'CollectionDataViews loading styles', () => {
+	it( 'does not reserve table space for empty DataViews loading notices', () => {
+		const stylesheet = readFileSync(
+			join( process.cwd(), 'src/components/CollectionDataViews.scss' ),
+			'utf8'
+		);
+
+		const nonEmptyLoadingRule =
+			stylesheet.match(
+				/\.dataviews-loading:not\(:empty\)\s*\{[^}]*\}/
+			)?.[ 0 ] ?? '';
+		const emptyLoadingRule =
+			stylesheet.match(
+				/\.dataviews-loading:empty\s*\{[^}]*\}/
+			)?.[ 0 ] ?? '';
+
+		expect( nonEmptyLoadingRule ).toContain( 'min-height: 160px;' );
+		expect( emptyLoadingRule ).toContain( 'display: none;' );
+	} );
+} );
 
 describe( 'scrollToEndQuickly', () => {
 	let matchMedia;


### PR DESCRIPTION
## What

Fixes the small blink that happens after editing a cell in an embedded collection table. The table now keeps its rows and horizontal scrollbar in place while the save refreshes in the background.

## Testing Instructions

1. Open a page with an embedded collection table wide enough to show a horizontal scrollbar.
2. Edit a select cell and pick a different option.
3. Confirm the table does not blink while the change saves.
4. Confirm the horizontal scrollbar stays put and no blank strip appears below the rows.

## Screen recording
Before:

https://github.com/user-attachments/assets/97c9290b-68d0-4967-9b27-f3fcd56d681c

After:

https://github.com/user-attachments/assets/385ae340-05be-4907-a8b5-f1a1947f5c16

