### PR TITLE
Fix: row dnd reordering regression from #273

### DIFF
--- a/src/components/DataViewRowReorder.js
+++ b/src/components/DataViewRowReorder.js
@@ -574,13 +574,20 @@ function findRenderedRows( wrapper, view, rows ) {
 		.filter( Boolean );
 }
 
-function useRenderedRows( wrapperRef, view, rows ) {
+function useRenderedRows( wrapperRef, view, rows, isDragging ) {
 	const [ renderedRows, setRenderedRows ] = useState( [] );
 	const renderedRowsRef = useRef( renderedRows );
 	renderedRowsRef.current = renderedRows;
 	const decoratedRowsRef = useRef( [] );
 	const decoratedCellsRef = useRef( [] );
 	const isLinear = usesLinearGaps( view );
+	// Keep row measurements fixed during a drag. Moving rows toggles classes as
+	// the drop target changes; if the MutationObserver runs `sync()` in the
+	// middle of that transition, `rowRect` can read a half-animated rect and save
+	// bad gap positions. The table layout should not change while the pointer is
+	// down, so keep the snapshot from drag start.
+	const isDraggingRef = useRef( isDragging );
+	isDraggingRef.current = isDragging;
 
 	useEffect( () => {
 		const wrapper = wrapperRef.current;
@@ -590,11 +597,16 @@ function useRenderedRows( wrapperRef, view, rows ) {
 
 		let frame = null;
 		const sync = () => {
-			if ( frame ) {
+			if ( frame || isDraggingRef.current ) {
 				return;
 			}
 			frame = window.requestAnimationFrame( () => {
 				frame = null;
+				// A sync queued just before drag start can still fire after the
+				// pointer is down. Ignore it so the snapshot stays put.
+				if ( isDraggingRef.current ) {
+					return;
+				}
 				const next = findRenderedRows( wrapper, view, rows );
 				const nextRows = next.map( ( item ) => item.el );
 				const nextCells = next.map( ( item ) => item.handleEl );
@@ -625,8 +637,6 @@ function useRenderedRows( wrapperRef, view, rows ) {
 		sync();
 		const observer = new window.MutationObserver( sync );
 		observer.observe( wrapper, {
-			attributeFilter: [ 'class' ],
-			attributes: true,
 			childList: true,
 			subtree: true,
 		} );
@@ -1092,8 +1102,13 @@ export default function DataViewRowReorder( {
 	mutateRows,
 	onReordered,
 } ) {
-	const renderedRows = useRenderedRows( wrapperRef, view, rows );
 	const [ activeRow, setActiveRow ] = useState( null );
+	const renderedRows = useRenderedRows(
+		wrapperRef,
+		view,
+		rows,
+		activeRow !== null
+	);
 	const [ activeDrop, setActiveDrop ] = useState( null );
 	const [ visualRow, setVisualRow ] = useState( null );
 	const [ visualDrop, setVisualDrop ] = useState( null );

--- a/src/components/DataViewRowReorder.scss
+++ b/src/components/DataViewRowReorder.scss
@@ -115,12 +115,14 @@ body.cortext-row-dragging .cortext-row-drop-indicator {
 	bottom: 0;
 }
 
-.cortext-row-drop-indicator--gap::before {
-	top: var(--cortext-row-drop-line-top, 50%);
-}
-
 .cortext-row-drop-indicator.is-active::before {
 	opacity: 1;
+}
+
+// Moving the neighboring rows already shows the drop gap. Hide the gap line so
+// the table does not draw a second cue over the animation.
+.cortext-row-drop-indicator--gap::before {
+	content: none;
 }
 
 // The preview gets the source row's measured width. Use inset shadows for the

--- a/src/components/DataViewRowReorder.scss
+++ b/src/components/DataViewRowReorder.scss
@@ -38,6 +38,18 @@ body.cortext-row-dragging .cortext-row-reorder-target {
 	will-change: transform;
 }
 
+// List layout sets its own row `transition` (background-color/box-shadow) that
+// outranks the rule above, so displaced list rows would snap to the new spot
+// instead of sliding. Re-assert transform easing for reordered list rows while
+// a drag is active so list matches the table.
+body.cortext-row-dragging
+.dataviews-view-list
+div[role="row"].cortext-row-reorder-target {
+	transition:
+		transform 120ms ease,
+		opacity 120ms ease;
+}
+
 // Last-resort guard for `clearVisualState({ withoutTransition: true })`.
 // The body-class flip above is what prevents the drop flicker.
 body.cortext-row-reorder-no-transition .cortext-row-reorder-target {

--- a/tests/js/components/DataViewRowReorder.test.js
+++ b/tests/js/components/DataViewRowReorder.test.js
@@ -714,6 +714,79 @@ describe( 'DataViewRowReorder', () => {
 		window.requestAnimationFrame = originalRequestAnimationFrame;
 	} );
 
+	it( 'keeps row measurements frozen during drag', async () => {
+		// Let rAF queue up so each `sync()` clears its frame guard when we flush
+		// it. The default synchronous mock would hide the re-measure path this
+		// test cares about.
+		const originalRequestAnimationFrame = window.requestAnimationFrame;
+		const frames = [];
+		window.requestAnimationFrame = ( callback ) => {
+			frames.push( callback );
+			return frames.length;
+		};
+		const flush = () =>
+			act( () => {
+				frames.splice( 0 ).forEach( ( callback ) => callback() );
+			} );
+
+		// Render directly instead of using `renderReorder`: with deferred rAF,
+		// that helper would wait forever before the first gap render.
+		const wrapper = createWrapper( [ 40, 40, 40 ] );
+		const wrapperRef = { current: wrapper };
+		render(
+			<DataViewRowReorder
+				wrapperRef={ wrapperRef }
+				view={ { type: 'table', sort: null } }
+				onChangeView={ jest.fn() }
+				collectionId={ 7 }
+				rows={ rows }
+				data={ rows }
+				mutateRows={ jest.fn() }
+				onReordered={ jest.fn() }
+			/>
+		);
+		flush();
+		await waitFor( () =>
+			expect( screen.getByTestId( 'dnd-context' ) ).toBeInTheDocument()
+		);
+
+		// Start dragging the second row. Drag displacement changes row classes;
+		// before the fix, the MutationObserver treated that as a reason to
+		// measure again and saved mid-transition geometry.
+		dragStart( 2 );
+
+		const gapBoxes = () =>
+			[
+				...document.querySelectorAll(
+					'.cortext-row-drop-indicator--gap'
+				),
+			].map( ( gap ) => `${ gap.style.top }/${ gap.style.height }` );
+		const before = gapBoxes();
+		expect( before.length ).toBeGreaterThan( 0 );
+
+		// Pretend the DOM now reports a shifted row and let the observer run.
+		// During a drag, `sync()` should ignore that and keep the original
+		// snapshot.
+		act( () => {
+			const lastRow = wrapperRef.current.querySelectorAll( 'tr' )[ 2 ];
+			lastRow.getBoundingClientRect = () => ( {
+				top: 200,
+				left: 10,
+				width: 320,
+				height: 120,
+				right: 330,
+				bottom: 320,
+			} );
+			for ( const observer of mockResizeObserverInstances ) {
+				observer.callback();
+			}
+		} );
+		flush();
+
+		expect( gapBoxes() ).toEqual( before );
+		window.requestAnimationFrame = originalRequestAnimationFrame;
+	} );
+
 	it( 'mounts row drag handles inside the row cell', async () => {
 		await renderReorder();
 


### PR DESCRIPTION
## What

Fixes a #273 regression where row reordering could jitter while dragging. The drop target now stays put, and the duplicate gap line is hidden.

## Why

#273 started re-measuring rows on class changes. During a drag, that could save in-between animation positions and make the target jump.

## Testing Instructions

1. Open a collection in table layout.
2. Drag a row slowly up and down the table.
3. Drop it near the top, middle, and bottom.
4. Check that the target stays in place and the animation does not wobble.

## Screen recording
Before:

https://github.com/user-attachments/assets/28b45979-d7e3-404a-9b42-b2a0d0f9862b

After:

https://github.com/user-attachments/assets/a6189656-32f8-469e-94b0-cd3878cbc2c6

