### PR TITLE
Copy: polish/unify document/page/collection UI copy

### DIFF
--- a/src/blocks/data-view/block.json
+++ b/src/blocks/data-view/block.json
@@ -5,7 +5,7 @@
 	"title": "Collection view",
 	"category": "collections",
 	"icon": "database",
-	"description": "Displays a Cortext collection's rows as a table, grid, or list.",
+	"description": "Displays a collection as a table, grid, or list.",
 	"textdomain": "cortext",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -527,7 +527,7 @@ function CollectionInspectorControls( {
 							__nextHasNoMarginBottom
 						/>
 						<SelectControl
-							label={ __( 'Rows per page', 'cortext' ) }
+							label={ __( 'Per page', 'cortext' ) }
 							value={ String( view?.perPage ?? 25 ) }
 							options={ PER_PAGE_OPTIONS }
 							onChange={ ( perPage ) =>
@@ -541,7 +541,7 @@ function CollectionInspectorControls( {
 							__nextHasNoMarginBottom
 						/>
 						<ToggleGroupControl
-							label={ __( 'Row detail', 'cortext' ) }
+							label={ __( 'Detail view', 'cortext' ) }
 							value={
 								view?.rowDetailMode ?? DEFAULT_ROW_DETAIL_MODE
 							}
@@ -686,10 +686,7 @@ export default function Edit( {
 					}
 					error={
 						<Notice status="error" isDismissible={ false }>
-							{ __(
-								'Collection rows could not be loaded.',
-								'cortext'
-							) }
+							{ __( 'Could not load documents.', 'cortext' ) }
 						</Notice>
 					}
 				/>

--- a/src/blocks/document-cover/block.json
+++ b/src/blocks/document-cover/block.json
@@ -2,10 +2,10 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "cortext/document-cover",
-	"title": "Document cover",
+	"title": "Cover",
 	"category": "collections",
 	"icon": "format-image",
-	"description": "Document cover image, bound to the document's featured image.",
+	"description": "Cover image, bound to the featured image.",
 	"textdomain": "cortext",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {

--- a/src/blocks/document-cover/edit.js
+++ b/src/blocks/document-cover/edit.js
@@ -98,7 +98,7 @@ export default function Edit( { context, clientId } ) {
 		return (
 			<div { ...blockProps }>
 				<span className="cortext-document-cover-block__hint">
-					{ __( 'Document cover is unavailable here.', 'cortext' ) }
+					{ __( 'Cover is unavailable here.', 'cortext' ) }
 				</span>
 			</div>
 		);

--- a/src/blocks/document-icon/block.json
+++ b/src/blocks/document-icon/block.json
@@ -2,10 +2,10 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "cortext/document-icon",
-	"title": "Document icon",
+	"title": "Icon",
 	"category": "collections",
 	"icon": "smiley",
-	"description": "Document identity icon. Reads from the cortext_document_icon post meta.",
+	"description": "Identity icon stored in post meta.",
 	"textdomain": "cortext",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {

--- a/src/blocks/document-icon/edit.js
+++ b/src/blocks/document-icon/edit.js
@@ -61,7 +61,7 @@ export default function Edit( { context, clientId } ) {
 		return (
 			<div { ...blockProps }>
 				<span className="cortext-document-icon-block__hint">
-					{ __( 'Document icon is unavailable here.', 'cortext' ) }
+					{ __( 'Icon is unavailable here.', 'cortext' ) }
 				</span>
 			</div>
 		);

--- a/src/blocks/document-properties/block.json
+++ b/src/blocks/document-properties/block.json
@@ -2,10 +2,10 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "cortext/document-properties",
-	"title": "Document properties",
+	"title": "Properties",
 	"category": "collections",
 	"icon": "list-view",
-	"description": "Row properties shown between the title and body, using the collection schema and row meta.",
+	"description": "Properties shown between the title and body, using the collection schema and saved metadata.",
 	"textdomain": "cortext",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {

--- a/src/components/CollectionDataViewChrome.js
+++ b/src/components/CollectionDataViewChrome.js
@@ -66,18 +66,23 @@ export function DataViewsBulkSelectionControls( {
 	const countLabel =
 		selectedCount > 0
 			? sprintf(
-					/* translators: %d: number of selected rows. */
+					/* translators: %d: number of selected documents. */
 					_n(
-						'%d row selected',
-						'%d rows selected',
+						'%d document selected',
+						'%d documents selected',
 						selectedCount,
 						'cortext'
 					),
 					selectedCount
 			  )
 			: sprintf(
-					/* translators: %d: number of visible rows. */
-					_n( '%d row', '%d rows', visibleCount, 'cortext' ),
+					/* translators: %d: number of visible documents. */
+					_n(
+						'%d document',
+						'%d documents',
+						visibleCount,
+						'cortext'
+					),
 					visibleCount
 			  );
 
@@ -91,8 +96,8 @@ export function DataViewsBulkSelectionControls( {
 				onChange={ onToggleVisibleSelection }
 				aria-label={
 					allVisibleSelected
-						? __( 'Deselect visible rows', 'cortext' )
-						: __( 'Select visible rows', 'cortext' )
+						? __( 'Deselect visible', 'cortext' )
+						: __( 'Select visible', 'cortext' )
 				}
 			/>
 			<span className="dataviews-bulk-actions-footer__item-count">
@@ -107,7 +112,7 @@ export function DataViewsBulkSelectionControls( {
 					<Button
 						icon={ trash }
 						isDestructive
-						label={ __( 'Trash selected rows', 'cortext' ) }
+						label={ __( 'Move selected to Trash', 'cortext' ) }
 						onClick={ onDeleteSelected }
 						size="compact"
 						showTooltip

--- a/src/components/CollectionDataViewFields.js
+++ b/src/components/CollectionDataViewFields.js
@@ -126,7 +126,7 @@ function TitleCell( { item } ) {
 				<Button
 					className="cortext-title-cell__open"
 					icon={ icon }
-					label={ __( 'Open row', 'cortext' ) }
+					label={ __( 'Open', 'cortext' ) }
 					size="small"
 					variant="tertiary"
 					onClick={ openRow }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -979,7 +979,7 @@ export default function CollectionDataViews( {
 			} catch ( apiError ) {
 				setRowActionError(
 					apiError?.message ??
-						__( 'Could not duplicate row.', 'cortext' )
+						__( 'Could not duplicate this document.', 'cortext' )
 				);
 			}
 		},
@@ -1055,14 +1055,14 @@ export default function CollectionDataViews( {
 				refresh();
 				notifyDocumentTrashChanged();
 				notifyCollectionRowsChanged();
-				// Prune favorites for the rows we just trashed. The server cleans
+				// Prune favorites for the documents we just trashed. The server cleans
 				// stale entries on the next read, but doing it here keeps the next
-				// favorites PUT from sending these row ids back.
+				// favorites PUT from sending these document ids back.
 				setFavorites( ( current ) =>
 					filterFavoritesByDeletedIds( current, { row: deleted } )
 				).catch( () => {
 					// Keep this quiet. The next favorites read asks the server to
-					// prune stale rows anyway.
+					// prune stale documents anyway.
 				} );
 			}
 
@@ -1070,20 +1070,20 @@ export default function CollectionDataViews( {
 				let deleteErrorMessage;
 				if ( nextRows.length === 1 ) {
 					deleteErrorMessage = __(
-						'Could not move row to Trash.',
+						'Could not move document to Trash.',
 						'cortext'
 					);
 				} else if ( failedRows.length === nextRows.length ) {
 					deleteErrorMessage = __(
-						'Could not move selected rows to Trash.',
+						'Could not move selected documents to Trash.',
 						'cortext'
 					);
 				} else {
 					deleteErrorMessage = sprintf(
-						/* translators: %d: number of rows that failed to move to Trash. */
+						/* translators: %d: number of documents that failed to move to Trash. */
 						_n(
-							'%d row could not be moved to Trash.',
-							'%d rows could not be moved to Trash.',
+							'%d document could not be moved to Trash.',
+							'%d documents could not be moved to Trash.',
 							failedRows.length,
 							'cortext'
 						),
@@ -1109,13 +1109,13 @@ export default function CollectionDataViews( {
 
 	const rowActions = useMemo( () => {
 		const actions = [];
-		// The row itself opens in grid/list, and table has the inline Open
-		// button in the title cell. Keep the mode choices in the row menu.
+		// The document itself opens in grid/list, and table has the inline Open
+		// button in the title cell. Keep the mode choices in the document menu.
 		for ( const mode of [ 'side', 'modal', 'full' ] ) {
 			actions.push( {
 				id: `open-in-${ mode }`,
 				label: sprintf(
-					/* translators: %s: row detail mode (Side peek, Center modal, Full page). */
+					/* translators: %s: document detail mode (Side peek, Center modal, Full view). */
 					__( 'Open in %s', 'cortext' ),
 					ROW_DETAIL_MODE_LABELS[ mode ]
 				),
@@ -1463,12 +1463,7 @@ export default function CollectionDataViews( {
 		return (
 			<DataViewStateShell status="error">
 				{ error ?? (
-					<p>
-						{ __(
-							'Collection rows could not be loaded.',
-							'cortext'
-						) }
-					</p>
+					<p>{ __( 'Could not load documents.', 'cortext' ) }</p>
 				) }
 			</DataViewStateShell>
 		);

--- a/src/components/CortextCommandMenu.js
+++ b/src/components/CortextCommandMenu.js
@@ -30,10 +30,7 @@ const ITEM_ID_PREFIX = 'command-palette-item-';
 const RECENT_COMMAND_PREFIX = 'cortext/recent/';
 const DOCUMENT_COMMAND_PREFIX = 'cortext/document/';
 const commandMenuLabel = __( 'Search or run a command', 'cortext' );
-const inputPlaceholder = __(
-	'Search pages, collections, and actions',
-	'cortext'
-);
+const inputPlaceholder = __( 'Search or run a command', 'cortext' );
 
 const CATEGORY_LABELS = {
 	command: __( 'Command' ),

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -78,7 +78,7 @@ export default function DataViewNewRowButton( {
 			onCreated( created );
 		} catch ( err ) {
 			setError(
-				err?.message ?? __( 'Could not create row.', 'cortext' )
+				err?.message ?? __( 'Could not create a document.', 'cortext' )
 			);
 		} finally {
 			setIsCreating( false );

--- a/src/components/DataViewRowReorder.js
+++ b/src/components/DataViewRowReorder.js
@@ -1240,10 +1240,13 @@ export default function DataViewRowReorder( {
 						sort: request.previousSort,
 					} );
 				}
-				createErrorNotice( __( "Couldn't move the row.", 'cortext' ), {
-					id: ROW_REORDER_NOTICE_ID,
-					type: 'snackbar',
-				} );
+				createErrorNotice(
+					__( "Couldn't move the document.", 'cortext' ),
+					{
+						id: ROW_REORDER_NOTICE_ID,
+						type: 'snackbar',
+					}
+				);
 			} finally {
 				setIsPosting( false );
 			}
@@ -1427,7 +1430,7 @@ export default function DataViewRowReorder( {
 				>
 					<p>
 						{ __(
-							'Rows will stay where you dropped them, and the current sort will be cleared.',
+							'Documents will stay where you dropped them, and the current sort will be cleared.',
 							'cortext'
 						) }
 					</p>

--- a/src/components/DocumentIdentityControls.js
+++ b/src/components/DocumentIdentityControls.js
@@ -386,7 +386,7 @@ function PickerBody( {
 							</Button>
 							<p className="cortext-document-identity-popover__hint">
 								{ __(
-									'Pick or upload an image to use as this document’s icon.',
+									'Pick or upload an image for the icon.',
 									'cortext'
 								) }
 							</p>

--- a/src/components/DocumentInspectorSidebar.js
+++ b/src/components/DocumentInspectorSidebar.js
@@ -24,7 +24,7 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	home as homeIcon,
 	starEmpty,
@@ -43,7 +43,6 @@ import CanvasOwnerInspector, {
 import './DocumentInspectorSidebar.scss';
 
 import DocumentPropertiesActions from './DocumentPropertiesActions';
-import { useDocumentPropertiesContext } from './DocumentPropertiesContext';
 import MediaPicker, { MediaUploadCheck } from './MediaPicker';
 import DocumentIcon from './DocumentIcon';
 import DocumentIdentityControls from './DocumentIdentityControls';
@@ -495,7 +494,7 @@ function PageActionsPanel( { postId } ) {
 			await setHome( { id: postId } );
 		} catch ( err ) {
 			setError(
-				err?.message ?? __( 'Could not set page as home.', 'cortext' )
+				err?.message ?? __( 'Could not set as home.', 'cortext' )
 			);
 		}
 	}, [ isHome, postId, setHome ] );
@@ -543,14 +542,15 @@ function PageActionsPanel( { postId } ) {
 				setError(
 					err?.message ??
 						__(
-							'Page moved to Trash, but Favorites could not be updated.',
+							'Document moved to Trash, but Favorites could not be updated.',
 							'cortext'
 						)
 				);
 			}
 		} catch ( err ) {
 			setError(
-				err?.message ?? __( 'Could not move page to Trash.', 'cortext' )
+				err?.message ??
+					__( 'Could not move document to Trash.', 'cortext' )
 			);
 		} finally {
 			setIsTrashing( false );
@@ -626,7 +626,7 @@ function DocumentInspectorContent( { postId } ) {
 			<PageIdentityInspectorPanel
 				postId={ postId }
 				postType={ POST_TYPE }
-				title={ __( 'Page identity', 'cortext' ) }
+				title={ __( 'Identity', 'cortext' ) }
 			/>
 			<PageActionsPanel postId={ postId } />
 		</div>
@@ -640,7 +640,7 @@ function CollectionInspectorContent( { postId, postType } ) {
 			<PageIdentityInspectorPanel
 				postId={ postId }
 				postType={ postType }
-				title={ __( 'Collection identity', 'cortext' ) }
+				title={ __( 'Identity', 'cortext' ) }
 			/>
 			<CanvasOwnerInspector.Slot />
 		</div>
@@ -671,43 +671,7 @@ export default function DocumentInspectorSidebar( { postId, postType } ) {
 	const hasTrait =
 		Array.isArray( currentRecord?.crtxt_trait ) &&
 		currentRecord.crtxt_trait.length > 0;
-	const propertiesCtx = useDocumentPropertiesContext();
-	const rowCollectionId = propertiesCtx?.collectionId;
-	const { record: rowCollection } = useEntityRecord(
-		'postType',
-		'crtxt_document',
-		rowCollectionId || 0
-	);
-	const { record: ownedCollection } = useEntityRecord(
-		'postType',
-		'crtxt_document',
-		isCollection ? postId : 0
-	);
-	const rowCollectionTitle = (
-		rowCollection?.title?.rendered ||
-		rowCollection?.title?.raw ||
-		''
-	).trim();
-	const ownedCollectionTitle = (
-		ownedCollection?.title?.rendered ||
-		ownedCollection?.title?.raw ||
-		''
-	).trim();
-	let documentTabLabel;
-	if ( isCollection ) {
-		documentTabLabel =
-			ownedCollectionTitle || __( 'Collection', 'cortext' );
-	} else if ( hasTrait ) {
-		documentTabLabel = rowCollectionTitle
-			? sprintf(
-					/* translators: %s: collection name (e.g. "Books Item") */
-					__( '%s Item', 'cortext' ),
-					rowCollectionTitle
-			  )
-			: __( 'Collection Item', 'cortext' );
-	} else {
-		documentTabLabel = __( 'Page', 'cortext' );
-	}
+	const documentTabLabel = __( 'Document', 'cortext' );
 	const isTrashed = useSelect(
 		( select ) =>
 			select( editorStore ).getCurrentPostAttribute( 'status' ) ===

--- a/src/components/DocumentPeekProvider.js
+++ b/src/components/DocumentPeekProvider.js
@@ -175,7 +175,7 @@ export function DocumentPeekProvider( { children } ) {
 					setPendingTransition( transition );
 					setSaveError(
 						__(
-							'Cortext could not save row changes. Retry or discard your edits to continue.',
+							'Cortext could not save changes. Retry or discard your edits to continue.',
 							'cortext'
 						)
 					);

--- a/src/components/DocumentPublishToggle.js
+++ b/src/components/DocumentPublishToggle.js
@@ -91,7 +91,7 @@ export default function DocumentPublishToggle( { postId } ) {
 				if ( results.some( ( r ) => r.status === 'rejected' ) ) {
 					createErrorNotice(
 						__(
-							"Couldn't publish referenced collections. The document was not published.",
+							"Couldn't publish referenced documents that contain rows. The document was not published.",
 							'cortext'
 						),
 						{
@@ -153,7 +153,7 @@ export default function DocumentPublishToggle( { postId } ) {
 					{ isLoading && (
 						<p>
 							{ __(
-								'Checking for public dependent pages…',
+								'Checking for public dependent documents…',
 								'cortext'
 							) }
 						</p>
@@ -161,7 +161,7 @@ export default function DocumentPublishToggle( { postId } ) {
 					{ error && (
 						<p>
 							{ __(
-								'Could not check for public dependent pages.',
+								'Could not check for public dependent documents.',
 								'cortext'
 							) }
 						</p>
@@ -170,7 +170,7 @@ export default function DocumentPublishToggle( { postId } ) {
 						<>
 							<p>
 								{ __(
-									'The following pages are currently public and reference this document.',
+									'The following documents are currently public and reference this document.',
 									'cortext'
 								) }
 							</p>

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -436,7 +436,7 @@ function DocumentIdentityActions( { postId, postType } ) {
 			ref={ actionsRef }
 			className="cortext-canvas__identity-actions"
 			role="group"
-			aria-label={ __( 'Document identity actions', 'cortext' ) }
+			aria-label={ __( 'Identity actions', 'cortext' ) }
 		>
 			{ ! hasIcon && ! hasCover && (
 				<DocumentIdentityControls
@@ -924,7 +924,8 @@ function TrashedNotice( { postId, postType, onRestored } ) {
 			onRestored?.( postId, postType, response );
 		} catch ( err ) {
 			setError(
-				err?.message ?? __( 'Could not restore document.', 'cortext' )
+				err?.message ??
+					__( 'Could not restore this document.', 'cortext' )
 			);
 		} finally {
 			setIsRestoring( false );
@@ -945,7 +946,9 @@ function TrashedNotice( { postId, postType, onRestored } ) {
 				},
 			] }
 		>
-			{ error ? error : __( 'This document is in trash.', 'cortext' ) }
+			{ error
+				? error
+				: __( 'This document is in the Trash.', 'cortext' ) }
 		</Notice>
 	);
 }

--- a/src/components/ImportPane.js
+++ b/src/components/ImportPane.js
@@ -323,9 +323,9 @@ function CollectionCard( { collection, job, onImport } ) {
 			if ( timeUntilRetry !== null ) {
 				statusLine = processed
 					? sprintf(
-							/* translators: 1: rows processed so far, 2: seconds remaining before retry */
+							/* translators: 1: documents processed so far, 2: seconds remaining before retry */
 							__(
-								'Imported %1$d rows. Waiting for Notion: %2$d s…',
+								'Imported %1$d documents. Waiting for Notion: %2$d s…',
 								'cortext'
 							),
 							processed,
@@ -338,8 +338,8 @@ function CollectionCard( { collection, job, onImport } ) {
 					  );
 			} else if ( processed ) {
 				statusLine = sprintf(
-					/* translators: %d: rows processed */
-					__( 'Importing %d rows…', 'cortext' ),
+					/* translators: %d: documents processed */
+					__( 'Importing %d documents…', 'cortext' ),
 					processed
 				);
 			}
@@ -348,8 +348,8 @@ function CollectionCard( { collection, job, onImport } ) {
 		case 'done':
 			if ( processed ) {
 				statusLine = sprintf(
-					/* translators: %d: rows processed */
-					__( '%d rows imported.', 'cortext' ),
+					/* translators: %d: documents processed */
+					__( '%d documents imported.', 'cortext' ),
 					processed
 				);
 			}

--- a/src/components/PublishedDocumentsPane.js
+++ b/src/components/PublishedDocumentsPane.js
@@ -197,9 +197,7 @@ export default function PublishedDocumentsPane() {
 	if ( isLoading && items.length === 0 ) {
 		return (
 			<VStack className="cortext-published-pane" spacing={ 5 }>
-				<Heading level={ 2 }>
-					{ __( 'Published documents', 'cortext' ) }
-				</Heading>
+				<Heading level={ 2 }>{ __( 'Published', 'cortext' ) }</Heading>
 				<Spinner />
 			</VStack>
 		);
@@ -208,14 +206,9 @@ export default function PublishedDocumentsPane() {
 	return (
 		<VStack className="cortext-published-pane" spacing={ 5 }>
 			<VStack spacing={ 1 }>
-				<Heading level={ 2 }>
-					{ __( 'Published documents', 'cortext' ) }
-				</Heading>
+				<Heading level={ 2 }>{ __( 'Published', 'cortext' ) }</Heading>
 				<Text variant="muted">
-					{ __(
-						'Visible to anyone with the public link.',
-						'cortext'
-					) }
+					{ __( 'Public on the web.', 'cortext' ) }
 				</Text>
 			</VStack>
 			<DataViews
@@ -229,7 +222,7 @@ export default function PublishedDocumentsPane() {
 				isLoading={ isLoading }
 				empty={
 					<Text variant="muted">
-						{ __( 'No public documents yet.', 'cortext' ) }
+						{ __( 'Nothing is public yet.', 'cortext' ) }
 					</Text>
 				}
 			/>

--- a/src/components/RowDetailSidebarSlot.js
+++ b/src/components/RowDetailSidebarSlot.js
@@ -226,10 +226,7 @@ export function RowDetailSidebarSlot() {
 					<div
 						className="cortext-row-detail-sidebar-shell__resize-handle"
 						role="separator"
-						aria-label={ __(
-							'Resize row detail panel',
-							'cortext'
-						) }
+						aria-label={ __( 'Resize detail panel', 'cortext' ) }
 						aria-orientation="vertical"
 						aria-valuemin={ MIN_WIDTH }
 						aria-valuemax={ maxWidth }

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -65,7 +65,7 @@ export const ROW_DETAIL_MODE_ICONS = {
 export const ROW_DETAIL_MODE_LABELS = {
 	side: __( 'Side peek', 'cortext' ),
 	modal: __( 'Center modal', 'cortext' ),
-	full: __( 'Full page', 'cortext' ),
+	full: __( 'Full view', 'cortext' ),
 };
 const ROW_DETAIL_MODAL_CLOSE_MS = 240;
 const ROW_DETAIL_SWITCH_MS = 180;
@@ -169,7 +169,7 @@ function DetailShell( {
 				<div
 					className="cortext-row-detail__toolbar"
 					role="toolbar"
-					aria-label={ __( 'Row detail tools', 'cortext' ) }
+					aria-label={ __( 'Detail tools', 'cortext' ) }
 				>
 					<div className="cortext-row-detail__toolbar-group">
 						<Button
@@ -202,14 +202,14 @@ function DetailShell( {
 						<Button
 							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--icon"
 							icon={ chevronUp }
-							label={ __( 'Row above', 'cortext' ) }
+							label={ __( 'Previous', 'cortext' ) }
 							onClick={ onPrevious }
 							disabled={ ! canGoPrevious }
 						/>
 						<Button
 							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--icon"
 							icon={ chevronDown }
-							label={ __( 'Row below', 'cortext' ) }
+							label={ __( 'Next', 'cortext' ) }
 							onClick={ onNext }
 							disabled={ ! canGoNext }
 						/>
@@ -677,7 +677,7 @@ export default function RowDetailView( {
 						? ' cortext-row-detail-modal--closing'
 						: '' )
 				}
-				title={ __( 'Row detail', 'cortext' ) }
+				title={ __( 'Detail', 'cortext' ) }
 				overlayClassName={
 					isModalClosing ? 'is-animating-out' : undefined
 				}
@@ -695,7 +695,7 @@ export default function RowDetailView( {
 		<div
 			className={ `cortext-row-detail cortext-row-detail--${ normalizedMode }` }
 			role="dialog"
-			aria-label={ __( 'Row detail', 'cortext' ) }
+			aria-label={ __( 'Detail', 'cortext' ) }
 		>
 			{ content }
 		</div>

--- a/src/components/RowDragHandle.js
+++ b/src/components/RowDragHandle.js
@@ -32,7 +32,7 @@ export default function RowDragHandle( { row, keyboardFocusable = true } ) {
 		data: row,
 		attributes: {
 			role: 'button',
-			roleDescription: __( 'draggable row', 'cortext' ),
+			roleDescription: __( 'draggable item', 'cortext' ),
 		},
 	} );
 
@@ -104,8 +104,8 @@ export default function RowDragHandle( { row, keyboardFocusable = true } ) {
 			ref={ setHandleRef }
 			className="cortext-row-drag-handle"
 			aria-label={ sprintf(
-				/* translators: %s: row title */
-				__( 'Reorder row: %s', 'cortext' ),
+				/* translators: %s: item title */
+				__( 'Reorder: %s', 'cortext' ),
 				row.label
 			) }
 			data-dragging={ isDragging ? 'true' : 'false' }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -443,15 +443,13 @@ export default function Sidebar( {
 				{ publicWebAffordances ? (
 					<Button
 						className="cortext-sidebar__quick-action cortext-sidebar__quick-action--published"
-						label={ __( 'Published documents', 'cortext' ) }
+						label={ __( 'Published', 'cortext' ) }
 						isPressed={ isPublishedActive }
 						onClick={ goPublished }
 					>
 						<Icon icon={ globe } size={ 16 } />
 						{ ! collapsed && (
-							<span>
-								{ __( 'Published documents', 'cortext' ) }
-							</span>
+							<span>{ __( 'Published', 'cortext' ) }</span>
 						) }
 					</Button>
 				) : null }
@@ -526,7 +524,7 @@ export default function Sidebar( {
 						>
 							<SidebarSection
 								id="pages"
-								title={ __( 'Pages', 'cortext' ) }
+								title={ __( 'Documents', 'cortext' ) }
 								isCollapsed={ isSectionCollapsed( 'pages' ) }
 								onToggle={ () => toggleSection( 'pages' ) }
 								actions={
@@ -534,7 +532,10 @@ export default function Sidebar( {
 										className="cortext-sidebar__section-action"
 										icon={ plus }
 										size="small"
-										label={ __( 'New page', 'cortext' ) }
+										label={ __(
+											'New document',
+											'cortext'
+										) }
 										onClick={ createRootPage }
 									/>
 								}
@@ -546,7 +547,7 @@ export default function Sidebar( {
 									) }
 								{ ! isResolvingPages && pages.length === 0 && (
 									<p className="cortext-sidebar__empty">
-										{ __( 'No pages yet.', 'cortext' ) }
+										{ __( 'Nothing here yet.', 'cortext' ) }
 									</p>
 								) }
 

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -435,7 +435,7 @@ export default function SidebarFavorites( {
 			{ isEmpty ? (
 				<p className="cortext-sidebar__empty cortext-sidebar__empty--inline">
 					{ __(
-						'Star a page from its title menu to pin it here.',
+						'Star from the title menu to pin it here.',
 						'cortext'
 					) }
 				</p>

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -49,8 +49,8 @@ function runNodeAnimation( node, keyframes, options ) {
 }
 
 /**
- * One item in Recents. The descriptor supplies the icon and type label, while
- * this row only adds collection context when the recent item is a row.
+ * One item in Recents. The descriptor supplies the icon; this row only adds
+ * collection context when it helps distinguish matching document titles.
  *
  * @param {Object}   props
  * @param {Object}   props.recent     Recent activity record from the server.
@@ -68,7 +68,7 @@ function SidebarRecentsRow( { recent, setNodeRef, onSelect } ) {
 		recent.id || 0
 	);
 	const merged = record ? { ...recent, ...record } : recent;
-	const { listIcon, kindLabel } = useDocumentRecord( merged );
+	const { listIcon } = useDocumentRecord( merged );
 	const title = recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
 	const contextTitle = recent?.collection?.title?.trim?.() ?? '';
 
@@ -83,15 +83,14 @@ function SidebarRecentsRow( { recent, setNodeRef, onSelect } ) {
 
 	const ariaLabel = contextTitle
 		? sprintf(
-				/* translators: 1: row title, 2: collection title */
-				__( 'Recent row: %1$s in %2$s', 'cortext' ),
+				/* translators: 1: recent title, 2: collection title */
+				__( 'Recent: %1$s in %2$s', 'cortext' ),
 				title,
 				contextTitle
 		  )
 		: sprintf(
-				/* translators: 1: recent item type, 2: recent item title */
-				__( 'Recent %1$s: %2$s', 'cortext' ),
-				kindLabel.toLowerCase(),
+				/* translators: %s: recent title */
+				__( 'Recent: %s', 'cortext' ),
 				title
 		  );
 

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -11,6 +11,7 @@ import useDelayedFlag, {
 import { useRecents } from '../hooks/useRecents';
 import { useDocumentRecord } from '../documents';
 import { DOCUMENT_POST_TYPE } from '../collections';
+import { definesTrait } from '../documents/capabilities';
 
 const RECENT_REPOSITION_OPTIONS = {
 	duration: 180,
@@ -48,16 +49,43 @@ function runNodeAnimation( node, keyframes, options ) {
 	node.animate( keyframes, options );
 }
 
+function recentTitle( recent ) {
+	return recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
+}
+
+function recentContextTitle( recent ) {
+	return recent?.collection?.title?.trim?.() ?? '';
+}
+
+function recentDisplayTitle( recent ) {
+	const title = recentTitle( recent );
+	const contextTitle = recentContextTitle( recent );
+	return contextTitle
+		? sprintf(
+				/* translators: 1: document title, 2: collection title */
+				__( '%1$s in %2$s', 'cortext' ),
+				title,
+				contextTitle
+		  )
+		: title;
+}
+
 /**
  * One item in Recents. The descriptor supplies the icon; this row only adds
  * collection context when it helps distinguish matching document titles.
  *
  * @param {Object}   props
- * @param {Object}   props.recent     Recent activity record from the server.
- * @param {Function} props.setNodeRef Ref setter used by the FLIP animation.
- * @param {Function} props.onSelect   Navigate to the recent's path.
+ * @param {Object}   props.recent           Recent activity record from the server.
+ * @param {boolean}  props.isDuplicateLabel Whether another recent has the same display label.
+ * @param {Function} props.setNodeRef       Ref setter used by the FLIP animation.
+ * @param {Function} props.onSelect         Navigate to the recent's path.
  */
-function SidebarRecentsRow( { recent, setNodeRef, onSelect } ) {
+function SidebarRecentsRow( {
+	recent,
+	isDuplicateLabel,
+	setNodeRef,
+	onSelect,
+} ) {
 	// Recents wire shape only carries id/title/path/icon (and optional row
 	// context). Capability checks need `meta.cortext_fields` / `crtxt_trait`,
 	// so we load the document record at render time and merge it with the
@@ -69,29 +97,22 @@ function SidebarRecentsRow( { recent, setNodeRef, onSelect } ) {
 	);
 	const merged = record ? { ...recent, ...record } : recent;
 	const { listIcon } = useDocumentRecord( merged );
-	const title = recent?.title?.trim?.() || __( '(untitled)', 'cortext' );
-	const contextTitle = recent?.collection?.title?.trim?.() ?? '';
+	const displayTitle = recentDisplayTitle( recent );
+	const duplicateContext = definesTrait( merged )
+		? __( 'contains rows', 'cortext' )
+		: __( 'plain document', 'cortext' );
 
-	const displayTitle = contextTitle
+	const ariaLabel = isDuplicateLabel
 		? sprintf(
-				/* translators: 1: row title, 2: collection title */
-				__( '%1$s in %2$s', 'cortext' ),
-				title,
-				contextTitle
-		  )
-		: title;
-
-	const ariaLabel = contextTitle
-		? sprintf(
-				/* translators: 1: recent title, 2: collection title */
-				__( 'Recent: %1$s in %2$s', 'cortext' ),
-				title,
-				contextTitle
+				/* translators: 1: recent title, 2: context for duplicate recent titles */
+				__( 'Recent: %1$s, %2$s', 'cortext' ),
+				displayTitle,
+				duplicateContext
 		  )
 		: sprintf(
 				/* translators: %s: recent title */
 				__( 'Recent: %s', 'cortext' ),
-				title
+				displayTitle
 		  );
 
 	return (
@@ -129,6 +150,11 @@ export default function SidebarRecents() {
 	const recentNodes = useRef( new Map() );
 	const previousRects = useRef( new Map() );
 	const hasCompletedInitialLoad = useRef( false );
+	const labelCounts = new Map();
+	recents.forEach( ( recent ) => {
+		const label = recentDisplayTitle( recent );
+		labelCounts.set( label, ( labelCounts.get( label ) ?? 0 ) + 1 );
+	} );
 	const setRecentNodeRef = useCallback(
 		( key ) => ( node ) => {
 			if ( node ) {
@@ -220,6 +246,11 @@ export default function SidebarRecents() {
 							<SidebarRecentsRow
 								key={ key }
 								recent={ recent }
+								isDuplicateLabel={
+									( labelCounts.get(
+										recentDisplayTitle( recent )
+									) ?? 0 ) > 1
+								}
 								setNodeRef={ setRecentNodeRef( key ) }
 								onSelect={ onSelectRecent }
 							/>

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -17,7 +17,6 @@ import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
 } from '../hooks/useDelayedFlag';
 import { useDocumentActions, useDocumentRecord } from '../documents';
-import { definesTrait, hasTrait } from '../documents/capabilities';
 
 const EMPTY_TRASHED_DOCUMENTS_STATE = {
 	documents: [],
@@ -69,16 +68,11 @@ export function computeSidebarTrashRoots( trashedDocuments = [] ) {
 
 	const descendantCountById = new Map();
 	roots.forEach( ( root ) => {
-		const counts = { pages: 0, collections: 0, total: 0 };
+		const counts = { total: 0 };
 		const stack = [ ...( childrenByMarker.get( root.id ) ?? [] ) ];
 		while ( stack.length ) {
 			const node = stack.pop();
 			counts.total++;
-			if ( definesTrait( node ) ) {
-				counts.collections++;
-			} else if ( ! hasTrait( node ) ) {
-				counts.pages++;
-			}
 			const kids = childrenByMarker.get( node.id );
 			if ( kids ) {
 				stack.push( ...kids );
@@ -90,11 +84,11 @@ export function computeSidebarTrashRoots( trashedDocuments = [] ) {
 	return { roots, descendantCountById };
 }
 
-function titleText( title, fallback ) {
+function titleText( title ) {
 	if ( typeof title === 'string' && title.trim() ) {
 		return title.trim();
 	}
-	return title?.rendered?.trim() || title?.raw?.trim() || fallback;
+	return title?.rendered?.trim() || title?.raw?.trim() || '';
 }
 
 function buildBreadcrumb( record, ancestorById ) {
@@ -103,19 +97,20 @@ function buildBreadcrumb( record, ancestorById ) {
 	const seen = new Set( [ record.id ] );
 	while ( current && ! seen.has( current.id ) ) {
 		seen.add( current.id );
-		ancestors.unshift( {
-			id: current.id,
-			title:
-				current.title?.rendered?.trim() ||
-				__( '(untitled)', 'cortext' ),
-			icon: current.meta?.cortext_document_icon ?? '',
-		} );
+		const title = titleText( current.title );
+		if ( title ) {
+			ancestors.unshift( {
+				id: current.id,
+				title,
+				icon: current.meta?.cortext_document_icon ?? '',
+			} );
+		}
 		current = current.parent ? ancestorById.get( current.parent ) : null;
 	}
 	return ancestors;
 }
 
-const EMPTY_COUNTS = Object.freeze( { pages: 0, collections: 0, total: 0 } );
+const EMPTY_COUNTS = Object.freeze( { total: 0 } );
 
 /**
  * One row in the trash list. Display copy comes from `useDocumentRecord`, so
@@ -128,7 +123,7 @@ const EMPTY_COUNTS = Object.freeze( { pages: 0, collections: 0, total: 0 } );
  * @param {boolean}                        props.isSelected       Whether the canvas is currently showing this document.
  * @param {boolean}                        props.isBusy           Restore or delete in flight for this row.
  * @param {?{id: number, message: string}} props.error            Per-row error to display under the row.
- * @param {Function}                       props.onRestore        Parent callback `(record, restoreErrorMessage)`.
+ * @param {Function}                       props.onRestore        Parent callback `(record)`.
  * @param {Function}                       props.onRequestDelete  Parent callback `(record)` to open the confirm dialog.
  */
 function SidebarTrashRow( {
@@ -142,7 +137,7 @@ function SidebarTrashRow( {
 	onRequestDelete,
 } ) {
 	const navigate = useNavigate();
-	const { title, features, descendantLabel, restoreErrorMessage } =
+	const { title, features, nestedDocumentCountLabel } =
 		useDocumentRecord( record );
 
 	const breadcrumb = features.hierarchy
@@ -150,21 +145,19 @@ function SidebarTrashRow( {
 		: [];
 	const documentIcon = record.meta?.cortext_document_icon ?? '';
 	const collectionTitle = record.collection?.id
-		? titleText( record.collection?.title, __( 'Collection', 'cortext' ) )
+		? titleText( record.collection?.title )
 		: '';
 	// Inline collections are the only trash items with an owner. If that page
 	// is still active, show its title so similar inline tables are easier to
 	// tell apart.
-	const ownerTitle = record.owner
-		? titleText( record.owner?.title, __( 'Page', 'cortext' ) )
-		: '';
+	const ownerTitle = record.owner ? titleText( record.owner?.title ) : '';
 	const meta = descendantCounts.total
-		? descendantLabel( descendantCounts )
+		? nestedDocumentCountLabel( descendantCounts )
 		: '';
 
 	const handleRestore = useCallback( () => {
-		onRestore( record, restoreErrorMessage );
-	}, [ onRestore, record, restoreErrorMessage ] );
+		onRestore( record );
+	}, [ onRestore, record ] );
 
 	const handleRequestDelete = useCallback( () => {
 		onRequestDelete( record );
@@ -276,20 +269,20 @@ function SidebarTrashRow( {
  * @param {Object}   props
  * @param {Object}   props.record    Trashed record pending delete.
  * @param {Object}   props.counts    Cascade counts for the pending root.
- * @param {Function} props.onConfirm Parent callback `(record, permanentDeleteErrorMessage)`.
+ * @param {Function} props.onConfirm Parent callback `(record)`.
  * @param {Function} props.onCancel  Closes the dialog without deleting.
  */
 function SidebarTrashConfirmDialog( { record, counts, onConfirm, onCancel } ) {
-	const { title, permanentDeleteConfirmation, permanentDeleteErrorMessage } =
+	const { title, permanentDeleteDocumentConfirmation } =
 		useDocumentRecord( record );
-	const dialogConfig = permanentDeleteConfirmation( counts ) ?? {
+	const dialogConfig = permanentDeleteDocumentConfirmation( counts ) ?? {
 		title: '',
 		message: '',
 	};
 
 	const handleConfirm = useCallback( () => {
-		onConfirm( record, permanentDeleteErrorMessage );
-	}, [ onConfirm, record, permanentDeleteErrorMessage ] );
+		onConfirm( record );
+	}, [ onConfirm, record ] );
 
 	if ( dialogConfig.requireTypeToConfirm ) {
 		return (
@@ -322,7 +315,7 @@ function SidebarTrashConfirmDialog( { record, counts, onConfirm, onCancel } ) {
  * deleted with that parent. If a marker points to a parent that is no longer
  * in Trash, the orphan still appears so it can be recovered.
  *
- * Restore and permanent delete go through the descriptors, keeping per-kind
+ * Restore and permanent delete go through the descriptors, keeping per-case
  * refreshes and error copy out of this component.
  *
  * @param {Object}      props
@@ -399,7 +392,7 @@ export default function SidebarTrash( {
 	);
 
 	const handleRestore = useCallback(
-		async ( record, restoreErrorMessage ) => {
+		async ( record ) => {
 			setRowError( null );
 			setBusyId( record.id );
 			try {
@@ -407,7 +400,9 @@ export default function SidebarTrash( {
 			} catch ( error ) {
 				setRowError( {
 					id: record.id,
-					message: error?.message ?? restoreErrorMessage,
+					message:
+						error?.message ??
+						__( 'Could not restore this document.', 'cortext' ),
 				} );
 			} finally {
 				setBusyId( null );
@@ -417,7 +412,7 @@ export default function SidebarTrash( {
 	);
 
 	const handlePermanentDelete = useCallback(
-		async ( record, permanentDeleteErrorMessage ) => {
+		async ( record ) => {
 			setPendingDelete( null );
 			setRowError( null );
 			setBusyId( record.id );
@@ -436,7 +431,9 @@ export default function SidebarTrash( {
 			} catch ( error ) {
 				setRowError( {
 					id: record.id,
-					message: error?.message ?? permanentDeleteErrorMessage,
+					message:
+						error?.message ??
+						__( 'Could not delete this document.', 'cortext' ),
 				} );
 			} finally {
 				setBusyId( null );

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -84,7 +84,7 @@ export function computeSidebarTrashRoots( trashedDocuments = [] ) {
 	return { roots, descendantCountById };
 }
 
-function titleText( title ) {
+function optionalTitleText( title ) {
 	if ( typeof title === 'string' && title.trim() ) {
 		return title.trim();
 	}
@@ -97,7 +97,7 @@ function buildBreadcrumb( record, ancestorById ) {
 	const seen = new Set( [ record.id ] );
 	while ( current && ! seen.has( current.id ) ) {
 		seen.add( current.id );
-		const title = titleText( current.title );
+		const title = optionalTitleText( current.title );
 		if ( title ) {
 			ancestors.unshift( {
 				id: current.id,
@@ -145,12 +145,14 @@ function SidebarTrashRow( {
 		: [];
 	const documentIcon = record.meta?.cortext_document_icon ?? '';
 	const collectionTitle = record.collection?.id
-		? titleText( record.collection?.title )
+		? optionalTitleText( record.collection?.title )
 		: '';
 	// Inline collections are the only trash items with an owner. If that page
 	// is still active, show its title so similar inline tables are easier to
 	// tell apart.
-	const ownerTitle = record.owner ? titleText( record.owner?.title ) : '';
+	const ownerTitle = record.owner
+		? optionalTitleText( record.owner?.title )
+		: '';
 	const meta = descendantCounts.total
 		? nestedDocumentCountLabel( descendantCounts )
 		: '';

--- a/src/components/fields/AddFieldPopover.js
+++ b/src/components/fields/AddFieldPopover.js
@@ -19,7 +19,7 @@ import { FIELD_TYPES, FieldTypeIcon, fieldTypeLabel } from './fieldTypes';
 
 const RELATION_LIMIT_OPTIONS = [
 	{ value: 'many', label: __( 'No limit', 'cortext' ) },
-	{ value: 'one', label: __( '1 page', 'cortext' ) },
+	{ value: 'one', label: __( '1 document', 'cortext' ) },
 ];
 
 const ROLLUP_AGGREGATORS = [

--- a/src/components/fields/DeleteOptionDialog.js
+++ b/src/components/fields/DeleteOptionDialog.js
@@ -13,9 +13,9 @@ import { useOptionUsage } from '../../hooks/useFieldMutations';
 const ACTION_CLEAR = 'clear';
 const ACTION_REPLACE = 'replace';
 
-// Lazy-fetches the row count for the option being deleted, then asks the
-// user to either clear the value across those rows or replace it with
-// another option. When no row uses the value, `onConfirm` fires
+// Lazy-fetches the document count for the option being deleted, then asks the
+// user to either clear the value across those documents or replace it with
+// another option. When no document uses the value, `onConfirm` fires
 // immediately with no migration so the parent can simply drop the option
 // without prompting.
 export default function DeleteOptionDialog( {
@@ -51,7 +51,7 @@ export default function DeleteOptionDialog( {
 				if ( ! cancelled ) {
 					setError(
 						__(
-							'Could not check whether rows use this option.',
+							'Could not check whether documents use this option.',
 							'cortext'
 						)
 					);
@@ -121,10 +121,10 @@ export default function DeleteOptionDialog( {
 		>
 			<p>
 				{ sprintf(
-					/* translators: 1: option label, 2: number of rows referencing it */
+					/* translators: 1: option label, 2: number of documents referencing it */
 					_n(
-						'%2$d row currently uses "%1$s".',
-						'%2$d rows currently use "%1$s".',
+						'%2$d document currently uses "%1$s".',
+						'%2$d documents currently use "%1$s".',
 						count,
 						'cortext'
 					),
@@ -141,7 +141,7 @@ export default function DeleteOptionDialog( {
 						checked={ action === ACTION_CLEAR }
 						onChange={ () => setAction( ACTION_CLEAR ) }
 					/>
-					{ __( 'Clear the value on those rows.', 'cortext' ) }
+					{ __( 'Clear this value in those documents.', 'cortext' ) }
 				</label>
 				<label htmlFor="cortext-delete-option-action-replace">
 					<input

--- a/src/components/relations/RelationEditor.js
+++ b/src/components/relations/RelationEditor.js
@@ -220,7 +220,7 @@ export default function RelationEditor( {
 			const createdId = Number( created?.id );
 			if ( ! createdId ) {
 				throw new Error(
-					__( 'Related row could not be created.', 'cortext' )
+					__( 'Related item could not be created.', 'cortext' )
 				);
 			}
 			touchRecent( {
@@ -242,7 +242,7 @@ export default function RelationEditor( {
 		} catch ( error ) {
 			setCreateError(
 				error?.message ||
-					__( 'Related row could not be created.', 'cortext' )
+					__( 'Related item could not be created.', 'cortext' )
 			);
 		} finally {
 			setIsCreating( false );
@@ -287,7 +287,7 @@ export default function RelationEditor( {
 						</span>
 					) : (
 						<span className="cortext-relation-edit__toggle-placeholder">
-							{ __( 'Select rows…', 'cortext' ) }
+							{ __( 'Select…', 'cortext' ) }
 						</span>
 					) }
 					<Icon
@@ -311,11 +311,8 @@ export default function RelationEditor( {
 							onChange={ ( event ) =>
 								setSearch( event.target.value )
 							}
-							placeholder={ __(
-								'Search or create a row…',
-								'cortext'
-							) }
-							aria-label={ __( 'Search rows', 'cortext' ) }
+							placeholder={ __( 'Search or create…', 'cortext' ) }
+							aria-label={ __( 'Search', 'cortext' ) }
 						/>
 					</div>
 					{ selectedIds.length > 0 ? (
@@ -349,7 +346,7 @@ export default function RelationEditor( {
 					) : null }
 					<div className="cortext-relation-edit__section cortext-relation-edit__section--more">
 						<div className="cortext-relation-edit__section-label">
-							{ __( 'Rows', 'cortext' ) }
+							{ __( 'Available', 'cortext' ) }
 						</div>
 						{ isLoading && accumulatedRows.length === 0 ? (
 							<div className="cortext-relation-edit__loading">
@@ -360,7 +357,7 @@ export default function RelationEditor( {
 							<div className="cortext-relation-edit__empty">
 								{ createTitle
 									? __( 'No results', 'cortext' )
-									: __( 'No rows', 'cortext' ) }
+									: __( 'Nothing available', 'cortext' ) }
 							</div>
 						) : null }
 						{ unselectedRows.map( ( row ) => (
@@ -400,8 +397,8 @@ export default function RelationEditor( {
 								/>
 								<span className="cortext-relation-edit__row-title">
 									{ sprintf(
-										/* translators: %s: row title */
-										__( 'Create row "%s"', 'cortext' ),
+										/* translators: %s: item title */
+										__( 'Create "%s"', 'cortext' ),
 										createTitle
 									) }
 								</span>

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -260,8 +260,8 @@ export default function DocumentRow( {
 							icon={ plus }
 							size="small"
 							label={ sprintf(
-								/* translators: %s: parent page title */
-								__( 'Add a page inside %s', 'cortext' ),
+								/* translators: %s: parent document title */
+								__( 'Add a document inside %s', 'cortext' ),
 								title
 							) }
 							onClick={ ( e ) => {
@@ -347,9 +347,7 @@ export default function DocumentRow( {
 										onClose();
 									} }
 								>
-									{ features.hierarchy
-										? __( 'Trash', 'cortext' )
-										: __( 'Move to Trash', 'cortext' ) }
+									{ __( 'Move to Trash', 'cortext' ) }
 								</MenuItem>
 							</MenuGroup>
 						) }

--- a/src/documents/hooks.js
+++ b/src/documents/hooks.js
@@ -20,11 +20,8 @@ import {
 import { iconForRecord, listIconForRecord } from './icons';
 import { documentFeatures } from './capabilities';
 import {
-	documentLabel,
-	descendantLabel,
-	permanentDeleteConfirmation,
-	permanentDeleteErrorMessage,
-	restoreErrorMessage,
+	nestedDocumentCountLabel,
+	permanentDeleteDocumentConfirmation,
 } from './labels';
 import {
 	renameDocument,
@@ -163,8 +160,7 @@ export function useDocumentActions() {
 }
 
 /**
- * Display data for a record: title, icons, feature flags, localized labels,
- * and trash-list copy.
+ * Display data for a record: title, icons, feature flags, and trash-list copy.
  *
  * @param {Object} record Document record.
  */
@@ -173,13 +169,11 @@ export function useDocumentRecord( record ) {
 		title: documentTitle( record ),
 		icon: iconForRecord( record ),
 		listIcon: ( size ) => listIconForRecord( record, size ),
-		kindLabel: documentLabel( record ),
 		features: documentFeatures( record ),
-		descendantLabel: ( counts ) => descendantLabel( counts ),
-		permanentDeleteConfirmation: ( counts ) =>
-			permanentDeleteConfirmation( record, counts ),
-		restoreErrorMessage: restoreErrorMessage( record ),
-		permanentDeleteErrorMessage: permanentDeleteErrorMessage( record ),
+		nestedDocumentCountLabel: ( counts ) =>
+			nestedDocumentCountLabel( counts ),
+		permanentDeleteDocumentConfirmation: ( counts ) =>
+			permanentDeleteDocumentConfirmation( record, counts ),
 	};
 }
 

--- a/src/documents/labels.js
+++ b/src/documents/labels.js
@@ -1,143 +1,56 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 
-import { definesTrait, hasTrait } from './capabilities';
+import { definesTrait } from './capabilities';
 
 /**
- * Localized noun for a record (used in aria labels, headers, etc.).
+ * Label for descendants that will be restored or deleted with a trash root.
  *
- * @param {Object} record Document record.
+ * @param {Object} counts Cascade counts `{ total }`.
  */
-export function documentLabel( record ) {
-	if ( definesTrait( record ) ) {
-		return __( 'Collection', 'cortext' );
-	}
-	if ( hasTrait( record ) ) {
-		return __( 'Row', 'cortext' );
-	}
-	return __( 'Page', 'cortext' );
-}
-
-export function restoreErrorMessage( record ) {
-	if ( definesTrait( record ) ) {
-		return __( 'Could not restore collection.', 'cortext' );
-	}
-	if ( hasTrait( record ) ) {
-		return __( 'Could not restore row.', 'cortext' );
-	}
-	return __( 'Could not restore page.', 'cortext' );
-}
-
-export function permanentDeleteErrorMessage( record ) {
-	if ( definesTrait( record ) ) {
-		return __( 'Could not delete collection.', 'cortext' );
-	}
-	if ( hasTrait( record ) ) {
-		return __( 'Could not delete row.', 'cortext' );
-	}
-	return __( 'Could not delete page.', 'cortext' );
-}
-
-export function descendantLabel( counts ) {
-	const pages = counts?.pages ?? 0;
-	const collections = counts?.collections ?? 0;
+export function nestedDocumentCountLabel( counts ) {
 	const total = counts?.total ?? 0;
-	if ( pages > 0 && collections === 0 ) {
-		return sprintf(
-			/* translators: %d: number of subpages */
-			_n( '%d subpage', '%d subpages', pages, 'cortext' ),
-			pages
-		);
-	}
-	if ( collections > 0 && pages === 0 ) {
-		return sprintf(
-			/* translators: %d: number of nested collections */
-			_n( '%d collection', '%d collections', collections, 'cortext' ),
-			collections
-		);
-	}
 	return sprintf(
 		/* translators: %d: number of nested trashed documents */
-		_n( '%d nested item', '%d nested items', total, 'cortext' ),
+		_n( '%d nested document', '%d nested documents', total, 'cortext' ),
 		total
 	);
 }
 
 /**
- * Confirmation copy for permanent delete. Schema-bearing documents take rows
- * down with them, so the dialog asks the user to type the title.
+ * Confirmation copy for permanent delete. Documents that contain rows take
+ * those rows down with them, so the dialog asks the user to type the title.
  *
  * @param {Object} record Document being deleted.
- * @param {Object} counts Cascade counts `{ pages, collections, total }`.
+ * @param {Object} counts Cascade counts `{ total }`.
  */
-export function permanentDeleteConfirmation( record, counts ) {
+export function permanentDeleteDocumentConfirmation( record, counts ) {
 	const total = counts?.total ?? 0;
 	if ( definesTrait( record ) ) {
 		return {
-			title: __( 'Permanently delete collection?', 'cortext' ),
+			title: __( 'Delete this document permanently?', 'cortext' ),
 			message: __(
-				"Permanently delete this collection and all its rows? You can't undo this.",
+				"Delete this document and all rows it contains? This can't be undone.",
 				'cortext'
 			),
 			requireTypeToConfirm: true,
 		};
 	}
-	if ( hasTrait( record ) ) {
-		if ( total === 0 ) {
-			return {
-				title: __( 'Permanently delete row?', 'cortext' ),
-				message: __(
-					"Permanently delete this row? You can't undo this.",
-					'cortext'
-				),
-			};
-		}
-		return {
-			title: __( 'Permanently delete row?', 'cortext' ),
-			message: sprintf(
-				/* translators: %d: number of nested trashed items deleted along with the row. */
-				_n(
-					"Permanently delete this row and %d nested item? You can't undo this.",
-					"Permanently delete this row and %d nested items? You can't undo this.",
-					total,
-					'cortext'
-				),
-				total
-			),
-		};
-	}
 	if ( total === 0 ) {
 		return {
-			title: __( 'Permanently delete page?', 'cortext' ),
+			title: __( 'Delete this document permanently?', 'cortext' ),
 			message: __(
-				"Permanently delete this page? You can't undo this.",
+				"Delete this document permanently? This can't be undone.",
 				'cortext'
 			),
 		};
 	}
-	const pages = counts?.pages ?? 0;
-	const collections = counts?.collections ?? 0;
-	if ( pages > 0 && collections === 0 ) {
-		return {
-			title: __( 'Permanently delete page?', 'cortext' ),
-			message: sprintf(
-				/* translators: %d: number of subpages deleted along with the page. */
-				_n(
-					"Permanently delete this page and %d subpage? You can't undo this.",
-					"Permanently delete this page and %d subpages? You can't undo this.",
-					pages,
-					'cortext'
-				),
-				pages
-			),
-		};
-	}
 	return {
-		title: __( 'Permanently delete page?', 'cortext' ),
+		title: __( 'Delete this document permanently?', 'cortext' ),
 		message: sprintf(
-			/* translators: %d: number of nested trashed items deleted along with the page. */
+			/* translators: %d: number of nested documents deleted along with the document. */
 			_n(
-				"Permanently delete this page and %d nested item? You can't undo this.",
-				"Permanently delete this page and %d nested items? You can't undo this.",
+				"Delete this document and %d nested document? This can't be undone.",
+				"Delete this document and %d nested documents? This can't be undone.",
 				total,
 				'cortext'
 			),

--- a/src/router/EmptyState.js
+++ b/src/router/EmptyState.js
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 export default function EmptyState() {
 	return (
 		<div className="cortext-canvas__empty">
-			<p>{ __( 'Select a page to start editing.', 'cortext' ) }</p>
+			<p>{ __( 'Choose something to edit.', 'cortext' ) }</p>
 		</div>
 	);
 }

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -510,7 +510,7 @@ async function dragRenderedRow(
 	const sourceTitle = orderedTitles[ fromIndex ];
 	const targetTitle = orderedTitles[ toIndex ];
 	const source = canvas.getByRole( 'button', {
-		name: `Reorder row: ${ sourceTitle }`,
+		name: `Reorder: ${ sourceTitle }`,
 	} );
 	const target = canvas.getByText( targetTitle, { exact: true } ).first();
 
@@ -731,7 +731,7 @@ test.describe( 'Collection view block', () => {
 				await dragRenderedRow( page, canvas, 2, 0, 'before', layout );
 				await expect(
 					page.getByText(
-						'Rows will stay where you dropped them, and the current sort will be cleared.'
+						'Documents will stay where you dropped them, and the current sort will be cleared.'
 					)
 				).toBeVisible();
 				await page
@@ -739,7 +739,7 @@ test.describe( 'Collection view block', () => {
 					.click();
 				await expect(
 					page.getByText(
-						'Rows will stay where you dropped them, and the current sort will be cleared.'
+						'Documents will stay where you dropped them, and the current sort will be cleared.'
 					)
 				).not.toBeVisible();
 				await expect
@@ -851,7 +851,7 @@ test.describe( 'Collection view block', () => {
 					);
 					await expect(
 						page.getByText(
-							'Rows will stay where you dropped them, and the current sort will be cleared.'
+							'Documents will stay where you dropped them, and the current sort will be cleared.'
 						)
 					).toBeVisible();
 					await page
@@ -859,7 +859,7 @@ test.describe( 'Collection view block', () => {
 						.click();
 					await expect(
 						page.getByText(
-							'Rows will stay where you dropped them, and the current sort will be cleared.'
+							'Documents will stay where you dropped them, and the current sort will be cleared.'
 						)
 					).not.toBeVisible();
 					await expect
@@ -934,7 +934,7 @@ test.describe( 'Collection view block', () => {
 				.boundingBox();
 			const handleBox = await canvas
 				.getByRole( 'button', {
-					name: 'Reorder row: Alpha Manual',
+					name: 'Reorder: Alpha Manual',
 				} )
 				.boundingBox();
 			expect( dataViewBox ).toBeTruthy();
@@ -945,7 +945,7 @@ test.describe( 'Collection view block', () => {
 					Number(
 						await canvas
 							.getByRole( 'button', {
-								name: 'Reorder row: Alpha Manual',
+								name: 'Reorder: Alpha Manual',
 							} )
 							.evaluate(
 								( node ) =>
@@ -1566,22 +1566,30 @@ test.describe( 'Collection view block', () => {
 			await alphaRow
 				.locator( '.dataviews-selection-checkbox input' )
 				.check();
-			await expect( canvas.getByText( '1 row selected' ) ).toBeVisible();
+			await expect(
+				canvas.getByText( '1 document selected' )
+			).toBeVisible();
 			await betaRow
 				.locator( '.dataviews-selection-checkbox input' )
 				.check();
-			await expect( canvas.getByText( '2 rows selected' ) ).toBeVisible();
+			await expect(
+				canvas.getByText( '2 documents selected' )
+			).toBeVisible();
 			await canvas
 				.getByRole( 'button', { name: 'Clear selection' } )
 				.click();
-			await expect( canvas.getByText( '2 rows selected' ) ).toBeHidden();
+			await expect(
+				canvas.getByText( '2 documents selected' )
+			).toBeHidden();
 
 			await alphaRow.dispatchEvent( 'click' );
-			await expect( canvas.getByText( '1 row selected' ) ).toHaveCount(
-				0
-			);
+			await expect(
+				canvas.getByText( '1 document selected' )
+			).toHaveCount( 0 );
 			await betaRow.dispatchEvent( 'click', { shiftKey: true } );
-			await expect( canvas.getByText( '2 rows selected' ) ).toBeVisible();
+			await expect(
+				canvas.getByText( '2 documents selected' )
+			).toBeVisible();
 
 			await canvas.getByRole( 'button', { name: 'Next page' } ).click();
 
@@ -1589,16 +1597,22 @@ test.describe( 'Collection view block', () => {
 				.locator( 'tbody > tr' )
 				.filter( { hasText: 'Gamma Book' } );
 			await expect( gammaRow ).toBeVisible();
-			await expect( canvas.getByText( '2 rows selected' ) ).toBeVisible();
+			await expect(
+				canvas.getByText( '2 documents selected' )
+			).toBeVisible();
 			await gammaRow.dispatchEvent( 'click', {
 				[ process.platform === 'darwin' ? 'metaKey' : 'ctrlKey' ]: true,
 			} );
-			await expect( canvas.getByText( '3 rows selected' ) ).toBeVisible();
+			await expect(
+				canvas.getByText( '3 documents selected' )
+			).toBeVisible();
 
 			await canvas
-				.getByRole( 'button', { name: 'Trash selected rows' } )
+				.getByRole( 'button', { name: 'Move selected to Trash' } )
 				.click();
-			await expect( canvas.getByText( '3 rows selected' ) ).toBeHidden();
+			await expect(
+				canvas.getByText( '3 documents selected' )
+			).toBeHidden();
 
 			await expect
 				.poll( async () => {
@@ -1793,7 +1807,7 @@ test.describe( 'Collection view block', () => {
 			await titleCellOpenButton.click();
 
 			const detail = page.getByRole( 'dialog', {
-				name: 'Row detail',
+				name: 'Detail',
 			} );
 			await expect( detail ).toBeVisible();
 			await selectParentDataViewBlock( page );
@@ -1964,7 +1978,7 @@ test.describe( 'Collection view block', () => {
 				.first();
 			await expect( titleCellOpenButton ).toHaveAttribute(
 				'aria-label',
-				'Open row'
+				'Open'
 			);
 			await expect( titleCellOpenButton ).toHaveCSS( 'opacity', '0' );
 			await firstRow.hover();
@@ -1985,12 +1999,12 @@ test.describe( 'Collection view block', () => {
 
 			await expect(
 				canvas.getByRole( 'dialog', {
-					name: 'Row detail',
+					name: 'Detail',
 				} )
 			).toHaveCount( 0 );
 
 			const detail = page.getByRole( 'dialog', {
-				name: 'Row detail',
+				name: 'Detail',
 			} );
 			await expect( detail ).toBeVisible();
 			await detail.hover();
@@ -2133,7 +2147,7 @@ test.describe( 'Collection view block', () => {
 				}
 			};
 			await page.route( delayedSecondRowPattern, delaySecondRow );
-			await detail.getByRole( 'button', { name: 'Row below' } ).click();
+			await detail.getByRole( 'button', { name: 'Next' } ).click();
 			await expect( detail.locator( '.components-spinner' ) ).toHaveCount(
 				0
 			);
@@ -2149,14 +2163,14 @@ test.describe( 'Collection view block', () => {
 					.filter( { hasText: 'Tags' } )
 			).toBeVisible();
 			await page.unroute( delayedSecondRowPattern, delaySecondRow );
-			await detail.getByRole( 'button', { name: 'Row above' } ).click();
+			await detail.getByRole( 'button', { name: 'Previous' } ).click();
 			await expect( detailTitle ).toHaveText(
 				'The Left Hand of Darkness'
 			);
 			await expectSidePeekShellStayedOpen( page );
 			// Side and modal panes are local React state, not URL state, so
 			// browser Back/Forward doesn't navigate between rows anymore.
-			// The Row above / Row below buttons above already cover that.
+			// The Previous / Next buttons above already cover that.
 
 			// Collapsing properties keeps the block selectable as a stub.
 			const propertiesSlot = detailCanvas.locator(
@@ -2166,7 +2180,7 @@ test.describe( 'Collection view block', () => {
 			// button. Scope to the row-detail toolbar so the locator stays
 			// unambiguous regardless of editor selection.
 			const rowDetailToolbar = detail.getByRole( 'toolbar', {
-				name: 'Row detail tools',
+				name: 'Detail tools',
 			} );
 			await rowDetailToolbar
 				.getByRole( 'button', { name: 'Collapse properties' } )
@@ -2214,7 +2228,7 @@ test.describe( 'Collection view block', () => {
 				detail.getByRole( 'button', { name: 'Center modal' } )
 			).toBeVisible();
 			await expect(
-				detail.getByRole( 'button', { name: 'Full page' } )
+				detail.getByRole( 'button', { name: 'Full view' } )
 			).toBeVisible();
 			await expect(
 				detail.getByRole( 'button', { name: 'Change layout' } )
@@ -2233,10 +2247,10 @@ test.describe( 'Collection view block', () => {
 				modalDetail.getByRole( 'button', { name: 'Side peek' } )
 			).toBeVisible();
 			await expect(
-				modalDetail.getByRole( 'button', { name: 'Full page' } )
+				modalDetail.getByRole( 'button', { name: 'Full view' } )
 			).toBeVisible();
 			await modalDetail
-				.getByRole( 'button', { name: 'Full page' } )
+				.getByRole( 'button', { name: 'Full view' } )
 				.click();
 			await expect( detail ).toBeHidden();
 			await expect(
@@ -2262,9 +2276,7 @@ test.describe( 'Collection view block', () => {
 				'[name="editor-canvas"]'
 			);
 			await expect(
-				collectionCanvas
-					.getByRole( 'button', { name: 'Open row' } )
-					.first()
+				collectionCanvas.getByRole( 'button', { name: 'Open' } ).first()
 			).toBeAttached();
 
 			await expect
@@ -2385,7 +2397,7 @@ test.describe( 'Collection view block', () => {
 			await openRowButton.click();
 
 			const detail = page.getByRole( 'dialog', {
-				name: 'Row detail',
+				name: 'Detail',
 			} );
 			await expect( detail ).toBeVisible();
 

--- a/tests/e2e/specs/page-trash.spec.js
+++ b/tests/e2e/specs/page-trash.spec.js
@@ -3,7 +3,7 @@
  *
  * Walks the user-visible path the unit tests can't: open a page, trash it
  * from the sidebar dropdown, see the Trash panel pick it up with the
- * cascade subpage count, the canvas locked behind a notice, and Restore
+ * nested document count, the canvas locked behind a notice, and Restore
  * via the banner unwinding the whole thing.
  */
 
@@ -91,7 +91,7 @@ test.describe( 'Page trash flow', () => {
 			await page.getByRole( 'menuitem', { name: 'Trash' } ).click();
 
 			// Active sidebar drops the whole subtree; the Trash panel
-			// shows the cascade root with the subpage count.
+			// shows the cascade root with the nested document count.
 			await expect(
 				sidebar.getByRole( 'button', {
 					name: PARENT_TITLE,
@@ -107,12 +107,12 @@ test.describe( 'Page trash flow', () => {
 
 			const trashList = page.locator( '.cortext-sidebar__trash-list' );
 			await expect( trashList ).toContainText( PARENT_TITLE );
-			await expect( trashList ).toContainText( '1 subpage' );
+			await expect( trashList ).toContainText( '1 nested document' );
 
 			// Canvas keeps the parent open with a trashed banner.
 			const notice = page.locator( '.cortext-canvas__notice' );
 			await expect( notice ).toContainText(
-				'This document is in trash.'
+				'This document is in the Trash.'
 			);
 
 			// Restore via the banner. Subtree returns; banner disappears.

--- a/tests/e2e/specs/palette-search.spec.js
+++ b/tests/e2e/specs/palette-search.spec.js
@@ -37,7 +37,7 @@ async function openPalette( page ) {
 		window.dispatchEvent( new Event( 'cortext:open-command-palette' ) );
 	} );
 	await expect(
-		page.getByPlaceholder( 'Search pages, collections, and actions' )
+		page.getByPlaceholder( 'Search or run a command' )
 	).toBeVisible( { timeout: 5000 } );
 }
 
@@ -67,7 +67,7 @@ test.describe( 'Command palette search', () => {
 
 			await openPalette( page );
 			await page
-				.getByPlaceholder( 'Search pages, collections, and actions' )
+				.getByPlaceholder( 'Search or run a command' )
 				.fill( token );
 
 			const result = page.getByRole( 'option', { name: pageTitle } );
@@ -120,7 +120,7 @@ test.describe( 'Command palette search', () => {
 
 			await openPalette( page );
 			await page
-				.getByPlaceholder( 'Search pages, collections, and actions' )
+				.getByPlaceholder( 'Search or run a command' )
 				.fill( rowToken );
 
 			const result = page.getByRole( 'option', { name: rowToken } );

--- a/tests/e2e/specs/perf-ui.spec.js
+++ b/tests/e2e/specs/perf-ui.spec.js
@@ -25,7 +25,7 @@
  *   - workspace_home_ready: root Cortext URL until sidebar and home content render.
  *   - shell_navigation_warm: sidebar navigation from one loaded collection to another.
  *   - search_rows_ready: DataView search input to filtered rows.
- *   - row_navigate_next: "Row below" click in full row detail to the next row.
+ *   - row_navigate_next: "Next" click in full detail view to the next row.
  */
 
 const { expect, test } = require( '@wordpress/e2e-test-utils-playwright' );
@@ -265,7 +265,7 @@ test.describe( 'Cortext UI performance', () => {
 				const startedAt = Date.now();
 
 				await activeCollectionView( page )
-					.getByLabel( 'Open row' )
+					.getByLabel( 'Open' )
 					.first()
 					.click( { force: true } );
 				await waitForRowDetailReady( page );
@@ -492,9 +492,7 @@ test.describe( 'Cortext UI performance', () => {
 		} );
 		await waitForCommandPaletteReady( page );
 
-		const input = page.getByPlaceholder(
-			'Search pages, collections, and actions'
-		);
+		const input = page.getByPlaceholder( 'Search or run a command' );
 
 		await probe.reset();
 		const responsePromise = page.waitForResponse(
@@ -639,7 +637,7 @@ test.describe( 'Cortext UI performance', () => {
 				await waitForCollectionReady( page );
 				await clearCollectionSearch( page );
 				await activeCollectionView( page )
-					.getByLabel( 'Open row' )
+					.getByLabel( 'Open' )
 					.first()
 					.click( { force: true } );
 				await waitForRowDetailReady( page );
@@ -661,7 +659,7 @@ test.describe( 'Cortext UI performance', () => {
 				);
 				const startedAt = Date.now();
 
-				await page.getByLabel( 'Row below' ).click();
+				await page.getByLabel( 'Next' ).click();
 				await responsePromise;
 				await expect
 					.poll( () => titleLocator.getAttribute( 'data-block' ), {

--- a/tests/e2e/specs/recents.spec.js
+++ b/tests/e2e/specs/recents.spec.js
@@ -42,7 +42,7 @@ async function readRecentsPlacement( page ) {
 		).map( ( title ) => title.textContent.trim() );
 		return {
 			recents: titles.indexOf( 'Recents' ),
-			pages: titles.indexOf( 'Pages' ),
+			pages: titles.indexOf( 'Documents' ),
 		};
 	} );
 }
@@ -198,7 +198,7 @@ test.describe( 'Sidebar recents', () => {
 			await expandRecentsIfCollapsed( page );
 			await expect(
 				sidebar.getByRole( 'button', {
-					name: `Recent page: ${ pageTitle }`,
+					name: `Recent: ${ pageTitle }`,
 				} )
 			).toBeVisible();
 
@@ -218,19 +218,19 @@ test.describe( 'Sidebar recents', () => {
 			).toBeVisible( { timeout: 15_000 } );
 			await expect(
 				sidebar.getByRole( 'button', {
-					name: `Recent collection: ${ collectionTitle }`,
+					name: `Recent: ${ collectionTitle }`,
 				} )
 			).toBeVisible();
 
 			await page.reload();
 			await expect(
 				sidebar.getByRole( 'button', {
-					name: `Recent collection: ${ collectionTitle }`,
+					name: `Recent: ${ collectionTitle }`,
 				} )
 			).toBeVisible();
 			await expect(
 				sidebar.getByRole( 'button', {
-					name: `Recent page: ${ pageTitle }`,
+					name: `Recent: ${ pageTitle }`,
 				} )
 			).toBeVisible();
 		} finally {
@@ -305,7 +305,7 @@ test.describe( 'Sidebar recents', () => {
 			const sidebar = page.locator( '.cortext-sidebar' );
 			await expandRecentsIfCollapsed( page );
 			const recentRow = sidebar.getByRole( 'button', {
-				name: `Recent row: The Left Hand of Darkness in ${ fixture.collectionTitle }`,
+				name: `Recent: The Left Hand of Darkness in ${ fixture.collectionTitle }`,
 			} );
 			await expect( recentRow ).toBeVisible( { timeout: 15_000 } );
 

--- a/tests/e2e/specs/sidebar-layout.spec.js
+++ b/tests/e2e/specs/sidebar-layout.spec.js
@@ -584,7 +584,7 @@ test.describe( 'Sidebar layout controls', () => {
 			).toBeVisible();
 
 			await sidebar
-				.getByRole( 'button', { name: 'Collapse Pages' } )
+				.getByRole( 'button', { name: 'Collapse Documents' } )
 				.click();
 
 			await expect(
@@ -597,7 +597,7 @@ test.describe( 'Sidebar layout controls', () => {
 			await page.reload();
 
 			await expect(
-				sidebar.getByRole( 'button', { name: 'Expand Pages' } )
+				sidebar.getByRole( 'button', { name: 'Expand Documents' } )
 			).toBeVisible();
 			await expect(
 				sidebar.getByRole( 'button', {
@@ -607,7 +607,7 @@ test.describe( 'Sidebar layout controls', () => {
 			).toHaveCount( 0 );
 
 			await sidebar
-				.getByRole( 'button', { name: 'Expand Pages' } )
+				.getByRole( 'button', { name: 'Expand Documents' } )
 				.click();
 
 			await expect(

--- a/tests/js/components/CortextCommandMenu.test.js
+++ b/tests/js/components/CortextCommandMenu.test.js
@@ -102,9 +102,7 @@ describe( 'CortextCommandMenu', () => {
 		} );
 
 		expect(
-			await screen.findByPlaceholderText(
-				'Search pages, collections, and actions'
-			)
+			await screen.findByPlaceholderText( 'Search or run a command' )
 		).toBeInTheDocument();
 		expect( screen.getByText( 'Test command' ) ).toBeInTheDocument();
 	} );

--- a/tests/js/components/DataViewRowReorder.test.js
+++ b/tests/js/components/DataViewRowReorder.test.js
@@ -407,7 +407,7 @@ describe( 'DataViewRowReorder', () => {
 		expect( itemButtons[ 2 ] ).not.toHaveClass(
 			'cortext-row-reorder-target'
 		);
-		const handles = screen.getAllByLabelText( /^Reorder row:/ );
+		const handles = screen.getAllByLabelText( /^Reorder:/ );
 		expect( handles ).toHaveLength( 3 );
 		expect( handles[ 0 ] ).toHaveAttribute( 'tabindex', '-1' );
 	} );
@@ -791,7 +791,7 @@ describe( 'DataViewRowReorder', () => {
 		await renderReorder();
 
 		const handle = screen.getByRole( 'button', {
-			name: 'Reorder row: One',
+			name: 'Reorder: One',
 		} );
 
 		expect( handle.parentElement?.tagName ).toBe( 'TD' );
@@ -804,7 +804,7 @@ describe( 'DataViewRowReorder', () => {
 		await renderReorder();
 
 		const handle = screen.getByRole( 'button', {
-			name: 'Reorder row: One',
+			name: 'Reorder: One',
 		} );
 		const renderedTableRows = document.querySelectorAll( 'tr' );
 
@@ -1073,7 +1073,7 @@ describe( 'DataViewRowReorder', () => {
 
 		await waitFor( () =>
 			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
-				"Couldn't move the row.",
+				"Couldn't move the document.",
 				{
 					id: 'cortext-row-reorder-failed',
 					type: 'snackbar',
@@ -1139,7 +1139,7 @@ describe( 'DataViewRowReorder', () => {
 
 		expect(
 			screen.getByText(
-				'Rows will stay where you dropped them, and the current sort will be cleared.'
+				'Documents will stay where you dropped them, and the current sort will be cleared.'
 			)
 		).toBeInTheDocument();
 		expect( mockApiFetch ).not.toHaveBeenCalled();
@@ -1232,7 +1232,7 @@ describe( 'DataViewRowReorder', () => {
 
 		await waitFor( () =>
 			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
-				"Couldn't move the row.",
+				"Couldn't move the document.",
 				{
 					id: 'cortext-row-reorder-failed',
 					type: 'snackbar',
@@ -1257,7 +1257,7 @@ describe( 'DataViewRowReorder', () => {
 
 		await waitFor( () =>
 			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
-				"Couldn't move the row.",
+				"Couldn't move the document.",
 				{
 					id: 'cortext-row-reorder-failed',
 					type: 'snackbar',
@@ -1284,7 +1284,7 @@ describe( 'DataViewRowReorder', () => {
 		await renderReorderInParent( { onPointerDown: onParentPointerDown } );
 
 		fireEvent.pointerDown(
-			screen.getByRole( 'button', { name: 'Reorder row: One' } )
+			screen.getByRole( 'button', { name: 'Reorder: One' } )
 		);
 
 		expect( onPointerDown ).toHaveBeenCalledTimes( 1 );
@@ -1297,7 +1297,7 @@ describe( 'DataViewRowReorder', () => {
 		await renderReorder();
 
 		fireEvent.pointerDown(
-			screen.getByRole( 'button', { name: 'Reorder row: One' } )
+			screen.getByRole( 'button', { name: 'Reorder: One' } )
 		);
 
 		expect( document.body ).toHaveClass(

--- a/tests/js/components/EditOptionsPopover.test.js
+++ b/tests/js/components/EditOptionsPopover.test.js
@@ -393,7 +393,7 @@ describe( 'EditOptionsPopover', () => {
 		fireEvent.click( screen.getByRole( 'button', { name: 'Delete' } ) );
 
 		expect( await screen.findByRole( 'dialog' ) ).toHaveTextContent(
-			'Could not check whether rows use this option.'
+			'Could not check whether documents use this option.'
 		);
 		expect( mockUpdateRun ).not.toHaveBeenCalled();
 	} );

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -38,9 +38,7 @@ describe( 'SidebarFavorites helpers', () => {
 		renderFavorites();
 
 		expect(
-			screen.getByText(
-				'Star a page from its title menu to pin it here.'
-			)
+			screen.getByText( 'Star from the title menu to pin it here.' )
 		).toBeInTheDocument();
 	} );
 
@@ -328,9 +326,7 @@ describe( 'SidebarFavorites helpers', () => {
 		const { container, rerender } = renderFavorites();
 
 		expect(
-			screen.getByText(
-				'Star a page from its title menu to pin it here.'
-			)
+			screen.getByText( 'Star from the title menu to pin it here.' )
 		).toBeInTheDocument();
 
 		rerender(
@@ -348,9 +344,7 @@ describe( 'SidebarFavorites helpers', () => {
 		);
 
 		expect(
-			screen.getByText(
-				'Star a page from its title menu to pin it here.'
-			)
+			screen.getByText( 'Star from the title menu to pin it here.' )
 		).toBeInTheDocument();
 		expect(
 			container.querySelector( '.cortext-sidebar__loading' )

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -138,7 +138,7 @@ describe( 'SidebarRecents animation', () => {
 
 		render( <SidebarRecents /> );
 		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Recent page: Alpha' } )
+			screen.getByRole( 'button', { name: 'Recent: Alpha' } )
 		);
 
 		expect( blurSpy ).toHaveBeenCalled();
@@ -160,7 +160,7 @@ describe( 'SidebarRecents animation', () => {
 		).toBeInTheDocument();
 		expect(
 			screen.getByRole( 'button', {
-				name: 'Recent row: War and Peace in Books',
+				name: 'Recent: War and Peace in Books',
 			} )
 		).toBeInTheDocument();
 	} );
@@ -177,7 +177,7 @@ describe( 'SidebarRecents animation', () => {
 		const { container } = render( <SidebarRecents /> );
 
 		expect(
-			screen.getByRole( 'button', { name: 'Recent collection: Library' } )
+			screen.getByRole( 'button', { name: 'Recent: Library' } )
 		).toBeInTheDocument();
 		expect(
 			container.querySelector( '[data-testid="icon-table"]' )

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -184,6 +184,37 @@ describe( 'SidebarRecents animation', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'adds accessible context when recent titles collide', () => {
+		mockRecents = [
+			pageRecent( 21, 'Roadmap' ),
+			collectionRecent( 33, 'Roadmap' ),
+		];
+		mockRecordsById.set( 21, {
+			id: 21,
+			crtxt_trait: [],
+			meta: {},
+		} );
+		mockRecordsById.set( 33, {
+			id: 33,
+			crtxt_trait: [],
+			cortext_defines_trait: true,
+			meta: { cortext_fields: [ 1 ] },
+		} );
+
+		render( <SidebarRecents /> );
+
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Recent: Roadmap, plain document',
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', {
+				name: 'Recent: Roadmap, contains rows',
+			} )
+		).toBeInTheDocument();
+	} );
+
 	it( 'shows a row recent with its custom icon when set', () => {
 		// A row that has a `cortext_document_icon` stored renders that glyph
 		// instead of the generic list-item fallback.

--- a/tests/js/components/SidebarSection.test.js
+++ b/tests/js/components/SidebarSection.test.js
@@ -7,20 +7,20 @@ describe( 'SidebarSection', () => {
 		render(
 			<SidebarSection
 				id="pages"
-				title="Pages"
+				title="Documents"
 				isCollapsed={ false }
 				onToggle={ jest.fn() }
 			>
-				<div>Page row</div>
+				<div>Document row</div>
 			</SidebarSection>
 		);
 
 		const toggle = screen.getByRole( 'button', {
-			name: 'Collapse Pages',
+			name: 'Collapse Documents',
 		} );
 
 		expect( toggle ).toHaveAttribute( 'aria-expanded', 'true' );
-		expect( screen.getByText( 'Page row' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Document row' ) ).toBeInTheDocument();
 	} );
 
 	it( 'hides the body when collapsed and calls onToggle from the title', () => {
@@ -28,27 +28,27 @@ describe( 'SidebarSection', () => {
 		render(
 			<SidebarSection
 				id="pages"
-				title="Pages"
+				title="Documents"
 				isCollapsed
 				onToggle={ onToggle }
 			>
-				<div>Page row</div>
+				<div>Document row</div>
 			</SidebarSection>
 		);
 
 		const toggle = screen.getByRole( 'button', {
-			name: 'Expand Pages',
+			name: 'Expand Documents',
 		} );
 
 		expect( toggle ).toHaveAttribute( 'aria-expanded', 'false' );
 		expect(
 			screen
-				.getByText( 'Page row' )
+				.getByText( 'Document row' )
 				.closest( '.cortext-sidebar__section-body-wrapper' )
 		).toHaveAttribute( 'aria-hidden', 'true' );
 		expect(
 			screen
-				.getByText( 'Page row' )
+				.getByText( 'Document row' )
 				.closest( '.cortext-sidebar__section-body-wrapper' )
 		).toHaveAttribute( 'inert' );
 
@@ -63,16 +63,18 @@ describe( 'SidebarSection', () => {
 		render(
 			<SidebarSection
 				id="pages"
-				title="Pages"
+				title="Documents"
 				isCollapsed={ false }
 				onToggle={ onToggle }
-				actions={ <button onClick={ onAction }>New page</button> }
+				actions={ <button onClick={ onAction }>New document</button> }
 			>
-				<div>Page row</div>
+				<div>Document row</div>
 			</SidebarSection>
 		);
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'New page' } ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'New document' } )
+		);
 
 		expect( onAction ).toHaveBeenCalledTimes( 1 );
 		expect( onToggle ).not.toHaveBeenCalled();

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -665,10 +665,10 @@ describe( 'SidebarTrash', () => {
 
 		expect(
 			container.querySelector( '.cortext-sidebar__breadcrumb' )
-		).toHaveTextContent( '2 subpages' );
+		).toHaveTextContent( '2 nested documents' );
 	} );
 
-	it( 'shows a collection count when a trashed page owns only nested collections', () => {
+	it( 'shows a nested document count when a trashed page owns only nested collections', () => {
 		const root = makePage( {
 			id: 1,
 			title: { rendered: 'Quarterly review', raw: 'Quarterly review' },
@@ -686,10 +686,10 @@ describe( 'SidebarTrash', () => {
 
 		expect(
 			container.querySelector( '.cortext-sidebar__breadcrumb' )
-		).toHaveTextContent( '1 collection' );
+		).toHaveTextContent( '1 nested document' );
 	} );
 
-	it( 'falls back to nested items when a trashed page mixes subpages and nested collections', () => {
+	it( 'shows nested documents when a trashed page mixes child documents and nested collections', () => {
 		const root = makePage( {
 			id: 1,
 			title: { rendered: 'Quarterly review', raw: 'Quarterly review' },
@@ -711,14 +711,14 @@ describe( 'SidebarTrash', () => {
 
 		expect(
 			container.querySelector( '.cortext-sidebar__breadcrumb' )
-		).toHaveTextContent( '2 nested items' );
+		).toHaveTextContent( '2 nested documents' );
 	} );
 
 	it( 'shows the cascade count beside a row that owns a trashed collection', () => {
 		// TrashCascade applies to any document with descendants via
 		// `post_parent`, rows included. The owned collection points back at
 		// the row through `_cortext_trashed_by_parent`, so the row surfaces
-		// the collection-count badge.
+		// the nested-document badge.
 		const row = makeRow( {
 			id: 17,
 			title: { rendered: 'Sprint 12', raw: 'Sprint 12' },
@@ -736,7 +736,7 @@ describe( 'SidebarTrash', () => {
 
 		expect(
 			container.querySelector( '.cortext-sidebar__breadcrumb' )
-		).toHaveTextContent( '1 collection' );
+		).toHaveTextContent( '1 nested document' );
 	} );
 
 	it( 'nests cascade-trashed rows under their collection via the COLLECTION marker', () => {
@@ -765,7 +765,7 @@ describe( 'SidebarTrash', () => {
 		expect( screen.getByText( 'Sprint board' ) ).toBeInTheDocument();
 		expect(
 			container.querySelector( '.cortext-sidebar__breadcrumb' )
-		).toHaveTextContent( '2 nested items' );
+		).toHaveTextContent( '2 nested documents' );
 	} );
 
 	it( 'promotes orphaned descendants (stale marker) back to roots', () => {
@@ -911,7 +911,7 @@ describe( 'SidebarTrash', () => {
 
 		expect(
 			screen.getByText(
-				"Permanently delete this collection and all its rows? You can't undo this."
+				"Delete this document and all rows it contains? This can't be undone."
 			)
 		).toBeInTheDocument();
 	} );
@@ -937,7 +937,7 @@ describe( 'SidebarTrash', () => {
 
 		expect(
 			screen.getByText(
-				"Permanently delete this page and 1 subpage? You can't undo this."
+				"Delete this document and 1 nested document? This can't be undone."
 			)
 		).toBeInTheDocument();
 	} );
@@ -981,7 +981,7 @@ describe( 'SidebarTrash', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'falls back to nested items in the confirm when subpages and nested collections mix', () => {
+	it( 'mentions nested documents in the confirm when child documents and nested collections mix', () => {
 		const root = makePage( {
 			id: 1,
 			title: { rendered: 'Workspace', raw: 'Workspace' },
@@ -1007,7 +1007,7 @@ describe( 'SidebarTrash', () => {
 
 		expect(
 			screen.getByText(
-				"Permanently delete this page and 2 nested items? You can't undo this."
+				"Delete this document and 2 nested documents? This can't be undone."
 			)
 		).toBeInTheDocument();
 	} );

--- a/tests/js/components/SidebarTrash.test.js
+++ b/tests/js/components/SidebarTrash.test.js
@@ -404,6 +404,30 @@ describe( 'SidebarTrash', () => {
 		).toHaveTextContent( 'Workspace / Project' );
 	} );
 
+	it( 'omits blank ancestor titles from trashed breadcrumbs', () => {
+		const parent = makePage( {
+			id: 11,
+			title: { rendered: '', raw: '' },
+		} );
+		const child = makePage( {
+			id: 12,
+			parent: 11,
+			title: { rendered: 'Notes', raw: 'Notes' },
+		} );
+
+		setTrashRecords( { records: [ child ] } );
+
+		const { container } = renderSidebarTrash( {
+			activePages: [ parent ],
+		} );
+
+		expect( screen.getByText( 'Notes' ) ).toBeInTheDocument();
+		expect(
+			container.querySelector( '.cortext-sidebar__breadcrumb' )
+		).toBeFalsy();
+		expect( screen.queryByText( '(untitled)' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'falls back to no breadcrumb when ancestors are missing (orphan)', () => {
 		const orphan = makePage( { id: 5, parent: 99 } );
 
@@ -460,6 +484,23 @@ describe( 'SidebarTrash', () => {
 
 		expect( screen.getByText( 'Draft record' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Research' ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits blank collection context for trashed rows', () => {
+		const row = makeRow( {
+			id: 17,
+			title: { rendered: 'Draft record', raw: 'Draft record' },
+			collection: {
+				id: 22,
+				title: { rendered: '', raw: '' },
+			},
+		} );
+		setTrashRecords( { records: [ row ] } );
+
+		renderSidebarTrash();
+
+		expect( screen.getByText( 'Draft record' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '(untitled)' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'restores a row through the document endpoint', async () => {
@@ -868,6 +909,25 @@ describe( 'SidebarTrash', () => {
 		expect(
 			container.querySelector( '.cortext-sidebar__breadcrumb' )
 		).toHaveTextContent( 'Quarterly review' );
+	} );
+
+	it( 'omits blank owner context for inline collections', () => {
+		const inline = makeCollection( {
+			id: 34,
+			title: { rendered: 'Action items', raw: 'Action items' },
+			owner: {
+				id: 99,
+				title: { rendered: '', raw: '' },
+				path: 'page/quarterly-99',
+			},
+		} );
+
+		setTrashRecords( { records: [ inline ] } );
+
+		renderSidebarTrash();
+
+		expect( screen.getByText( 'Action items' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '(untitled)' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'nests a collection under its owner page when both are in trash', () => {

--- a/tests/js/components/relations/RelationEditor.test.js
+++ b/tests/js/components/relations/RelationEditor.test.js
@@ -131,7 +131,7 @@ describe( 'RelationEditor', () => {
 			/>
 		);
 
-		fireEvent.change( screen.getByLabelText( 'Search rows' ), {
+		fireEvent.change( screen.getByLabelText( 'Search' ), {
 			target: { value: 'abc' },
 		} );
 
@@ -230,7 +230,7 @@ describe( 'RelationEditor', () => {
 		await flushPopoverEffects();
 	} );
 
-	it( 'hides "Create row" while the debounced search has not caught up', async () => {
+	it( 'hides create while the debounced search has not caught up', async () => {
 		// Pin the debounced value so search ('New Row') stays unsettled.
 		useDebouncedValue.mockImplementation( () => '' );
 
@@ -244,17 +244,19 @@ describe( 'RelationEditor', () => {
 			/>
 		);
 
-		fireEvent.change( screen.getByLabelText( 'Search rows' ), {
+		fireEvent.change( screen.getByLabelText( 'Search' ), {
 			target: { value: 'New Row' },
 		} );
 
 		expect(
-			screen.queryByRole( 'button', { name: 'Create row "New Row"' } )
+			screen.queryByRole( 'button', {
+				name: 'Create "New Row"',
+			} )
 		).toBeNull();
 		await flushPopoverEffects();
 	} );
 
-	it( 'hides "Create row" when an exact-title match exists in results', async () => {
+	it( 'hides create when an exact-title match exists in results', async () => {
 		mockRowsResponse( {
 			data: [ { id: 5, title: { raw: 'Exact Match' } } ],
 		} );
@@ -269,12 +271,14 @@ describe( 'RelationEditor', () => {
 			/>
 		);
 
-		fireEvent.change( screen.getByLabelText( 'Search rows' ), {
+		fireEvent.change( screen.getByLabelText( 'Search' ), {
 			target: { value: 'Exact Match' },
 		} );
 
 		expect(
-			screen.queryByRole( 'button', { name: 'Create row "Exact Match"' } )
+			screen.queryByRole( 'button', {
+				name: 'Create "Exact Match"',
+			} )
 		).toBeNull();
 		await flushPopoverEffects();
 	} );
@@ -345,12 +349,14 @@ describe( 'RelationEditor', () => {
 			/>
 		);
 
-		fireEvent.change( screen.getByLabelText( 'Search rows' ), {
+		fireEvent.change( screen.getByLabelText( 'Search' ), {
 			target: { value: 'New Ada' },
 		} );
 
 		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Create row "New Ada"' } )
+			screen.getByRole( 'button', {
+				name: 'Create "New Ada"',
+			} )
 		);
 
 		await waitFor( () =>

--- a/tests/js/components/sidebar/DocumentRow.test.js
+++ b/tests/js/components/sidebar/DocumentRow.test.js
@@ -189,7 +189,9 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 	it( 'renders an add-child button', () => {
 		const { props } = renderRow();
 		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Add a page inside Hello' } )
+			screen.getByRole( 'button', {
+				name: 'Add a document inside Hello',
+			} )
 		);
 		expect( props.onCreateChild ).toHaveBeenCalledWith( 1 );
 	} );
@@ -272,7 +274,9 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 	it( 'invokes the document layer trash action from the menu', () => {
 		const { container, props } = renderRow();
 		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
-		fireEvent.click( screen.getByRole( 'menuitem', { name: 'Trash' } ) );
+		fireEvent.click(
+			screen.getByRole( 'menuitem', { name: 'Move to Trash' } )
+		);
 		expect( mockTrash ).toHaveBeenCalledWith( props.record );
 	} );
 


### PR DESCRIPTION
## What

Refs #280.

This follows up on the universal document model by cleaning up UI copy that still talked about pages, rows, or collections. Cortext now uses "document" as the default term across the sidebar, inspector, data views, relation picker, Trash, command palette, and Published view.

Published now labels content as "Plain document" or "Contains rows", so users can still tell when a published document defines row-backed content.

## Why

After #280, the product model is simpler, but some UI still exposed the old terms. This makes the language catch up.

## How

- Keeps "collection" where users choose or configure a collection as a data source.
- Keeps explicit Trash/delete copy when nested documents or contained rows are affected.
- Removes label helpers that no longer branch by type.

## Testing Instructions

1. Open Cortext and check the sidebar, recents, favorites, and inspector copy.
2. Open a collection data view and check open, detail, reorder, and bulk-trash labels.
3. Move a document to Trash and check restore/delete copy and nested document counts.
4. Open Published and confirm documents show as "Plain document" or "Contains rows".

## Screenshot
<img width="1914" height="679" alt="image" src="https://github.com/user-attachments/assets/0c9f3511-d501-46fe-b68a-8ff2b2680f60" />
