### PR TITLE
Fix: Hide admin bar on public Cortext pages

### DIFF
--- a/includes/Frontend/AdminBar.php
+++ b/includes/Frontend/AdminBar.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Hides the WordPress admin bar on public Cortext pages.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Frontend;
+
+use Cortext\PostType\Document;
+
+final class AdminBar {
+
+	public function register(): void {
+		add_filter( 'show_admin_bar', array( $this, 'hide_on_public_document_pages' ) );
+	}
+
+	public function hide_on_public_document_pages( bool $show ): bool {
+		if ( is_singular( Document::POST_TYPE ) ) {
+			return false;
+		}
+
+		return $show;
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -16,6 +16,7 @@ use Cortext\Editor\DocumentIconBlock;
 use Cortext\Editor\DocumentPropertiesBlock;
 use Cortext\Editor\RevisionThrottle;
 use Cortext\FieldValues\FieldValueIndex;
+use Cortext\Frontend\AdminBar;
 use Cortext\Frontend\Assets;
 use Cortext\Frontend\Template;
 use Cortext\PostType\Document;
@@ -71,6 +72,7 @@ final class Plugin {
 		( new WorkspaceHomeController() )->register();
 		( new NotionController() )->register();
 		( new NotionImporter() )->register();
+		( new AdminBar() )->register();
 		( new Template() )->register();
 		( new Assets() )->register();
 		( new DataView() )->register();

--- a/tests/e2e/specs/public-page.spec.js
+++ b/tests/e2e/specs/public-page.spec.js
@@ -64,6 +64,37 @@ test.describe( 'Public page rendering', () => {
 		}
 	} );
 
+	test( 'published page hides the WordPress admin bar for logged-in visitors', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		let createdPage;
+
+		try {
+			createdPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: `Public page while logged in ${ suffix }`,
+					status: 'publish',
+				},
+			} );
+
+			const response = await page.goto(
+				`/cortext/${ createdPage.slug }/`
+			);
+
+			expect( response?.status() ).toBe( 200 );
+			await expect( page.locator( '#wpadminbar' ) ).toHaveCount( 0 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				createdPage && `/wp/v2/crtxt_documents/${ createdPage.id }`
+			);
+		}
+	} );
+
 	test( 'private page returns 404 for anonymous visitors', async ( {
 		page,
 		requestUtils,

--- a/tests/php/test-frontend-admin-bar.php
+++ b/tests/php/test-frontend-admin-bar.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for Cortext\Frontend\AdminBar.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Frontend\AdminBar;
+use Cortext\PostType\Document;
+use WorDBless\BaseTestCase;
+use WP_Query;
+
+final class Test_Frontend_Admin_Bar extends BaseTestCase {
+
+	private ?WP_Query $previous_wp_query = null;
+
+	private ?AdminBar $admin_bar = null;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_query;
+		$this->previous_wp_query = $wp_query ?? null;
+
+		( new Document() )->register_post_type();
+	}
+
+	public function tear_down(): void {
+		if ( $this->admin_bar ) {
+			remove_filter( 'show_admin_bar', array( $this->admin_bar, 'hide_on_public_document_pages' ) );
+		}
+
+		global $wp_query;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the query object swapped in by this test.
+		$wp_query = $this->previous_wp_query;
+
+		parent::tear_down();
+	}
+
+	public function test_filter_hides_admin_bar_on_public_cortext_pages(): void {
+		$document_id = $this->create_post_of_type( Document::POST_TYPE );
+		$this->set_singular_query_for_post( $document_id );
+
+		$this->admin_bar = new AdminBar();
+		$this->admin_bar->register();
+
+		$this->assertFalse( apply_filters( 'show_admin_bar', true ) );
+	}
+
+	public function test_filter_leaves_other_frontend_pages_alone(): void {
+		$post_id = $this->create_post_of_type( 'post' );
+		$this->set_singular_query_for_post( $post_id );
+
+		$this->admin_bar = new AdminBar();
+		$this->admin_bar->register();
+
+		$this->assertTrue( apply_filters( 'show_admin_bar', true ) );
+		$this->assertFalse( apply_filters( 'show_admin_bar', false ) );
+	}
+
+	private function create_post_of_type( string $post_type ): int {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => $post_type,
+				'post_status' => 'publish',
+				'post_title'  => 'Admin bar test ' . wp_generate_uuid4(),
+			)
+		);
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		return (int) $post_id;
+	}
+
+	private function set_singular_query_for_post( int $post_id ): void {
+		global $wp_query;
+
+		$post = get_post( $post_id );
+		$this->assertNotNull( $post );
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Exercise the same query conditional the filter uses.
+		$wp_query                    = new WP_Query();
+		$wp_query->post              = $post;
+		$wp_query->queried_object    = $post;
+		$wp_query->queried_object_id = $post_id;
+		$wp_query->is_single         = true;
+		$wp_query->is_singular       = true;
+	}
+}


### PR DESCRIPTION
## What

Hide the WordPress admin bar on public Cortext document pages for logged-in visitors. Regular frontend posts and pages still behave the way WordPress expects.

## Why

A public Cortext page should feel like Cortext, not like a half-step back into wp-admin.

## Testing Instructions

1. Log in as an admin.
2. Publish a Cortext document and open its public `/cortext/{slug}/` URL.
3. Check that the WordPress admin bar is gone.
4. Open a regular frontend post or page while still logged in.
5. Check that the WordPress admin bar still behaves normally there.
