### PR TITLE
Add document post locks to avoid concurrent users

### DIFF
--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -71,6 +71,11 @@ final class Screen {
 		// core/post-featured-image block inside the editor iframe) can open
 		// the WordPress media library.
 		wp_enqueue_media();
+		wp_enqueue_script( 'heartbeat' );
+		wp_add_inline_script(
+			'heartbeat',
+			'if ( window.wp && wp.heartbeat ) { wp.heartbeat.interval( 10 ); }'
+		);
 
 		$asset_path = CORTEXT_PATH . 'build/index.asset.php';
 		if ( ! file_exists( $asset_path ) ) {
@@ -128,6 +133,24 @@ final class Screen {
 		if ( ! isset( $editor_settings['styles'] ) || ! is_array( $editor_settings['styles'] ) ) {
 			$editor_settings['styles'] = array();
 		}
+		if ( ! isset( $editor_settings['postLock'] ) || ! is_array( $editor_settings['postLock'] ) ) {
+			$editor_settings['postLock'] = array();
+		}
+		$editor_settings['postLock'] = array_merge(
+			array( 'isLocked' => false ),
+			$editor_settings['postLock']
+		);
+		if ( ! isset( $editor_settings['postLockUtils'] ) || ! is_array( $editor_settings['postLockUtils'] ) ) {
+			$editor_settings['postLockUtils'] = array();
+		}
+		$editor_settings['postLockUtils'] = array_merge(
+			array(
+				'nonce'       => '',
+				'unlockNonce' => '',
+				'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
+			),
+			$editor_settings['postLockUtils']
+		);
 
 		// The block editor iframe only sees stylesheets listed in
 		// `editor_settings.styles`. Webpack splits Cortext's CSS into

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -28,6 +28,7 @@ use Cortext\Rest\FavoritesController;
 use Cortext\Rest\FieldsController;
 use Cortext\Notion\Importer as NotionImporter;
 use Cortext\Rest\NotionController;
+use Cortext\Rest\PostLocksController;
 use Cortext\Rest\RecentsController;
 use Cortext\Rest\RowsController;
 use Cortext\Rest\WorkspaceHomeController;
@@ -66,6 +67,7 @@ final class Plugin {
 		( new FieldsController() )->register();
 		( new DocumentLocatorController() )->register();
 		( new DocumentsController( null, $trash_cascade ) )->register();
+		( new PostLocksController() )->register();
 		( new RecentsController() )->register();
 		( new RowsController() )->register();
 		( new WorkspaceHomeController() )->register();

--- a/includes/Rest/PostLocksController.php
+++ b/includes/Rest/PostLocksController.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * REST endpoint for locking Cortext documents.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class PostLocksController {
+
+	private const NAMESPACE = 'cortext/v1';
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/documents/(?P<id>\d+)/lock',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'lock' ),
+					'permission_callback' => array( $this, 'can_lock' ),
+					'args'                => array(
+						'id'    => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'force' => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission check for the lock endpoint.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function can_lock( WP_REST_Request $request ) {
+		$post = get_post( (int) $request->get_param( 'id' ) );
+		if ( ! $post instanceof WP_Post || ! post_type_supports( $post->post_type, 'cortext-document' ) ) {
+			return new WP_Error(
+				'cortext_document_not_found',
+				__( 'Document not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return current_user_can( 'edit_post', (int) $post->ID );
+	}
+
+	public function lock( WP_REST_Request $request ) {
+		$this->ensure_post_lock_functions();
+
+		$post_id = (int) $request->get_param( 'id' );
+		$post    = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return new WP_Error(
+				'cortext_document_not_found',
+				__( 'Document not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'trash' === $post->post_status ) {
+			return new WP_Error(
+				'cortext_document_in_trash',
+				__(
+					'Move this document out of Trash before editing it.',
+					'cortext'
+				),
+				array( 'status' => 409 )
+			);
+		}
+
+		$force          = rest_sanitize_boolean( $request->get_param( 'force' ) );
+		$locked_user_id = $force ? false : wp_check_post_lock( $post_id );
+		if ( $locked_user_id ) {
+			return new WP_REST_Response(
+				array(
+					'postLock'      => $this->locked_post_lock( (int) $locked_user_id ),
+					'postLockUtils' => $this->post_lock_utils( $post_id ),
+				),
+				200
+			);
+		}
+
+		$active_post_lock = wp_set_post_lock( $post_id );
+		if ( ! $active_post_lock ) {
+			return new WP_Error(
+				'cortext_document_lock_failed',
+				__( "Couldn't lock this document.", 'cortext' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$data = array(
+			'postLock'      => array(
+				'isLocked'       => false,
+				'activePostLock' => esc_attr( implode( ':', $active_post_lock ) ),
+			),
+			'postLockUtils' => $this->post_lock_utils( $post_id ),
+		);
+
+		if ( $force ) {
+			$fresh_post = get_post( $post_id );
+			if ( $fresh_post instanceof WP_Post ) {
+				$data['post'] = $this->prepare_post_for_response( $fresh_post );
+			}
+		}
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Builds the locked postLock object expected by core/editor.
+	 *
+	 * @param int $user_id Lock owner's user id.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function locked_post_lock( int $user_id ): array {
+		$user = get_userdata( $user_id );
+		$lock = array(
+			'isLocked' => true,
+			'user'     => array(
+				'name' => $user ? $user->display_name : __( 'Someone', 'cortext' ),
+			),
+		);
+
+		if ( $user && get_option( 'show_avatars' ) ) {
+			$lock['user']['avatar'] = get_avatar_url( $user_id, array( 'size' => 128 ) );
+		}
+
+		return $lock;
+	}
+
+	/**
+	 * Builds the nonce and AJAX URL bundle used by core/editor lock code.
+	 *
+	 * @param int $post_id Post id.
+	 *
+	 * @return array<string,string>
+	 */
+	private function post_lock_utils( int $post_id ): array {
+		return array(
+			'nonce'       => wp_create_nonce( 'lock-post_' . $post_id ),
+			'unlockNonce' => wp_create_nonce( 'update-post_' . $post_id ),
+			'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
+		);
+	}
+
+	private function ensure_post_lock_functions(): void {
+		if ( function_exists( 'wp_check_post_lock' ) && function_exists( 'wp_set_post_lock' ) ) {
+			return;
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/post.php';
+	}
+
+	/**
+	 * Builds a fresh core REST post payload after takeover.
+	 *
+	 * @param WP_Post $post Post to prepare.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private function prepare_post_for_response( WP_Post $post ): ?array {
+		$post_type = get_post_type_object( $post->post_type );
+		if ( ! $post_type || ! $post_type->show_in_rest ) {
+			return null;
+		}
+
+		$controller = $post_type->get_rest_controller();
+		if ( ! $controller || ! method_exists( $controller, 'prepare_item_for_response' ) ) {
+			return null;
+		}
+
+		$request = new WP_REST_Request( 'GET', rest_get_route_for_post( $post ) );
+		$request->set_param( 'context', 'edit' );
+		$response = $controller->prepare_item_for_response( $post, $request );
+
+		return rest_get_server()->response_to_data( $response, false );
+	}
+}

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -21,6 +21,7 @@ import './Canvas.scss';
 import { getEditorSettings } from './initEditor';
 import useAutosave from '../hooks/useAutosave';
 import useDelayedFlag from '../hooks/useDelayedFlag';
+import usePostLock from '../hooks/usePostLock';
 import { withViewTransition } from '../hooks/viewTransition';
 import { definesTrait } from '../documents/capabilities';
 import { POST_TYPE } from './page-queries';
@@ -28,6 +29,7 @@ import CortextInserterSidebar from './CortextInserterSidebar';
 import { DocumentPropertiesProvider } from './DocumentPropertiesContext';
 import DocumentPublishToggle from './DocumentPublishToggle';
 import EditorBody from './EditorBody';
+import { PostLockFailureNotice, PostLockModal } from './PostLockControls';
 import { CanvasProgressBar } from './Skeleton';
 import { TopBarActionsFill } from './WorkspaceTopBar';
 import DocumentInspectorSidebar, {
@@ -37,12 +39,18 @@ import DocumentInspectorSidebar, {
 	isInspectorArea,
 } from './DocumentInspectorSidebar';
 
-function InserterToggle() {
+function InserterToggle( { disabled = false } ) {
 	const isOpen = useSelect(
 		( select ) => !! select( editorStore ).isInserterOpened(),
 		[]
 	);
 	const { setIsInserterOpened } = useDispatch( editorStore );
+
+	useEffect( () => {
+		if ( disabled && isOpen ) {
+			setIsInserterOpened( false );
+		}
+	}, [ disabled, isOpen, setIsInserterOpened ] );
 
 	return (
 		<Button
@@ -51,12 +59,18 @@ function InserterToggle() {
 			size="compact"
 			label={ __( 'Add block', 'cortext' ) }
 			isPressed={ isOpen }
-			onClick={ () => setIsInserterOpened( ! isOpen ) }
+			disabled={ disabled }
+			onClick={ () => {
+				if ( ! disabled ) {
+					setIsInserterOpened( ! isOpen );
+				}
+			} }
 		/>
 	);
 }
 
 function DocumentActions( {
+	disabled = false,
 	isActive,
 	postId,
 	topBarActions,
@@ -92,9 +106,12 @@ function DocumentActions( {
 	return (
 		<TopBarActionsFill>
 			<div className="cortext-document-actions">
-				<InserterToggle />
+				<InserterToggle disabled={ disabled } />
 				{ topBarActions }
-				<DocumentPublishToggle postId={ postId } />
+				<DocumentPublishToggle
+					postId={ postId }
+					disabled={ disabled }
+				/>
 				{ hasProperties ? (
 					<>
 						<Button
@@ -107,6 +124,7 @@ function DocumentActions( {
 									: __( 'Expand properties', 'cortext' )
 							}
 							isPressed={ arePropertiesVisible }
+							disabled={ disabled }
 							onClick={ onTogglePropertiesVisible }
 						/>
 						<Button
@@ -119,6 +137,7 @@ function DocumentActions( {
 									: __( 'Customize properties', 'cortext' )
 							}
 							isPressed={ isPropertiesLayoutEditing }
+							disabled={ disabled }
 							onClick={ onEditPropertiesLayout }
 						/>
 					</>
@@ -146,6 +165,7 @@ function DocumentActions( {
 function VisualCanvas( {
 	featuredMedia,
 	isActive,
+	isLocked = false,
 	postId,
 	postType,
 	onReady,
@@ -155,6 +175,7 @@ function VisualCanvas( {
 		<EditorBody
 			featuredMedia={ featuredMedia }
 			isActive={ isActive }
+			isLocked={ isLocked }
 			postId={ postId }
 			postType={ postType }
 			onReady={ onReady }
@@ -199,6 +220,11 @@ function CanvasEditor( {
 		( post?.id && ! isCollection && ! hasTrait ? { id: post.id } : null );
 	const { status, flushNow, isDirty, isSaving } = useAutosave( {
 		recentTarget: autosaveRecentTarget,
+	} );
+	const postLock = usePostLock( {
+		postId: post.id,
+		postType: post.type ?? postType,
+		enabled: isActive,
 	} );
 	const { resetPost } = useDispatch( editorStore );
 	const discard = useCallback( () => resetPost(), [ resetPost ] );
@@ -302,6 +328,7 @@ function CanvasEditor( {
 			onToggleVisible={ togglePropertiesVisible }
 		>
 			<DocumentActions
+				disabled={ postLock.isReadOnly }
 				isActive={ isActive }
 				postId={ post.id }
 				topBarActions={ topBarActions }
@@ -316,9 +343,15 @@ function CanvasEditor( {
 				content={
 					<>
 						{ notice }
+						<PostLockFailureNotice
+							error={ postLock.error }
+							isRetrying={ postLock.isAcquiring }
+							onRetry={ postLock.retry }
+						/>
 						<VisualCanvas
 							featuredMedia={ post.featured_media }
 							isActive={ isActive }
+							isLocked={ postLock.isReadOnly }
 							postId={ post.id }
 							postType={ post.type ?? postType }
 							onReady={ onDisplayedPost }
@@ -331,7 +364,15 @@ function CanvasEditor( {
 				}
 				sidebar={ <InspectorSidebarSlot /> }
 			/>
+			<PostLockModal
+				isOpen={ postLock.isLocked }
+				isTakeover={ postLock.isTakeover }
+				isTakingOver={ postLock.isTakingOver }
+				onTakeOver={ postLock.takeOver }
+				user={ postLock.user }
+			/>
 			<DocumentInspectorSidebar
+				isLocked={ postLock.isReadOnly }
 				postId={ post.id }
 				postType={ postType }
 			/>

--- a/src/components/Canvas.scss
+++ b/src/components/Canvas.scss
@@ -10,7 +10,6 @@
 @use "../../node_modules/@wordpress/editor/build-style/style.css" as editor;
 
 .cortext-canvas {
-
 	// Cross-document navigation keeps the previous post visible until autosave
 	// finishes. Put the progress bar over it while the next document loads.
 	&__pending-progress {
@@ -75,5 +74,17 @@
 		flex: 1 1 auto;
 		min-height: 0;
 		opacity: 0.7;
+	}
+}
+
+.cortext-post-lock-modal__content {
+	display: flex;
+	align-items: flex-start;
+	gap: $grid-unit-30;
+
+	.editor-post-locked-modal__buttons {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: $grid-unit-30;
 	}
 }

--- a/src/components/DocumentInspectorSidebar.js
+++ b/src/components/DocumentInspectorSidebar.js
@@ -709,11 +709,15 @@ function RowInspectorContent() {
 	);
 }
 
-function InspectorFrame( { children, isTrashed } ) {
-	return isTrashed ? <Disabled>{ children }</Disabled> : children;
+function InspectorFrame( { children, isLocked } ) {
+	return isLocked ? <Disabled>{ children }</Disabled> : children;
 }
 
-export default function DocumentInspectorSidebar( { postId, postType } ) {
+export default function DocumentInspectorSidebar( {
+	isLocked = false,
+	postId,
+	postType,
+} ) {
 	const { record: currentRecord } = useEntityRecord(
 		'postType',
 		postType,
@@ -766,6 +770,11 @@ export default function DocumentInspectorSidebar( { postId, postType } ) {
 			'trash',
 		[]
 	);
+	const isStoreLocked = useSelect(
+		( select ) => select( editorStore ).isPostLocked?.() ?? false,
+		[]
+	);
+	const isReadOnly = isTrashed || isLocked || isStoreLocked;
 	const activeArea = useSelect(
 		( select ) =>
 			select( interfaceStore ).getActiveComplementaryArea(
@@ -832,7 +841,7 @@ export default function DocumentInspectorSidebar( { postId, postType } ) {
 				isActiveByDefault
 				tabs={ tabs }
 			>
-				<InspectorFrame isTrashed={ isTrashed }>
+				<InspectorFrame isLocked={ isReadOnly }>
 					{ isCollection && (
 						<CollectionInspectorContent
 							postId={ postId }
@@ -851,7 +860,7 @@ export default function DocumentInspectorSidebar( { postId, postType } ) {
 					title={ __( 'Block', 'cortext' ) }
 					tabs={ tabs }
 				>
-					<InspectorFrame isTrashed={ isTrashed }>
+					<InspectorFrame isLocked={ isReadOnly }>
 						<BlockInspector />
 					</InspectorFrame>
 				</InspectorComplementaryArea>

--- a/src/components/DocumentPublishToggle.js
+++ b/src/components/DocumentPublishToggle.js
@@ -35,33 +35,36 @@ function referencedCollectionIds( blocks ) {
 	return [ ...ids ];
 }
 
-export default function DocumentPublishToggle( { postId } ) {
+export default function DocumentPublishToggle( { disabled = false, postId } ) {
 	const publicWebAffordances = isPublicWebAffordancesEnabled();
 	const { editPost, savePost } = useDispatch( editorStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
 
-	const { status, link, title, isSaving, blocks, isCollection } = useSelect(
-		( select ) => {
-			const editor = select( editorStore );
-			const record = select( coreStore ).getEntityRecord(
-				'postType',
-				'crtxt_document',
-				postId
-			);
-			return {
-				status: editor.getEditedPostAttribute( 'status' ),
-				link: editor.getEditedPostAttribute( 'link' ),
-				title: editor.getEditedPostAttribute( 'title' ),
-				isSaving: editor.isSavingPost(),
-				blocks: select( blockEditorStore ).getBlocks(),
-				isCollection: definesTrait( record ),
-			};
-		},
-		[ postId ]
-	);
+	const { status, link, title, isSaving, isLocked, blocks, isCollection } =
+		useSelect(
+			( select ) => {
+				const editor = select( editorStore );
+				const record = select( coreStore ).getEntityRecord(
+					'postType',
+					'crtxt_document',
+					postId
+				);
+				return {
+					status: editor.getEditedPostAttribute( 'status' ),
+					link: editor.getEditedPostAttribute( 'link' ),
+					title: editor.getEditedPostAttribute( 'title' ),
+					isSaving: editor.isSavingPost(),
+					isLocked: editor.isPostLocked?.() ?? false,
+					blocks: select( blockEditorStore ).getBlocks(),
+					isCollection: definesTrait( record ),
+				};
+			},
+			[ postId ]
+		);
 
 	const isPublic = status === 'publish';
+	const isDisabled = disabled || isLocked;
 	// A collection can be embedded in other documents through a data-view block,
 	// so unpublishing it may strand public dependents. Identity is the mirror
 	// term (`cortext_defines_trait`), true even for a collection with no custom
@@ -75,6 +78,9 @@ export default function DocumentPublishToggle( { postId } ) {
 	);
 
 	const togglePublishStatus = useCallback( async () => {
+		if ( isDisabled ) {
+			return;
+		}
 		if ( ! isPublic ) {
 			const collectionIds = referencedCollectionIds( blocks );
 			if ( collectionIds.length > 0 ) {
@@ -113,6 +119,7 @@ export default function DocumentPublishToggle( { postId } ) {
 		createErrorNotice,
 		removeNotice,
 		isPublic,
+		isDisabled,
 		blocks,
 	] );
 
@@ -130,10 +137,17 @@ export default function DocumentPublishToggle( { postId } ) {
 			<PublishToggle
 				isPublic={ isPublic }
 				isSaving={ isSaving }
+				disabled={ isDisabled }
 				link={ link }
 				onToggle={ togglePublishStatus }
 				onRequestUnpublish={
-					isReferenceable ? () => setIsConfirming( true ) : undefined
+					isReferenceable
+						? () => {
+								if ( ! isDisabled ) {
+									setIsConfirming( true );
+								}
+						  }
+						: undefined
 				}
 			/>
 			{ isConfirming && isReferenceable ? (

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -237,6 +237,7 @@ function syncHeaderBoundaryMoveUpState( root, shouldDisable ) {
 
 function HeaderPrefixToolbarGuard( {
 	isActive = true,
+	isLocked = false,
 	postId,
 	postType,
 	toolbarRootRef,
@@ -246,7 +247,7 @@ function HeaderPrefixToolbarGuard( {
 	const guardId = useRef( Symbol( DISABLE_HEADER_BOUNDARY_MOVE_UP_CLASS ) );
 	const shouldDisableMoveUp = useSelect(
 		( select ) => {
-			if ( ! isActive ) {
+			if ( ! isActive || isLocked ) {
 				return false;
 			}
 			const store = select( blockEditorStore );
@@ -280,7 +281,7 @@ function HeaderPrefixToolbarGuard( {
 
 			return Math.min( ...selectedRootIndexes ) === firstBodyIndex;
 		},
-		[ isActive, ownerBlockName ]
+		[ isActive, isLocked, ownerBlockName ]
 	);
 
 	useEffect( () => {
@@ -311,7 +312,7 @@ function HeaderPrefixToolbarGuard( {
 	return null;
 }
 
-function DocumentIdentityActions( { postId, postType } ) {
+function DocumentIdentityActions( { isLocked = false, postId, postType } ) {
 	const isInsertingCoverRef = useRef( false );
 	const actionsRef = useRef( null );
 	const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId );
@@ -343,7 +344,7 @@ function DocumentIdentityActions( { postId, postType } ) {
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
 	useEffect( () => {
-		if ( isTrashed || hasCover ) {
+		if ( isTrashed || isLocked || hasCover ) {
 			return undefined;
 		}
 		const node = actionsRef.current;
@@ -395,14 +396,14 @@ function DocumentIdentityActions( { postId, postType } ) {
 				focusFirstActionFromTitle,
 				true
 			);
-	}, [ hasCover, isTrashed, selectedBlockName ] );
+	}, [ hasCover, isLocked, isTrashed, selectedBlockName ] );
 
-	if ( isTrashed || hasCover ) {
+	if ( isTrashed || isLocked || hasCover ) {
 		return null;
 	}
 
 	const ensureIconBlock = () => {
-		if ( hasIcon ) {
+		if ( hasIcon || isLocked ) {
 			return;
 		}
 		const block = createBlock( DOCUMENT_ICON_BLOCK, {
@@ -412,7 +413,7 @@ function DocumentIdentityActions( { postId, postType } ) {
 	};
 
 	const insertCover = async ( mediaId ) => {
-		if ( hasCover || isInsertingCoverRef.current ) {
+		if ( hasCover || isLocked || isInsertingCoverRef.current ) {
 			return;
 		}
 		isInsertingCoverRef.current = true;
@@ -476,7 +477,7 @@ function DocumentIdentityActions( { postId, postType } ) {
 	);
 }
 
-function EnsureHeaderBlocks( { postId, postType } ) {
+function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 	const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId );
 	const [ featuredId ] = useEntityProp(
 		'postType',
@@ -596,7 +597,7 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 	} = useDispatch( blockEditorStore );
 
 	useLayoutEffect( () => {
-		if ( isTrashed ) {
+		if ( isTrashed || isLocked ) {
 			return;
 		}
 
@@ -621,6 +622,7 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 		duplicateHeaderIds,
 		hasProperties,
 		hasSchema,
+		isLocked,
 		isTrashed,
 		propertiesClientId,
 		propertiesContextStable,
@@ -629,11 +631,16 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 	] );
 
 	useLayoutEffect( () => {
-		if ( isTrashed || ! shouldHideHeaderInsertionPoint ) {
+		if ( isTrashed || isLocked || ! shouldHideHeaderInsertionPoint ) {
 			return;
 		}
 		hideInsertionPoint();
-	}, [ hideInsertionPoint, isTrashed, shouldHideHeaderInsertionPoint ] );
+	}, [
+		hideInsertionPoint,
+		isLocked,
+		isTrashed,
+		shouldHideHeaderInsertionPoint,
+	] );
 
 	// useLayoutEffect rather than useEffect: we want the insertion to
 	// happen between render and paint so the user never sees the
@@ -647,7 +654,7 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 	// reads as "the icon is being inserted right now" when really the
 	// document is just hydrating.
 	useLayoutEffect( () => {
-		if ( isTrashed ) {
+		if ( isTrashed || isLocked ) {
 			return;
 		}
 
@@ -756,6 +763,7 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 		hasTitle,
 		iconMeta,
 		insertBlocks,
+		isLocked,
 		isTrashed,
 		ownerBlockName,
 		postId,
@@ -768,6 +776,7 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 	useLayoutEffect( () => {
 		if (
 			isTrashed ||
+			isLocked ||
 			! bodyBlockBeforeTitleId ||
 			headerEndIndex < 0 ||
 			duplicateHeaderIds.length > 0 ||
@@ -800,6 +809,7 @@ function EnsureHeaderBlocks( { postId, postType } ) {
 		hasTitle,
 		headerEndIndex,
 		iconMeta,
+		isLocked,
 		isTrashed,
 		moveBlocksToPosition,
 		startTyping,
@@ -1145,6 +1155,7 @@ function CanvasReadyEffect( {
 export default function EditorBody( {
 	featuredMedia,
 	isActive = true,
+	isLocked = false,
 	postId,
 	postType,
 	extraStyles,
@@ -1208,21 +1219,33 @@ export default function EditorBody( {
 		},
 		[ ownerBlockName ]
 	);
-	const renderAppender = shouldUseHeaderAwareAppender
-		? () => <HeaderAwareRootAppender ownerBlockName={ ownerBlockName } />
-		: undefined;
+	const isReadOnly = isTrashed || isLocked;
+	const renderAppender =
+		shouldUseHeaderAwareAppender && ! isReadOnly
+			? () => (
+					<HeaderAwareRootAppender
+						ownerBlockName={ ownerBlockName }
+					/>
+			  )
+			: undefined;
 
 	const blockCanvas = (
 		<div className="cortext-canvas__block-canvas" ref={ blockCanvasRef }>
 			<BlockCanvas height="100%" styles={ styles }>
 				<DocumentIdentityActions
+					isLocked={ isReadOnly }
 					postId={ postId }
 					postType={ postType }
 				/>
-				<EnsureHeaderBlocks postId={ postId } postType={ postType } />
+				<EnsureHeaderBlocks
+					isLocked={ isReadOnly }
+					postId={ postId }
+					postType={ postType }
+				/>
 				<HideHeaderBlockKebab postId={ postId } postType={ postType } />
 				<HeaderPrefixToolbarGuard
 					isActive={ isActive }
+					isLocked={ isReadOnly }
 					postId={ postId }
 					postType={ postType }
 					toolbarRootRef={ blockCanvasRef }
@@ -1261,7 +1284,7 @@ export default function EditorBody( {
 					onRestored={ onRestored }
 				/>
 			) }
-			{ isTrashed ? (
+			{ isReadOnly ? (
 				<Disabled className="cortext-canvas__locked">
 					{ blockCanvas }
 				</Disabled>

--- a/src/components/PostLockControls.js
+++ b/src/components/PostLockControls.js
@@ -1,0 +1,114 @@
+import { Button, Modal, Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+export function PostLockFailureNotice( { error, isRetrying, onRetry } ) {
+	if ( ! error ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			className="cortext-canvas__notice"
+			status="warning"
+			isDismissible={ false }
+			actions={ [
+				{
+					label: __( 'Retry', 'cortext' ),
+					onClick: onRetry,
+					disabled: isRetrying,
+					variant: 'primary',
+				},
+			] }
+		>
+			{ error }
+		</Notice>
+	);
+}
+
+export function PostLockModal( {
+	isOpen,
+	isTakeover,
+	isTakingOver,
+	onTakeOver,
+	user,
+} ) {
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const userName = user?.name || __( 'Someone', 'cortext' );
+	const userAvatar = user?.avatar;
+
+	return (
+		<Modal
+			title={
+				isTakeover
+					? __(
+							'Someone else is editing this document now',
+							'cortext'
+					  )
+					: __( 'This document is already being edited', 'cortext' )
+			}
+			focusOnMount
+			shouldCloseOnClickOutside={ false }
+			shouldCloseOnEsc={ false }
+			isDismissible={ false }
+			className="editor-post-locked-modal"
+			size="medium"
+		>
+			<div className="cortext-post-lock-modal__content">
+				{ userAvatar ? (
+					<img
+						src={ userAvatar }
+						alt={ sprintf(
+							/* translators: %s: user display name */
+							__( 'Avatar for %s', 'cortext' ),
+							userName
+						) }
+						className="editor-post-locked-modal__avatar"
+						width={ 64 }
+						height={ 64 }
+					/>
+				) : null }
+				<div>
+					<p>
+						{ isTakeover
+							? sprintf(
+									/* translators: %s: user display name */
+									__(
+										'%s is editing this document now. You can keep viewing it, or take over to make changes.',
+										'cortext'
+									),
+									userName
+							  )
+							: sprintf(
+									/* translators: %s: user display name */
+									__(
+										'%s is editing this document right now. To make changes, take over from them.',
+										'cortext'
+									),
+									userName
+							  ) }
+					</p>
+					<p>
+						{ __(
+							'Taking over lets you edit here in Cortext. The other user will switch to read-only.',
+							'cortext'
+						) }
+					</p>
+					<div className="editor-post-locked-modal__buttons">
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							isBusy={ isTakingOver }
+							disabled={ isTakingOver }
+							onClick={ onTakeOver }
+						>
+							{ __( 'Take over', 'cortext' ) }
+						</Button>
+					</div>
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/src/components/PublishToggle.js
+++ b/src/components/PublishToggle.js
@@ -18,8 +18,10 @@ import './PublishToggle.scss';
  *                                             calls this instead of onToggle so
  *                                             the wrapper can interpose a
  *                                             confirmation dialog.
+ * @param {boolean}   props.disabled           Disables write actions.
  */
 export default function PublishToggle( {
+	disabled = false,
 	isPublic,
 	isSaving,
 	link = null,
@@ -29,27 +31,30 @@ export default function PublishToggle( {
 	const [ copied, setCopied ] = useState( false );
 
 	const handleClick = useCallback( () => {
+		if ( disabled ) {
+			return;
+		}
 		if ( isPublic && onRequestUnpublish ) {
 			onRequestUnpublish();
 			return;
 		}
 		onToggle();
-	}, [ isPublic, onRequestUnpublish, onToggle ] );
+	}, [ disabled, isPublic, onRequestUnpublish, onToggle ] );
 
 	const copyLink = useCallback( async () => {
-		if ( link ) {
+		if ( link && ! disabled ) {
 			await navigator.clipboard.writeText( link );
 			setCopied( true );
 			setTimeout( () => setCopied( false ), 2000 );
 		}
-	}, [ link ] );
+	}, [ disabled, link ] );
 
 	return (
 		<div className="cortext-publish-toggle">
 			<Button
 				icon={ isPublic ? globe : lock }
 				onClick={ handleClick }
-				disabled={ isSaving }
+				disabled={ isSaving || disabled }
 				variant="tertiary"
 				size="compact"
 				isPressed={ isPublic }
@@ -62,6 +67,7 @@ export default function PublishToggle( {
 				<Button
 					className="cortext-publish-toggle__copy"
 					onClick={ copyLink }
+					disabled={ disabled }
 					size="compact"
 				>
 					{ copied

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 
 import useAutosave from '../hooks/useAutosave';
+import usePostLock from '../hooks/usePostLock';
 // Registers core + Cortext blocks before any editor renders. Living here
 // (rather than at a static import in RowDetailView) keeps the Cortext
 // block sources and the registerCoreBlocks call site off the initial
@@ -19,6 +20,7 @@ import { getEditorSettings } from './initEditor';
 import { DocumentPropertiesProvider } from './DocumentPropertiesContext';
 import { EditorSurfaceProvider } from './EditorSurfaceContext';
 import EditorBody from './EditorBody';
+import { PostLockFailureNotice, PostLockModal } from './PostLockControls';
 import { RowMutationContext } from './EditableCell';
 
 const ROW_DETAIL_EDITOR_CSS = `
@@ -122,6 +124,11 @@ function DetailPaneContent( {
 		() => onPaneReady( detailKey ),
 		[ detailKey, onPaneReady ]
 	);
+	const postLock = usePostLock( {
+		postId: row?.id ?? rowId,
+		postType,
+		enabled: isActive && ! isHidden,
+	} );
 
 	const content = (
 		<DocumentPropertiesProvider
@@ -138,13 +145,26 @@ function DetailPaneContent( {
 			onRequestLayoutEdit={ onRequestLayoutEdit }
 			onToggleVisible={ onTogglePropertiesVisible }
 		>
+			<PostLockFailureNotice
+				error={ postLock.error }
+				isRetrying={ postLock.isAcquiring }
+				onRetry={ postLock.retry }
+			/>
 			<EditorBody
 				isActive={ isActive && ! isHidden }
+				isLocked={ postLock.isReadOnly }
 				postId={ row?.id }
 				postType={ postType }
 				extraStyles={ ROW_DETAIL_EXTRA_STYLES }
 				onReady={ handleReady }
 				onRestored={ onRestored }
+			/>
+			<PostLockModal
+				isOpen={ postLock.isLocked }
+				isTakeover={ postLock.isTakeover }
+				isTakingOver={ postLock.isTakingOver }
+				onTakeOver={ postLock.takeOver }
+				user={ postLock.user }
 			/>
 		</DocumentPropertiesProvider>
 	);

--- a/src/hooks/useAutosave.js
+++ b/src/hooks/useAutosave.js
@@ -28,6 +28,7 @@ export default function useAutosave( options = {} ) {
 		didSucceed,
 		didFail,
 		editsReference,
+		isPostLocked,
 		postStatus,
 		postTitle,
 		currentPostId,
@@ -39,6 +40,7 @@ export default function useAutosave( options = {} ) {
 			isSaving: editor.isSavingPost(),
 			didSucceed: editor.didPostSaveRequestSucceed(),
 			didFail: editor.didPostSaveRequestFail(),
+			isPostLocked: editor.isPostLocked?.() ?? false,
 			editsReference:
 				select( coreDataStore ).getReferenceByDistinctEdits(),
 			postStatus: editor.getEditedPostAttribute( 'status' ),
@@ -71,6 +73,7 @@ export default function useAutosave( options = {} ) {
 		isDirty,
 		isSaveable,
 		isSaving,
+		isPostLocked,
 		savePost,
 		editPost,
 		postStatus,
@@ -81,6 +84,7 @@ export default function useAutosave( options = {} ) {
 		isDirty,
 		isSaveable,
 		isSaving,
+		isPostLocked,
 		savePost,
 		editPost,
 		postStatus,
@@ -154,9 +158,10 @@ export default function useAutosave( options = {} ) {
 			isDirty: d,
 			isSaveable: s,
 			isSaving: saving,
+			isPostLocked: locked,
 			postStatus: ps,
 		} = stateRef.current;
-		if ( ! d || ! s || ps === 'trash' ) {
+		if ( ! d || ! s || locked || ps === 'trash' ) {
 			return true;
 		}
 		if ( saving ) {
@@ -176,7 +181,7 @@ export default function useAutosave( options = {} ) {
 	}, [ didFail, isSaving ] );
 
 	useEffect( () => {
-		if ( ! isDirty || ! isSaveable ) {
+		if ( ! isDirty || ! isSaveable || isPostLocked ) {
 			return undefined;
 		}
 		// Trashed pages are read-only in the canvas; never autosave them.
@@ -200,6 +205,7 @@ export default function useAutosave( options = {} ) {
 				isDirty: d,
 				isSaveable: s,
 				isSaving: saving,
+				isPostLocked: locked,
 				postStatus: ps,
 				editsReference: editsRef,
 			} = stateRef.current;
@@ -207,6 +213,7 @@ export default function useAutosave( options = {} ) {
 				d &&
 				s &&
 				! saving &&
+				! locked &&
 				ps !== 'trash' &&
 				failedEditsReferenceRef.current !== editsRef
 			) {
@@ -224,6 +231,7 @@ export default function useAutosave( options = {} ) {
 		debounceMs,
 		editsReference,
 		isDirty,
+		isPostLocked,
 		isSaveable,
 		isSaving,
 		minSaveIntervalMs,

--- a/src/hooks/usePostLock.js
+++ b/src/hooks/usePostLock.js
@@ -6,6 +6,55 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { addAction, removeAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
+const POST_LOCK_HEARTBEAT_NUDGE_MS = 5000;
+const heartbeatNudgeRefs = new Set();
+let heartbeatNudgeTimerId = null;
+
+function hasVisibleDocument() {
+	return (
+		typeof document === 'undefined' || document.visibilityState !== 'hidden'
+	);
+}
+
+function hasOwnedPostLock() {
+	for ( const ref of heartbeatNudgeRefs ) {
+		if ( ref.current?.activePostLock ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function nudgePostLockHeartbeat() {
+	if ( ! hasVisibleDocument() || ! hasOwnedPostLock() ) {
+		return;
+	}
+
+	window.wp?.heartbeat?.connectNow?.();
+}
+
+function registerHeartbeatNudgeRef( ref ) {
+	if ( typeof window === 'undefined' ) {
+		return () => {};
+	}
+
+	heartbeatNudgeRefs.add( ref );
+	if ( heartbeatNudgeTimerId === null ) {
+		heartbeatNudgeTimerId = window.setInterval(
+			nudgePostLockHeartbeat,
+			POST_LOCK_HEARTBEAT_NUDGE_MS
+		);
+	}
+
+	return () => {
+		heartbeatNudgeRefs.delete( ref );
+		if ( heartbeatNudgeRefs.size === 0 && heartbeatNudgeTimerId !== null ) {
+			window.clearInterval( heartbeatNudgeTimerId );
+			heartbeatNudgeTimerId = null;
+		}
+	};
+}
+
 function defaultPostLockUtils() {
 	return globalThis?.cortextEditorSettings?.postLockUtils ?? null;
 }
@@ -275,11 +324,14 @@ export default function usePostLock( {
 		addAction( 'heartbeat.send', hookName, sendPostLock );
 		addAction( 'heartbeat.tick', hookName, receivePostLock );
 		window.addEventListener( 'beforeunload', releasePostLock );
+		const unregisterHeartbeatNudge =
+			registerHeartbeatNudgeRef( ownedLockRef );
 
 		return () => {
 			removeAction( 'heartbeat.send', hookName );
 			removeAction( 'heartbeat.tick', hookName );
 			window.removeEventListener( 'beforeunload', releasePostLock );
+			unregisterHeartbeatNudge();
 		};
 	}, [
 		autosave,

--- a/src/hooks/usePostLock.js
+++ b/src/hooks/usePostLock.js
@@ -1,0 +1,308 @@
+import apiFetch from '@wordpress/api-fetch';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { addAction, removeAction } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+function defaultPostLockUtils() {
+	return globalThis?.cortextEditorSettings?.postLockUtils ?? null;
+}
+
+function errorMessage( error ) {
+	return (
+		error?.message ??
+		__( "Couldn't check whether this document is locked.", 'cortext' )
+	);
+}
+
+function lockUserFromHeartbeat( lockError ) {
+	return {
+		name: lockError?.name ?? __( 'Someone', 'cortext' ),
+		avatar: lockError?.avatar_src_2x ?? lockError?.avatar ?? undefined,
+	};
+}
+
+function sendReleaseRequest( { activePostLock, postId, postLockUtils } ) {
+	if ( ! activePostLock || ! postId || ! postLockUtils?.ajaxUrl ) {
+		return;
+	}
+
+	const data = new window.FormData();
+	data.append( 'action', 'wp-remove-post-lock' );
+	data.append( '_wpnonce', postLockUtils.unlockNonce ?? '' );
+	data.append( 'post_ID', postId );
+	data.append( 'active_post_lock', activePostLock );
+
+	if ( window.navigator?.sendBeacon ) {
+		window.navigator.sendBeacon( postLockUtils.ajaxUrl, data );
+		return;
+	}
+
+	const xhr = new window.XMLHttpRequest();
+	xhr.open( 'POST', postLockUtils.ajaxUrl, false );
+	xhr.send( data );
+}
+
+export default function usePostLock( {
+	postId,
+	postType,
+	enabled = true,
+} = {} ) {
+	const hookNameRef = useRef( null );
+	if ( ! hookNameRef.current ) {
+		hookNameRef.current =
+			'cortext/post-lock-' + Math.random().toString( 36 ).slice( 2 );
+	}
+
+	const { autosave, updatePostLock } = useDispatch( editorStore );
+	const { clearEntityRecordEdits, receiveEntityRecords } =
+		useDispatch( coreDataStore );
+	const [ isAcquiring, setIsAcquiring ] = useState( false );
+	const [ isTakingOver, setIsTakingOver ] = useState( false );
+	const [ error, setError ] = useState( null );
+	const [ checkedPostId, setCheckedPostId ] = useState( null );
+	const [ postLockUtils, setPostLockUtils ] =
+		useState( defaultPostLockUtils );
+	const requestIdRef = useRef( 0 );
+
+	const { isLocked, isTakeover, settingsPostLockUtils, user } = useSelect(
+		( select ) => {
+			const editor = select( editorStore );
+			const editorSettings = editor.getEditorSettings?.() ?? {};
+			return {
+				isLocked: editor.isPostLocked?.() ?? false,
+				isTakeover: editor.isPostLockTakeover?.() ?? false,
+				settingsPostLockUtils: editorSettings.postLockUtils ?? null,
+				user: editor.getPostLockUser?.() ?? null,
+			};
+		},
+		[]
+	);
+	const postLockUtilsRef = useRef( postLockUtils );
+	postLockUtilsRef.current =
+		postLockUtils ?? settingsPostLockUtils ?? defaultPostLockUtils();
+
+	const ownedLockRef = useRef( null );
+
+	const rememberOwnedLock = useCallback(
+		( lock, lockPostId, lockPostLockUtils ) => {
+			if ( lock?.activePostLock && ! lock?.isLocked ) {
+				ownedLockRef.current = {
+					activePostLock: lock.activePostLock,
+					postId: lockPostId,
+					postLockUtils: lockPostLockUtils,
+				};
+				return;
+			}
+
+			if ( ownedLockRef.current?.postId === lockPostId ) {
+				ownedLockRef.current = null;
+			}
+		},
+		[]
+	);
+
+	const releasePostLock = useCallback( () => {
+		const current = ownedLockRef.current;
+		if ( ! current?.activePostLock ) {
+			return;
+		}
+
+		sendReleaseRequest( current );
+		ownedLockRef.current = null;
+	}, [] );
+
+	const acquireLock = useCallback(
+		async ( { force = false } = {} ) => {
+			if ( ! enabled || ! postId ) {
+				return null;
+			}
+
+			const requestId = requestIdRef.current + 1;
+			requestIdRef.current = requestId;
+			setError( null );
+			setIsAcquiring( ! force );
+			setIsTakingOver( force );
+
+			try {
+				const response = await apiFetch( {
+					path: `/cortext/v1/documents/${ postId }/lock`,
+					method: 'POST',
+					data: force ? { force: true } : {},
+				} );
+
+				if ( requestId !== requestIdRef.current ) {
+					return response;
+				}
+
+				const nextPostLockUtils =
+					response?.postLockUtils ?? postLockUtilsRef.current;
+				if ( response?.postLockUtils ) {
+					setPostLockUtils( response.postLockUtils );
+				}
+				setCheckedPostId( postId );
+				if ( force && response?.post ) {
+					const entityPostType = response.post.type ?? postType;
+					if ( entityPostType ) {
+						clearEntityRecordEdits?.(
+							'postType',
+							entityPostType,
+							postId
+						);
+						receiveEntityRecords?.(
+							'postType',
+							entityPostType,
+							[ response.post ],
+							undefined,
+							true
+						);
+					}
+				}
+				if ( response?.postLock ) {
+					updatePostLock?.( response.postLock );
+					rememberOwnedLock(
+						response.postLock,
+						postId,
+						nextPostLockUtils
+					);
+				}
+
+				return response;
+			} catch ( err ) {
+				if ( requestId === requestIdRef.current ) {
+					setError( errorMessage( err ) );
+					setCheckedPostId( postId );
+				}
+				return null;
+			} finally {
+				if ( requestId === requestIdRef.current ) {
+					setIsAcquiring( false );
+					setIsTakingOver( false );
+				}
+			}
+		},
+		[
+			clearEntityRecordEdits,
+			enabled,
+			postId,
+			postType,
+			receiveEntityRecords,
+			rememberOwnedLock,
+			updatePostLock,
+		]
+	);
+
+	const retry = useCallback( () => acquireLock(), [ acquireLock ] );
+	const takeOver = useCallback(
+		() => acquireLock( { force: true } ),
+		[ acquireLock ]
+	);
+
+	useEffect( () => {
+		if ( ! enabled || ! postId ) {
+			setError( null );
+			setIsAcquiring( false );
+			setIsTakingOver( false );
+			setCheckedPostId( null );
+			return undefined;
+		}
+
+		acquireLock();
+
+		return () => {
+			requestIdRef.current += 1;
+			releasePostLock();
+			updatePostLock?.( { isLocked: false } );
+		};
+	}, [ acquireLock, enabled, postId, releasePostLock, updatePostLock ] );
+
+	useEffect( () => {
+		if ( ! enabled || ! postId ) {
+			return undefined;
+		}
+
+		const hookName = hookNameRef.current;
+
+		function sendPostLock( data ) {
+			const current = ownedLockRef.current;
+			if ( ! current?.activePostLock || current.postId !== postId ) {
+				return;
+			}
+
+			data[ 'wp-refresh-post-lock' ] = {
+				lock: current.activePostLock,
+				post_id: current.postId,
+			};
+		}
+
+		function receivePostLock( data ) {
+			const received = data?.[ 'wp-refresh-post-lock' ];
+			if ( ! received ) {
+				return;
+			}
+
+			if ( received.lock_error ) {
+				autosave?.();
+				if ( ownedLockRef.current?.postId === postId ) {
+					ownedLockRef.current = null;
+				}
+				updatePostLock?.( {
+					isLocked: true,
+					isTakeover: true,
+					user: lockUserFromHeartbeat( received.lock_error ),
+				} );
+				return;
+			}
+
+			if ( received.new_lock ) {
+				rememberOwnedLock(
+					{
+						activePostLock: received.new_lock,
+						isLocked: false,
+					},
+					postId,
+					postLockUtilsRef.current
+				);
+				updatePostLock?.( {
+					isLocked: false,
+					activePostLock: received.new_lock,
+				} );
+			}
+		}
+
+		addAction( 'heartbeat.send', hookName, sendPostLock );
+		addAction( 'heartbeat.tick', hookName, receivePostLock );
+		window.addEventListener( 'beforeunload', releasePostLock );
+
+		return () => {
+			removeAction( 'heartbeat.send', hookName );
+			removeAction( 'heartbeat.tick', hookName );
+			window.removeEventListener( 'beforeunload', releasePostLock );
+		};
+	}, [
+		autosave,
+		enabled,
+		postId,
+		releasePostLock,
+		rememberOwnedLock,
+		updatePostLock,
+	] );
+
+	const isPendingLockCheck =
+		!! enabled && !! postId && checkedPostId !== postId;
+
+	return {
+		error,
+		isAcquiring,
+		isFailed: !! error,
+		isLocked,
+		isReadOnly: isPendingLockCheck || isAcquiring || !! error || isLocked,
+		isTakeover,
+		isTakingOver,
+		retry,
+		takeOver,
+		user,
+	};
+}

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -38,7 +38,7 @@ async function deleteIfCreated( requestUtils, path ) {
 			path,
 			params: { force: true },
 		} );
-	} catch ( _error ) {
+	} catch {
 		// Best-effort cleanup; the record may already be gone.
 	}
 }
@@ -61,23 +61,57 @@ async function waitForEditorPost( page, postId ) {
 	);
 }
 
+function isDetachedFrameError( error ) {
+	return /\bFrame was detached\b/.test( error?.message || '' );
+}
+
 async function coverImagePainted( page ) {
 	const frame = page.frame( { name: 'editor-canvas' } );
 	if ( ! frame ) {
 		return false;
 	}
-	const image = frame.locator( '.cortext-document-cover-block__image' );
-	if ( ( await image.count() ) === 0 ) {
+	try {
+		const image = frame.locator( '.cortext-document-cover-block__image' );
+		if ( ( await image.count() ) === 0 ) {
+			return false;
+		}
+		return await image.evaluate( ( node ) => {
+			const style =
+				node.ownerDocument.defaultView.getComputedStyle( node );
+			return (
+				node.complete &&
+				node.naturalWidth > 0 &&
+				Number( style.opacity ) === 1
+			);
+		} );
+	} catch ( error ) {
+		if ( isDetachedFrameError( error ) ) {
+			return false;
+		}
+		throw error;
+	}
+}
+
+async function canvasContainsAnyTitle( page, titles ) {
+	const frame = page.frame( { name: 'editor-canvas' } );
+	if ( ! frame ) {
 		return false;
 	}
-	return image.evaluate( ( node ) => {
-		const style = node.ownerDocument.defaultView.getComputedStyle( node );
-		return (
-			node.complete &&
-			node.naturalWidth > 0 &&
-			Number( style.opacity ) === 1
-		);
-	} );
+	try {
+		return await frame
+			.locator( 'body' )
+			.evaluate( ( body, expectedTitles ) => {
+				const text = body.innerText || '';
+				return expectedTitles.some( ( title ) =>
+					text.includes( title )
+				);
+			}, titles );
+	} catch ( error ) {
+		if ( isDetachedFrameError( error ) ) {
+			return false;
+		}
+		throw error;
+	}
 }
 
 async function waitForCoverImagePainted( page ) {
@@ -87,17 +121,6 @@ async function waitForCoverImagePainted( page ) {
 				'the cover image should paint before the canvas is marked ready',
 		} )
 		.toBe( true );
-}
-
-async function canvasContainsAnyTitle( page, titles ) {
-	const frame = page.frame( { name: 'editor-canvas' } );
-	if ( ! frame ) {
-		return false;
-	}
-	return frame.locator( 'body' ).evaluate( ( body, expectedTitles ) => {
-		const text = body.innerText || '';
-		return expectedTitles.some( ( title ) => text.includes( title ) );
-	}, titles );
 }
 
 async function oldCanvasSnapshotState( page ) {
@@ -114,13 +137,18 @@ async function oldCanvasSnapshotState( page ) {
 			mode === 'hold-old-canvas' &&
 			animationName.includes( 'cortext-hold-old-canvas' ) &&
 			opacity === 1;
-		return { animationName, isHolding, mode, opacity };
+		const isVisible =
+			isHolding ||
+			( mode === 'reveal-old-canvas' &&
+				animationName.includes( 'cortext-reveal-old-canvas' ) &&
+				opacity > 0 );
+		return { animationName, isHolding, isVisible, mode, opacity };
 	} );
 }
 
-async function isHoldingOldCanvasSnapshot( page ) {
+async function isOldCanvasSnapshotVisible( page ) {
 	const state = await oldCanvasSnapshotState( page );
-	return state.isHolding;
+	return state.isVisible;
 }
 
 async function expectOldCanvasSnapshotHeld( page ) {
@@ -135,17 +163,22 @@ async function expectOldCanvasSnapshotHeld( page ) {
 	);
 }
 
+async function expectOldCanvasSnapshotVisible( page ) {
+	const state = await oldCanvasSnapshotState( page );
+	expect( state.isVisible ).toBe( true );
+}
+
 async function waitForCanvasTitleWithoutBlanking( page, titles, targetTitle ) {
 	const deadline = Date.now() + 5000;
 	while ( Date.now() < deadline ) {
-		const [ hasAnyTitle, hasTargetTitle, isHoldingSnapshot ] =
+		const [ hasAnyTitle, hasTargetTitle, isSnapshotVisible ] =
 			await Promise.all( [
 				canvasContainsAnyTitle( page, titles ),
 				canvasContainsAnyTitle( page, [ targetTitle ] ),
-				isHoldingOldCanvasSnapshot( page ),
+				isOldCanvasSnapshotVisible( page ),
 			] );
 
-		if ( ! hasAnyTitle && ! isHoldingSnapshot ) {
+		if ( ! hasAnyTitle && ! isSnapshotVisible ) {
 			throw new Error(
 				'The canvas went blank while the old snapshot was not covering it.'
 			);
@@ -513,12 +546,14 @@ test.describe( 'Navigation lifecycle', () => {
 				.click();
 			await locatorRequest;
 			await page.waitForTimeout( 100 );
-			expect(
-				await canvasContainsAnyTitle( page, [
+			if (
+				! ( await canvasContainsAnyTitle( page, [
 					NO_FLASH_FIRST_PAGE_TITLE,
 					NO_FLASH_SECOND_PAGE_TITLE,
-				] )
-			).toBe( true );
+				] ) )
+			) {
+				await expectOldCanvasSnapshotVisible( page );
+			}
 
 			releaseLocator();
 			await waitForCanvasTitleWithoutBlanking(

--- a/tests/js/components/RowEditor.test.js
+++ b/tests/js/components/RowEditor.test.js
@@ -43,6 +43,20 @@ jest.mock( '../../../src/hooks/useAutosave', () =>
 	} ) )
 );
 
+jest.mock( '../../../src/hooks/usePostLock', () =>
+	jest.fn( () => ( {
+		error: null,
+		isAcquiring: false,
+		isLocked: false,
+		isReadOnly: false,
+		isTakeover: false,
+		isTakingOver: false,
+		retry: jest.fn(),
+		takeOver: jest.fn(),
+		user: null,
+	} ) )
+);
+
 describe( 'RowEditor', () => {
 	beforeEach( () => {
 		EditorBody.mockClear();

--- a/tests/js/hooks/usePostLock.test.js
+++ b/tests/js/hooks/usePostLock.test.js
@@ -1,0 +1,390 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	store: { name: 'core/editor' },
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: { name: 'core' },
+} ) );
+
+let mockHeartbeatActions;
+jest.mock( '@wordpress/hooks', () => ( {
+	addAction: jest.fn( ( hookName, namespace, callback ) => {
+		if ( ! mockHeartbeatActions[ hookName ] ) {
+			mockHeartbeatActions[ hookName ] = {};
+		}
+		mockHeartbeatActions[ hookName ][ namespace ] = callback;
+	} ),
+	removeAction: jest.fn( ( hookName, namespace ) => {
+		delete mockHeartbeatActions[ hookName ]?.[ namespace ];
+	} ),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch, useSelect } from '@wordpress/data';
+import usePostLock from '../../../src/hooks/usePostLock';
+
+const postLockUtils = {
+	ajaxUrl: 'https://example.test/wp-admin/admin-ajax.php',
+	nonce: 'lock-nonce',
+	unlockNonce: 'unlock-nonce',
+};
+
+let editorState;
+let mockAutosave;
+let mockClearEntityRecordEdits;
+let mockReceiveEntityRecords;
+let mockUpdatePostLock;
+
+function installDataMocks() {
+	useDispatch.mockImplementation( ( store ) => {
+		if ( store.name === 'core/editor' ) {
+			return {
+				autosave: mockAutosave,
+				updatePostLock: mockUpdatePostLock,
+			};
+		}
+
+		return {
+			clearEntityRecordEdits: mockClearEntityRecordEdits,
+			receiveEntityRecords: mockReceiveEntityRecords,
+		};
+	} );
+
+	useSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( ( store ) => {
+			if ( store.name === 'core/editor' ) {
+				return {
+					getActivePostLock: () => editorState.activePostLock,
+					getEditorSettings: () => ( {
+						postLockUtils: editorState.postLockUtils,
+					} ),
+					getPostLockUser: () => editorState.user,
+					isPostLocked: () => editorState.isLocked,
+					isPostLockTakeover: () => editorState.isTakeover,
+				};
+			}
+
+			return {};
+		} )
+	);
+}
+
+function receivePostLock( lock ) {
+	editorState = {
+		...editorState,
+		activePostLock: lock.activePostLock ?? null,
+		isLocked: !! lock.isLocked,
+		isTakeover: !! lock.isTakeover,
+		user: lock.user ?? null,
+	};
+}
+
+function heartbeatCallback( hookName ) {
+	return Object.values( mockHeartbeatActions[ hookName ] ?? {} )[ 0 ];
+}
+
+beforeEach( () => {
+	mockHeartbeatActions = {};
+	editorState = {
+		activePostLock: null,
+		isLocked: false,
+		isTakeover: false,
+		postLockUtils,
+		user: null,
+	};
+	mockAutosave = jest.fn();
+	mockClearEntityRecordEdits = jest.fn();
+	mockReceiveEntityRecords = jest.fn();
+	mockUpdatePostLock = jest.fn( receivePostLock );
+	apiFetch.mockReset();
+	installDataMocks();
+	globalThis.cortextEditorSettings = { postLockUtils };
+	Object.defineProperty( window.navigator, 'sendBeacon', {
+		configurable: true,
+		value: jest.fn(),
+	} );
+} );
+
+afterEach( () => {
+	delete globalThis.cortextEditorSettings;
+	jest.clearAllMocks();
+} );
+
+it( 'locks the document on mount', async () => {
+	apiFetch.mockResolvedValue( {
+		postLock: { isLocked: false, activePostLock: '100:1' },
+		postLockUtils,
+	} );
+
+	const { result } = renderHook( () =>
+		usePostLock( { postId: 7, postType: 'crtxt_document' } )
+	);
+
+	expect( result.current.isReadOnly ).toBe( true );
+
+	await waitFor( () =>
+		expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+			isLocked: false,
+			activePostLock: '100:1',
+		} )
+	);
+	expect( apiFetch ).toHaveBeenCalledWith( {
+		path: '/cortext/v1/documents/7/lock',
+		method: 'POST',
+		data: {},
+	} );
+} );
+
+it( 'keeps the document read-only when someone else has the lock', async () => {
+	apiFetch.mockResolvedValue( {
+		postLock: {
+			isLocked: true,
+			user: { name: 'Current Editor', avatar: 'avatar.png' },
+		},
+		postLockUtils,
+	} );
+
+	const { result, rerender } = renderHook( () =>
+		usePostLock( { postId: 7, postType: 'crtxt_document' } )
+	);
+
+	await waitFor( () =>
+		expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+			isLocked: true,
+			user: { name: 'Current Editor', avatar: 'avatar.png' },
+		} )
+	);
+	rerender();
+
+	expect( result.current.isLocked ).toBe( true );
+	expect( result.current.isReadOnly ).toBe( true );
+	expect( result.current.user.name ).toBe( 'Current Editor' );
+} );
+
+it( 'refreshes our lock through heartbeat', async () => {
+	apiFetch.mockResolvedValue( {
+		postLock: { isLocked: false, activePostLock: '100:1' },
+		postLockUtils,
+	} );
+
+	const { rerender } = renderHook( () =>
+		usePostLock( { postId: 7, postType: 'crtxt_document' } )
+	);
+
+	await waitFor( () =>
+		expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+			isLocked: false,
+			activePostLock: '100:1',
+		} )
+	);
+	rerender();
+
+	const sent = {};
+	act( () => heartbeatCallback( 'heartbeat.send' )( sent ) );
+	expect( sent[ 'wp-refresh-post-lock' ] ).toEqual( {
+		lock: '100:1',
+		post_id: 7,
+	} );
+
+	act( () =>
+		heartbeatCallback( 'heartbeat.tick' )( {
+			'wp-refresh-post-lock': { new_lock: '110:1' },
+		} )
+	);
+	expect( mockUpdatePostLock ).toHaveBeenLastCalledWith( {
+		isLocked: false,
+		activePostLock: '110:1',
+	} );
+} );
+
+it( 'becomes read-only when heartbeat says someone took over', async () => {
+	apiFetch.mockResolvedValue( {
+		postLock: { isLocked: false, activePostLock: '100:1' },
+		postLockUtils,
+	} );
+
+	renderHook( () =>
+		usePostLock( { postId: 7, postType: 'crtxt_document' } )
+	);
+
+	await waitFor( () =>
+		expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+			isLocked: false,
+			activePostLock: '100:1',
+		} )
+	);
+
+	act( () =>
+		heartbeatCallback( 'heartbeat.tick' )( {
+			'wp-refresh-post-lock': {
+				lock_error: {
+					name: 'Second Editor',
+					avatar_src_2x: 'second.png',
+				},
+			},
+		} )
+	);
+
+	expect( mockAutosave ).toHaveBeenCalledTimes( 1 );
+	expect( mockUpdatePostLock ).toHaveBeenLastCalledWith( {
+		isLocked: true,
+		isTakeover: true,
+		user: { name: 'Second Editor', avatar: 'second.png' },
+	} );
+} );
+
+it( 'releases its lock on unmount', async () => {
+	const sendBeacon = jest.fn();
+	Object.defineProperty( window.navigator, 'sendBeacon', {
+		configurable: true,
+		value: sendBeacon,
+	} );
+	apiFetch.mockResolvedValue( {
+		postLock: { isLocked: false, activePostLock: '100:1' },
+		postLockUtils,
+	} );
+
+	const { rerender, unmount } = renderHook( () =>
+		usePostLock( { postId: 7, postType: 'crtxt_document' } )
+	);
+
+	await waitFor( () =>
+		expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+			isLocked: false,
+			activePostLock: '100:1',
+		} )
+	);
+	rerender();
+	unmount();
+
+	expect( sendBeacon ).toHaveBeenCalledTimes( 1 );
+	const [ url, body ] = sendBeacon.mock.calls[ 0 ];
+	expect( url ).toBe( postLockUtils.ajaxUrl );
+	expect( body.get( 'action' ) ).toBe( 'wp-remove-post-lock' );
+	expect( body.get( 'post_ID' ) ).toBe( '7' );
+	expect( body.get( 'active_post_lock' ) ).toBe( '100:1' );
+} );
+
+it( "releases the previous document's lock when navigating", async () => {
+	const sendBeacon = jest.fn();
+	Object.defineProperty( window.navigator, 'sendBeacon', {
+		configurable: true,
+		value: sendBeacon,
+	} );
+	apiFetch
+		.mockResolvedValueOnce( {
+			postLock: { isLocked: false, activePostLock: '100:1' },
+			postLockUtils,
+		} )
+		.mockResolvedValueOnce( {
+			postLock: { isLocked: false, activePostLock: '200:1' },
+			postLockUtils,
+		} );
+
+	const { rerender } = renderHook(
+		( { postId } ) => usePostLock( { postId, postType: 'crtxt_document' } ),
+		{ initialProps: { postId: 7 } }
+	);
+
+	await waitFor( () =>
+		expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+			isLocked: false,
+			activePostLock: '100:1',
+		} )
+	);
+
+	await act( async () => {
+		rerender( { postId: 8 } );
+	} );
+
+	expect( sendBeacon ).toHaveBeenCalledTimes( 1 );
+	const [ url, body ] = sendBeacon.mock.calls[ 0 ];
+	expect( url ).toBe( postLockUtils.ajaxUrl );
+	expect( body.get( 'action' ) ).toBe( 'wp-remove-post-lock' );
+	expect( body.get( 'post_ID' ) ).toBe( '7' );
+	expect( body.get( 'active_post_lock' ) ).toBe( '100:1' );
+	await waitFor( () =>
+		expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+			isLocked: false,
+			activePostLock: '200:1',
+		} )
+	);
+} );
+
+it( 'keeps the document read-only when the lock check fails', async () => {
+	apiFetch.mockRejectedValue( new Error( 'No connection' ) );
+
+	const { result } = renderHook( () =>
+		usePostLock( { postId: 7, postType: 'crtxt_document' } )
+	);
+
+	await waitFor( () =>
+		expect( result.current.error ).toBe( 'No connection' )
+	);
+	expect( result.current.isReadOnly ).toBe( true );
+} );
+
+it( 'takes over in-app and reloads the fresh post', async () => {
+	apiFetch
+		.mockResolvedValueOnce( {
+			postLock: {
+				isLocked: true,
+				user: { name: 'Current Editor' },
+			},
+			postLockUtils,
+		} )
+		.mockResolvedValueOnce( {
+			post: { id: 7, type: 'crtxt_document', title: { raw: 'Fresh' } },
+			postLock: { isLocked: false, activePostLock: '120:2' },
+			postLockUtils,
+		} );
+
+	const { result } = renderHook( () =>
+		usePostLock( { postId: 7, postType: 'crtxt_document' } )
+	);
+
+	await waitFor( () =>
+		expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+			isLocked: true,
+			user: { name: 'Current Editor' },
+		} )
+	);
+
+	await act( async () => {
+		await result.current.takeOver();
+	} );
+
+	expect( apiFetch ).toHaveBeenLastCalledWith( {
+		path: '/cortext/v1/documents/7/lock',
+		method: 'POST',
+		data: { force: true },
+	} );
+	expect( mockReceiveEntityRecords ).toHaveBeenCalledWith(
+		'postType',
+		'crtxt_document',
+		[ { id: 7, type: 'crtxt_document', title: { raw: 'Fresh' } } ],
+		undefined,
+		true
+	);
+	expect( mockClearEntityRecordEdits ).toHaveBeenCalledWith(
+		'postType',
+		'crtxt_document',
+		7
+	);
+	expect(
+		mockClearEntityRecordEdits.mock.invocationCallOrder[ 0 ]
+	).toBeLessThan( mockReceiveEntityRecords.mock.invocationCallOrder[ 0 ] );
+	expect( mockUpdatePostLock ).toHaveBeenLastCalledWith( {
+		isLocked: false,
+		activePostLock: '120:2',
+	} );
+} );

--- a/tests/js/hooks/usePostLock.test.js
+++ b/tests/js/hooks/usePostLock.test.js
@@ -43,6 +43,7 @@ let mockAutosave;
 let mockClearEntityRecordEdits;
 let mockReceiveEntityRecords;
 let mockUpdatePostLock;
+let originalWp;
 
 function installDataMocks() {
 	useDispatch.mockImplementation( ( store ) => {
@@ -93,6 +94,7 @@ function heartbeatCallback( hookName ) {
 }
 
 beforeEach( () => {
+	originalWp = window.wp;
 	mockHeartbeatActions = {};
 	editorState = {
 		activePostLock: null,
@@ -115,7 +117,13 @@ beforeEach( () => {
 } );
 
 afterEach( () => {
+	if ( originalWp === undefined ) {
+		delete window.wp;
+	} else {
+		window.wp = originalWp;
+	}
 	delete globalThis.cortextEditorSettings;
+	jest.restoreAllMocks();
 	jest.clearAllMocks();
 } );
 
@@ -204,6 +212,56 @@ it( 'refreshes our lock through heartbeat', async () => {
 		isLocked: false,
 		activePostLock: '110:1',
 	} );
+} );
+
+it( 'nudges heartbeat while holding a visible lock', async () => {
+	const connectNow = jest.fn();
+	let nudgeHeartbeat;
+	const setIntervalSpy = jest
+		.spyOn( window, 'setInterval' )
+		.mockImplementation( ( callback ) => {
+			nudgeHeartbeat = callback;
+			return 123;
+		} );
+	const clearIntervalSpy = jest
+		.spyOn( window, 'clearInterval' )
+		.mockImplementation( () => {} );
+	window.wp = {
+		...( originalWp ?? {} ),
+		heartbeat: {
+			...( originalWp?.heartbeat ?? {} ),
+			connectNow,
+		},
+	};
+	apiFetch.mockResolvedValue( {
+		postLock: { isLocked: false, activePostLock: '100:1' },
+		postLockUtils,
+	} );
+
+	const { unmount } = renderHook( () =>
+		usePostLock( { postId: 7, postType: 'crtxt_document' } )
+	);
+
+	await act( async () => {
+		await Promise.resolve();
+		await Promise.resolve();
+	} );
+	expect( mockUpdatePostLock ).toHaveBeenCalledWith( {
+		isLocked: false,
+		activePostLock: '100:1',
+	} );
+	expect( setIntervalSpy ).toHaveBeenCalledWith(
+		expect.any( Function ),
+		5000
+	);
+
+	act( () => nudgeHeartbeat() );
+
+	expect( connectNow ).toHaveBeenCalledTimes( 1 );
+
+	unmount();
+
+	expect( clearIntervalSpy ).toHaveBeenCalledWith( 123 );
 } );
 
 it( 'becomes read-only when heartbeat says someone took over', async () => {

--- a/tests/js/useAutosave.test.js
+++ b/tests/js/useAutosave.test.js
@@ -38,6 +38,7 @@ const DEFAULT_STATE = {
 	isSaving: false,
 	didSucceed: false,
 	didFail: false,
+	isPostLocked: false,
 	postStatus: 'private',
 	postTitle: '',
 	currentPostId: 1,
@@ -53,6 +54,7 @@ function setStoreState( state ) {
 		isSavingPost: () => merged.isSaving,
 		didPostSaveRequestSucceed: () => merged.didSucceed,
 		didPostSaveRequestFail: () => merged.didFail,
+		isPostLocked: () => merged.isPostLocked,
 		getCurrentPostId: () => merged.currentPostId,
 		getEditedPostAttribute: ( name ) => {
 			if ( name === 'status' ) {
@@ -180,6 +182,19 @@ describe( 'useAutosave: debounce', () => {
 		const savePost = jest.fn();
 		useDispatch.mockReturnValue( { savePost } );
 		setStoreState( { isDirty: true, isSaving: true } );
+
+		renderHook( () => useAutosave() );
+
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+		expect( savePost ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips save while the post is locked', () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true, isPostLocked: true } );
 
 		renderHook( () => useAutosave() );
 
@@ -361,6 +376,22 @@ describe( 'useAutosave: flush triggers', () => {
 		act( () => {
 			window.dispatchEvent( new Event( 'blur' ) );
 		} );
+		expect( savePost ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not flush while the post is locked', async () => {
+		const savePost = jest.fn();
+		useDispatch.mockReturnValue( { savePost } );
+		setStoreState( { isDirty: true, isPostLocked: true } );
+
+		const { result } = renderHook( () => useAutosave() );
+
+		let didFlush;
+		await act( async () => {
+			didFlush = await result.current.flushNow();
+		} );
+
+		expect( didFlush ).toBe( true );
 		expect( savePost ).not.toHaveBeenCalled();
 	} );
 

--- a/tests/php/test-rest-post-locks-controller.php
+++ b/tests/php/test-rest-post-locks-controller.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Tests for Cortext\Rest\PostLocksController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Document;
+use Cortext\PostType\DocumentIdentity;
+use Cortext\Rest\PostLocksController;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Post_Locks_Controller extends BaseTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once ABSPATH . 'wp-admin/includes/post.php';
+
+		( new Document() )->register_post_type();
+		( new DocumentIdentity() )->register();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new PostLocksController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_route_is_registered(): void {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/cortext/v1/documents/(?P<id>\d+)/lock', $routes );
+	}
+
+	public function test_acquires_lock_when_document_is_unlocked(): void {
+		$user_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_id );
+		$post_id = $this->create_document();
+
+		$response = $this->lock( $post_id );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertFalse( $data['postLock']['isLocked'] );
+		$this->assertStringContainsString( ':' . $user_id, $data['postLock']['activePostLock'] );
+		$this->assertArrayHasKey( 'postLockUtils', $data );
+		$this->assertStringContainsString( ':' . $user_id, (string) get_post_meta( $post_id, '_edit_lock', true ) );
+	}
+
+	public function test_returns_current_editor_when_locked_by_another_user(): void {
+		$owner_id = $this->create_user( 'administrator', 'Current Editor' );
+		$post_id  = $this->create_document();
+		wp_set_current_user( $owner_id );
+		wp_set_post_lock( $post_id );
+
+		wp_set_current_user( $this->create_user( 'administrator', 'Second Editor' ) );
+		$response = $this->lock( $post_id );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $data['postLock']['isLocked'] );
+		$this->assertSame( 'Current Editor', $data['postLock']['user']['name'] );
+		$this->assertStringContainsString( ':' . $owner_id, (string) get_post_meta( $post_id, '_edit_lock', true ) );
+	}
+
+	public function test_force_takes_over_lock_and_returns_fresh_post(): void {
+		$owner_id = $this->create_user( 'administrator', 'Current Editor' );
+		$post_id  = $this->create_document();
+		wp_set_current_user( $owner_id );
+		wp_set_post_lock( $post_id );
+
+		$takeover_id = $this->create_user( 'administrator', 'Second Editor' );
+		wp_set_current_user( $takeover_id );
+		$response = $this->lock( $post_id, array( 'force' => true ) );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertFalse( $data['postLock']['isLocked'] );
+		$this->assertStringContainsString( ':' . $takeover_id, $data['postLock']['activePostLock'] );
+		$this->assertSame( $post_id, $data['post']['id'] );
+		$this->assertStringContainsString( ':' . $takeover_id, (string) get_post_meta( $post_id, '_edit_lock', true ) );
+	}
+
+	public function test_rejects_non_document_post_type(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$post_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'private',
+				'post_title'  => 'Plain post',
+			)
+		);
+
+		$response = $this->lock( $post_id );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	public function test_rejects_trashed_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$post_id = $this->create_document();
+		wp_trash_post( $post_id );
+
+		$response = $this->lock( $post_id );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_in_trash', $response->as_error()->get_error_code() );
+	}
+
+	public function test_rejects_user_without_edit_permission(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$post_id = $this->create_document();
+
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+		$response = $this->lock( $post_id );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	private function lock( int $post_id, array $params = array() ) {
+		$request = new WP_REST_Request( 'POST', '/cortext/v1/documents/' . $post_id . '/lock' );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return rest_do_request( $request );
+	}
+
+	private function create_user( string $role, ?string $display_name = null ): int {
+		$args = array(
+			'user_login' => uniqid( 'cortext_', false ),
+			'user_pass'  => 'password',
+			'role'       => $role,
+		);
+		if ( null !== $display_name ) {
+			$args['display_name'] = $display_name;
+		}
+
+		$user_id = (int) wp_insert_user( $args );
+
+		$this->assertGreaterThan( 0, $user_id );
+		return $user_id;
+	}
+
+	private function create_document(): int {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Test document ' . wp_generate_uuid4(),
+			)
+		);
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+		return (int) $post_id;
+	}
+}


### PR DESCRIPTION
## What

Part of #85 

Cortext is currently supporting one user, but we still need to avoid major issues if there is more than one user: this PR adds post locking to Cortext documents. If someone else is editing the same document, Cortext keeps your editor read-only and displays a takeover modal.

## Why

This avoids the easy bad case: two people editing the same document and one person unknowingly saving over the other.

## How

- Using WordPress post locks and heartbeat.
- Making the canvas, inspector, autosave, publish controls, and document identity controls respect the lock.
- Dropping stale local edits before editing resumes after takeover.

## Testing Instructions

1. Log in as two different users in separate browsers.
2. Open the same Cortext document as the first user.
3. Open that document as the second user.
4. Confirm the second user sees a read-only editor and a takeover modal.
5. Click Take over as the second user and confirm editing resumes without leaving Cortext.
6. Go back to the first user and confirm their editor becomes read-only.

## Screen recording


https://github.com/user-attachments/assets/ff8ab99e-44e2-4868-b088-f87904b52cbc



