### PR TITLE
Ensure Cortext documents stay in the shell

### DIFF
--- a/docs/architecture/shell.md
+++ b/docs/architecture/shell.md
@@ -4,7 +4,7 @@ Cortext runs as a React app inside wp-admin. The shell is full-screen, but it st
 
 ## Server entry
 
-`Cortext\Admin\Screen` registers the Cortext admin page, prints the React mount point, loads the built assets, and applies a full-screen body class for this screen. It also keeps the core Pages list table reachable as an escape hatch for bulk operations the shell does not cover yet.
+`Cortext\Admin\Screen` registers the Cortext admin page, prints the React mount point, loads the built assets, and adds the full-screen body class. Document editing stays in that shell; Cortext does not expose core's Documents list table or `post.php` editor for `crtxt_document`.
 
 The plugin bootstraps editor settings on the server and exposes them to the client. That lets Cortext mount the block editor without recreating the editor environment from scratch.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,14 @@ Running log of significant design decisions. Newest first. Each entry captures *
 
 Desktop-specific runtime and packaging decisions live in `docs/desktop-decisions.md`.
 
+## 2026-05-29 — Document editing stays in the Cortext shell
+
+**Decision.** `crtxt_document` no longer exposes the core wp-admin editing screens. The Cortext menu goes straight to the React shell, and the document post type uses `show_ui => false` while staying available over REST. The inspector also leaves out WordPress's permalink and parent-page panels. Page hierarchy and order stay in the Cortext sidebar, where users already move pages around.
+
+**Why.** Cortext has one editing surface: the shell. The core list table, `post.php`, and generic inspector panels would give users a second, half-compatible way to edit the same documents. They also surface things we do not want here, like slug editing and a parent selector that does not behave well in Cortext.
+
+**Trade-off.** Bulk actions from the core list table are gone for now. When we need them, they should come back as shell features instead of as a fallback to WordPress screens.
+
 ## 2026-05-23 — Field values stay in postmeta while the sidecar proves itself
 
 **Decision.** Row field values still live in `wp_postmeta`. Cortext can also maintain a derived `cortext_field_values` table for row `field-*` values. If the host can create the table and the index is enabled, Cortext installs it and schedules a background rebuild/verify. Production reads stay on postmeta until the materialization benchmark shows at least a 10x filter or sort win at 50K rows without unacceptable write cost. The index covers row values only; collection schema, field definitions, column order, options, relation config, and rollup config stay in collection/field posts and postmeta.
@@ -42,6 +50,8 @@ Id-based URLs sidestep both issues. The id is stable from creation, renames cann
 **Revisit when.** Legacy `untitled`-slugged pages surface in a user-visible context where their slug matters (export, share link, breadcrumb), or product decides to hide abandoned blank drafts from the sidebar.
 
 ## 2026-04-23 — Core admin is an escape hatch, not the primary UI
+
+**Superseded by 2026-05-29 — Document editing stays in the Cortext shell.**
 
 **Decision.** `crtxt_page` registers with `show_ui => true` and `show_in_menu => false`. `Admin\Screen` adds a "Manage Pages" submenu under the Cortext top-level that links to `edit.php?post_type=crtxt_page`. The React shell remains the primary editing surface.
 

--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -15,7 +15,6 @@ declare( strict_types=1 );
 
 namespace Cortext\Admin;
 
-use Cortext\PostType\Document;
 use Cortext\Runtime\Features;
 use Cortext\Theming\Preferences;
 
@@ -44,17 +43,6 @@ final class Screen {
 			array( $this, 'render' ),
 			'dashicons-welcome-write-blog',
 			3
-		);
-
-		// Escape hatch: core's list table + post.php editor for Cortext
-		// documents, nested under the shell menu. Primary UI stays the
-		// React shell.
-		add_submenu_page(
-			self::MENU_SLUG,
-			__( 'Manage Documents', 'cortext' ),
-			__( 'Manage Documents', 'cortext' ),
-			'edit_posts',
-			'edit.php?post_type=' . Document::POST_TYPE
 		);
 	}
 

--- a/includes/PostType/Document.php
+++ b/includes/PostType/Document.php
@@ -842,10 +842,9 @@ final class Document {
 					'slug'       => 'cortext',
 					'with_front' => false,
 				),
-				// The React shell is the primary UI. Core's admin screens
-				// (edit.php list + post.php editor) stay enabled as an
-				// escape hatch, exposed through Admin\Screen's submenu.
-				'show_ui'               => true,
+				// Documents are edited in the React shell. REST stays on for the
+				// shell, but the core list table and post.php editor stay hidden.
+				'show_ui'               => false,
 				'show_in_menu'          => false,
 				'show_in_rest'          => true,
 				'rest_base'             => 'crtxt_documents',

--- a/src/components/DocumentInspectorSidebar.js
+++ b/src/components/DocumentInspectorSidebar.js
@@ -17,11 +17,7 @@ import {
 	store as coreStore,
 } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	PageAttributesPanel,
-	PostURLPanel,
-	store as editorStore,
-} from '@wordpress/editor';
+import { store as editorStore } from '@wordpress/editor';
 import {
 	useCallback,
 	useContext,
@@ -132,51 +128,6 @@ function InspectorComplementaryArea( {
 				</Tabs.TabPanel>
 			</Tabs.Context.Provider>
 		</ComplementaryArea>
-	);
-}
-
-function PageLinkPanel() {
-	const isVisible = useSelect( ( select ) => {
-		const editor = select( editorStore );
-		const postTypeSlug = editor.getCurrentPostType();
-		const postType = select( coreStore ).getPostType( postTypeSlug );
-		if ( ! postType?.viewable ) {
-			return false;
-		}
-		if ( ! editor.getCurrentPost()?.link ) {
-			return false;
-		}
-		return Boolean( editor.getPermalinkParts() );
-	}, [] );
-
-	if ( ! isVisible ) {
-		return null;
-	}
-
-	return (
-		<PanelBody title={ __( 'Link', 'cortext' ) }>
-			<PostURLPanel />
-		</PanelBody>
-	);
-}
-
-function PageAttributesInspectorPanel() {
-	const supportsPageAttributes = useSelect( ( select ) => {
-		const editor = select( editorStore );
-		const postType = select( coreStore ).getPostType(
-			editor.getEditedPostAttribute( 'type' )
-		);
-		return Boolean( postType?.supports?.[ 'page-attributes' ] );
-	}, [] );
-
-	if ( ! supportsPageAttributes ) {
-		return null;
-	}
-
-	return (
-		<PanelBody title={ __( 'Page attributes', 'cortext' ) }>
-			<PageAttributesPanel />
-		</PanelBody>
 	);
 }
 
@@ -677,8 +628,6 @@ function DocumentInspectorContent( { postId } ) {
 				postType={ POST_TYPE }
 				title={ __( 'Page identity', 'cortext' ) }
 			/>
-			<PageLinkPanel />
-			<PageAttributesInspectorPanel />
 			<PageActionsPanel postId={ postId } />
 		</div>
 	);
@@ -693,7 +642,6 @@ function CollectionInspectorContent( { postId, postType } ) {
 				postType={ postType }
 				title={ __( 'Collection identity', 'cortext' ) }
 			/>
-			<PageLinkPanel />
 			<CanvasOwnerInspector.Slot />
 		</div>
 	);

--- a/tests/php/test-admin-screen.php
+++ b/tests/php/test-admin-screen.php
@@ -10,13 +10,15 @@ declare( strict_types=1 );
 namespace Cortext\Tests;
 
 use Cortext\Admin\Screen;
+use Cortext\PostType\Document;
 use WorDBless\BaseTestCase;
 
 final class Test_Admin_Screen extends BaseTestCase {
 
 	public function test_register_menu_adds_top_level_page_with_expected_slug_and_capability(): void {
-		global $menu, $admin_page_hooks;
+		global $menu, $submenu, $admin_page_hooks;
 		$menu             = array();
+		$submenu          = array();
 		$admin_page_hooks = array();
 
 		( new Screen() )->register_menu();
@@ -34,6 +36,11 @@ final class Test_Admin_Screen extends BaseTestCase {
 		$this->assertNotNull( $cortext_item, 'Cortext menu entry was not registered.' );
 		$this->assertSame( 'edit_posts', $cortext_item[1], 'Cortext menu capability should be edit_posts.' );
 		$this->assertSame( 'Cortext', $cortext_item[0], 'Cortext menu title should be "Cortext".' );
+
+		foreach ( $submenu[ Screen::MENU_SLUG ] ?? array() as $item ) {
+			$this->assertNotSame( 'Manage Documents', $item[0] ?? null, 'Cortext should not add a Manage Documents submenu.' );
+			$this->assertNotSame( 'edit.php?post_type=' . Document::POST_TYPE, $item[2] ?? null, 'Cortext should not link to the core crtxt_document list table.' );
+		}
 	}
 
 	public function test_add_body_class_appends_fullscreen_class_on_cortext_screen(): void {

--- a/tests/php/test-post-type-document.php
+++ b/tests/php/test-post-type-document.php
@@ -55,6 +55,14 @@ final class Test_Post_Type_Document extends BaseTestCase {
 		$this->assertTrue( post_type_exists( Document::POST_TYPE ) );
 	}
 
+	public function test_registered_post_type_uses_shell_for_editing_ui(): void {
+		$object = get_post_type_object( Document::POST_TYPE );
+
+		$this->assertNotNull( $object );
+		$this->assertFalse( $object->show_ui, 'crtxt_document editing belongs in the Cortext shell, not in core admin screens.' );
+		$this->assertFalse( $object->show_in_menu, 'show_in_menu stays false because navigation lives in the Cortext shell.' );
+	}
+
 	public function test_registered_post_type_supports_cortext_document_capability(): void {
 		$this->assertTrue( post_type_supports( Document::POST_TYPE, 'cortext-document' ) );
 	}


### PR DESCRIPTION
## What

`crtxt_document` editing now stays in the Cortext shell. This removes the "Manage Documents" submenu, stops exposing the core document admin UI, removes the visible Page attributes panel, and drops the leftover WordPress Link panel wiring that was already hidden in the normal Cortext flow.

## Why

Those controls either send users back into wp-admin or expose WordPress page settings that do not fit Cortext well. The Link panel usually did not render because Cortext documents do not give Gutenberg the permalink parts it expects, but keeping it wired made that depend on core behavior instead of a Cortext choice.

## Testing Instructions

1. Open wp-admin with Cortext active.
2. Check that the Cortext menu opens the shell and no longer shows "Manage Documents".
3. Open a page inspector and check that "Page attributes" is gone.
4. Open a collection inspector and check that its identity and data-view panels still render normally.
