### PR TITLE
Include collection items in Published documents

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -674,14 +674,3 @@ The rows endpoint is still the hard case. `RowsController` unit tests cover rout
 **Where.** `Document::register_field_meta` in `includes/PostType/Document.php`.
 
 **Solution.** Call `update_meta_cache( 'post', $field_ids )` once before the foreach so the subsequent `get_post_meta` calls are cache hits. The field-id list is already in memory from the preceding `get_posts`, so the warmup is a one-liner.
-
-<a id="td-published-documents-panel-row-gap"></a>
-
-**Published Documents panel hides published rows.**
-
-**What.** Any `crtxt_document` is publishable now, but `PublishedDocumentsPane` only queries pages (`PUBLISHED_PAGES_QUERY`, with `cortext_no_trait + cortext_no_collections`) and collections (`PUBLISHED_COLLECTIONS_QUERY`, with `cortext_collections`). A row that the user explicitly publishes ends up reachable via its public URL but is not listed in the panel.
-
-**Where.** `PublishedDocumentsPane.js` and the constants in `src/components/page-queries.js` / `src/collections.js`.
-
-**Solution.** Add a third query for published rows (any document with a `crtxt_trait` term and `status = publish`), or replace the three queries with a single "status = publish, every document" pass and let `documentLabel` / icon helpers render the type chip. The Type column already covers Page / Collection / Row, so the rendering layer needs no change.
-

--- a/src/collections.js
+++ b/src/collections.js
@@ -8,8 +8,3 @@ export const COLLECTION_QUERY = {
 };
 
 export const FULL_PAGE_COLLECTION_QUERY = COLLECTION_QUERY;
-
-export const PUBLISHED_COLLECTIONS_QUERY = {
-	...COLLECTION_QUERY,
-	status: 'publish',
-};

--- a/src/components/PublishedDocumentsPane.js
+++ b/src/components/PublishedDocumentsPane.js
@@ -20,16 +20,11 @@ import './PublishedDocumentsPane.scss';
 
 import DocumentIcon from './DocumentIcon';
 import {
-	POST_TYPE as PAGE_POST_TYPE,
-	PUBLISHED_PAGES_QUERY,
+	POST_TYPE as DOCUMENT_POST_TYPE,
+	PUBLISHED_DOCUMENTS_QUERY,
 } from './page-queries';
-import {
-	DOCUMENT_POST_TYPE,
-	PUBLISHED_COLLECTIONS_QUERY,
-} from '../collections';
 import { computeDocumentUri } from '../router/useResolveEntity';
-import { definesTrait } from '../documents/capabilities';
-import { documentLabel } from '../documents/labels';
+import { definesTrait, hasTrait } from '../documents/capabilities';
 
 const DEFAULT_LAYOUTS = { table: { density: 'compact' }, grid: {}, list: {} };
 
@@ -44,11 +39,9 @@ const DEFAULT_VIEW = {
 	layout: {},
 };
 
-// Local enum values for the Type filter. These stay in this component so
-// DataViews has stable filter elements; the display label still comes from
-// `documentLabel` reading capabilities.
-const FILTER_PAGE = 'page';
-const FILTER_COLLECTION = 'collection';
+const TYPE_PAGE = 'page';
+const TYPE_COLLECTION_ITEM = 'collection-item';
+const TYPE_COLLECTION = 'collection';
 
 function titleText( entity ) {
 	const title = entity?.title;
@@ -58,42 +51,37 @@ function titleText( entity ) {
 	return title?.raw?.trim() || title?.rendered?.trim() || '';
 }
 
-// Pages and collections both live in `crtxt_document`, so ids do not collide,
-// but the lists arrive from separate queries (`/wp/v2/pages` vs the universal
-// document filter for collections). Capability-derived `source` flags drive
-// the Type filter; `.source` carries the underlying record for navigation
-// and link rendering.
-function buildItems( pages, collections ) {
-	const items = [];
+function documentTypeValue( record ) {
+	if ( definesTrait( record ) ) {
+		return TYPE_COLLECTION;
+	}
+	if ( hasTrait( record ) ) {
+		return TYPE_COLLECTION_ITEM;
+	}
+	return TYPE_PAGE;
+}
+
+function documentTypeLabel( record ) {
+	if ( definesTrait( record ) ) {
+		return __( 'Collection', 'cortext' );
+	}
+	if ( hasTrait( record ) ) {
+		return __( 'Collection item', 'cortext' );
+	}
+	return __( 'Page', 'cortext' );
+}
+
+function buildItems( documents ) {
 	const untitled = __( '(untitled)', 'cortext' );
-
-	for ( const page of pages ?? [] ) {
-		items.push( {
-			key: `page-${ page.id }`,
-			id: page.id,
-			postType: PAGE_POST_TYPE,
-			title: titleText( page ) || untitled,
-			modified: page.modified ?? page.modified_gmt ?? '',
-			link: page.link ?? '',
-			icon: page?.meta?.cortext_document_icon ?? '',
-			source: page,
-		} );
-	}
-
-	for ( const collection of collections ?? [] ) {
-		items.push( {
-			key: `collection-${ collection.id }`,
-			id: collection.id,
-			postType: DOCUMENT_POST_TYPE,
-			title: titleText( collection ) || untitled,
-			modified: collection.modified ?? collection.modified_gmt ?? '',
-			link: collection.link ?? '',
-			icon: collection?.meta?.cortext_document_icon ?? '',
-			source: collection,
-		} );
-	}
-
-	return items;
+	return ( documents ?? [] ).map( ( document ) => ( {
+		key: `document-${ document.id }`,
+		id: document.id,
+		title: titleText( document ) || untitled,
+		modified: document.modified ?? document.modified_gmt ?? '',
+		link: document.link ?? '',
+		icon: document?.meta?.cortext_document_icon ?? '',
+		source: document,
+	} ) );
 }
 
 function formatModified( value ) {
@@ -109,19 +97,11 @@ export default function PublishedDocumentsPane() {
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const navigate = useNavigate();
 
-	const { records: pages, isResolving: isResolvingPages } = useEntityRecords(
+	const { records: documents, isResolving: isLoading } = useEntityRecords(
 		'postType',
-		PAGE_POST_TYPE,
-		PUBLISHED_PAGES_QUERY
+		DOCUMENT_POST_TYPE,
+		PUBLISHED_DOCUMENTS_QUERY
 	);
-	const { records: collections, isResolving: isResolvingCollections } =
-		useEntityRecords(
-			'postType',
-			DOCUMENT_POST_TYPE,
-			PUBLISHED_COLLECTIONS_QUERY
-		);
-
-	const isLoading = isResolvingPages || isResolvingCollections;
 
 	const openItem = useCallback(
 		( item ) => {
@@ -133,10 +113,7 @@ export default function PublishedDocumentsPane() {
 		[ navigate ]
 	);
 
-	const items = useMemo(
-		() => buildItems( pages, collections ),
-		[ pages, collections ]
-	);
+	const items = useMemo( () => buildItems( documents ), [ documents ] );
 
 	const fields = useMemo(
 		() => [
@@ -167,18 +144,19 @@ export default function PublishedDocumentsPane() {
 				id: 'type',
 				label: __( 'Type', 'cortext' ),
 				elements: [
-					{ value: FILTER_PAGE, label: __( 'Page', 'cortext' ) },
+					{ value: TYPE_PAGE, label: __( 'Page', 'cortext' ) },
 					{
-						value: FILTER_COLLECTION,
+						value: TYPE_COLLECTION_ITEM,
+						label: __( 'Collection item', 'cortext' ),
+					},
+					{
+						value: TYPE_COLLECTION,
 						label: __( 'Collection', 'cortext' ),
 					},
 				],
 				filterBy: { operators: [ 'is', 'isAny' ] },
-				getValue: ( { item } ) =>
-					definesTrait( item.source )
-						? FILTER_COLLECTION
-						: FILTER_PAGE,
-				render: ( { item } ) => documentLabel( item.source ),
+				getValue: ( { item } ) => documentTypeValue( item.source ),
+				render: ( { item } ) => documentTypeLabel( item.source ),
 			},
 			{
 				id: 'modified',
@@ -235,7 +213,7 @@ export default function PublishedDocumentsPane() {
 				</Heading>
 				<Text variant="muted">
 					{ __(
-						'Pages and collections that are currently public.',
+						'Visible to anyone with the public link.',
 						'cortext'
 					) }
 				</Text>
@@ -251,10 +229,7 @@ export default function PublishedDocumentsPane() {
 				isLoading={ isLoading }
 				empty={
 					<Text variant="muted">
-						{ __(
-							'No documents are currently public.',
-							'cortext'
-						) }
+						{ __( 'No public documents yet.', 'cortext' ) }
 					</Text>
 				}
 			/>

--- a/src/components/page-queries.js
+++ b/src/components/page-queries.js
@@ -26,13 +26,10 @@ export const TRASHED_PAGES_QUERY = {
 	cortext_no_collections: 1,
 };
 
-// Used by the Published documents screen. Same shape as ACTIVE_PAGES_QUERY so
-// it deep-matches alongside it for invalidation when a page is published or
-// unpublished.
-export const PUBLISHED_PAGES_QUERY = {
+// The Published documents screen needs every published document, including
+// collection items, so leave trait and collection filters off.
+export const PUBLISHED_DOCUMENTS_QUERY = {
 	per_page: 100,
 	status: 'publish',
 	context: 'edit',
-	cortext_no_trait: 1,
-	cortext_no_collections: 1,
 };

--- a/tests/js/components/DocumentPublishToggle.test.js
+++ b/tests/js/components/DocumentPublishToggle.test.js
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( value ) => value,
+	sprintf: ( value ) => value,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	__esModule: true,
+	__experimentalConfirmDialog: ( { children, onConfirm } ) => (
+		<div role="dialog">
+			{ children }
+			<button type="button" onClick={ onConfirm }>
+				Confirm
+			</button>
+		</div>
+	),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	__esModule: true,
+	store: { name: 'core/editor' },
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	__esModule: true,
+	store: { name: 'core/block-editor' },
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	__esModule: true,
+	store: { name: 'core' },
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	__esModule: true,
+	store: { name: 'core/notices' },
+} ) );
+
+jest.mock( '../../../src/settings', () => ( {
+	__esModule: true,
+	isPublicWebAffordancesEnabled: () => true,
+} ) );
+
+jest.mock( '../../../src/hooks/useCollectionDependentPages', () => ( {
+	__esModule: true,
+	default: () => ( {
+		isLoading: false,
+		dependentPages: [],
+		error: null,
+	} ),
+} ) );
+
+jest.mock( '../../../src/components/PublishToggle', () => ( {
+	__esModule: true,
+	default: ( { isPublic, onToggle, onRequestUnpublish } ) => (
+		<button
+			type="button"
+			onClick={ isPublic ? onRequestUnpublish : onToggle }
+		>
+			{ isPublic ? 'Unpublish' : 'Publish' }
+		</button>
+	),
+} ) );
+
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+
+import DocumentPublishToggle from '../../../src/components/DocumentPublishToggle';
+
+const editorDispatch = {
+	editPost: jest.fn(),
+	savePost: jest.fn(),
+};
+const coreDispatch = {
+	saveEntityRecord: jest.fn(),
+};
+const noticesDispatch = {
+	createErrorNotice: jest.fn(),
+	removeNotice: jest.fn(),
+};
+
+let editorState;
+let blocks;
+let record;
+
+beforeEach( () => {
+	jest.clearAllMocks();
+
+	editorState = {
+		status: 'private',
+		link: 'https://example.test/doc/',
+		title: 'Published page',
+		isSaving: false,
+	};
+	blocks = [];
+	record = { id: 7, cortext_defines_trait: false };
+
+	coreDispatch.saveEntityRecord.mockResolvedValue( { id: 44 } );
+
+	useDispatch.mockImplementation( ( store ) => {
+		if ( store === editorStore ) {
+			return editorDispatch;
+		}
+		if ( store === coreStore ) {
+			return coreDispatch;
+		}
+		if ( store === noticesStore ) {
+			return noticesDispatch;
+		}
+		return {};
+	} );
+
+	useSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( ( store ) => {
+			if ( store === editorStore ) {
+				return {
+					getEditedPostAttribute: ( key ) => editorState[ key ],
+					isSavingPost: () => editorState.isSaving,
+				};
+			}
+			if ( store === blockEditorStore ) {
+				return {
+					getBlocks: () => blocks,
+				};
+			}
+			if ( store === coreStore ) {
+				return {
+					getEntityRecord: () => record,
+				};
+			}
+			return {};
+		} )
+	);
+} );
+
+describe( 'DocumentPublishToggle', () => {
+	it( 'publishes referenced collections before publishing the document', async () => {
+		blocks = [
+			{
+				name: 'core/group',
+				attributes: {},
+				innerBlocks: [
+					{
+						name: 'cortext/data-view',
+						attributes: { collectionId: 44 },
+						innerBlocks: [],
+					},
+				],
+			},
+		];
+
+		render( <DocumentPublishToggle postId={ 7 } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Publish' } ) );
+
+		await waitFor( () =>
+			expect( coreDispatch.saveEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'crtxt_document',
+				{ id: 44, status: 'publish' },
+				{ throwOnError: true }
+			)
+		);
+		expect( editorDispatch.editPost ).toHaveBeenCalledWith( {
+			status: 'publish',
+		} );
+		expect( editorDispatch.savePost ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/tests/js/components/PublishedDocumentsPane.test.js
+++ b/tests/js/components/PublishedDocumentsPane.test.js
@@ -1,0 +1,216 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( value ) => value,
+	_n: ( single, plural, count ) => ( count === 1 ? single : plural ),
+	sprintf: ( value ) => value,
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const ReactLib = require( 'react' );
+	return {
+		__esModule: true,
+		Button: ( { children, onClick, className } ) =>
+			ReactLib.createElement(
+				'button',
+				{ type: 'button', className, onClick },
+				children
+			),
+		ExternalLink: ( { children, href } ) =>
+			ReactLib.createElement( 'a', { href }, children ),
+		Spinner: () =>
+			ReactLib.createElement( 'div', { 'data-testid': 'spinner' } ),
+		__experimentalHeading: ( { children, level = 2 } ) =>
+			ReactLib.createElement( `h${ level }`, null, children ),
+		__experimentalText: ( { children } ) =>
+			ReactLib.createElement( 'span', null, children ),
+		__experimentalVStack: ( { children, className } ) =>
+			ReactLib.createElement( 'div', { className }, children ),
+	};
+} );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	__esModule: true,
+	useEntityRecords: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/dataviews', () => {
+	const ReactLib = require( 'react' );
+	return {
+		__esModule: true,
+		DataViews: jest.fn( ( { data, fields, getItemId } ) =>
+			ReactLib.createElement(
+				'div',
+				{ 'data-testid': 'dataviews' },
+				data.map( ( item ) => {
+					const itemId = getItemId( item );
+					return ReactLib.createElement(
+						'div',
+						{
+							key: itemId,
+							role: 'row',
+							'data-testid': itemId,
+						},
+						fields.map( ( field ) =>
+							ReactLib.createElement(
+								'div',
+								{
+									key: field.id,
+									'data-testid': `${ itemId }-${ field.id }`,
+								},
+								field.render
+									? field.render( { item } )
+									: field.getValue( { item } )
+							)
+						)
+					);
+				} )
+			)
+		),
+		filterSortAndPaginate: jest.fn( ( data ) => ( {
+			data,
+			paginationInfo: {
+				totalItems: data.length,
+				totalPages: data.length > 0 ? 1 : 0,
+			},
+		} ) ),
+	};
+} );
+
+jest.mock( '@wordpress/date', () => ( {
+	__esModule: true,
+	dateI18n: ( format, value ) => value,
+	getSettings: () => ( { formats: { date: 'Y-m-d', time: 'H:i' } } ),
+} ) );
+
+jest.mock( '@tanstack/react-router', () => ( {
+	__esModule: true,
+	useNavigate: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/components/DocumentIcon', () => ( {
+	__esModule: true,
+	default: ( { icon } ) => <span data-testid="document-icon">{ icon }</span>,
+} ) );
+
+import { useEntityRecords } from '@wordpress/core-data';
+import { DataViews } from '@wordpress/dataviews';
+import { useNavigate } from '@tanstack/react-router';
+
+import PublishedDocumentsPane from '../../../src/components/PublishedDocumentsPane';
+import {
+	POST_TYPE,
+	PUBLISHED_DOCUMENTS_QUERY,
+} from '../../../src/components/page-queries';
+
+const navigate = jest.fn();
+
+function documentRecord( overrides ) {
+	return {
+		id: 1,
+		slug: 'document',
+		title: { raw: 'Document' },
+		modified: '2026-05-31T10:00:00',
+		link: 'https://example.test/document/',
+		meta: {},
+		crtxt_trait: [],
+		cortext_defines_trait: false,
+		...overrides,
+	};
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	useNavigate.mockReturnValue( navigate );
+	useEntityRecords.mockReturnValue( {
+		records: [],
+		isResolving: false,
+	} );
+} );
+
+describe( 'PublishedDocumentsPane', () => {
+	it( 'loads the panel with one published document query', () => {
+		render( <PublishedDocumentsPane /> );
+
+		expect( useEntityRecords ).toHaveBeenCalledTimes( 1 );
+		expect( useEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			POST_TYPE,
+			PUBLISHED_DOCUMENTS_QUERY
+		);
+		expect( PUBLISHED_DOCUMENTS_QUERY ).toEqual( {
+			per_page: 100,
+			status: 'publish',
+			context: 'edit',
+		} );
+		expect( PUBLISHED_DOCUMENTS_QUERY ).not.toHaveProperty(
+			'cortext_no_trait'
+		);
+		expect( PUBLISHED_DOCUMENTS_QUERY ).not.toHaveProperty(
+			'cortext_collections'
+		);
+		expect( PUBLISHED_DOCUMENTS_QUERY ).not.toHaveProperty(
+			'cortext_no_collections'
+		);
+	} );
+
+	it( 'shows pages, collection items, and collections from the same response', () => {
+		useEntityRecords.mockReturnValue( {
+			records: [
+				documentRecord( {
+					id: 10,
+					slug: 'public-page',
+					title: { raw: 'Public Page' },
+				} ),
+				documentRecord( {
+					id: 20,
+					slug: 'public-collection-item',
+					title: { raw: 'Public Collection Item' },
+					crtxt_trait: [ 99 ],
+				} ),
+				documentRecord( {
+					id: 30,
+					slug: 'public-collection',
+					title: { raw: 'Public Collection' },
+					cortext_defines_trait: true,
+				} ),
+			],
+			isResolving: false,
+		} );
+
+		render( <PublishedDocumentsPane /> );
+
+		expect( DataViews ).toHaveBeenCalledTimes( 1 );
+		expect( screen.getByText( 'Public Page' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Public Collection Item' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Public Collection' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'document-10-type' ) ).toHaveTextContent(
+			'Page'
+		);
+		expect( screen.getByTestId( 'document-20-type' ) ).toHaveTextContent(
+			'Collection item'
+		);
+		expect( screen.getByTestId( 'document-30-type' ) ).toHaveTextContent(
+			'Collection'
+		);
+
+		const typeField = DataViews.mock.calls[ 0 ][ 0 ].fields.find(
+			( field ) => field.id === 'type'
+		);
+		expect( typeField.elements ).toEqual( [
+			{ value: 'page', label: 'Page' },
+			{ value: 'collection-item', label: 'Collection item' },
+			{ value: 'collection', label: 'Collection' },
+		] );
+		expect( typeField.filterBy ).toEqual( {
+			operators: [ 'is', 'isAny' ],
+		} );
+		expect(
+			DataViews.mock.calls[ 0 ][ 0 ].data.map( ( item ) =>
+				typeField.getValue( { item } )
+			)
+		).toEqual( [ 'page', 'collection-item', 'collection' ] );
+	} );
+} );


### PR DESCRIPTION
## What

The Published documents panel now lists all public documents in one place. That includes collection items, which could already be opened from their public URL but did not show up in the table. The Type filter stays available with Page, Collection item, and Collection.

## Why

If something can be published, it should also show up where people review what is public.

## How

- Fetching the public list from the shared document type.
- Keeping type as a label and filter, not as a loading rule.
- Leaving collection cascade publishing in the publish flow.

## Testing Instructions

1. Publish a page, a collection item, and a collection.
2. Open Published documents.
3. Check that all three are listed.
4. Filter by Type and check that each option narrows the table correctly.
5. Publish a document with a Data View pointing to a private collection, then check that the collection is published too.

## Screen recording

https://github.com/user-attachments/assets/2a2e241e-a683-45fc-8917-378e1c63f378

