### PR TITLE
Create collections from the sidebar

### DIFF
--- a/src/components/DocumentIconWp.js
+++ b/src/components/DocumentIconWp.js
@@ -1,11 +1,13 @@
 import * as icons from '@wordpress/icons';
 import { isValidElement } from '@wordpress/element';
 
-// Resolve one @wordpress/icons export by name. Keeping this in the lazy module
-// means sidebar rows that only use emoji or images do not load the whole icon
-// namespace.
+import { CORTEXT_GLYPHS } from './cortextIcons';
+
+// Resolve a glyph by name: Cortext's own glyphs first, then @wordpress/icons.
+// Keeping this in the lazy module means sidebar rows that only use emoji or
+// images do not load the whole icon namespace.
 export default function DocumentIconWp( { name, size = 16 } ) {
-	const Glyph = icons[ name ];
+	const Glyph = CORTEXT_GLYPHS[ name ] ?? icons[ name ];
 	const Icon = icons.Icon;
 	if ( ! Icon || ! isValidElement( Glyph ) || ! Glyph.type ) {
 		return null;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -2,13 +2,23 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
-import { Button, Icon, Notice } from '@wordpress/components';
+import {
+	Button,
+	Dropdown,
+	Icon,
+	MenuGroup,
+	MenuItem,
+	Notice,
+} from '@wordpress/components';
 import { displayShortcut } from '@wordpress/keycodes';
 import {
+	chevronDown,
 	globe,
 	home as homeIcon,
+	page,
 	plus,
 	search,
+	table,
 	trash as trashIcon,
 	upload,
 	wordpress,
@@ -105,6 +115,7 @@ import {
 	favoriteIdentForRecord,
 	favoriteKey,
 	favoriteKeyForRecord,
+	useCreateCollectionDocument,
 	useCreateDocument,
 	useDocumentSelection,
 	useFavoriteToggle,
@@ -334,9 +345,11 @@ export default function Sidebar( {
 	);
 
 	const create = useCreateDocument();
-	const createAndOpen = useCallback(
-		async ( input ) => {
-			const created = await create( input );
+	const createCollection = useCreateCollectionDocument();
+	// After creating a page or collection, open it and put its sidebar row into
+	// rename mode.
+	const openAfterCreate = useCallback(
+		( created ) => {
 			if ( created?.id ) {
 				setAutoRenameId( created.id );
 				navigate( {
@@ -346,15 +359,31 @@ export default function Sidebar( {
 			}
 			return created;
 		},
-		[ create, navigate ]
+		[ navigate ]
+	);
+	const createAndOpen = useCallback(
+		async ( input ) => openAfterCreate( await create( input ) ),
+		[ create, openAfterCreate ]
+	);
+	const createCollectionAndOpen = useCallback(
+		async ( input ) => openAfterCreate( await createCollection( input ) ),
+		[ createCollection, openAfterCreate ]
 	);
 	const createRootPage = useCallback(
 		() => createAndOpen( {} ),
 		[ createAndOpen ]
 	);
+	const createRootCollection = useCallback(
+		() => createCollectionAndOpen( {} ),
+		[ createCollectionAndOpen ]
+	);
 	const createChildPage = useCallback(
 		( parentId ) => createAndOpen( { parent: parentId } ),
 		[ createAndOpen ]
+	);
+	const createChildCollection = useCallback(
+		( parentId ) => createCollectionAndOpen( { parent: parentId } ),
+		[ createCollectionAndOpen ]
 	);
 
 	// Props shared by every DocumentRow in the Pages tree.
@@ -374,6 +403,7 @@ export default function Sidebar( {
 		autoRenameId,
 		onAutoRenameConsumed: () => setAutoRenameId( null ),
 		onCreateChild: createChildPage,
+		onCreateChildCollection: createChildCollection,
 	};
 
 	// --- Render ------------------------------------------------------------
@@ -528,16 +558,69 @@ export default function Sidebar( {
 								isCollapsed={ isSectionCollapsed( 'pages' ) }
 								onToggle={ () => toggleSection( 'pages' ) }
 								actions={
-									<Button
-										className="cortext-sidebar__section-action"
-										icon={ plus }
-										size="small"
-										label={ __(
-											'New document',
-											'cortext'
-										) }
-										onClick={ createRootPage }
-									/>
+									<div className="cortext-sidebar__split-action">
+										<Button
+											className="cortext-sidebar__section-action cortext-sidebar__split-action-primary"
+											icon={ plus }
+											size="small"
+											label={ __(
+												'New document',
+												'cortext'
+											) }
+											onClick={ createRootPage }
+										/>
+										<Dropdown
+											contentClassName="cortext-sidebar__create-menu"
+											popoverProps={ {
+												placement: 'bottom-end',
+											} }
+											renderToggle={ ( {
+												isOpen,
+												onToggle,
+											} ) => (
+												<Button
+													className="cortext-sidebar__section-action cortext-sidebar__split-action-toggle"
+													icon={ chevronDown }
+													size="small"
+													label={ __(
+														'Create a document or collection',
+														'cortext'
+													) }
+													onClick={ onToggle }
+													isPressed={ isOpen }
+													aria-expanded={ isOpen }
+												/>
+											) }
+											renderContent={ ( { onClose } ) => (
+												<MenuGroup>
+													<MenuItem
+														icon={ page }
+														onClick={ () => {
+															createRootPage();
+															onClose();
+														} }
+													>
+														{ __(
+															'New document',
+															'cortext'
+														) }
+													</MenuItem>
+													<MenuItem
+														icon={ table }
+														onClick={ () => {
+															createRootCollection();
+															onClose();
+														} }
+													>
+														{ __(
+															'New collection',
+															'cortext'
+														) }
+													</MenuItem>
+												</MenuGroup>
+											) }
+										/>
+									</div>
 								}
 							>
 								{ isResolvingPages &&

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -18,7 +18,6 @@ import {
 	page,
 	plus,
 	search,
-	table,
 	trash as trashIcon,
 	upload,
 	wordpress,
@@ -90,6 +89,7 @@ const cortextMarkIcon = (
 import { DndContext, DragOverlay, pointerWithin } from '@dnd-kit/core';
 
 import { openCommandPalette } from './CommandPalette';
+import { collectionIcon } from './cortextIcons';
 import SidebarFavorites from './SidebarFavorites';
 import SidebarResizeHandle from './SidebarResizeHandle';
 import SidebarRecents from './SidebarRecents';
@@ -606,7 +606,7 @@ export default function Sidebar( {
 														) }
 													</MenuItem>
 													<MenuItem
-														icon={ table }
+														icon={ collectionIcon }
 														onClick={ () => {
 															createRootCollection();
 															onClose();

--- a/src/components/Sidebar.scss
+++ b/src/components/Sidebar.scss
@@ -202,6 +202,20 @@
 		}
 	}
 
+	&__split-action {
+		display: flex;
+		align-items: center;
+	}
+
+	// Keep the create-menu toggle visible while its dropdown is open: the
+	// popover takes focus, so the header's focus-within reveal no longer holds.
+	@media (hover: hover) and (pointer: fine) {
+
+		&__split-action-toggle.components-button[aria-expanded="true"] {
+			opacity: 1;
+		}
+	}
+
 	&__content {
 		flex: 1 1 auto;
 		min-height: 0;

--- a/src/components/cortextIcons.js
+++ b/src/components/cortextIcons.js
@@ -1,0 +1,41 @@
+// Cortext's own document glyphs, drawn to sit at the same visual weight as the
+// WordPress document outline in the sidebar. `collectionIcon` is a rounded table
+// with the same ~14-wide extent as the page glyph, so a collection row lines up
+// with a page row instead of reading bigger or heavier.
+
+export const collectionIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<rect
+			x="5"
+			y="6"
+			width="14"
+			height="12"
+			rx="1.8"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.45"
+		/>
+		<path
+			d="M5 10h14M9.5 6v12M14.5 6v12"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.35"
+			strokeLinecap="round"
+		/>
+	</svg>
+);
+
+// Cortext glyphs addressable by name, the same way DocumentIcon resolves a
+// `{ type: 'wp', name }` meta against @wordpress/icons. Lets a collection render
+// its own glyph through DocumentIcon (same scale and box as every other row)
+// instead of needing a special render path.
+export const CORTEXT_GLYPHS = {
+	collection: collectionIcon,
+};

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -14,6 +14,7 @@ import {
 	plus,
 	starEmpty,
 	starFilled,
+	table,
 } from '@wordpress/icons';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 
@@ -32,25 +33,26 @@ import { useDocumentActions, useDocumentRecord } from '../../documents';
  * inspect for each kind.
  *
  * @param {Object}                            props
- * @param {Object}                            props.record               Raw document record.
- * @param {Array}                             [props.childNodes]         Child tree nodes (hierarchy only).
- * @param {number}                            [props.depth]              Nesting depth, 0 at the root.
- * @param {Set<number>}                       props.expandedIds          Currently expanded row ids.
- * @param {?number}                           [props.draggedId]          Id of the row being dragged.
- * @param {?{zone: string, targetId: number}} [props.activeDrop]         Active drop target metadata.
- * @param {boolean}                           [props.isHidden]           True when an ancestor is collapsed.
- * @param {Function|boolean}                  props.isSelected           Selection predicate or flag.
- * @param {Function}                          props.onSelect             Called with the record on title click.
- * @param {Function}                          props.onToggleExpand       Called with the record id on chevron click.
- * @param {Function}                          props.onCreateChild        Called with the parent id from the add-child button.
- * @param {Function|boolean}                  props.isFavorite           Favorite predicate or flag.
- * @param {boolean}                           [props.isFavoriteDisabled] Disable favorite toggling.
- * @param {Function}                          props.onToggleFavorite     Called with the record from the menu.
- * @param {Function|boolean}                  props.isHome               Home predicate or flag.
- * @param {Function}                          props.onSetHome            Called with the record from the menu.
- * @param {boolean}                           [props.isHomeUpdating]     Disable set-as-home while a save is in flight.
- * @param {?number}                           [props.autoRenameId]       Row id that should immediately enter rename mode.
- * @param {Function}                          props.onAutoRenameConsumed Called once rename mode has opened.
+ * @param {Object}                            props.record                    Raw document record.
+ * @param {Array}                             [props.childNodes]              Child tree nodes (hierarchy only).
+ * @param {number}                            [props.depth]                   Nesting depth, 0 at the root.
+ * @param {Set<number>}                       props.expandedIds               Currently expanded row ids.
+ * @param {?number}                           [props.draggedId]               Id of the row being dragged.
+ * @param {?{zone: string, targetId: number}} [props.activeDrop]              Active drop target metadata.
+ * @param {boolean}                           [props.isHidden]                True when an ancestor is collapsed.
+ * @param {Function|boolean}                  props.isSelected                Selection predicate or flag.
+ * @param {Function}                          props.onSelect                  Called with the record on title click.
+ * @param {Function}                          props.onToggleExpand            Called with the record id on chevron click.
+ * @param {Function}                          props.onCreateChild             Called with the parent id from the add-child button.
+ * @param {Function}                          [props.onCreateChildCollection] Called with the parent id to create a child collection.
+ * @param {Function|boolean}                  props.isFavorite                Favorite predicate or flag.
+ * @param {boolean}                           [props.isFavoriteDisabled]      Disable favorite toggling.
+ * @param {Function}                          props.onToggleFavorite          Called with the record from the menu.
+ * @param {Function|boolean}                  props.isHome                    Home predicate or flag.
+ * @param {Function}                          props.onSetHome                 Called with the record from the menu.
+ * @param {boolean}                           [props.isHomeUpdating]          Disable set-as-home while a save is in flight.
+ * @param {?number}                           [props.autoRenameId]            Row id that should immediately enter rename mode.
+ * @param {Function}                          props.onAutoRenameConsumed      Called once rename mode has opened.
  */
 export default function DocumentRow( {
 	record,
@@ -64,6 +66,7 @@ export default function DocumentRow( {
 	onSelect,
 	onToggleExpand,
 	onCreateChild,
+	onCreateChildCollection,
 	isFavorite,
 	isFavoriteDisabled = false,
 	onToggleFavorite,
@@ -291,65 +294,90 @@ export default function DocumentRow( {
 							/>
 						) }
 						renderContent={ ( { onClose } ) => (
-							<MenuGroup>
-								<MenuItem
-									icon={
-										rowIsFavorite ? starFilled : starEmpty
-									}
-									disabled={ isFavoriteDisabled }
-									onClick={ () => {
-										onToggleFavorite?.( record );
-										onClose();
-									} }
-								>
-									{ rowIsFavorite
-										? __(
-												'Remove from favorites',
+							<>
+								{ features.canCreateChild && (
+									<MenuGroup>
+										<MenuItem
+											icon={ table }
+											onClick={ () => {
+												onCreateChildCollection?.(
+													recordId
+												);
+												onClose();
+											} }
+										>
+											{ __(
+												'Add collection inside',
 												'cortext'
-										  )
-										: __( 'Add to favorites', 'cortext' ) }
-								</MenuItem>
-								<MenuItem
-									icon={ homeIcon }
-									disabled={ rowIsHome || isHomeUpdating }
-									onClick={ () => {
-										onSetHome( record );
-										onClose();
-									} }
-								>
-									{ rowIsHome
-										? __( 'Home', 'cortext' )
-										: __( 'Set as home', 'cortext' ) }
-								</MenuItem>
-								<MenuItem
-									icon="edit"
-									onClick={ () => {
-										startRename();
-										onClose();
-									} }
-								>
-									{ __( 'Rename', 'cortext' ) }
-								</MenuItem>
-								<MenuItem
-									icon="admin-page"
-									onClick={ () => {
-										duplicate( record );
-										onClose();
-									} }
-								>
-									{ __( 'Duplicate', 'cortext' ) }
-								</MenuItem>
-								<MenuItem
-									icon="trash"
-									isDestructive
-									onClick={ () => {
-										trash( record );
-										onClose();
-									} }
-								>
-									{ __( 'Move to Trash', 'cortext' ) }
-								</MenuItem>
-							</MenuGroup>
+											) }
+										</MenuItem>
+									</MenuGroup>
+								) }
+								<MenuGroup>
+									<MenuItem
+										icon={
+											rowIsFavorite
+												? starFilled
+												: starEmpty
+										}
+										disabled={ isFavoriteDisabled }
+										onClick={ () => {
+											onToggleFavorite?.( record );
+											onClose();
+										} }
+									>
+										{ rowIsFavorite
+											? __(
+													'Remove from favorites',
+													'cortext'
+											  )
+											: __(
+													'Add to favorites',
+													'cortext'
+											  ) }
+									</MenuItem>
+									<MenuItem
+										icon={ homeIcon }
+										disabled={ rowIsHome || isHomeUpdating }
+										onClick={ () => {
+											onSetHome( record );
+											onClose();
+										} }
+									>
+										{ rowIsHome
+											? __( 'Home', 'cortext' )
+											: __( 'Set as home', 'cortext' ) }
+									</MenuItem>
+									<MenuItem
+										icon="edit"
+										onClick={ () => {
+											startRename();
+											onClose();
+										} }
+									>
+										{ __( 'Rename', 'cortext' ) }
+									</MenuItem>
+									<MenuItem
+										icon="admin-page"
+										onClick={ () => {
+											duplicate( record );
+											onClose();
+										} }
+									>
+										{ __( 'Duplicate', 'cortext' ) }
+									</MenuItem>
+									<MenuItem
+										icon="trash"
+										isDestructive
+										onClick={ () => {
+											trash( record );
+											onClose();
+										} }
+									>
+										{ __( 'Move to Trash', 'cortext' ) }
+									</MenuItem>
+								</MenuGroup>
+							</>
 						) }
 					/>
 
@@ -408,6 +436,9 @@ export default function DocumentRow( {
 								onSelect={ onSelect }
 								onToggleExpand={ onToggleExpand }
 								onCreateChild={ onCreateChild }
+								onCreateChildCollection={
+									onCreateChildCollection
+								}
 								isFavorite={ isFavorite }
 								isFavoriteDisabled={ isFavoriteDisabled }
 								onToggleFavorite={ onToggleFavorite }

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -14,10 +14,10 @@ import {
 	plus,
 	starEmpty,
 	starFilled,
-	table,
 } from '@wordpress/icons';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 
+import { collectionIcon } from '../cortextIcons';
 import { useDocumentActions, useDocumentRecord } from '../../documents';
 
 /**
@@ -298,7 +298,7 @@ export default function DocumentRow( {
 								{ features.canCreateChild && (
 									<MenuGroup>
 										<MenuItem
-											icon={ table }
+											icon={ collectionIcon }
 											onClick={ () => {
 												onCreateChildCollection?.(
 													recordId

--- a/src/documents/actions.js
+++ b/src/documents/actions.js
@@ -49,6 +49,17 @@ export function useCreateDocument() {
 	);
 }
 
+// Create a collection document. The REST layer reads `cortext_collection` while
+// saving, mirrors the trait term, and creates the owner data view. The flag is
+// not stored on the post.
+export function useCreateCollectionDocument() {
+	const create = useCreateDocument();
+	return useCallback(
+		( input = {} ) => create( { ...input, cortext_collection: true } ),
+		[ create ]
+	);
+}
+
 // First rename of a draft promotes status to private so core regenerates
 // `post_name` from the new title via `wp_unique_post_slug(sanitize_title())`.
 export async function renameDocument( record, title, ctx ) {

--- a/src/documents/icons.js
+++ b/src/documents/icons.js
@@ -3,18 +3,18 @@ import { Icon, customPostType } from '@wordpress/icons';
 import DocumentIcon from '../components/DocumentIcon';
 import { definesTrait, hasTrait } from './capabilities';
 
-// A collection with no custom icon shows the table glyph, but rendered through
-// DocumentIcon (as a wp glyph) so it inherits the same 1.4x glyph scale and box
-// as a page's document glyph; a raw <Icon> reads noticeably smaller next to
-// page rows in the tree.
-const COLLECTION_ICON = JSON.stringify( { type: 'wp', name: 'table' } );
+// A collection with no custom icon shows the collection glyph, rendered through
+// DocumentIcon (as a named glyph) so it inherits the same 1.4x glyph scale and
+// box as a page's document glyph; the glyph is drawn to the page glyph's extent
+// so a collection row lines up with a page row instead of reading heavier.
+const COLLECTION_ICON = JSON.stringify( { type: 'wp', name: 'collection' } );
 // Same idea for a row's list glyph in the compact lists (Recents, Favorites,
 // Command Palette), so collection and row icons line up with page icons there.
 const ROW_ICON = JSON.stringify( { type: 'wp', name: 'listItem' } );
 
 /**
  * Sidebar-tree icon for a document record. A custom document-identity icon
- * always wins. Without one, a collection shows the table glyph (through
+ * always wins. Without one, a collection shows the collection glyph (through
  * DocumentIcon, so its size matches a page), a row takes the static post-type
  * glyph, and a page falls back to the document glyph.
  *

--- a/src/documents/icons.js
+++ b/src/documents/icons.js
@@ -3,18 +3,28 @@ import { Icon, customPostType, listItem, table } from '@wordpress/icons';
 import DocumentIcon from '../components/DocumentIcon';
 import { definesTrait, hasTrait } from './capabilities';
 
+// A collection with no custom icon shows the table glyph, but rendered through
+// DocumentIcon (as a wp glyph) so it inherits the same 1.4x glyph scale and box
+// as a page's document glyph; a raw <Icon> reads noticeably smaller next to
+// page rows in the tree.
+const COLLECTION_ICON = JSON.stringify( { type: 'wp', name: 'table' } );
+
 /**
- * Sidebar icon for a document record. Pages and collections opt into the
- * shared document-identity meta and render via DocumentIcon; rows take the
- * static post-type glyph.
+ * Sidebar-tree icon for a document record. A custom document-identity icon
+ * always wins. Without one, a collection shows the table glyph (through
+ * DocumentIcon, so its size matches a page), a row takes the static post-type
+ * glyph, and a page falls back to the document glyph.
  *
  * @param {Object} record Document record.
  * @param {number} [size] Icon size in pixels.
  * @return {Object} Rendered React node for the icon.
  */
 export function iconForRecord( record, size = 16 ) {
+	const iconMeta = record?.meta?.cortext_document_icon ?? '';
+	if ( ! iconMeta && definesTrait( record ) ) {
+		return <DocumentIcon icon={ COLLECTION_ICON } size={ size } />;
+	}
 	if ( ! hasTrait( record ) ) {
-		const iconMeta = record?.meta?.cortext_document_icon ?? '';
 		return <DocumentIcon icon={ iconMeta } size={ size } />;
 	}
 	return <Icon icon={ customPostType } size={ size } />;

--- a/src/documents/icons.js
+++ b/src/documents/icons.js
@@ -1,4 +1,4 @@
-import { Icon, customPostType, listItem, table } from '@wordpress/icons';
+import { Icon, customPostType } from '@wordpress/icons';
 
 import DocumentIcon from '../components/DocumentIcon';
 import { definesTrait, hasTrait } from './capabilities';
@@ -8,6 +8,9 @@ import { definesTrait, hasTrait } from './capabilities';
 // as a page's document glyph; a raw <Icon> reads noticeably smaller next to
 // page rows in the tree.
 const COLLECTION_ICON = JSON.stringify( { type: 'wp', name: 'table' } );
+// Same idea for a row's list glyph in the compact lists (Recents, Favorites,
+// Command Palette), so collection and row icons line up with page icons there.
+const ROW_ICON = JSON.stringify( { type: 'wp', name: 'listItem' } );
 
 /**
  * Sidebar-tree icon for a document record. A custom document-identity icon
@@ -44,10 +47,10 @@ export function listIconForRecord( record, size = 16 ) {
 		return <DocumentIcon icon={ icon } size={ size } />;
 	}
 	if ( definesTrait( record ) ) {
-		return <Icon icon={ table } size={ size } />;
+		return <DocumentIcon icon={ COLLECTION_ICON } size={ size } />;
 	}
 	if ( hasTrait( record ) ) {
-		return <Icon icon={ listItem } size={ size } />;
+		return <DocumentIcon icon={ ROW_ICON } size={ size } />;
 	}
 	return <DocumentIcon icon="" size={ size } />;
 }

--- a/src/documents/index.js
+++ b/src/documents/index.js
@@ -9,7 +9,7 @@ export {
 	useDocumentSelection,
 	useFavoriteToggle,
 } from './hooks';
-export { useCreateDocument } from './actions';
+export { useCreateDocument, useCreateCollectionDocument } from './actions';
 export { documentTitle } from './title';
 export { listIconForRecord } from './icons';
 export { documentUri } from './uri';

--- a/tests/e2e/specs/collection-creation.spec.js
+++ b/tests/e2e/specs/collection-creation.spec.js
@@ -1,0 +1,203 @@
+/**
+ * Covers the two sidebar entry points for collection creation: the Pages split
+ * button and the row menu on a page. Both should open the new collection and
+ * render the server-created owner data view.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SHELL_PATH = 'admin.php';
+const SHELL_QUERY = 'page=cortext';
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+async function currentPostId( page ) {
+	return page.evaluate(
+		() =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ?? 0
+	);
+}
+
+test.describe( 'Collection creation from the sidebar', () => {
+	test( 'creates a top-level collection from the Pages split button', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const title = `E2E Sidebar Collection ${ suffix }`;
+
+		try {
+			await admin.visitAdminPage( SHELL_PATH, SHELL_QUERY );
+			await expect( page.locator( '#cortext-sidebar' ) ).toBeVisible();
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			await sidebar.locator( '.cortext-sidebar__section--pages' ).hover();
+			await sidebar
+				.getByRole( 'button', {
+					name: 'Create a document or collection',
+				} )
+				.click();
+			await page
+				.getByRole( 'menuitem', {
+					name: 'New collection',
+					exact: true,
+				} )
+				.click();
+
+			// The new row opens in rename mode.
+			const renameInput = page.locator(
+				'.cortext-sidebar__rename input'
+			);
+			await expect( renameInput ).toBeVisible( { timeout: 15_000 } );
+			await renameInput.fill( title );
+			await renameInput.press( 'Enter' );
+
+			// The collection opens in the canvas with its own table.
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			await expect( canvas.locator( '.cortext-data-view' ) ).toBeVisible(
+				{
+					timeout: 15_000,
+				}
+			);
+
+			fixture.collectionId = await currentPostId( page );
+			expect( fixture.collectionId ).toBeGreaterThan( 0 );
+
+			// The sidebar shows the new title.
+			await expect(
+				sidebar.getByRole( 'button', { name: title, exact: true } )
+			).toBeVisible();
+
+			// The server marked it as a collection.
+			const saved = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_documents/${ fixture.collectionId }`,
+				params: { context: 'edit' },
+			} );
+			expect( saved.cortext_defines_trait ).toBe( true );
+
+			// It remains in the sidebar after a reload.
+			await page.reload();
+			await expect(
+				sidebar.getByRole( 'button', { name: title, exact: true } )
+			).toBeVisible();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collectionId &&
+					`/wp/v2/crtxt_documents/${ fixture.collectionId }`
+			);
+		}
+	} );
+
+	test( "creates a nested collection from a page's row menu", async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+		const parentTitle = `E2E Parent Page ${ suffix }`;
+		const childTitle = `E2E Nested Collection ${ suffix }`;
+
+		try {
+			fixture.parent = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: { title: parentTitle, status: 'private' },
+			} );
+
+			await admin.visitAdminPage(
+				SHELL_PATH,
+				`page=cortext&p=/${ fixture.parent.id }`
+			);
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			const parentRow = sidebar.getByRole( 'button', {
+				name: parentTitle,
+				exact: true,
+			} );
+			await expect( parentRow ).toBeVisible();
+			await parentRow.hover();
+			await sidebar
+				.getByRole( 'button', {
+					name: `Actions for ${ parentTitle }`,
+					exact: true,
+				} )
+				.click();
+			await page
+				.getByRole( 'menuitem', {
+					name: 'Add collection inside',
+				} )
+				.click();
+
+			const renameInput = page.locator(
+				'.cortext-sidebar__rename input'
+			);
+			await expect( renameInput ).toBeVisible( { timeout: 15_000 } );
+			await renameInput.fill( childTitle );
+			await renameInput.press( 'Enter' );
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			await expect( canvas.locator( '.cortext-data-view' ) ).toBeVisible(
+				{
+					timeout: 15_000,
+				}
+			);
+
+			fixture.childId = await currentPostId( page );
+			expect( fixture.childId ).toBeGreaterThan( 0 );
+
+			// The saved record is nested under the parent and marked as a collection.
+			const saved = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_documents/${ fixture.childId }`,
+				params: { context: 'edit' },
+			} );
+			expect( saved.parent ).toBe( fixture.parent.id );
+			expect( saved.cortext_defines_trait ).toBe( true );
+
+			// A collection row does not offer another child collection.
+			const childRow = sidebar.getByRole( 'button', {
+				name: childTitle,
+				exact: true,
+			} );
+			await expect( childRow ).toBeVisible();
+			await childRow.hover();
+			await sidebar
+				.getByRole( 'button', {
+					name: `Actions for ${ childTitle }`,
+					exact: true,
+				} )
+				.click();
+			await expect(
+				page.getByRole( 'menuitem', {
+					name: 'Add collection inside',
+				} )
+			).toHaveCount( 0 );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.childId && `/wp/v2/crtxt_documents/${ fixture.childId }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.parent &&
+					`/wp/v2/crtxt_documents/${ fixture.parent.id }`
+			);
+		}
+	} );
+} );

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -33,8 +33,8 @@ jest.mock( '@wordpress/core-data', () => ( {
 	} ),
 } ) );
 
-jest.mock( '../../../src/components/DocumentIcon', () => () => (
-	<span data-testid="document-icon" />
+jest.mock( '../../../src/components/DocumentIcon', () => ( { icon } ) => (
+	<span data-testid="document-icon" data-icon={ icon } />
 ) );
 
 jest.mock( '../../../src/hooks/useRecents', () => ( {
@@ -179,9 +179,14 @@ describe( 'SidebarRecents animation', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Recent: Library' } )
 		).toBeInTheDocument();
+		// The collection's table glyph now renders through DocumentIcon (so its
+		// size matches a page); the icon prop carries the table wp glyph.
 		expect(
-			container.querySelector( '[data-testid="icon-table"]' )
-		).toBeInTheDocument();
+			container.querySelector( '[data-testid="document-icon"]' )
+		).toHaveAttribute(
+			'data-icon',
+			JSON.stringify( { type: 'wp', name: 'table' } )
+		);
 	} );
 
 	it( 'adds accessible context when recent titles collide', () => {

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -165,7 +165,7 @@ describe( 'SidebarRecents animation', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'shows a collection recent with the table icon', () => {
+	it( 'shows a collection recent with the collection icon', () => {
 		mockRecents = [ collectionRecent( 33, 'Library' ) ];
 		mockRecordsById.set( 33, {
 			id: 33,
@@ -179,13 +179,13 @@ describe( 'SidebarRecents animation', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Recent: Library' } )
 		).toBeInTheDocument();
-		// The collection's table glyph now renders through DocumentIcon (so its
-		// size matches a page); the icon prop carries the table wp glyph.
+		// The collection glyph renders through DocumentIcon (so its size matches
+		// a page); the icon prop carries the collection wp glyph.
 		expect(
 			container.querySelector( '[data-testid="document-icon"]' )
 		).toHaveAttribute(
 			'data-icon',
-			JSON.stringify( { type: 'wp', name: 'table' } )
+			JSON.stringify( { type: 'wp', name: 'collection' } )
 		);
 	} );
 

--- a/tests/js/components/sidebar/DocumentRow.test.js
+++ b/tests/js/components/sidebar/DocumentRow.test.js
@@ -71,6 +71,16 @@ function makeRow( overrides = {} ) {
 	};
 }
 
+function makeCollection( overrides = {} ) {
+	return {
+		id: 5,
+		type: 'crtxt_document',
+		cortext_defines_trait: true,
+		title: { rendered: 'Tasks', raw: 'Tasks' },
+		...overrides,
+	};
+}
+
 function baseProps( overrides = {} ) {
 	return {
 		record: makePage(),
@@ -83,6 +93,7 @@ function baseProps( overrides = {} ) {
 		onSelect: jest.fn(),
 		onToggleExpand: jest.fn(),
 		onCreateChild: jest.fn(),
+		onCreateChildCollection: jest.fn(),
 		isFavorite: false,
 		isFavoriteDisabled: false,
 		onToggleFavorite: jest.fn(),
@@ -194,6 +205,27 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 			} )
 		);
 		expect( props.onCreateChild ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'creates a child collection from the menu', () => {
+		const { container, props } = renderRow();
+		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
+		fireEvent.click(
+			screen.getByRole( 'menuitem', {
+				name: 'Add collection inside',
+			} )
+		);
+		expect( props.onCreateChildCollection ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'does not show the child collection action for collections', () => {
+		const { container } = renderRow( { record: makeCollection() } );
+		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
+		expect(
+			screen.queryByRole( 'menuitem', {
+				name: 'Add collection inside',
+			} )
+		).toBeNull();
 	} );
 
 	it( 'calls onSelect with the record when the title is clicked', () => {
@@ -353,6 +385,16 @@ describe( 'DocumentRow (leaf mode)', () => {
 		const { container } = renderRow( { record: makeRow() } );
 		expect(
 			container.querySelector( '.cortext-sidebar__add-child' )
+		).toBeNull();
+	} );
+
+	it( 'does not show the child collection action for rows', () => {
+		const { container } = renderRow( { record: makeRow() } );
+		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
+		expect(
+			screen.queryByRole( 'menuitem', {
+				name: 'Add collection inside',
+			} )
 		).toBeNull();
 	} );
 

--- a/tests/js/documents/actions.test.js
+++ b/tests/js/documents/actions.test.js
@@ -17,6 +17,7 @@ jest.mock( '@wordpress/data', () => {
 import { useDispatch } from '@wordpress/data';
 import {
 	createDocument,
+	useCreateCollectionDocument,
 	useCreateDocument,
 } from '../../../src/documents/actions';
 import { DOCUMENT_POST_TYPE } from '../../../src/collections';
@@ -145,6 +146,59 @@ describe( 'useCreateDocument', () => {
 			'postType',
 			DOCUMENT_POST_TYPE,
 			{ status: 'draft' }
+		);
+	} );
+} );
+
+describe( 'useCreateCollectionDocument', () => {
+	beforeEach( () => {
+		useDispatch.mockReset();
+	} );
+
+	it( 'adds cortext_collection to the caller payload', async () => {
+		const saveEntityRecord = jest.fn().mockResolvedValue( { id: 21 } );
+		const invalidateResolution = jest.fn();
+		useDispatch.mockReturnValue( {
+			saveEntityRecord,
+			invalidateResolution,
+		} );
+
+		const { result } = renderHook( () => useCreateCollectionDocument() );
+
+		await act( async () => {
+			await result.current( { title: 'Tasks', parent: 3 } );
+		} );
+
+		expect( saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			DOCUMENT_POST_TYPE,
+			{
+				status: 'draft',
+				title: 'Tasks',
+				parent: 3,
+				cortext_collection: true,
+			}
+		);
+	} );
+
+	it( 'creates a draft with only the collection flag by default', async () => {
+		const saveEntityRecord = jest.fn().mockResolvedValue( { id: 22 } );
+		const invalidateResolution = jest.fn();
+		useDispatch.mockReturnValue( {
+			saveEntityRecord,
+			invalidateResolution,
+		} );
+
+		const { result } = renderHook( () => useCreateCollectionDocument() );
+
+		await act( async () => {
+			await result.current();
+		} );
+
+		expect( saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			DOCUMENT_POST_TYPE,
+			{ status: 'draft', cortext_collection: true }
 		);
 	} );
 } );

--- a/tests/js/documents/icons.test.js
+++ b/tests/js/documents/icons.test.js
@@ -1,9 +1,10 @@
 /**
  * Tests for `iconForRecord` and `listIconForRecord` in `src/documents/icons.js`.
  *
- * In the sidebar tree, a collection without a custom icon reads as the table
- * glyph rendered through DocumentIcon (so its size matches a page); a custom
- * icon wins, pages keep the document glyph, and rows take the post-type glyph.
+ * In the sidebar tree, a collection without a custom icon reads as the
+ * collection glyph rendered through DocumentIcon (so its size matches a page); a
+ * custom icon wins, pages keep the document glyph, and rows take the post-type
+ * glyph.
  * In the compact lists, collection and row glyphs also go through DocumentIcon
  * so they line up in size with page icons.
  *
@@ -15,12 +16,12 @@ import { Icon, customPostType } from '@wordpress/icons';
 import { iconForRecord, listIconForRecord } from '../../../src/documents/icons';
 import DocumentIcon from '../../../src/components/DocumentIcon';
 
-it( 'renders a collection without a custom icon as the table glyph through DocumentIcon', () => {
+it( 'renders a collection without a custom icon as the collection glyph through DocumentIcon', () => {
 	const element = iconForRecord( { cortext_defines_trait: true } );
 	expect( element.type ).toBe( DocumentIcon );
 	expect( JSON.parse( element.props.icon ) ).toEqual( {
 		type: 'wp',
-		name: 'table',
+		name: 'collection',
 	} );
 } );
 
@@ -47,12 +48,12 @@ it( 'gives a row the static post-type glyph', () => {
 } );
 
 describe( 'listIconForRecord', () => {
-	it( 'renders a collection as the table glyph through DocumentIcon', () => {
+	it( 'renders a collection as the collection glyph through DocumentIcon', () => {
 		const element = listIconForRecord( { cortext_defines_trait: true } );
 		expect( element.type ).toBe( DocumentIcon );
 		expect( JSON.parse( element.props.icon ) ).toEqual( {
 			type: 'wp',
-			name: 'table',
+			name: 'collection',
 		} );
 	} );
 

--- a/tests/js/documents/icons.test.js
+++ b/tests/js/documents/icons.test.js
@@ -1,17 +1,18 @@
 /**
- * Tests for `iconForRecord` in `src/documents/icons.js`.
+ * Tests for `iconForRecord` and `listIconForRecord` in `src/documents/icons.js`.
  *
- * A collection without a custom icon must read as a collection in the sidebar
- * tree (the table glyph), rendered through DocumentIcon so its size matches a
- * page, while a custom icon still wins, pages keep the document glyph, and rows
- * take the post-type glyph.
+ * In the sidebar tree, a collection without a custom icon reads as the table
+ * glyph rendered through DocumentIcon (so its size matches a page); a custom
+ * icon wins, pages keep the document glyph, and rows take the post-type glyph.
+ * In the compact lists, collection and row glyphs also go through DocumentIcon
+ * so they line up in size with page icons.
  *
- * The helper returns a React element, so the assertions inspect its type and
+ * Each helper returns a React element, so the assertions inspect its type and
  * props directly rather than rendering the icon SVGs.
  */
 import { Icon, customPostType } from '@wordpress/icons';
 
-import { iconForRecord } from '../../../src/documents/icons';
+import { iconForRecord, listIconForRecord } from '../../../src/documents/icons';
 import DocumentIcon from '../../../src/components/DocumentIcon';
 
 it( 'renders a collection without a custom icon as the table glyph through DocumentIcon', () => {
@@ -43,4 +44,40 @@ it( 'gives a row the static post-type glyph', () => {
 	const element = iconForRecord( { crtxt_trait: [ 12 ] } );
 	expect( element.type ).toBe( Icon );
 	expect( element.props.icon ).toBe( customPostType );
+} );
+
+describe( 'listIconForRecord', () => {
+	it( 'renders a collection as the table glyph through DocumentIcon', () => {
+		const element = listIconForRecord( { cortext_defines_trait: true } );
+		expect( element.type ).toBe( DocumentIcon );
+		expect( JSON.parse( element.props.icon ) ).toEqual( {
+			type: 'wp',
+			name: 'table',
+		} );
+	} );
+
+	it( 'renders a row as the list glyph through DocumentIcon', () => {
+		const element = listIconForRecord( { crtxt_trait: [ 12 ] } );
+		expect( element.type ).toBe( DocumentIcon );
+		expect( JSON.parse( element.props.icon ) ).toEqual( {
+			type: 'wp',
+			name: 'listItem',
+		} );
+	} );
+
+	it( 'lets a custom icon win', () => {
+		const meta = JSON.stringify( { type: 'emoji', value: '📚' } );
+		const element = listIconForRecord( {
+			cortext_defines_trait: true,
+			meta: { cortext_document_icon: meta },
+		} );
+		expect( element.type ).toBe( DocumentIcon );
+		expect( element.props.icon ).toBe( meta );
+	} );
+
+	it( 'renders a page through DocumentIcon', () => {
+		const element = listIconForRecord( {} );
+		expect( element.type ).toBe( DocumentIcon );
+		expect( element.props.icon ).toBe( '' );
+	} );
 } );

--- a/tests/js/documents/icons.test.js
+++ b/tests/js/documents/icons.test.js
@@ -1,0 +1,46 @@
+/**
+ * Tests for `iconForRecord` in `src/documents/icons.js`.
+ *
+ * A collection without a custom icon must read as a collection in the sidebar
+ * tree (the table glyph), rendered through DocumentIcon so its size matches a
+ * page, while a custom icon still wins, pages keep the document glyph, and rows
+ * take the post-type glyph.
+ *
+ * The helper returns a React element, so the assertions inspect its type and
+ * props directly rather than rendering the icon SVGs.
+ */
+import { Icon, customPostType } from '@wordpress/icons';
+
+import { iconForRecord } from '../../../src/documents/icons';
+import DocumentIcon from '../../../src/components/DocumentIcon';
+
+it( 'renders a collection without a custom icon as the table glyph through DocumentIcon', () => {
+	const element = iconForRecord( { cortext_defines_trait: true } );
+	expect( element.type ).toBe( DocumentIcon );
+	expect( JSON.parse( element.props.icon ) ).toEqual( {
+		type: 'wp',
+		name: 'table',
+	} );
+} );
+
+it( 'lets a custom icon win for a collection', () => {
+	const meta = JSON.stringify( { type: 'emoji', value: '📚' } );
+	const element = iconForRecord( {
+		cortext_defines_trait: true,
+		meta: { cortext_document_icon: meta },
+	} );
+	expect( element.type ).toBe( DocumentIcon );
+	expect( element.props.icon ).toBe( meta );
+} );
+
+it( 'renders a page through DocumentIcon', () => {
+	const element = iconForRecord( {} );
+	expect( element.type ).toBe( DocumentIcon );
+	expect( element.props.icon ).toBe( '' );
+} );
+
+it( 'gives a row the static post-type glyph', () => {
+	const element = iconForRecord( { crtxt_trait: [ 12 ] } );
+	expect( element.type ).toBe( Icon );
+	expect( element.props.icon ).toBe( customPostType );
+} );


### PR DESCRIPTION
## What

You can now create collections directly from the Pages sidebar. The section create button opens a small menu for choosing a page or collection, and page row menus now include Add collection inside. New collections open right away in rename mode, show their table in the canvas, and use the table icon in the sidebar when they do not have a custom icon.

## Why

Creating a collection should not require dropping into the editor first. This keeps the flow where people are already organizing pages.

## How

- Reusing the same create-and-rename flow pages already use.
- Sending the collection flag during save so the server creates the collection data view.
- Hiding the child collection action on rows that cannot have children.

## Testing Instructions

1. Open Cortext and hover the Pages section header.
2. Open the create dropdown and choose New collection.
3. Rename the collection and confirm it opens with a table in the canvas.
4. Open a page row menu and choose Add collection inside.
5. Confirm the new collection appears under that page and opens in the canvas.
6. Open a collection row menu and confirm Add collection inside is not shown.

## Screen recording

https://github.com/user-attachments/assets/9dc743d7-4972-44f6-9ec8-28268461cdf7


