### PR TITLE
Refactor: Rename `PageIcon` to `DocumentIcon`

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -461,9 +461,9 @@ Relations and list-style rollups now keep sorting disabled. Scalar rollups can s
 
 **Frontend stylesheet doesn't carry the cover/icon rules.**
 
-**What.** The PHP `render_callback`s emit `.cortext-document-cover-block`, `.cortext-document-icon-block`, and `.cortext-document-icon` markup on public pages, but their CSS still doesn't load there. Since the shell-style split, the admin/editor rules live in block edit partials and `PageIcon.scss`; `src/frontend.scss` still has none. On a public `crtxt_page`, the cover image renders at intrinsic size and the icon block falls back to inline layout.
+**What.** The PHP `render_callback`s emit `.cortext-document-cover-block`, `.cortext-document-icon-block`, and `.cortext-document-icon` markup on public pages, but their CSS still doesn't load there. Since the shell-style split, the admin/editor rules live in block edit partials and `DocumentIcon.scss`; `src/frontend.scss` still has none. On a public `crtxt_page`, the cover image renders at intrinsic size and the icon block falls back to inline layout.
 
-**Where.** `src/blocks/document-cover/edit.scss`, `src/blocks/document-icon/edit.scss`, and `src/components/PageIcon.scss` versus `src/frontend.scss`, plus the PHP render callbacks in `includes/Editor/DocumentCoverBlock.php` and `includes/Editor/DocumentIconBlock.php`.
+**Where.** `src/blocks/document-cover/edit.scss`, `src/blocks/document-icon/edit.scss`, and `src/components/DocumentIcon.scss` versus `src/frontend.scss`, plus the PHP render callbacks in `includes/Editor/DocumentCoverBlock.php` and `includes/Editor/DocumentIconBlock.php`.
 
 **Solution.** Extract the persisted cover/icon markup rules into a shared partial that both admin/editor and frontend stylesheets `@use`. Keep editor-only chrome, such as hover replace/remove controls and picker popovers, in the block edit partials.
 

--- a/src/components/DocumentIcon.js
+++ b/src/components/DocumentIcon.js
@@ -225,5 +225,3 @@ export default function DocumentIcon( {
 		/>
 	);
 }
-
-export const parsePageIcon = parseDocumentIcon;

--- a/src/components/DocumentIcon.js
+++ b/src/components/DocumentIcon.js
@@ -13,25 +13,23 @@ import './DocumentIcon.scss';
 import useDelayedFlag from '../hooks/useDelayedFlag';
 import { ICON_COLOR_BY_NAME } from './iconColors';
 
-// DocumentIconWp does `import * as icons from '@wordpress/icons'` so it can look
-// glyphs up by name at runtime. That defeats tree-shaking and would pull the
-// entire icon set (~238 KiB) into the initial bundle. Lazy-load it: most
-// document icons are emoji/image, and documents that do use a wp glyph only trigger
-// the chunk download on first render.
+// DocumentIconWp imports the full @wordpress/icons namespace so it can resolve
+// a glyph by saved name. Keep that out of the main bundle: most document icons
+// are emoji or images, and WP glyphs can pay the lazy-load cost when needed.
 const DocumentIconWp = lazy( () =>
 	import( /* webpackChunkName: "document-icon-wp" */ './DocumentIconWp' )
 );
-const DEFAULT_PAGE_ICON_SIZE = 16;
+const DEFAULT_DOCUMENT_ICON_SIZE = 16;
 const EMOJI_VISUAL_SCALE = 0.875;
 const GLYPH_VISUAL_SCALE = 1.4;
 
-// Three shapes are persisted in the cortext_document_icon meta:
+// cortext_document_icon stores one of three shapes:
 //   { type: 'emoji', value: '📘' }
 //   { type: 'image', id: 123 }
 //   { type: 'wp', name: 'home', color?: 'red' }
-// Anything else (empty meta, parse error) falls through to the page glyph.
+// Empty or invalid meta falls back to the page glyph.
 
-export function parsePageIcon( raw ) {
+export function parseDocumentIcon( raw ) {
 	if ( ! raw ) {
 		return null;
 	}
@@ -65,7 +63,7 @@ export function parsePageIcon( raw ) {
 			return { type: 'wp', name: decoded.name, color };
 		}
 	} catch {
-		// Malformed meta is treated as no icon; the surface picks its fallback.
+		// Bad meta should not break the row; render the fallback instead.
 	}
 
 	return null;
@@ -77,9 +75,8 @@ function ImageIcon( { id, size, alt, className } ) {
 		record?.media_details?.sizes?.thumbnail?.source_url ??
 		record?.source_url ??
 		null;
-	// Keep the swatch until REST has a URL and the browser has loaded it.
-	// Otherwise the swatch disappears first and the icon slot looks empty
-	// while the image bytes arrive.
+	// Keep the swatch until the browser has painted the image. REST can return
+	// a URL before the bytes are ready, which otherwise leaves an empty slot.
 	const [ hasImagePainted, setHasImagePainted ] = useState( false );
 	useEffect( () => {
 		setHasImagePainted( false );
@@ -120,9 +117,8 @@ function ImageIcon( { id, size, alt, className } ) {
 					loading="lazy"
 					decoding="async"
 					onLoad={ () => setHasImagePainted( true ) }
-					// Drop the swatch on a failed fetch too. Without this the
-					// swatch pulses forever for 404s or deleted media; we'd
-					// rather show the browser's broken-image fallback.
+					// Failed images should not leave the loading swatch running
+					// forever. Let the browser show its normal broken-image UI.
 					onError={ () => setHasImagePainted( true ) }
 					style={ { opacity: hasImagePainted ? 1 : 0 } }
 				/>
@@ -133,11 +129,11 @@ function ImageIcon( { id, size, alt, className } ) {
 
 export default function DocumentIcon( {
 	icon,
-	size = DEFAULT_PAGE_ICON_SIZE,
+	size = DEFAULT_DOCUMENT_ICON_SIZE,
 	alt,
 	className,
 } ) {
-	const parsed = useMemo( () => parsePageIcon( icon ), [ icon ] );
+	const parsed = useMemo( () => parseDocumentIcon( icon ), [ icon ] );
 	const classes = [ 'cortext-document-icon' ];
 	const numericSize = typeof size === 'number' ? size : parseFloat( size );
 	const hasNumericSize = Number.isFinite( numericSize );
@@ -147,12 +143,9 @@ export default function DocumentIcon( {
 	const glyphSize = hasNumericSize
 		? Math.round( numericSize * GLYPH_VISUAL_SCALE )
 		: size;
-	// `display: inline-flex` is the load-bearing bit: spans are inline by
-	// default, so width/height get ignored and the emoji variant ends up
-	// sized by `font-size * line-height` — taller than the SVG-based
-	// variants. inline-flex makes the dimensions effective and centers
-	// whatever's inside, so swapping between emoji, wp icon, and image
-	// keeps the icon block the exact same height.
+	// Spans are inline by default, so width/height would be ignored and emoji
+	// would end up taller than SVG icons. inline-flex makes the slot size real
+	// and keeps emoji, WP glyphs, images, and the fallback aligned.
 	const boxStyle = {
 		display: 'inline-flex',
 		alignItems: 'center',
@@ -163,7 +156,7 @@ export default function DocumentIcon( {
 	};
 	const glyphBoxStyle = {
 		...boxStyle,
-		'--cortext-page-icon-glyph-size':
+		'--cortext-document-icon-glyph-size':
 			typeof glyphSize === 'number' ? `${ glyphSize }px` : glyphSize,
 	};
 	if ( className ) {
@@ -232,3 +225,5 @@ export default function DocumentIcon( {
 		/>
 	);
 }
+
+export const parsePageIcon = parseDocumentIcon;

--- a/src/components/DocumentIcon.scss
+++ b/src/components/DocumentIcon.scss
@@ -10,8 +10,12 @@
 	vertical-align: middle;
 
 	&--emoji {
-		font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji",
-			"Twemoji Mozilla", sans-serif;
+		font-family:
+			"Apple Color Emoji",
+			"Segoe UI Emoji",
+			"Noto Color Emoji",
+			"Twemoji Mozilla",
+			sans-serif;
 	}
 
 	&--image {
@@ -60,6 +64,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+
 	.cortext-document-icon--image-loading-visible {
 		animation: none;
 	}

--- a/src/components/DocumentIcon.scss
+++ b/src/components/DocumentIcon.scss
@@ -10,12 +10,8 @@
 	vertical-align: middle;
 
 	&--emoji {
-		font-family:
-			"Apple Color Emoji",
-			"Segoe UI Emoji",
-			"Noto Color Emoji",
-			"Twemoji Mozilla",
-			sans-serif;
+		font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji",
+			"Twemoji Mozilla", sans-serif;
 	}
 
 	&--image {
@@ -25,15 +21,14 @@
 
 	&--fallback svg,
 	&--wp svg {
-		width: var(--cortext-page-icon-glyph-size);
-		min-width: var(--cortext-page-icon-glyph-size);
-		height: var(--cortext-page-icon-glyph-size);
-		flex: 0 0 var(--cortext-page-icon-glyph-size);
+		width: var(--cortext-document-icon-glyph-size);
+		min-width: var(--cortext-document-icon-glyph-size);
+		height: var(--cortext-document-icon-glyph-size);
+		flex: 0 0 var(--cortext-document-icon-glyph-size);
 		max-width: none;
 	}
 
-	// Wrapper for image icons. The swatch stays under the <img> until the image
-	// has loaded; REST returning a URL is not enough.
+	// Keep the swatch underneath the image until the browser has painted it.
 	&--image-wrap {
 		position: relative;
 		display: inline-block;
@@ -49,9 +44,8 @@
 		transition: opacity 80ms ease-out;
 	}
 
-	// Reserve the icon slot as soon as an image icon is parsed. Keep it
-	// transparent during the useDelayedFlag window so cache hits do not flash a
-	// swatch; `--visible` paints it after the delay.
+	// Reserve the image slot immediately. The swatch stays transparent during
+	// the delay so cached images do not flash a placeholder.
 	&--image-loading {
 		position: absolute;
 		inset: 0;
@@ -66,7 +60,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-
 	.cortext-document-icon--image-loading-visible {
 		animation: none;
 	}

--- a/src/components/DocumentIconWp.js
+++ b/src/components/DocumentIconWp.js
@@ -1,9 +1,9 @@
 import * as icons from '@wordpress/icons';
 import { isValidElement } from '@wordpress/element';
 
-// Renders a single icon from `@wordpress/icons` by export name. Lives in
-// its own module so DocumentIcon can `lazy()` it; the sidebar tree (which
-// only ever renders emoji/image icons) doesn't pay the import cost.
+// Resolve one @wordpress/icons export by name. Keeping this in the lazy module
+// means sidebar rows that only use emoji or images do not load the whole icon
+// namespace.
 export default function DocumentIconWp( { name, size = 16 } ) {
 	const Glyph = icons[ name ];
 	const Icon = icons.Icon;

--- a/src/components/DocumentInspectorSidebar.js
+++ b/src/components/DocumentInspectorSidebar.js
@@ -141,7 +141,7 @@ function InspectorToolGroup( { label, children } ) {
 	);
 }
 
-function PageIconInspectorControls( { postId, postType } ) {
+function DocumentIconInspectorControls( { postId, postType } ) {
 	const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId );
 	const iconMeta = meta?.cortext_document_icon ?? '';
 	const { coverIndex, hasCoverBlock, iconBlockId } = useSelect(
@@ -429,7 +429,7 @@ function PageIdentityInspectorPanel( { postId, postType, title } ) {
 	return (
 		<PanelBody title={ title } initialOpen>
 			<div className="cortext-document-inspector__tools">
-				<PageIconInspectorControls
+				<DocumentIconInspectorControls
 					postId={ postId }
 					postType={ postType }
 				/>

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -1,2 +1,0 @@
-export { default } from './DocumentIcon';
-export { parseDocumentIcon as parsePageIcon } from './DocumentIcon';

--- a/src/components/PageIcon.js
+++ b/src/components/PageIcon.js
@@ -1,0 +1,2 @@
+export { default } from './DocumentIcon';
+export { parseDocumentIcon as parsePageIcon } from './DocumentIcon';

--- a/tests/js/components/DocumentIcon.test.js
+++ b/tests/js/components/DocumentIcon.test.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 jest.mock( '@wordpress/core-data', () => ( {
 	__esModule: true,
@@ -23,11 +23,14 @@ jest.mock( '../../../src/components/DocumentIconWp', () => ( {
 import { useEntityRecord } from '@wordpress/core-data';
 
 import DocumentIcon, {
-	parsePageIcon,
+	parseDocumentIcon,
 } from '../../../src/components/DocumentIcon';
+import PageIcon, { parsePageIcon } from '../../../src/components/PageIcon';
 
+const BOOK_EMOJI = '\uD83D\uDCD8';
 const DEFAULT_SLOT_SIZE = '16px';
 const DEFAULT_GLYPH_SIZE = '22px';
+const DOCUMENT_GLYPH_SIZE_VAR = '--cortext-document-icon-glyph-size';
 
 function iconMeta( value ) {
 	return JSON.stringify( value );
@@ -44,7 +47,7 @@ function expectStableSlot( element, size = DEFAULT_SLOT_SIZE ) {
 	} );
 }
 
-describe( 'PageIcon', () => {
+describe( 'parseDocumentIcon', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		useEntityRecord.mockReturnValue( { record: null } );
@@ -52,23 +55,52 @@ describe( 'PageIcon', () => {
 
 	it( 'parses supported document icon metadata', () => {
 		expect(
-			parsePageIcon( iconMeta( { type: 'emoji', value: '\u{1F600}' } ) )
-		).toEqual( { type: 'emoji', value: '\u{1F600}' } );
+			parseDocumentIcon(
+				iconMeta( { type: 'emoji', value: BOOK_EMOJI } )
+			)
+		).toEqual( { type: 'emoji', value: BOOK_EMOJI } );
 		expect(
-			parsePageIcon( iconMeta( { type: 'image', id: 42 } ) )
+			parseDocumentIcon( iconMeta( { type: 'image', id: 42 } ) )
 		).toEqual( { type: 'image', id: 42 } );
 		expect(
-			parsePageIcon(
+			parseDocumentIcon(
 				iconMeta( { type: 'wp', name: 'bell', color: 'blue' } )
 			)
 		).toEqual( { type: 'wp', name: 'bell', color: 'blue' } );
-		expect( parsePageIcon( '{' ) ).toBeNull();
+	} );
+
+	it( 'rejects empty, malformed, and invalid meta', () => {
+		expect( parseDocumentIcon( '' ) ).toBeNull();
+		expect( parseDocumentIcon( '{' ) ).toBeNull();
 		expect(
-			parsePageIcon( iconMeta( { type: 'image', id: 0 } ) )
+			parseDocumentIcon( iconMeta( { type: 'emoji', value: '' } ) )
+		).toBeNull();
+		expect(
+			parseDocumentIcon( iconMeta( { type: 'image', id: 0 } ) )
+		).toBeNull();
+		expect(
+			parseDocumentIcon( iconMeta( { type: 'wp', name: '' } ) )
 		).toBeNull();
 	} );
 
-	it( 'keeps the same slot size for fallback, emoji, wp, and image icons', async () => {
+	it( 'leaves the old PageIcon parser import working', () => {
+		expect(
+			parsePageIcon( iconMeta( { type: 'emoji', value: BOOK_EMOJI } ) )
+		).toEqual(
+			parseDocumentIcon(
+				iconMeta( { type: 'emoji', value: BOOK_EMOJI } )
+			)
+		);
+	} );
+} );
+
+describe( 'DocumentIcon', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useEntityRecord.mockReturnValue( { record: null } );
+	} );
+
+	it( 'uses the same outer slot for fallback, emoji, wp, and image icons', async () => {
 		useEntityRecord.mockReturnValue( {
 			record: {
 				source_url: 'https://example.test/icon.jpg',
@@ -80,9 +112,7 @@ describe( 'PageIcon', () => {
 		expect( fallbackIcon ).toHaveClass( 'cortext-document-icon--fallback' );
 		expectStableSlot( fallbackIcon );
 		expect(
-			fallbackIcon.style.getPropertyValue(
-				'--cortext-page-icon-glyph-size'
-			)
+			fallbackIcon.style.getPropertyValue( DOCUMENT_GLYPH_SIZE_VAR )
 		).toBe( DEFAULT_GLYPH_SIZE );
 		expect( fallbackIcon.querySelector( 'svg' ) ).toHaveAttribute(
 			'width',
@@ -92,7 +122,7 @@ describe( 'PageIcon', () => {
 
 		const emoji = render(
 			<DocumentIcon
-				icon={ iconMeta( { type: 'emoji', value: '\u{1F600}' } ) }
+				icon={ iconMeta( { type: 'emoji', value: BOOK_EMOJI } ) }
 			/>
 		);
 		const emojiIcon = renderedIcon( emoji.container );
@@ -107,9 +137,9 @@ describe( 'PageIcon', () => {
 		const wpIcon = renderedIcon( wp.container );
 		expect( wpIcon ).toHaveClass( 'cortext-document-icon--wp' );
 		expectStableSlot( wpIcon );
-		expect(
-			wpIcon.style.getPropertyValue( '--cortext-page-icon-glyph-size' )
-		).toBe( DEFAULT_GLYPH_SIZE );
+		expect( wpIcon.style.getPropertyValue( DOCUMENT_GLYPH_SIZE_VAR ) ).toBe(
+			DEFAULT_GLYPH_SIZE
+		);
 		await waitFor( () =>
 			expect(
 				wp.container.querySelector( '[data-testid="wp-glyph"]' )
@@ -129,6 +159,60 @@ describe( 'PageIcon', () => {
 		);
 	} );
 
+	it( 'keeps the image wrapper and loading behavior intact', () => {
+		useEntityRecord.mockReturnValue( {
+			record: {
+				media_details: {
+					sizes: {
+						thumbnail: {
+							source_url: 'https://example.test/thumb.jpg',
+						},
+					},
+				},
+				source_url: 'https://example.test/full.jpg',
+			},
+		} );
+
+		const { container } = render(
+			<DocumentIcon
+				icon={ iconMeta( { type: 'image', id: 42 } ) }
+				size={ 28 }
+				alt="Cover"
+				className="extra-class"
+			/>
+		);
+		const wrapper = container.firstElementChild;
+		const image = screen.getByRole( 'img', { name: 'Cover' } );
+
+		expect( useEntityRecord ).toHaveBeenCalledWith( 'root', 'media', 42 );
+		expect( wrapper ).toHaveClass(
+			'cortext-document-icon',
+			'cortext-document-icon--image-wrap',
+			'extra-class'
+		);
+		expectStableSlot( wrapper, '28px' );
+		expect(
+			wrapper.querySelector( '.cortext-document-icon--image-loading' )
+		).toBeInTheDocument();
+		expect( image ).toHaveClass( 'cortext-document-icon--image' );
+		expect( image ).toHaveAttribute(
+			'src',
+			'https://example.test/thumb.jpg'
+		);
+		expect( image ).toHaveAttribute( 'width', '28' );
+		expect( image ).toHaveAttribute( 'height', '28' );
+		expect( image ).toHaveAttribute( 'loading', 'lazy' );
+		expect( image ).toHaveAttribute( 'decoding', 'async' );
+		expect( image ).toHaveStyle( { opacity: '0' } );
+
+		fireEvent.load( image );
+
+		expect(
+			wrapper.querySelector( '.cortext-document-icon--image-loading' )
+		).not.toBeInTheDocument();
+		expect( image ).toHaveStyle( { opacity: '1' } );
+	} );
+
 	it( 'keeps glyph svgs from shrinking in flex containers', () => {
 		const stylesheet = readFileSync(
 			join( process.cwd(), 'src/components/DocumentIcon.scss' ),
@@ -136,11 +220,25 @@ describe( 'PageIcon', () => {
 		);
 
 		expect( stylesheet ).toContain(
-			'min-width: var(--cortext-page-icon-glyph-size);'
+			'min-width: var(--cortext-document-icon-glyph-size);'
 		);
 		expect( stylesheet ).toContain(
-			'flex: 0 0 var(--cortext-page-icon-glyph-size);'
+			'flex: 0 0 var(--cortext-document-icon-glyph-size);'
 		);
 		expect( stylesheet ).toContain( 'max-width: none;' );
+	} );
+
+	it( 'keeps PageIcon working as a wrapper around DocumentIcon', () => {
+		const { container } = render(
+			<PageIcon
+				icon={ iconMeta( { type: 'emoji', value: BOOK_EMOJI } ) }
+			/>
+		);
+
+		expect( container.firstElementChild ).toHaveClass(
+			'cortext-document-icon',
+			'cortext-document-icon--emoji'
+		);
+		expect( screen.getByText( BOOK_EMOJI ) ).toBeInTheDocument();
 	} );
 } );

--- a/tests/js/components/DocumentIcon.test.js
+++ b/tests/js/components/DocumentIcon.test.js
@@ -25,7 +25,6 @@ import { useEntityRecord } from '@wordpress/core-data';
 import DocumentIcon, {
 	parseDocumentIcon,
 } from '../../../src/components/DocumentIcon';
-import PageIcon, { parsePageIcon } from '../../../src/components/PageIcon';
 
 const BOOK_EMOJI = '\uD83D\uDCD8';
 const DEFAULT_SLOT_SIZE = '16px';
@@ -83,15 +82,6 @@ describe( 'parseDocumentIcon', () => {
 		).toBeNull();
 	} );
 
-	it( 'leaves the old PageIcon parser import working', () => {
-		expect(
-			parsePageIcon( iconMeta( { type: 'emoji', value: BOOK_EMOJI } ) )
-		).toEqual(
-			parseDocumentIcon(
-				iconMeta( { type: 'emoji', value: BOOK_EMOJI } )
-			)
-		);
-	} );
 } );
 
 describe( 'DocumentIcon', () => {
@@ -228,17 +218,4 @@ describe( 'DocumentIcon', () => {
 		expect( stylesheet ).toContain( 'max-width: none;' );
 	} );
 
-	it( 'keeps PageIcon working as a wrapper around DocumentIcon', () => {
-		const { container } = render(
-			<PageIcon
-				icon={ iconMeta( { type: 'emoji', value: BOOK_EMOJI } ) }
-			/>
-		);
-
-		expect( container.firstElementChild ).toHaveClass(
-			'cortext-document-icon',
-			'cortext-document-icon--emoji'
-		);
-		expect( screen.getByText( BOOK_EMOJI ) ).toBeInTheDocument();
-	} );
 } );

--- a/tests/js/components/DocumentIcon.test.js
+++ b/tests/js/components/DocumentIcon.test.js
@@ -81,7 +81,6 @@ describe( 'parseDocumentIcon', () => {
 			parseDocumentIcon( iconMeta( { type: 'wp', name: '' } ) )
 		).toBeNull();
 	} );
-
 } );
 
 describe( 'DocumentIcon', () => {
@@ -217,5 +216,4 @@ describe( 'DocumentIcon', () => {
 		);
 		expect( stylesheet ).toContain( 'max-width: none;' );
 	} );
-
 } );

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -34,7 +34,7 @@ jest.mock( '@wordpress/core-data', () => ( {
 } ) );
 
 jest.mock( '../../../src/components/DocumentIcon', () => () => (
-	<span data-testid="page-icon" />
+	<span data-testid="document-icon" />
 ) );
 
 jest.mock( '../../../src/hooks/useRecents', () => ( {
@@ -226,7 +226,7 @@ describe( 'SidebarRecents animation', () => {
 		const { container } = render( <SidebarRecents /> );
 
 		expect(
-			container.querySelector( '[data-testid="page-icon"]' )
+			container.querySelector( '[data-testid="document-icon"]' )
 		).toBeInTheDocument();
 		expect(
 			container.querySelector( '[data-testid="icon-list-item"]' )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
 	},
 	// Scope wp-scripts' default 244 KiB asset-size warning to the initial
 	// entry. Intentional lazy chunks (emoji-mart data, icon library, the
-	// editor split, the icons vendor chunk pulled by PageIconWp) are gated
+	// editor split, the icons vendor chunk pulled by DocumentIconWp) are gated
 	// behind user actions, so flagging them is noise that drowns out the
 	// warning when index.js actually regresses. Source maps are dev-only
 	// and never served to end users. RTL stylesheets are alternates for
@@ -62,7 +62,7 @@ module.exports = {
 			if ( assetFilename.endsWith( '-rtl.css' ) ) {
 				return false;
 			}
-			return ! /^(emoji-mart-data|emoji-mart-react|icon-library-picker|page-icon-wp|editor|vendors-.*icons)/.test(
+			return ! /^(emoji-mart-data|emoji-mart-react|icon-library-picker|document-icon-wp|editor|vendors-.*icons)/.test(
 				assetFilename
 			);
 		},


### PR DESCRIPTION
## What

Follow-up to #280.

Renames the old `PageIcon` concept to `DocumentIcon`. The icon is used well beyond pages now, so this makes the name match what the component actually does.

The rendering behavior stays the same for fallback icons, emoji, uploaded images, and WordPress glyphs. The old `PageIcon` module and parser alias are removed, so new code has a single component name to use.

## Why

This avoids carrying a page-specific name through document identity UI that now appears in DataViews, identity controls, published documents, trash, and other shared document surfaces.

## How

- Renaming the parser and internal icon sizing names around `DocumentIcon`.
- Removing the old `PageIcon` wrapper and `parsePageIcon` alias.
- Adding focused coverage for the shared icon slot, image loading, glyph sizing, and parser behavior.

## Testing Instructions

1. Open a document with no custom icon and check that the fallback icon looks unchanged.
2. Switch the icon between an emoji, uploaded image, and WordPress glyph.
3. Check the icon in a DataView title cell, the identity controls, and a trash/sidebar-style list.