### PR TITLE
Fix: Scope the editor's media pickers to Cortext media

### DIFF
--- a/cortext.php
+++ b/cortext.php
@@ -60,4 +60,5 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command( 'cortext field-values', \Cortext\CLI\FieldValues::class );
 	\WP_CLI::add_command( 'cortext perf-seed', array( \Cortext\CLI\PerfBench::class, 'seed' ) );
 	\WP_CLI::add_command( 'cortext perf-bench', array( \Cortext\CLI\PerfBench::class, 'bench' ) );
+	\WP_CLI::add_command( 'cortext backfill-media', \Cortext\CLI\BackfillMedia::class );
 }

--- a/includes/CLI/BackfillMedia.php
+++ b/includes/CLI/BackfillMedia.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * WP-CLI command that stamps existing Cortext media with the `cortext_media`
+ * term so it surfaces in the Cortext media pickers.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\CLI;
+
+use Cortext\Media\CortextMedia;
+use WP_CLI;
+use WP_CLI_Command;
+
+final class BackfillMedia extends WP_CLI_Command {
+
+	/**
+	 * Tags media uploaded from Cortext that predates upload-time tagging:
+	 * attachments parented to a document, document covers, and image icons.
+	 * Idempotent, so it is safe to run more than once.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp cortext backfill-media
+	 *
+	 * @when after_wp_load
+	 */
+	public function __invoke(): void {
+		$result = ( new CortextMedia() )->backfill();
+
+		WP_CLI::success(
+			sprintf(
+				'Tagged %d attachment(s) across %d document(s).',
+				$result['tagged'],
+				$result['documents']
+			)
+		);
+	}
+}

--- a/includes/Media/CortextMedia.php
+++ b/includes/Media/CortextMedia.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * "Cortext media": attachments uploaded from inside Cortext.
+ *
+ * When an attachment is created with a Cortext document as its parent (the
+ * editor and the cover/icon picker both upload to the active document), it
+ * gets a private `cortext_media` term. The term records where the file came
+ * from, so it is set once at upload and never recomputed. It stays set if the
+ * attachment is later detached, reused in another document, or its original
+ * document is trashed.
+ *
+ * The term scopes the two media pickers:
+ *   - the inserter's Media tab (REST `/wp/v2/media`), via the `cortext_origin`
+ *     param this class maps to a tax_query;
+ *   - the wp.media modal for covers and icons, via the taxonomy `query_var`,
+ *     which survives core's `query-attachments` whitelist.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Media;
+
+use Cortext\PostType\Document;
+use WP_Post;
+use WP_REST_Request;
+
+final class CortextMedia {
+
+	public const TAXONOMY = 'cortext_media';
+	public const TERM     = 'cortext';
+
+	private const REST_PARAM = 'cortext_origin';
+
+	public function register(): void {
+		add_action( 'init', array( $this, 'register_taxonomy' ) );
+		add_action( 'add_attachment', array( $this, 'tag_if_from_cortext' ) );
+		add_filter( 'rest_attachment_query', array( $this, 'scope_inserter_query' ), 10, 2 );
+		add_filter( 'rest_attachment_collection_params', array( $this, 'expose_param' ) );
+	}
+
+	/**
+	 * Private taxonomy on attachments. `query_var` is what lets the wp.media
+	 * modal scope its library: core whitelists attachment taxonomy query vars
+	 * in `wp_ajax_query_attachments`, so `library: { cortext_media }` survives
+	 * to the WP_Query.
+	 */
+	public function register_taxonomy(): void {
+		register_taxonomy(
+			self::TAXONOMY,
+			'attachment',
+			array(
+				'public'            => false,
+				'show_ui'           => false,
+				'show_in_menu'      => false,
+				'show_in_nav_menus' => false,
+				'show_admin_column' => false,
+				'show_in_rest'      => false,
+				'hierarchical'      => false,
+				'rewrite'           => false,
+				'query_var'         => self::TAXONOMY,
+			)
+		);
+	}
+
+	/**
+	 * Stamps the origin term when a new attachment is parented to a Cortext
+	 * document. Runs on every upload site-wide but bails cheaply (two cached
+	 * reads) for anything not parented to a `crtxt_document`.
+	 *
+	 * @param int $attachment_id The new attachment's ID.
+	 */
+	public function tag_if_from_cortext( int $attachment_id ): void {
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment instanceof WP_Post ) {
+			return;
+		}
+
+		$parent_id = (int) $attachment->post_parent;
+		if ( $parent_id > 0 && Document::POST_TYPE === get_post_type( $parent_id ) ) {
+			$this->tag( $attachment_id );
+		}
+	}
+
+	/**
+	 * Stamps media that predates upload-time tagging: attachments parented to a
+	 * document, document covers (featured images), and image icons. Idempotent,
+	 * so it is safe to run repeatedly.
+	 *
+	 * @return array{documents:int,tagged:int}
+	 */
+	public function backfill(): array {
+		$document_ids = get_posts(
+			array(
+				'post_type'      => Document::POST_TYPE,
+				'post_status'    => array( 'publish', 'future', 'draft', 'pending', 'private', 'trash' ),
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+
+		$attachment_ids = array();
+		foreach ( $document_ids as $document_id ) {
+			$document_id = (int) $document_id;
+
+			$children = get_posts(
+				array(
+					'post_type'      => 'attachment',
+					'post_parent'    => $document_id,
+					'post_status'    => 'inherit',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				)
+			);
+			foreach ( $children as $child_id ) {
+				$attachment_ids[ (int) $child_id ] = true;
+			}
+
+			$cover_id = (int) get_post_thumbnail_id( $document_id );
+			if ( $cover_id > 0 ) {
+				$attachment_ids[ $cover_id ] = true;
+			}
+
+			$icon_id = $this->icon_attachment_id( $document_id );
+			if ( $icon_id > 0 ) {
+				$attachment_ids[ $icon_id ] = true;
+			}
+		}
+
+		$tagged = 0;
+		foreach ( array_keys( $attachment_ids ) as $attachment_id ) {
+			if ( 'attachment' === get_post_type( $attachment_id ) ) {
+				$this->tag( $attachment_id );
+				++$tagged;
+			}
+		}
+
+		return array(
+			'documents' => count( $document_ids ),
+			'tagged'    => $tagged,
+		);
+	}
+
+	private function tag( int $attachment_id ): void {
+		wp_set_object_terms( $attachment_id, self::TERM, self::TAXONOMY );
+	}
+
+	/**
+	 * Returns the attachment id from a document's image icon, or 0 when the
+	 * icon is an emoji, a built-in icon, or empty. The image icon is stored as
+	 * JSON: `{"type":"image","id":123}`.
+	 *
+	 * @param int $document_id Document post id.
+	 * @return int
+	 */
+	private function icon_attachment_id( int $document_id ): int {
+		$raw = (string) get_post_meta( $document_id, 'cortext_document_icon', true );
+		if ( '' === $raw ) {
+			return 0;
+		}
+
+		$decoded = json_decode( $raw, true );
+		if ( is_array( $decoded ) && 'image' === ( $decoded['type'] ?? '' ) ) {
+			return (int) ( $decoded['id'] ?? 0 );
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Limits the attachment REST collection to Cortext media when the inserter
+	 * asks for it. Mapped to a tax_query (not the taxonomy query var) so the
+	 * boolean param name never collides with the term lookup.
+	 *
+	 * @param array<string,mixed> $args    WP_Query args built for the request.
+	 * @param WP_REST_Request     $request The REST request.
+	 * @return array<string,mixed>
+	 */
+	public function scope_inserter_query( array $args, WP_REST_Request $request ): array {
+		$requested = $request->get_param( self::REST_PARAM );
+		if ( null === $requested || ! rest_sanitize_boolean( $requested ) ) {
+			return $args;
+		}
+
+		$tax_query   = isset( $args['tax_query'] ) && is_array( $args['tax_query'] ) ? $args['tax_query'] : array();
+		$tax_query[] = array(
+			'taxonomy' => self::TAXONOMY,
+			'field'    => 'slug',
+			'terms'    => array( self::TERM ),
+		);
+
+		$args['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+		return $args;
+	}
+
+	/**
+	 * Declares the inserter param so REST schema introspection lists and
+	 * accepts it.
+	 *
+	 * @param array<string,array<string,mixed>> $params Collection params.
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function expose_param( array $params ): array {
+		$params[ self::REST_PARAM ] = array(
+			'description' => __( 'Limit the result set to media uploaded from Cortext.', 'cortext' ),
+			'type'        => 'boolean',
+			'default'     => false,
+		);
+		return $params;
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -18,6 +18,7 @@ use Cortext\Editor\RevisionThrottle;
 use Cortext\FieldValues\FieldValueIndex;
 use Cortext\Frontend\Assets;
 use Cortext\Frontend\Template;
+use Cortext\Media\CortextMedia;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -74,6 +75,7 @@ final class Plugin {
 		( new Template() )->register();
 		( new Assets() )->register();
 		( new DataView() )->register();
+		( new CortextMedia() )->register();
 		( new Preferences() )->register();
 	}
 

--- a/src/blocks/document-cover/edit.js
+++ b/src/blocks/document-cover/edit.js
@@ -111,6 +111,7 @@ export default function Edit( { context, clientId } ) {
 					<MediaUploadCheck>
 						<MediaPicker
 							allowedTypes={ [ 'image' ] }
+							postId={ postId }
 							value={ featuredId }
 							onSelect={ ( picked ) =>
 								setFeaturedId( picked.id )
@@ -138,6 +139,7 @@ export default function Edit( { context, clientId } ) {
 					<MediaUploadCheck>
 						<MediaPicker
 							allowedTypes={ [ 'image' ] }
+							postId={ postId }
 							value={ featuredId }
 							onSelect={ ( picked ) =>
 								setFeaturedId( picked.id )
@@ -200,6 +202,7 @@ export default function Edit( { context, clientId } ) {
 					<MediaUploadCheck>
 						<MediaPicker
 							allowedTypes={ [ 'image' ] }
+							postId={ postId }
 							value={ featuredId }
 							onSelect={ ( picked ) =>
 								setFeaturedId( picked.id )

--- a/src/components/DocumentIdentityControls.js
+++ b/src/components/DocumentIdentityControls.js
@@ -374,6 +374,7 @@ function PickerBody( {
 			<MediaUploadCheck>
 				<MediaPicker
 					allowedTypes={ [ 'image' ] }
+					postId={ postId }
 					onSelect={ ( media ) => persist( encodeImage( media.id ) ) }
 					render={ ( { open } ) => (
 						<div className="cortext-document-identity-popover__upload">

--- a/src/components/DocumentInspectorSidebar.js
+++ b/src/components/DocumentInspectorSidebar.js
@@ -441,6 +441,7 @@ function PageFeaturedImageInspectorControls( { postId, postType } ) {
 				<MediaUploadCheck>
 					<MediaPicker
 						allowedTypes={ [ 'image' ] }
+						postId={ postId }
 						value={ featuredId }
 						onSelect={ setFeaturedImage }
 						render={ ( { open } ) => (

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -459,6 +459,7 @@ function DocumentIdentityActions( { postId, postType } ) {
 				<MediaUploadCheck>
 					<MediaPicker
 						allowedTypes={ [ 'image' ] }
+						postId={ postId }
 						onSelect={ ( media ) => insertCover( media.id ) }
 						render={ ( { open } ) => (
 							<Button

--- a/src/components/MediaPicker.js
+++ b/src/components/MediaPicker.js
@@ -1,43 +1,84 @@
 import { useCallback } from '@wordpress/element';
 import { MediaUploadCheck } from '@wordpress/block-editor';
 
-// Resolves to the wp.media (Backbone media library) instance available in
-// the host document. From inside the BlockCanvas iframe `window.wp.media`
-// is undefined — `wp_enqueue_media()` only enqueues media-views into the
-// parent — so we walk up to `window.parent` when needed. Returns null when
-// the host hasn't loaded media-views (e.g., the screen called this without
-// `wp_enqueue_media()`); callers should treat the trigger as a no-op.
-function getHostWpMedia() {
+// Resolves to the host document's `wp` global. Inside the BlockCanvas iframe
+// `window.wp.media` is undefined (wp_enqueue_media() only loads media-views in
+// the parent), so we walk up to `window.parent` when needed. Returns null when
+// the host has not loaded media-views (for example a screen that did not call
+// wp_enqueue_media()); callers should treat the trigger as a no-op.
+function getHostWp() {
 	if ( typeof window === 'undefined' ) {
 		return null;
 	}
 	const host =
 		window.parent && window.parent !== window ? window.parent : window;
-	return host?.wp?.media ?? null;
+	return host?.wp ?? null;
 }
 
 // Drop-in alternative to `<MediaUpload>` from `@wordpress/block-editor`
 // for the same use cases (single-select image picker). The render-prop
 // API matches: `({ open }) => <Trigger />`. Wrap with our own
-// `<MediaUploadCheck>` re-export so callers stay symmetrical.
+// `<MediaUploadCheck>` re-export so callers stay symmetrical. Pass `postId`
+// to attach uploads to that document so they count as Cortext media.
 export default function MediaPicker( {
 	allowedTypes = [ 'image' ],
 	value,
 	onSelect,
 	title,
 	render,
+	postId,
 } ) {
 	const open = useCallback( () => {
-		const wpMedia = getHostWpMedia();
+		const wp = getHostWp();
+		const wpMedia = wp?.media;
 		if ( ! wpMedia ) {
 			return;
 		}
 
+		// Parent uploads to the active document so they get stamped as Cortext
+		// media; otherwise cover/icon uploads land unattached and never enter
+		// the (now Cortext-scoped) picker. Core's uploader reads
+		// `wp.media.view.settings.post.id` in its `ready()`, so point it at the
+		// document for the frame's lifetime and restore it on close.
+		const postSettings = wpMedia.view?.settings?.post;
+		const shouldParent = !! ( postSettings && postId );
+		const previousPostId = postSettings?.id;
+		if ( shouldParent ) {
+			postSettings.id = postId;
+		}
+
 		const frame = wpMedia( {
 			title,
-			library: { type: allowedTypes },
+			// Scope the library to media uploaded from Cortext (the
+			// `cortext_media` taxonomy term; see Cortext\Media\CortextMedia).
+			// The term's query_var survives core's query-attachments whitelist.
+			library: { type: allowedTypes, cortext_media: 'cortext' },
 			multiple: false,
 		} );
+
+		if ( shouldParent ) {
+			frame.on( 'close', () => {
+				postSettings.id = previousPostId;
+			} );
+		}
+
+		// wp.media does not reinject a freshly uploaded attachment into a
+		// library filtered by a custom taxonomy, so a new upload would only
+		// appear after reopening. Re-query the library once the upload queue
+		// drains (every upload finished, and the new attachments are stamped
+		// server-side by then) so it shows immediately. Listening to `reset`
+		// avoids a loop: it fires on upload completion, not on library loads.
+		const uploaderQueue = wp?.Uploader?.queue;
+		if ( uploaderQueue ) {
+			const requery = () => {
+				const library = frame.state()?.get?.( 'library' );
+				if ( library?.props ) {
+					library.props.set( 'ignore', Date.now() );
+				}
+			};
+			uploaderQueue.on( 'reset', requery );
+			frame.on( 'close', () => uploaderQueue.off( 'reset', requery ) );
+		}
 
 		// Pre-select the current attachment so the modal opens with it
 		// highlighted, mirroring core's MediaUpload behavior.
@@ -58,7 +99,7 @@ export default function MediaPicker( {
 		} );
 
 		frame.open();
-	}, [ allowedTypes, value, onSelect, title ] );
+	}, [ allowedTypes, value, onSelect, title, postId ] );
 
 	return render( { open } );
 }

--- a/src/components/initInserterMediaCategories.js
+++ b/src/components/initInserterMediaCategories.js
@@ -16,6 +16,9 @@ function fetchMediaItems( mediaType ) {
 			path: addQueryArgs( '/wp/v2/media', {
 				...query,
 				media_type: mediaType,
+				// Scope the tab to media uploaded from Cortext. The server reads
+				// this on /wp/v2/media; see Cortext\Media\CortextMedia.
+				cortext_origin: 1,
 			} ),
 		} );
 		return items.map( ( item ) => ( {

--- a/tests/js/initInserterMediaCategories.test.js
+++ b/tests/js/initInserterMediaCategories.test.js
@@ -1,0 +1,103 @@
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+// The module registers its categories with the block-editor store at import
+// time. Stub the store and dispatch so that side effect is a no-op here.
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: () => ( { registerInserterMediaCategory: jest.fn() } ),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import { CORTEXT_INSERTER_MEDIA_CATEGORIES } from '../../src/components/initInserterMediaCategories';
+
+function lastRequestPath() {
+	return decodeURIComponent( apiFetch.mock.calls.at( -1 )[ 0 ].path );
+}
+
+function categoryByName( name ) {
+	return CORTEXT_INSERTER_MEDIA_CATEGORIES.find( ( c ) => c.name === name );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	apiFetch.mockResolvedValue( [] );
+} );
+
+describe( 'CORTEXT_INSERTER_MEDIA_CATEGORIES', () => {
+	it.each( [
+		[ 'images', 'image' ],
+		[ 'videos', 'video' ],
+		[ 'audio', 'audio' ],
+	] )(
+		'scopes the %s category fetch to Cortext documents',
+		async ( name, mediaType ) => {
+			await categoryByName( name ).fetch();
+
+			const path = lastRequestPath();
+			expect( path ).toContain( '/wp/v2/media' );
+			expect( path ).toContain( `media_type=${ mediaType }` );
+			expect( path ).toContain( 'cortext_origin=1' );
+		}
+	);
+
+	it( 'preserves the inserter query (search, pagination) alongside the scope', async () => {
+		await categoryByName( 'images' ).fetch( {
+			search: 'cat',
+			page: 2,
+			per_page: 20,
+		} );
+
+		const path = lastRequestPath();
+		expect( path ).toContain( 'search=cat' );
+		expect( path ).toContain( 'page=2' );
+		expect( path ).toContain( 'per_page=20' );
+		expect( path ).toContain( 'cortext_origin=1' );
+	} );
+
+	it( 'maps REST media fields to the shape the inserter expects', async () => {
+		apiFetch.mockResolvedValue( [
+			{
+				id: 7,
+				source_url: 'https://example.test/full.jpg',
+				alt_text: 'A cat',
+				caption: { raw: 'A caption' },
+				media_details: {
+					sizes: {
+						medium: {
+							source_url: 'https://example.test/medium.jpg',
+						},
+					},
+				},
+			},
+		] );
+
+		const items = await categoryByName( 'images' ).fetch();
+
+		expect( items[ 0 ] ).toMatchObject( {
+			id: 7,
+			previewUrl: 'https://example.test/medium.jpg',
+			url: 'https://example.test/full.jpg',
+			alt: 'A cat',
+			caption: 'A caption',
+		} );
+	} );
+
+	it( 'falls back to the full source_url when no medium size exists', async () => {
+		apiFetch.mockResolvedValue( [
+			{
+				id: 8,
+				source_url: 'https://example.test/only.png',
+				media_details: { sizes: {} },
+			},
+		] );
+
+		const items = await categoryByName( 'images' ).fetch();
+
+		expect( items[ 0 ].previewUrl ).toBe( 'https://example.test/only.png' );
+	} );
+} );

--- a/tests/php/test-cortext-media.php
+++ b/tests/php/test-cortext-media.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for Cortext\Media\CortextMedia.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Media\CortextMedia;
+use Cortext\PostType\Document;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+
+final class Test_Cortext_Media extends BaseTestCase {
+
+	use InMemoryTermStore;
+	use InMemoryPostsQuery;
+
+	private CortextMedia $media;
+
+	public function set_up(): void {
+		parent::set_up();
+		( new Document() )->register_post_type();
+		$this->media = new CortextMedia();
+		$this->media->register_taxonomy();
+		$this->install_in_memory_term_store();
+		$this->install_in_memory_posts_query();
+	}
+
+	public function tear_down(): void {
+		$this->uninstall_in_memory_posts_query();
+		$this->uninstall_in_memory_term_store();
+		parent::tear_down();
+	}
+
+	public function test_registers_taxonomy_on_attachments(): void {
+		$this->assertTrue( taxonomy_exists( CortextMedia::TAXONOMY ) );
+		$this->assertTrue( is_object_in_taxonomy( 'attachment', CortextMedia::TAXONOMY ) );
+	}
+
+	public function test_tags_attachment_uploaded_into_a_document(): void {
+		$attachment = $this->make_attachment( $this->make_document() );
+
+		$this->media->tag_if_from_cortext( $attachment );
+
+		$this->assertTrue( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $attachment ) );
+	}
+
+	public function test_does_not_tag_attachment_without_a_cortext_parent(): void {
+		$orphan  = $this->make_attachment( 0 );
+		$regular = (int) wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'Regular',
+				'post_status' => 'publish',
+			)
+		);
+		$foreign = $this->make_attachment( $regular );
+
+		$this->media->tag_if_from_cortext( $orphan );
+		$this->media->tag_if_from_cortext( $foreign );
+
+		$this->assertFalse( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $orphan ) );
+		$this->assertFalse( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $foreign ) );
+	}
+
+	public function test_inserter_param_adds_a_cortext_media_tax_query(): void {
+		$request = new WP_REST_Request();
+		$request->set_param( 'cortext_origin', '1' );
+
+		$args = $this->media->scope_inserter_query( array(), $request );
+
+		$this->assertArrayHasKey( 'tax_query', $args );
+		$this->assertSame( CortextMedia::TAXONOMY, $args['tax_query'][0]['taxonomy'] );
+		$this->assertSame( array( CortextMedia::TERM ), $args['tax_query'][0]['terms'] );
+	}
+
+	public function test_inserter_param_absent_leaves_query_unscoped(): void {
+		$args = $this->media->scope_inserter_query( array(), new WP_REST_Request() );
+
+		$this->assertArrayNotHasKey( 'tax_query', $args );
+	}
+
+	public function test_exposes_cortext_origin_param(): void {
+		$params = $this->media->expose_param( array() );
+
+		$this->assertArrayHasKey( 'cortext_origin', $params );
+		$this->assertSame( 'boolean', $params['cortext_origin']['type'] );
+	}
+
+	public function test_backfill_tags_parented_cover_and_icon_media(): void {
+		$document = $this->make_document();
+
+		$inline = $this->make_attachment( $document );
+
+		$cover = $this->make_attachment( 0 );
+		update_post_meta( $document, '_thumbnail_id', $cover );
+
+		$icon = $this->make_attachment( 0 );
+		update_post_meta(
+			$document,
+			'cortext_document_icon',
+			wp_json_encode(
+				array(
+					'type' => 'image',
+					'id'   => $icon,
+				)
+			)
+		);
+
+		$foreign = $this->make_attachment( 0 );
+
+		$result = $this->media->backfill();
+
+		$this->assertTrue( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $inline ) );
+		$this->assertTrue( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $cover ) );
+		$this->assertTrue( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $icon ) );
+		$this->assertFalse( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $foreign ) );
+		$this->assertSame( 3, $result['tagged'] );
+	}
+
+	private function make_document(): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_title'  => 'Doc',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	private function make_attachment( int $parent_id ): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_parent'    => $parent_id,
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Image',
+			)
+		);
+	}
+}


### PR DESCRIPTION
## What

Part of #85.

When you pick media inside a Cortext document, whether in the inserter's Media tab or the cover and icon pickers, you now only see media uploaded from Cortext, not everything in the site's media library.

## Why

A site's media library fills up with attachments that have nothing to do with Cortext (the main blog, the theme, whatever other plugins upload), and those were showing up when picking media for a document.

## How
Cortext media is marked with a private `cortext_media` taxonomy term, set on an attachment when it's uploaded with a Cortext document as its parent. Each picker filters by that term a different way: the inserter's Media tab sends a flag on its REST media request that becomes a taxonomy query, and the `wp.media` modal passes the taxonomy's query var. The cover and icon picker now attach their uploads to the current document, so those get the term too.


Sites with existing media need to run `wp cortext backfill-media` once, to tag what was uploaded before this change. Until then, older covers and icons won't show in the pickers, though the document still renders the cover it already has.

## Testing Instructions

1. Upload an image from the WordPress Media Library so there's some non-Cortext media around.
2. In a Cortext document, add an image block and upload an image. Open the inserter's Media tab, then the cover and icon pickers: they should only show Cortext media, not the one from step 1.
3. From the cover picker, upload a new image. It should appear in the grid right away, without reopening the picker, and be usable as the cover.
4. On a site with older media, run `wp cortext backfill-media` and check that earlier covers and inline images show up.

## Screen recording

https://github.com/user-attachments/assets/7e3243f3-2372-474f-b1ed-bc5da35afb1d


