### PR TITLE
Add block variations to create or link collections

### DIFF
--- a/src/blocks/data-view/block.json
+++ b/src/blocks/data-view/block.json
@@ -23,6 +23,9 @@
 		"collectionId": {
 			"type": "number"
 		},
+		"intent": {
+			"type": "string"
+		},
 		"view": {
 			"type": "object",
 			"default": {

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -17,6 +17,7 @@ import {
 	Notice,
 	PanelBody,
 	Placeholder,
+	SearchControl,
 	SelectControl,
 	Spinner,
 	TextControl,
@@ -27,7 +28,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useState } from '@wordpress/element';
 import { store as interfaceStore } from '@wordpress/interface';
-import { cog, plus, replace } from '@wordpress/icons';
+import { cog, link, plus, replace, table } from '@wordpress/icons';
 
 import CanvasOwnerInspector, {
 	useIsCanvasOwnerBlock,
@@ -39,7 +40,7 @@ import {
 	DOCUMENT_POST_TYPE,
 	FULL_PAGE_COLLECTION_QUERY,
 } from '../../collections';
-import { useCreateDocument } from '../../documents';
+import { useCreateCollectionDocument } from '../../documents';
 import { toDataViewId } from '../../hooks/fieldIds';
 import {
 	CollectionFieldsProvider,
@@ -112,6 +113,7 @@ function CollectionPicker( { selectedId = '', onSelect } ) {
 		DOCUMENT_POST_TYPE,
 		FULL_PAGE_COLLECTION_QUERY
 	);
+	const [ query, setQuery ] = useState( '' );
 
 	const hasCollections = Boolean( records?.length );
 
@@ -127,29 +129,48 @@ function CollectionPicker( { selectedId = '', onSelect } ) {
 		);
 	}
 
+	const collectionTitle = ( collection ) =>
+		collection.title?.rendered ||
+		collection.title?.raw ||
+		`#${ collection.id }`;
+	const needle = query.trim().toLowerCase();
+	const matches = needle
+		? ( records ?? [] ).filter( ( collection ) =>
+				collectionTitle( collection ).toLowerCase().includes( needle )
+		  )
+		: records ?? [];
+
 	return (
 		<div className="cortext-collection-chooser">
-			{ /* TODO: Add search once collection lists are long enough to make scanning noisy. */ }
-			{ ( records ?? [] ).map( ( collection ) => {
-				const title =
-					collection.title?.rendered ||
-					collection.title?.raw ||
-					`#${ collection.id }`;
-				const isSelected =
-					selectedId && Number( selectedId ) === collection.id;
+			<SearchControl
+				__nextHasNoMarginBottom
+				className="cortext-collection-chooser__search"
+				value={ query }
+				onChange={ setQuery }
+				placeholder={ __( 'Search collections', 'cortext' ) }
+			/>
+			{ matches.length === 0 ? (
+				<p className="cortext-data-view-picker__empty">
+					{ __( 'No collections match your search.', 'cortext' ) }
+				</p>
+			) : (
+				matches.map( ( collection ) => {
+					const isSelected =
+						selectedId && Number( selectedId ) === collection.id;
 
-				return (
-					<Button
-						key={ collection.id }
-						className="cortext-collection-chooser__item"
-						variant={ isSelected ? 'secondary' : 'tertiary' }
-						isPressed={ isSelected }
-						onClick={ () => onSelect( collection.id ) }
-					>
-						{ title }
-					</Button>
-				);
-			} ) }
+					return (
+						<Button
+							key={ collection.id }
+							className="cortext-collection-chooser__item"
+							variant={ isSelected ? 'secondary' : 'tertiary' }
+							isPressed={ isSelected }
+							onClick={ () => onSelect( collection.id ) }
+						>
+							{ collectionTitle( collection ) }
+						</Button>
+					);
+				} )
+			) }
 		</div>
 	);
 }
@@ -158,7 +179,7 @@ function CollectionCreator( { onCreate } ) {
 	const [ title, setTitle ] = useState( '' );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ error, setError ] = useState( '' );
-	const create = useCreateDocument();
+	const create = useCreateCollectionDocument();
 	const canCreate = title.trim() && ! isSaving;
 
 	// Nest the new collection under the current page so it appears beneath it
@@ -180,10 +201,6 @@ function CollectionCreator( { onCreate } ) {
 			const collection = await create( {
 				title: title.trim(),
 				status: 'private',
-				// Designate the new document a collection so its mirror term is
-				// created server-side, even though it starts with no custom
-				// fields (only the implicit title).
-				cortext_collection: true,
 				...( ownerPageId ? { parent: ownerPageId } : {} ),
 			} );
 			onCreate( collection );
@@ -576,7 +593,7 @@ export default function Edit( {
 	context,
 	setAttributes,
 } ) {
-	const { collectionId, view, align } = attributes;
+	const { collectionId, view, align, intent } = attributes;
 	const isOwner = useIsCanvasOwnerBlock(
 		clientId,
 		context?.postType,
@@ -597,9 +614,18 @@ export default function Edit( {
 		[ setAttributes ]
 	);
 
+	// The inserter variations stamp a transient `intent` to open the placeholder
+	// in create or link mode. Clear it once a collection is bound so resolved
+	// blocks only persist `collectionId` + `view`; until then it rides in the
+	// attributes and survives remounts (the canvas reconciles blocks on load),
+	// keeping the chosen mode.
 	const selectCollection = useCallback(
 		( id ) =>
-			setAttributes( { collectionId: id, view: createDefaultView() } ),
+			setAttributes( {
+				collectionId: id,
+				view: createDefaultView(),
+				intent: undefined,
+			} ),
 		[ setAttributes ]
 	);
 
@@ -624,6 +650,7 @@ export default function Edit( {
 	}, [] );
 
 	if ( ! collectionId ) {
+		const isLinkMode = intent === 'link-existing';
 		return (
 			<div { ...blockProps }>
 				<InspectorControls>
@@ -631,22 +658,33 @@ export default function Edit( {
 						<CollectionPicker onSelect={ selectCollection } />
 					</PanelBody>
 				</InspectorControls>
-				<Placeholder
-					label={ __( 'Collection view', 'cortext' ) }
-					instructions={ __(
-						'Pick a collection to display.',
-						'cortext'
-					) }
-				>
-					<CollectionPicker onSelect={ selectCollection } />
-					<div className="cortext-data-view-placeholder__create">
+				{ isLinkMode ? (
+					<Placeholder
+						icon={ link }
+						label={ __( 'Link a collection', 'cortext' ) }
+						instructions={ __(
+							'Show an existing collection here.',
+							'cortext'
+						) }
+					>
+						<CollectionPicker onSelect={ selectCollection } />
+					</Placeholder>
+				) : (
+					<Placeholder
+						icon={ table }
+						label={ __( 'New collection', 'cortext' ) }
+						instructions={ __(
+							'Name your collection to create it here.',
+							'cortext'
+						) }
+					>
 						<CollectionCreator
 							onCreate={ ( collection ) =>
 								selectCollection( collection.id )
 							}
 						/>
-					</div>
-				</Placeholder>
+					</Placeholder>
+				) }
 			</div>
 		);
 	}

--- a/src/blocks/data-view/index.js
+++ b/src/blocks/data-view/index.js
@@ -3,9 +3,12 @@ import { registerBlockType } from '@wordpress/blocks';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import { registerDataViewVariations } from './variations';
 
 registerBlockType( metadata.name, {
 	...metadata,
 	edit,
 	save,
 } );
+
+registerDataViewVariations();

--- a/src/blocks/data-view/variations.js
+++ b/src/blocks/data-view/variations.js
@@ -18,7 +18,7 @@ const matchesIntent = ( blockAttributes, variationAttributes ) =>
 export const DATA_VIEW_VARIATIONS = [
 	{
 		name: 'cortext-collection-new',
-		title: __( 'Collection', 'cortext' ),
+		title: __( 'New collection', 'cortext' ),
 		description: __(
 			'Create a new collection and show it here.',
 			'cortext'

--- a/src/blocks/data-view/variations.js
+++ b/src/blocks/data-view/variations.js
@@ -1,0 +1,63 @@
+import { __ } from '@wordpress/i18n';
+import { registerBlockVariation } from '@wordpress/blocks';
+import { link, table } from '@wordpress/icons';
+
+const BLOCK_NAME = 'cortext/data-view';
+
+// Each variation carries a transient `intent` attribute that the block's edit
+// reads once and clears on mount, so the inserter and slash menu offer two
+// single-purpose entries ("create a new collection" vs "link an existing one")
+// without persisting any extra attribute on saved blocks.
+const matchesIntent = ( blockAttributes, variationAttributes ) =>
+	blockAttributes.intent === variationAttributes.intent;
+
+export const DATA_VIEW_VARIATIONS = [
+	{
+		name: 'cortext-collection-new',
+		title: __( 'Collection', 'cortext' ),
+		description: __(
+			'Create a new collection and show it here.',
+			'cortext'
+		),
+		// Keywords surface the collection entries near the top of inserter and
+		// slash-menu searches for the terms people reach for ("database",
+		// "table", "grid"), since there is no hard inserter-priority API.
+		keywords: [
+			__( 'collection', 'cortext' ),
+			__( 'database', 'cortext' ),
+			__( 'table', 'cortext' ),
+			__( 'grid', 'cortext' ),
+			__( 'list', 'cortext' ),
+			__( 'data', 'cortext' ),
+		],
+		icon: table,
+		attributes: { intent: 'create-inline' },
+		// Replaces the bare block in the inserter so creating is the default
+		// entry, leaving exactly two Collections items instead of three.
+		isDefault: true,
+		scope: [ 'inserter' ],
+		isActive: matchesIntent,
+	},
+	{
+		name: 'cortext-collection-linked',
+		title: __( 'Linked collection view', 'cortext' ),
+		description: __( 'Show an existing collection here.', 'cortext' ),
+		keywords: [
+			__( 'collection', 'cortext' ),
+			__( 'database', 'cortext' ),
+			__( 'linked', 'cortext' ),
+			__( 'existing', 'cortext' ),
+			__( 'reference', 'cortext' ),
+		],
+		icon: link,
+		attributes: { intent: 'link-existing' },
+		scope: [ 'inserter' ],
+		isActive: matchesIntent,
+	},
+];
+
+export function registerDataViewVariations() {
+	DATA_VIEW_VARIATIONS.forEach( ( variation ) =>
+		registerBlockVariation( BLOCK_NAME, variation )
+	);
+}

--- a/src/blocks/data-view/variations.js
+++ b/src/blocks/data-view/variations.js
@@ -1,6 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockVariation } from '@wordpress/blocks';
-import { link, table } from '@wordpress/icons';
+
+import {
+	collectionIcon,
+	linkedCollectionIcon,
+} from '../../components/cortextIcons';
 
 const BLOCK_NAME = 'cortext/data-view';
 
@@ -30,7 +34,7 @@ export const DATA_VIEW_VARIATIONS = [
 			__( 'list', 'cortext' ),
 			__( 'data', 'cortext' ),
 		],
-		icon: table,
+		icon: collectionIcon,
 		attributes: { intent: 'create-inline' },
 		// Replaces the bare block in the inserter so creating is the default
 		// entry, leaving exactly two Collections items instead of three.
@@ -49,7 +53,7 @@ export const DATA_VIEW_VARIATIONS = [
 			__( 'existing', 'cortext' ),
 			__( 'reference', 'cortext' ),
 		],
-		icon: link,
+		icon: linkedCollectionIcon,
 		attributes: { intent: 'link-existing' },
 		scope: [ 'inserter' ],
 		isActive: matchesIntent,

--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -214,6 +214,10 @@ tbody > tr > td:not(:first-child) {
 	width: min(100%, 420px);
 }
 
+.cortext-collection-chooser__search {
+	margin-bottom: $grid-unit-05;
+}
+
 .cortext-collection-chooser__item.components-button {
 	justify-content: flex-start;
 	min-height: 36px;

--- a/src/components/cortextIcons.js
+++ b/src/components/cortextIcons.js
@@ -32,6 +32,46 @@ export const collectionIcon = (
 	</svg>
 );
 
+// The linked-collection-view variation reuses the collection table, nudged up and
+// left to make room for an arrow that marks it as a reference to an existing
+// collection rather than a new one.
+export const linkedCollectionIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<rect
+			x="4"
+			y="5"
+			width="12"
+			height="10"
+			rx="1.6"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.4"
+		/>
+		<path
+			d="M4 8.5h12M8 5v10M12 5v10"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.25"
+			strokeLinecap="round"
+		/>
+		<path
+			d="M13.5 13.5 19 19M19 19v-3.6M19 19h-3.6"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
+
 // Cortext glyphs addressable by name, the same way DocumentIcon resolves a
 // `{ type: 'wp', name }` meta against @wordpress/icons. Lets a collection render
 // its own glyph through DocumentIcon (same scale and box as every other row)

--- a/src/components/fields/AddFieldPopover.scss
+++ b/src/components/fields/AddFieldPopover.scss
@@ -6,13 +6,6 @@
 	margin: 0;
 }
 
-.cortext-data-view-placeholder__create {
-	border-top: $border-width solid $gray-200;
-	margin-top: $grid-unit-15;
-	padding-top: $grid-unit-15;
-	width: 100%;
-}
-
 .cortext-data-view-create {
 	display: grid;
 	gap: $grid-unit-15;

--- a/src/components/initEditor.js
+++ b/src/components/initEditor.js
@@ -21,6 +21,9 @@ import '../blocks';
 // Side-effect import: register media categories for the full inserter.
 import './initInserterMediaCategories';
 
+// Side-effect import: float Cortext blocks to the top of the slash inserter.
+import './prioritizeCortextInserterBlocks';
+
 // `core/post-title` is insertable by default. Cortext owns title placement
 // through EnsureHeaderBlocks, so users should not see the block in the
 // inserter. Flip the support before `registerCoreBlocks` reads it.

--- a/src/components/prioritizeCortextInserterBlocks.js
+++ b/src/components/prioritizeCortextInserterBlocks.js
@@ -1,0 +1,53 @@
+// Float Cortext's own blocks to the top of the `/` slash inserter. Gutenberg's
+// block autocompleter orders results by frecency and search relevance, so core
+// blocks (Columns, List, ...) outrank Cortext's collection blocks even when both
+// match. We hook the `editor.Autocomplete.completers` filter (the supported way
+// to extend autocompleters) and reorder the block completer's options so
+// `cortext/*` entries lead, keeping Gutenberg's relative order within each group
+// (Array.sort is stable).
+//
+// Scope: the slash menu only. The full inserter already lists the Collections
+// category first (see collectionsBlockCategory.js). `useItems` is a semi-private
+// shape, so we pass the completer through untouched if it ever changes.
+import { addFilter } from '@wordpress/hooks';
+import { useMemo } from '@wordpress/element';
+
+const isCortextOption = ( option ) =>
+	typeof option?.value?.name === 'string' &&
+	option.value.name.startsWith( 'cortext/' );
+
+export function prioritizeCortextOptions( options ) {
+	return [ ...options ].sort(
+		( a, b ) =>
+			Number( isCortextOption( b ) ) - Number( isCortextOption( a ) )
+	);
+}
+
+export function withCortextPriority( completers ) {
+	return completers.map( ( completer ) => {
+		if (
+			completer?.name !== 'blocks' ||
+			typeof completer.useItems !== 'function'
+		) {
+			return completer;
+		}
+		const { useItems } = completer;
+		return {
+			...completer,
+			useItems( filterValue ) {
+				const [ options ] = useItems( filterValue );
+				const ordered = useMemo(
+					() => prioritizeCortextOptions( options ),
+					[ options ]
+				);
+				return [ ordered ];
+			},
+		};
+	} );
+}
+
+addFilter(
+	'editor.Autocomplete.completers',
+	'cortext/prioritize-blocks-in-inserter',
+	withCortextPriority
+);

--- a/tests/e2e/specs/collection-block-variations.spec.js
+++ b/tests/e2e/specs/collection-block-variations.spec.js
@@ -1,0 +1,226 @@
+/**
+ * E2E coverage for the two `cortext/data-view` inserter variations. Each stamps
+ * a transient `intent` attribute; the block reads it once to open the
+ * placeholder straight into create or link mode, then clears it so saved blocks
+ * only ever carry `collectionId` + `view`.
+ *
+ * The variations are inserted by writing the `intent` into the block markup,
+ * which is exactly what `registerBlockVariation` produces on insert. The
+ * registration itself (two entries, create is the default) is unit-tested in
+ * tests/js/blocks/data-view-variations.test.js.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+async function createCollectionFixture( requestUtils ) {
+	const suffix = Date.now().toString( 36 ).slice( -4 );
+
+	const collection = await requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_documents',
+		data: { title: `E2E Books ${ suffix }`, status: 'private' },
+	} );
+	const field = await requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_fields',
+		data: { title: 'Author', status: 'private', meta: { type: 'text' } },
+	} );
+	await requestUtils.rest( {
+		method: 'POST',
+		path: `/wp/v2/crtxt_documents/${ collection.id }`,
+		data: { meta: { cortext_fields: [ String( field.id ) ] } },
+	} );
+	const entry = await requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_documents',
+		data: {
+			title: 'The Left Hand of Darkness',
+			status: 'private',
+			cortext_trait: collection.id,
+			meta: { [ `field-${ field.id }` ]: 'Ursula K. Le Guin' },
+		},
+	} );
+
+	return { collection, field, entry };
+}
+
+async function createPageWithBlock( requestUtils, title, intent ) {
+	return requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_documents',
+		data: {
+			title,
+			status: 'private',
+			content: `<!-- wp:cortext/data-view {"intent":"${ intent }"} /-->`,
+		},
+	} );
+}
+
+async function openDocument( admin, page, postId ) {
+	await admin.visitAdminPage( 'admin.php', `page=cortext&p=/${ postId }` );
+	await page.waitForFunction(
+		( id ) =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ===
+			id,
+		postId,
+		{ timeout: 15_000 }
+	);
+}
+
+async function dataViewCollectionId( page ) {
+	return page.evaluate( () => {
+		const block = window.wp.data
+			.select( 'core/block-editor' )
+			.getBlocks()
+			.find( ( item ) => item.name === 'cortext/data-view' );
+		return block?.attributes?.collectionId ?? 0;
+	} );
+}
+
+async function savePost( page ) {
+	await page.evaluate( async () => {
+		await window.wp.data.dispatch( 'core/editor' ).savePost();
+	} );
+	await page.waitForFunction(
+		() => ! window.wp.data.select( 'core/editor' ).isSavingPost()
+	);
+}
+
+test.describe( 'Collection block creation variations', () => {
+	test( 'the create variation names a new collection and drops the transient intent', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			fixture.page = await createPageWithBlock(
+				requestUtils,
+				'Inline create variation',
+				'create-inline'
+			);
+
+			await openDocument( admin, page, fixture.page.id );
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			// Create mode: the name form, not the picker.
+			await expect( canvas.getByLabel( 'Name' ) ).toBeVisible();
+			await expect(
+				canvas.getByPlaceholder( 'Search collections' )
+			).toHaveCount( 0 );
+
+			await canvas.getByLabel( 'Name' ).fill( 'Inline Variation Books' );
+			await canvas
+				.getByRole( 'button', { name: 'Create collection' } )
+				.click();
+
+			await expect( canvas.locator( '.cortext-data-view' ) ).toBeVisible(
+				{ timeout: 15_000 }
+			);
+
+			fixture.createdCollectionId = await dataViewCollectionId( page );
+			expect( fixture.createdCollectionId ).toBeGreaterThan( 0 );
+
+			await savePost( page );
+
+			const saved = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_documents/${ fixture.page.id }`,
+				params: { context: 'edit' },
+			} );
+			expect( saved.content.raw ).toContain(
+				`"collectionId":${ fixture.createdCollectionId }`
+			);
+			expect( saved.content.raw ).not.toContain( '"intent"' );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_documents/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.createdCollectionId &&
+					`/wp/v2/crtxt_documents/${ fixture.createdCollectionId }`
+			);
+		}
+	} );
+
+	test( 'the linked variation shows the searchable picker and binds an existing collection', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture( requestUtils )
+			);
+			fixture.page = await createPageWithBlock(
+				requestUtils,
+				'Inline link variation',
+				'link-existing'
+			);
+
+			await openDocument( admin, page, fixture.page.id );
+
+			const canvas = page.frameLocator( '[name="editor-canvas"]' );
+			// Link mode: the searchable picker, not the name form.
+			await expect(
+				canvas.getByPlaceholder( 'Search collections' )
+			).toBeVisible();
+			await expect( canvas.getByLabel( 'Name' ) ).toHaveCount( 0 );
+
+			await canvas.getByRole( 'button', { name: /E2E Books/ } ).click();
+
+			await expect(
+				canvas.getByText( 'The Left Hand of Darkness' )
+			).toBeVisible();
+
+			await savePost( page );
+
+			const saved = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_documents/${ fixture.page.id }`,
+				params: { context: 'edit' },
+			} );
+			expect( saved.content.raw ).toContain(
+				`"collectionId":${ fixture.collection.id }`
+			);
+			expect( saved.content.raw ).not.toContain( '"intent"' );
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.page && `/wp/v2/crtxt_documents/${ fixture.page.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.entry && `/wp/v2/crtxt_documents/${ fixture.entry.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.field && `/wp/v2/crtxt_fields/${ fixture.field.id }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collection &&
+					`/wp/v2/crtxt_documents/${ fixture.collection.id }`
+			);
+		}
+	} );
+} );

--- a/tests/js/blocks/data-view-variations.test.js
+++ b/tests/js/blocks/data-view-variations.test.js
@@ -1,0 +1,52 @@
+/**
+ * Tests for the `cortext/data-view` block variations.
+ *
+ * The inserter should offer two single-purpose entries: "Collection" (create a
+ * new collection inline, the default that replaces the bare block) and "Linked
+ * collection view" (point at an existing collection). They are told apart by a
+ * transient `intent` attribute the block clears on mount.
+ */
+import { DATA_VIEW_VARIATIONS } from '../../../src/blocks/data-view/variations';
+
+const byName = ( name ) =>
+	DATA_VIEW_VARIATIONS.find( ( variation ) => variation.name === name );
+
+it( 'exposes exactly the create and link variations', () => {
+	expect(
+		DATA_VIEW_VARIATIONS.map( ( variation ) => variation.name )
+	).toEqual( [ 'cortext-collection-new', 'cortext-collection-linked' ] );
+} );
+
+it( 'makes the create variation the inserter default', () => {
+	const create = byName( 'cortext-collection-new' );
+	expect( create.isDefault ).toBe( true );
+	expect( create.attributes.intent ).toBe( 'create-inline' );
+	expect( create.scope ).toEqual( [ 'inserter' ] );
+} );
+
+it( 'keeps the linked variation a non-default inserter entry', () => {
+	const linked = byName( 'cortext-collection-linked' );
+	expect( linked.isDefault ).toBeFalsy();
+	expect( linked.attributes.intent ).toBe( 'link-existing' );
+	expect( linked.scope ).toEqual( [ 'inserter' ] );
+} );
+
+it( 'gives both variations search keywords so they surface in the inserter', () => {
+	DATA_VIEW_VARIATIONS.forEach( ( variation ) => {
+		expect( variation.keywords ).toEqual(
+			expect.arrayContaining( [ 'collection', 'database' ] )
+		);
+	} );
+} );
+
+it( 'matches a block to its variation by intent', () => {
+	const create = byName( 'cortext-collection-new' );
+	expect(
+		create.isActive( { intent: 'create-inline' }, create.attributes )
+	).toBe( true );
+	expect(
+		create.isActive( { intent: 'link-existing' }, create.attributes )
+	).toBe( false );
+	// A bound block whose transient intent was cleared matches no variation.
+	expect( create.isActive( {}, create.attributes ) ).toBe( false );
+} );

--- a/tests/js/blocks/data-view-variations.test.js
+++ b/tests/js/blocks/data-view-variations.test.js
@@ -1,10 +1,10 @@
 /**
  * Tests for the `cortext/data-view` block variations.
  *
- * The inserter should offer two single-purpose entries: "Collection" (create a
- * new collection inline, the default that replaces the bare block) and "Linked
- * collection view" (point at an existing collection). They are told apart by a
- * transient `intent` attribute the block clears on mount.
+ * The inserter should offer two single-purpose entries: "New collection"
+ * (create a new collection inline, the default that replaces the bare block) and
+ * "Linked collection view" (point at an existing collection). They are told
+ * apart by a transient `intent` attribute the block clears on mount.
  */
 import { DATA_VIEW_VARIATIONS } from '../../../src/blocks/data-view/variations';
 

--- a/tests/js/components/prioritizeCortextInserterBlocks.test.js
+++ b/tests/js/components/prioritizeCortextInserterBlocks.test.js
@@ -1,0 +1,57 @@
+/**
+ * Tests for the slash-inserter reordering that floats Cortext's own blocks to
+ * the top. The completer wrapping is a thin hook; the orderable logic lives in
+ * `prioritizeCortextOptions`, which is what these tests pin down.
+ */
+import {
+	prioritizeCortextOptions,
+	withCortextPriority,
+} from '../../../src/components/prioritizeCortextInserterBlocks';
+
+const option = ( name ) => ( { value: { name } } );
+
+describe( 'prioritizeCortextOptions', () => {
+	it( 'floats cortext blocks ahead of core, preserving relative order', () => {
+		const ordered = prioritizeCortextOptions( [
+			option( 'core/columns' ),
+			option( 'cortext/data-view' ),
+			option( 'core/list' ),
+			option( 'cortext/document-properties' ),
+		] );
+
+		expect( ordered.map( ( o ) => o.value.name ) ).toEqual( [
+			'cortext/data-view',
+			'cortext/document-properties',
+			'core/columns',
+			'core/list',
+		] );
+	} );
+
+	it( 'leaves a list without cortext blocks untouched', () => {
+		const ordered = prioritizeCortextOptions( [
+			option( 'core/columns' ),
+			option( 'core/list' ),
+		] );
+
+		expect( ordered.map( ( o ) => o.value.name ) ).toEqual( [
+			'core/columns',
+			'core/list',
+		] );
+	} );
+} );
+
+describe( 'withCortextPriority', () => {
+	it( 'wraps only the block completer and passes others through', () => {
+		const other = { name: 'users', useItems: () => [ [] ] };
+		const blocks = { name: 'blocks', useItems: () => [ [] ] };
+
+		const [ wrappedOther, wrappedBlocks ] = withCortextPriority( [
+			other,
+			blocks,
+		] );
+
+		expect( wrappedOther ).toBe( other );
+		expect( wrappedBlocks ).not.toBe( blocks );
+		expect( wrappedBlocks.name ).toBe( 'blocks' );
+	} );
+} );


### PR DESCRIPTION
## What

You can now create or link a collection right from the block inserter. Searching for "collection" gives two entries instead of one catch-all placeholder: "New collection" starts a new one inline, and "Linked collection view" embeds a collection you already have. The new-collection entry asks for a name, then shows its table in place, nested under the document you started from. The linked entry opens a searchable picker. Cortext blocks also move to the top of the slash menu.

## Why

The old placeholder did both jobs in one box, with a create form above a list of existing collections. Two separate entries make it obvious whether you are starting a collection or reusing one.

## How

- Registering two inserter variations on the existing collection block, with the create variation as the default so the bare block does not show up as a third entry.
- Storing the choice between create and link on a transient flag the block reads once and clears, so nothing extra is saved on the block.

## Testing Instructions

1. Open a document, open the block inserter, and search for "collection".
2. Confirm two entries show up, "New collection" and "Linked collection view", each with the collection glyph.
3. Insert "New collection", type a name, and choose Create collection. Confirm its table shows in the canvas and the new collection appears under the current document in the sidebar.
4. Insert "Linked collection view", search for a collection, and pick one. Confirm its table shows in the canvas.
5. In a block, type "/" and confirm the Cortext collection entries appear at the top of the slash menu.

## Screen recording

https://github.com/user-attachments/assets/50755bb9-5750-4c9e-b6d8-09c7b01aa860


