### PR TITLE
Fix: Scope the editor link picker to Cortext documents

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -26,6 +26,7 @@ import { withViewTransition } from '../hooks/viewTransition';
 import { definesTrait } from '../documents/capabilities';
 import { POST_TYPE } from './page-queries';
 import CortextInserterSidebar from './CortextInserterSidebar';
+import CortextLinkSuggestions from './CortextLinkSuggestions';
 import { DocumentPropertiesProvider } from './DocumentPropertiesContext';
 import DocumentPublishToggle from './DocumentPublishToggle';
 import EditorBody from './EditorBody';
@@ -530,6 +531,7 @@ export default function Canvas( {
 				settings={ getEditorSettings() }
 				useSubRegistry={ useSubRegistry }
 			>
+				<CortextLinkSuggestions />
 				<CanvasEditor
 					post={ renderedPost }
 					postType={ renderedPost.type ?? postType }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -531,7 +531,7 @@ export default function Canvas( {
 				settings={ getEditorSettings() }
 				useSubRegistry={ useSubRegistry }
 			>
-				<CortextLinkSuggestions />
+				<CortextLinkSuggestions allowCreate />
 				<CanvasEditor
 					post={ renderedPost }
 					postType={ renderedPost.type ?? postType }

--- a/src/components/CortextLinkSuggestions.js
+++ b/src/components/CortextLinkSuggestions.js
@@ -1,20 +1,25 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 
 import { fetchCortextLinkSuggestions } from './fetchCortextLinkSuggestions';
 
 // Scopes the editor's link picker to Cortext documents.
 //
 // On the block-editor store it points `__experimentalFetchLinkSuggestions` at
-// Cortext documents and turns off the picker's "Create" action, so it never
-// spawns a stray page.
+// Cortext documents and controls the picker's "Create" action. With
+// `allowCreate` (the full document editor), "Create" makes a new Cortext
+// document as a child of the one being edited; otherwise it is hidden, so the
+// picker never spawns a stray page.
 //
 // `@wordpress/editor`'s useBlockEditorSettings overwrites these settings on
 // every recompute, so passing them through the editor settings never sticks.
 // This component renders nothing: it lives inside EditorProvider and re-applies
-// them whenever Gutenberg has replaced our fetcher.
-export default function CortextLinkSuggestions() {
+// the settings when the live fetcher drifts (a recompute) or the edited
+// document changes, so a created child still lands under the right parent.
+export default function CortextLinkSuggestions( { allowCreate = false } ) {
 	// Watched so we notice when Gutenberg swaps our fetcher back out: when this
 	// changes, the effect re-runs and re-applies every override.
 	const current = useSelect(
@@ -23,17 +28,27 @@ export default function CortextLinkSuggestions() {
 				.__experimentalFetchLinkSuggestions,
 		[]
 	);
+	const parentId = useSelect(
+		( select ) => select( editorStore ).getCurrentPostId(),
+		[]
+	);
 	const { updateSettings } = useDispatch( blockEditorStore );
 
 	useEffect( () => {
-		if ( current !== fetchCortextLinkSuggestions ) {
-			updateSettings( {
-				__experimentalFetchLinkSuggestions: fetchCortextLinkSuggestions,
-				__experimentalCreatePageEntity: undefined,
-				__experimentalUserCanCreatePages: false,
-			} );
-		}
-	}, [ current, updateSettings ] );
+		const canCreate = allowCreate && !! parentId;
+		updateSettings( {
+			__experimentalFetchLinkSuggestions: fetchCortextLinkSuggestions,
+			__experimentalUserCanCreatePages: canCreate,
+			__experimentalCreatePageEntity: canCreate
+				? ( { title, status = 'draft' } ) =>
+						apiFetch( {
+							path: '/wp/v2/crtxt_documents',
+							method: 'POST',
+							data: { title, status, parent: parentId },
+						} )
+				: undefined,
+		} );
+	}, [ current, allowCreate, parentId, updateSettings ] );
 
 	return null;
 }

--- a/src/components/CortextLinkSuggestions.js
+++ b/src/components/CortextLinkSuggestions.js
@@ -1,0 +1,39 @@
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
+
+import { fetchCortextLinkSuggestions } from './fetchCortextLinkSuggestions';
+
+// Scopes the editor's link picker to Cortext documents.
+//
+// On the block-editor store it points `__experimentalFetchLinkSuggestions` at
+// Cortext documents and turns off the picker's "Create" action, so it never
+// spawns a stray page.
+//
+// `@wordpress/editor`'s useBlockEditorSettings overwrites these settings on
+// every recompute, so passing them through the editor settings never sticks.
+// This component renders nothing: it lives inside EditorProvider and re-applies
+// them whenever Gutenberg has replaced our fetcher.
+export default function CortextLinkSuggestions() {
+	// Watched so we notice when Gutenberg swaps our fetcher back out: when this
+	// changes, the effect re-runs and re-applies every override.
+	const current = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()
+				.__experimentalFetchLinkSuggestions,
+		[]
+	);
+	const { updateSettings } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( current !== fetchCortextLinkSuggestions ) {
+			updateSettings( {
+				__experimentalFetchLinkSuggestions: fetchCortextLinkSuggestions,
+				__experimentalCreatePageEntity: undefined,
+				__experimentalUserCanCreatePages: false,
+			} );
+		}
+	}, [ current, updateSettings ] );
+
+	return null;
+}

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -21,6 +21,7 @@ import { DocumentPropertiesProvider } from './DocumentPropertiesContext';
 import { EditorSurfaceProvider } from './EditorSurfaceContext';
 import EditorBody from './EditorBody';
 import { PostLockFailureNotice, PostLockModal } from './PostLockControls';
+import CortextLinkSuggestions from './CortextLinkSuggestions';
 import { RowMutationContext } from './EditableCell';
 
 const ROW_DETAIL_EDITOR_CSS = `
@@ -224,6 +225,7 @@ export default function RowEditor( {
 			settings={ getEditorSettings() }
 			useSubRegistry
 		>
+			<CortextLinkSuggestions />
 			{ /* tech-debt.md#td-row-detail-toolbar-isolation: row detail owns these SlotFills while
 			     peek/modal are open. */ }
 			<SlotFillProvider>

--- a/src/components/fetchCortextLinkSuggestions.js
+++ b/src/components/fetchCortextLinkSuggestions.js
@@ -1,0 +1,48 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { __ } from '@wordpress/i18n';
+
+import { DOCUMENT_POST_TYPE } from '../collections';
+
+// Cortext-scoped source for Gutenberg's link autocomplete.
+//
+// The default picker queries `wp/v2/search`, which returns all site content
+// and never Cortext documents: `crtxt_document` is `public=false` and
+// `exclude_from_search=true`, so it stays out of that search. This hits the
+// document REST base instead, so the picker only offers Cortext documents,
+// rows included. CortextLinkSuggestions installs it on the block-editor store,
+// where both LinkControl and URLInput read it.
+//
+// Same signature as `__experimentalFetchLinkSuggestions`. We ignore `type` and
+// `subtype` from `searchOptions` because the answer is always documents, and
+// link to each document's permalink.
+export async function fetchCortextLinkSuggestions(
+	search,
+	searchOptions = {}
+) {
+	const { isInitialSuggestions, page = 1 } = searchOptions;
+	const perPage = searchOptions.perPage ?? ( isInitialSuggestions ? 3 : 20 );
+
+	// `crtxt_documents` is the REST base of the `crtxt_document` post type.
+	// Edit context returns drafts/private docs and the plain `title.raw`.
+	const records = await apiFetch( {
+		path: addQueryArgs( '/wp/v2/crtxt_documents', {
+			search,
+			page,
+			per_page: perPage,
+			context: 'edit',
+			status: [ 'draft', 'private', 'publish' ],
+			_fields: 'id,link,title',
+		} ),
+	} ).catch( () => [] ); // Fail by returning no suggestions, like core.
+
+	return ( Array.isArray( records ) ? records : [] )
+		.map( ( record ) => ( {
+			id: record.id,
+			url: record.link,
+			title: record.title?.raw || __( '(no title)', 'cortext' ),
+			type: DOCUMENT_POST_TYPE,
+			kind: 'post-type',
+		} ) )
+		.filter( ( suggestion ) => suggestion.id && suggestion.url );
+}

--- a/src/components/initEditor.js
+++ b/src/components/initEditor.js
@@ -12,6 +12,7 @@
 // they just do not appear in the UI.
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { addFilter } from '@wordpress/hooks';
+import { __, setLocaleData } from '@wordpress/i18n';
 
 // Register the Collections category before the `../blocks` barrel registers
 // Cortext blocks from block.json.
@@ -43,6 +44,19 @@ addFilter(
 		};
 	}
 );
+
+// Our link picker's "Create" action makes a Cortext document, not a WordPress
+// page, so relabel Gutenberg's create button. "Create: %s" (text and image
+// links) and "Create page: %s" (the button block) are core default-domain
+// strings; overriding them here, on a bundle that only loads on the Cortext
+// page, fixes the wording without forking the link UI.
+const createDocumentLabel =
+	/* translators: %s: the text typed into the link picker. */
+	__( 'Create document: <mark>%s</mark>', 'cortext' );
+setLocaleData( {
+	'Create: <mark>%s</mark>': [ createDocumentLabel ],
+	'Create page: <mark>%s</mark>': [ createDocumentLabel ],
+} );
 
 export { COLLECTIONS_BLOCK_CATEGORY };
 

--- a/tests/js/components/CortextLinkSuggestions.test.js
+++ b/tests/js/components/CortextLinkSuggestions.test.js
@@ -5,14 +5,34 @@ jest.mock( '@wordpress/data', () => ( {
 jest.mock( '@wordpress/block-editor', () => ( {
 	store: 'core/block-editor',
 } ) );
+jest.mock( '@wordpress/editor', () => ( { store: 'core/editor' } ) );
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
 
 import { render } from '@testing-library/react';
 import { useSelect, useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
 
 import CortextLinkSuggestions from '../../../src/components/CortextLinkSuggestions';
 import { fetchCortextLinkSuggestions } from '../../../src/components/fetchCortextLinkSuggestions';
 
 let updateSettings;
+
+function mockStores( { handler, postId } ) {
+	const stores = {
+		'core/block-editor': {
+			getSettings: () => ( {
+				__experimentalFetchLinkSuggestions: handler,
+			} ),
+		},
+		'core/editor': { getCurrentPostId: () => postId },
+	};
+	useSelect.mockImplementation( ( mapSelect ) =>
+		mapSelect( ( store ) => stores[ store ] )
+	);
+}
 
 beforeEach( () => {
 	jest.clearAllMocks();
@@ -20,8 +40,8 @@ beforeEach( () => {
 	useDispatch.mockReturnValue( { updateSettings } );
 } );
 
-it( 'installs the Cortext fetcher and disables page creation when another handler is active', () => {
-	useSelect.mockReturnValue( () => {} );
+it( 'installs the Cortext fetcher and disables page creation by default', () => {
+	mockStores( { handler: () => {}, postId: 10 } );
 
 	render( <CortextLinkSuggestions /> );
 
@@ -29,14 +49,35 @@ it( 'installs the Cortext fetcher and disables page creation when another handle
 		expect.objectContaining( {
 			__experimentalFetchLinkSuggestions: fetchCortextLinkSuggestions,
 			__experimentalUserCanCreatePages: false,
+			__experimentalCreatePageEntity: undefined,
 		} )
 	);
 } );
 
-it( 'does nothing when the Cortext fetcher is already installed', () => {
-	useSelect.mockReturnValue( fetchCortextLinkSuggestions );
+it( 'lets the full editor create a Cortext document as a child of the current document', async () => {
+	mockStores( { handler: () => {}, postId: 42 } );
+	apiFetch.mockResolvedValueOnce( {
+		id: 99,
+		type: 'crtxt_document',
+		title: { rendered: 'New doc' },
+		link: 'http://example.test/?post_type=crtxt_document&p=99',
+	} );
 
-	render( <CortextLinkSuggestions /> );
+	render( <CortextLinkSuggestions allowCreate /> );
 
-	expect( updateSettings ).not.toHaveBeenCalled();
+	const settings = updateSettings.mock.calls.at( -1 )[ 0 ];
+	expect( settings.__experimentalUserCanCreatePages ).toBe( true );
+
+	const created = await settings.__experimentalCreatePageEntity( {
+		title: 'New doc',
+		status: 'draft',
+	} );
+
+	expect( apiFetch ).toHaveBeenCalledWith( {
+		path: '/wp/v2/crtxt_documents',
+		method: 'POST',
+		data: { title: 'New doc', status: 'draft', parent: 42 },
+	} );
+	expect( created.id ).toBe( 99 );
+	expect( created.link ).toContain( 'p=99' );
 } );

--- a/tests/js/components/CortextLinkSuggestions.test.js
+++ b/tests/js/components/CortextLinkSuggestions.test.js
@@ -1,0 +1,42 @@
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+import { render } from '@testing-library/react';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+import CortextLinkSuggestions from '../../../src/components/CortextLinkSuggestions';
+import { fetchCortextLinkSuggestions } from '../../../src/components/fetchCortextLinkSuggestions';
+
+let updateSettings;
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	updateSettings = jest.fn();
+	useDispatch.mockReturnValue( { updateSettings } );
+} );
+
+it( 'installs the Cortext fetcher and disables page creation when another handler is active', () => {
+	useSelect.mockReturnValue( () => {} );
+
+	render( <CortextLinkSuggestions /> );
+
+	expect( updateSettings ).toHaveBeenCalledWith(
+		expect.objectContaining( {
+			__experimentalFetchLinkSuggestions: fetchCortextLinkSuggestions,
+			__experimentalUserCanCreatePages: false,
+		} )
+	);
+} );
+
+it( 'does nothing when the Cortext fetcher is already installed', () => {
+	useSelect.mockReturnValue( fetchCortextLinkSuggestions );
+
+	render( <CortextLinkSuggestions /> );
+
+	expect( updateSettings ).not.toHaveBeenCalled();
+} );

--- a/tests/js/components/RowEditor.test.js
+++ b/tests/js/components/RowEditor.test.js
@@ -28,6 +28,10 @@ jest.mock( '../../../src/components/EditorBody', () =>
 	jest.fn( () => <div data-testid="editor-body" /> )
 );
 
+jest.mock( '../../../src/components/CortextLinkSuggestions', () =>
+	jest.fn( () => null )
+);
+
 jest.mock( '../../../src/components/initEditor', () => ( {
 	getEditorSettings: () => ( {} ),
 } ) );

--- a/tests/js/components/fetchCortextLinkSuggestions.test.js
+++ b/tests/js/components/fetchCortextLinkSuggestions.test.js
@@ -1,0 +1,96 @@
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import { fetchCortextLinkSuggestions } from '../../../src/components/fetchCortextLinkSuggestions';
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	apiFetch.mockResolvedValue( [] );
+} );
+
+it( 'queries the Cortext document REST base, not wp/v2/search', async () => {
+	await fetchCortextLinkSuggestions( 'docs' );
+
+	const { path } = apiFetch.mock.calls[ 0 ][ 0 ];
+	expect( path ).toContain( '/wp/v2/crtxt_documents' );
+	expect( path ).not.toContain( '/wp/v2/search' );
+	expect( path ).toContain( 'search=docs' );
+	expect( path ).toContain( 'context=edit' );
+} );
+
+it( 'includes draft, private and publish statuses (and so excludes trash)', async () => {
+	await fetchCortextLinkSuggestions( 'x' );
+
+	const path = decodeURIComponent( apiFetch.mock.calls[ 0 ][ 0 ].path );
+	expect( path ).toContain( 'status[0]=draft' );
+	expect( path ).toContain( 'status[1]=private' );
+	expect( path ).toContain( 'status[2]=publish' );
+	expect( path ).not.toContain( 'trash' );
+} );
+
+it( 'defaults initial suggestions to 3 results and searches to 20', async () => {
+	await fetchCortextLinkSuggestions( 'x', { isInitialSuggestions: true } );
+	expect( apiFetch.mock.calls[ 0 ][ 0 ].path ).toContain( 'per_page=3' );
+
+	await fetchCortextLinkSuggestions( 'x' );
+	expect( apiFetch.mock.calls[ 1 ][ 0 ].path ).toContain( 'per_page=20' );
+} );
+
+it( 'honours explicit page and perPage', async () => {
+	await fetchCortextLinkSuggestions( 'x', { page: 4, perPage: 7 } );
+
+	const { path } = apiFetch.mock.calls[ 0 ][ 0 ];
+	expect( path ).toContain( 'page=4' );
+	expect( path ).toContain( 'per_page=7' );
+} );
+
+it( 'maps documents to permalink suggestions using the raw title', async () => {
+	apiFetch.mockResolvedValueOnce( [
+		{
+			id: 12,
+			link: 'https://example.test/cortext/about/',
+			title: { raw: 'About & Co' },
+		},
+	] );
+
+	const suggestions = await fetchCortextLinkSuggestions( 'about' );
+
+	expect( suggestions ).toEqual( [
+		{
+			id: 12,
+			url: 'https://example.test/cortext/about/',
+			title: 'About & Co',
+			type: 'crtxt_document',
+			kind: 'post-type',
+		},
+	] );
+} );
+
+it( 'falls back to a placeholder title and drops records without an id or url', async () => {
+	apiFetch.mockResolvedValueOnce( [
+		{ id: 1, link: 'https://example.test/?p=1', title: { raw: '' } },
+		{ id: 0, link: 'https://example.test/x', title: { raw: 'no id' } },
+		{ id: 2, link: '', title: { raw: 'no url' } },
+	] );
+
+	const suggestions = await fetchCortextLinkSuggestions( 'x' );
+
+	expect( suggestions ).toEqual( [
+		{
+			id: 1,
+			url: 'https://example.test/?p=1',
+			title: '(no title)',
+			type: 'crtxt_document',
+			kind: 'post-type',
+		},
+	] );
+} );
+
+it( 'returns an empty array when the request fails', async () => {
+	apiFetch.mockRejectedValueOnce( new Error( 'boom' ) );
+
+	await expect( fetchCortextLinkSuggestions( 'x' ) ).resolves.toEqual( [] );
+} );

--- a/tests/js/initEditor.test.js
+++ b/tests/js/initEditor.test.js
@@ -14,6 +14,7 @@ jest.mock( '@wordpress/blocks', () => ( {
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( str ) => str,
+	setLocaleData: jest.fn(),
 } ) );
 
 // Mock the block barrel; importing the real one pulls in every block edit/save


### PR DESCRIPTION
## What

Part of #85.

In a Cortext document, the link picker now suggests only Cortext documents (pages, collections, and rows), not posts and pages from elsewhere on the site. Its "Create document" action makes a new document as a child of the one you're editing, instead of a stray WordPress page. It applies everywhere you add a link, including buttons and image links.

## Why

Until now you couldn't link to another Cortext document from the picker at all (they're hidden from site search), so linking between documents meant pasting the URL by hand.

## How

- Linking to the target document's permalink, which for a draft stays plain until it's published.
- Offering "Create document" only in the full document editor, not the row peek.

## Testing Instructions

1. Open a Cortext document in the editor.
2. Select text and add a link (Cmd/Ctrl+K). Confirm the suggestions are only Cortext documents, with no posts or pages from elsewhere on the site.
3. Repeat with a Button block and an Image link, and confirm the suggestions are the same.
4. Type a name that doesn't match an existing document and choose "Create document". Confirm it creates a new document as a child of the current one and links to it.
5. Open a row in the peek editor and confirm the picker offers no "Create document" option.

## Screen recording

https://github.com/user-attachments/assets/f9015f6d-299f-4f91-895f-e65f2eb53e16

