### PR TITLE
DevEx: Only stop `wp-env` on archive when it's running

### DIFF
--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Stop the detached Playground server so it doesn't leak when the
-# worktree is archived.
+# Stop wp-env when the worktree is archived so the dev server and its
+# ports don't leak. Only a running environment needs stopping; one that
+# was never started or is already stopped has nothing to free.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-pnpm exec wp-env stop --runtime=playground
+
+if pnpm exec wp-env status --json | grep -q '"status":"running"'; then
+	pnpm exec wp-env stop
+fi


### PR DESCRIPTION
## What

Archiving a workspace ran `wp-env stop` to free the dev server's ports. When the environment was never started, that failed with `✖ Environment not initialized. Run wp-env start first.` and blocked the archive (it would also fail if Docker wasn't running or the environment was already gone). The archive script now checks `wp-env status` first and only stops a running environment, so archiving never breaks on the stop step.

## Testing Instructions

1. With a running environment (`pnpm run env:start`), run `bash scripts/archive.sh`. It should stop wp-env and exit successfully.
2. In a workspace where the environment was never started, run `bash scripts/archive.sh`. It should do nothing and exit successfully, with no error.