### PR TITLE
Fix: seeded Cortext media tagging

### DIFF
--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\CLI;
 
+use Cortext\Media\CortextMedia;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -3975,7 +3976,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			)
 		);
 		if ( $existing ) {
-			return (int) $existing[0];
+			return $this->tag_seed_attachment( (int) $existing[0] );
 		}
 
 		$upload_dir = wp_upload_dir();
@@ -4008,7 +4009,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		$metadata = wp_generate_attachment_metadata( $attach_id, $dest );
 		wp_update_attachment_metadata( $attach_id, $metadata );
 
-		return (int) $attach_id;
+		return $this->tag_seed_attachment( (int) $attach_id );
 	}
 
 	/**
@@ -4035,7 +4036,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			)
 		);
 		if ( $existing ) {
-			return (int) $existing[0];
+			return $this->tag_seed_attachment( (int) $existing[0] );
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -4082,7 +4083,15 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		$metadata = wp_generate_attachment_metadata( $attach_id, $dest );
 		wp_update_attachment_metadata( $attach_id, $metadata );
 
-		return (int) $attach_id;
+		return $this->tag_seed_attachment( (int) $attach_id );
+	}
+
+	private function tag_seed_attachment( int $attachment_id ): int {
+		if ( $attachment_id > 0 ) {
+			( new CortextMedia() )->tag( $attachment_id );
+		}
+
+		return $attachment_id;
 	}
 
 	/**

--- a/includes/Media/CortextMedia.php
+++ b/includes/Media/CortextMedia.php
@@ -65,7 +65,7 @@ final class CortextMedia {
 	}
 
 	/**
-	 * Stamps the origin term when a new attachment is parented to a Cortext
+	 * Marks the origin term when a new attachment is parented to a Cortext
 	 * document. Runs on every upload site-wide but bails cheaply (two cached
 	 * reads) for anything not parented to a `crtxt_document`.
 	 *
@@ -84,7 +84,7 @@ final class CortextMedia {
 	}
 
 	/**
-	 * Stamps media that predates upload-time tagging: attachments parented to a
+	 * Marks media that predates upload-time tagging: attachments parented to a
 	 * document, document covers (featured images), and image icons. Idempotent,
 	 * so it is safe to run repeatedly.
 	 *
@@ -142,7 +142,16 @@ final class CortextMedia {
 		);
 	}
 
-	private function tag( int $attachment_id ): void {
+	/**
+	 * Marks an attachment as Cortext media.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 */
+	public function tag( int $attachment_id ): void {
+		if ( 'attachment' !== get_post_type( $attachment_id ) ) {
+			return;
+		}
+
 		wp_set_object_terms( $attachment_id, self::TERM, self::TAXONOMY );
 	}
 

--- a/tests/php/test-cortext-media.php
+++ b/tests/php/test-cortext-media.php
@@ -49,6 +49,14 @@ final class Test_Cortext_Media extends BaseTestCase {
 		$this->assertTrue( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $attachment ) );
 	}
 
+	public function test_marks_attachment_explicitly_as_cortext_media(): void {
+		$attachment = $this->make_attachment( 0 );
+
+		$this->media->tag( $attachment );
+
+		$this->assertTrue( has_term( CortextMedia::TERM, CortextMedia::TAXONOMY, $attachment ) );
+	}
+
 	public function test_does_not_tag_attachment_without_a_cortext_parent(): void {
 		$orphan  = $this->make_attachment( 0 );
 		$regular = (int) wp_insert_post(


### PR DESCRIPTION
## What

Follow-up to #318 

Seeded icons and covers now get marked as Cortext media when the seeder creates or finds their attachments. That brings them back into the Cortext media pickers.

## Why

The media pickers only show attachments tagged as Cortext media. The seeder was still leaving its attachments untagged, so its own images disappeared from those pickers.

## How

- Tagging seeded attachments from bundled files and downloaded URLs.
- Reusing the Cortext media tagging path for seed-created media.

## Testing Instructions

1. Reseed a local Cortext workspace.
2. Open a seeded document or collection row with an icon or cover.
3. Open a Cortext media picker.
4. Confirm the seeded media is visible.
