### PR TITLE
Drop the user's name from the sidebar brand

### DIFF
--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -103,11 +103,10 @@ final class Screen {
 			self::SCRIPT_HANDLE,
 			'window.cortextSettings = ' . wp_json_encode(
 				array(
-					'adminUrl'        => admin_url(),
-					'features'        => ( new Features() )->to_client_settings(),
-					'iconUrl'         => $this->icon_url(),
-					'menuSlug'        => self::MENU_SLUG,
-					'userDisplayName' => wp_get_current_user()->display_name,
+					'adminUrl' => admin_url(),
+					'features' => ( new Features() )->to_client_settings(),
+					'iconUrl'  => $this->icon_url(),
+					'menuSlug' => self::MENU_SLUG,
 				)
 			) . ';',
 			'before'

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -148,17 +148,10 @@ export default function Sidebar( {
 		useDocumentSelection( { selectedId, selectedCollectionId } );
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
 	const brandIconUrl = window.cortextSettings?.iconUrl ?? '';
-	const userName = window.cortextSettings?.userDisplayName ?? '';
 	const publicWebAffordances = isPublicWebAffordancesEnabled();
 	const wordpressAffordances = isWordPressAffordancesEnabled();
 	const commandPaletteShortcut = displayShortcut.primary( 'k' );
-	const brandLabel = userName
-		? sprintf(
-				/* translators: %s: user display name */
-				__( "%s's Cortext", 'cortext' ),
-				userName
-		  )
-		: __( 'Cortext', 'cortext' );
+	const brandLabel = __( 'Cortext', 'cortext' );
 
 	const [ favoritesError, setFavoritesError ] = useState( null );
 	const [ duplicateNotice, setDuplicateNotice ] = useState( null );


### PR DESCRIPTION
## What

The sidebar now just says "Cortext". It used to put your account name in front, like "admin's Cortext".

## Why

There's only ever one user per site, so putting your name on it made it look like other people had their own Cortext somewhere. They don't.

## Testing Instructions

1. Open Cortext in wp-admin with the sidebar expanded.
2. Check that the brand at the top reads "Cortext", with no name in front.

## Screenshots
| Before | After |
| - | - |
| <img width="253" height="185" alt="image" src="https://github.com/user-attachments/assets/253fad74-b2b8-4ead-9e9c-a6ea1d3202f7" /> | <img width="271" height="204" alt="image" src="https://github.com/user-attachments/assets/0da36bb0-a3e2-4fd0-8f2e-13d55468f5a2" /> |