### PR TITLE
Docs: Disclose external service use in the readme FAQ

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,11 @@ Not yet. Cortext is ready to try, but still early. Use it somewhere low-stakes b
 
 = Does Cortext send data to an external service? =
 
-No. Cortext runs inside WordPress and does not call an external service during normal plugin use.
+Only when you ask it to. Everyday use (writing documents, building collections, publishing pages) stays inside WordPress with no external calls.
+
+The one exception is the optional Notion import. When you run it, Cortext sends the Notion token you provide and the collections you pick to api.notion.com so it can read that content into WordPress. Nothing leaves WordPress unless you start that import.
+
+The WP-CLI seeder is opt-in the same way: `wp cortext seed --with-real-images` (or the `--prefetch-*` flags) fetches sample cover art from public sources like Open Library, MusicBrainz, the Cover Art Archive, and Wikimedia. That only happens when you pass the flag.
 
 = Where is the source for the built JavaScript and CSS? =
 


### PR DESCRIPTION
## What

Part of #285.

The readme FAQ said Cortext never calls an external service, which isn't accurate. The answer now explains that everyday use stays inside WordPress, the optional Notion import sends the token you provide and the collections you pick to api.notion.com, and the WP-CLI seeder can fetch sample cover art from public sources when you pass a flag.

## Testing Instructions

1. Open `readme.txt` and read the "Does Cortext send data to an external service?" answer.
2. Confirm it covers the Notion import (api.notion.com) and the opt-in WP-CLI image lookups, and that normal use makes no external calls.

