### PR TITLE
Fix: Public rendering of covers, icons, titles, and tables

### DIFF
--- a/includes/Block/DataView.php
+++ b/includes/Block/DataView.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Block;
 
+use Cortext\Frontend\Assets;
 use Cortext\PostType\Document;
 
 final class DataView {
@@ -59,7 +60,7 @@ final class DataView {
 			return '';
 		}
 
-		$this->enqueue_assets();
+		Assets::enqueue_frontend_runtime();
 
 		$init_data = wp_json_encode(
 			array(
@@ -76,31 +77,6 @@ final class DataView {
 			'<div %s><script type="application/json" class="cortext-dv-init">%s</script></div>',
 			$wrapper_attributes,
 			$init_data
-		);
-	}
-
-	private function enqueue_assets(): void {
-		$asset_path = CORTEXT_PATH . 'build/frontend.asset.php';
-		$asset      = file_exists( $asset_path )
-			? require $asset_path
-			: array(
-				'dependencies' => array(),
-				'version'      => CORTEXT_VERSION,
-			);
-
-		wp_enqueue_script(
-			'cortext-frontend',
-			CORTEXT_URL . 'build/frontend.js',
-			$asset['dependencies'],
-			$asset['version'],
-			true
-		);
-
-		wp_enqueue_style(
-			'cortext-frontend',
-			CORTEXT_URL . 'build/frontend.css',
-			array( 'wp-block-library', 'wp-components' ),
-			$asset['version']
 		);
 	}
 }

--- a/includes/Editor/DocumentIconBlock.php
+++ b/includes/Editor/DocumentIconBlock.php
@@ -10,11 +10,28 @@ declare( strict_types=1 );
 
 namespace Cortext\Editor;
 
+use Cortext\Frontend\Assets;
 use Cortext\PostType\DocumentIdentity;
 
 final class DocumentIconBlock {
 
 	public const BLOCK_NAME = 'cortext/document-icon';
+
+	/**
+	 * Named icon colors to CSS, mirroring `src/components/iconColors.js`. The
+	 * `wp` glyph hydrates with `currentColor`, so the span's color flows in.
+	 */
+	private const ICON_COLOR_CSS = array(
+		'gray'   => '#9ca3af',
+		'brown'  => '#92400e',
+		'orange' => '#f97316',
+		'yellow' => '#eab308',
+		'green'  => '#22c55e',
+		'blue'   => '#3b82f6',
+		'purple' => '#a855f7',
+		'pink'   => '#ec4899',
+		'red'    => '#ef4444',
+	);
 
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_block' ) );
@@ -93,22 +110,23 @@ final class DocumentIconBlock {
 				return '<div class="cortext-document-icon-block">' . $img . '</div>';
 
 			case 'wp':
-				// We don't ship the SVG markup server-side; @wordpress/icons
-				// is JS-only. Emit a marker the frontend (or a future hydration
-				// step) can fill in. Keeps published markup deterministic
-				// even if the icon set isn't loaded.
-				//
-				// frontend.js is CSS-only today, so the marker stays empty
-				// on the public page and the saved color is dropped. See
-				// tech-debt.md#td-wp-icon-public-blank for the build-time SVG map vs. hydration
-				// trade-off.
+				// @wordpress/icons is JS-only, so the glyph isn't available in
+				// PHP. Emit a marker carrying the icon name (and color) and let
+				// the frontend runtime hydrate the SVG into it. Enqueue that
+				// runtime here so it loads on pages that have no data-view block.
 				$name = isset( $decoded['name'] ) ? (string) $decoded['name'] : '';
 				if ( '' === $name ) {
 					return '';
 				}
+				Assets::enqueue_frontend_runtime();
+				$color = isset( $decoded['color'] ) ? (string) $decoded['color'] : '';
+				$style = isset( self::ICON_COLOR_CSS[ $color ] )
+					? sprintf( ' style="color:%s"', esc_attr( self::ICON_COLOR_CSS[ $color ] ) )
+					: '';
 				return sprintf(
-					'<div class="cortext-document-icon-block"><span class="cortext-document-icon cortext-document-icon--wp" data-icon="%s" aria-hidden="true"></span></div>',
-					esc_attr( $name )
+					'<div class="cortext-document-icon-block"><span class="cortext-document-icon cortext-document-icon--wp" data-icon="%s"%s aria-hidden="true"></span></div>',
+					esc_attr( $name ),
+					$style
 				);
 		}
 

--- a/includes/Frontend/Assets.php
+++ b/includes/Frontend/Assets.php
@@ -37,4 +37,36 @@ final class Assets {
 			$version
 		);
 	}
+
+	/**
+	 * Enqueues the public frontend runtime (script + style) from a block
+	 * render callback. The page-level `enqueue()` already adds the style on
+	 * singular documents, but the script only ships where a block needs it
+	 * (the data-view block, or a WordPress-icon variant that hydrates its
+	 * glyph). Safe to call more than once; WordPress dedupes by handle.
+	 */
+	public static function enqueue_frontend_runtime(): void {
+		$asset_path = CORTEXT_PATH . 'build/frontend.asset.php';
+		$asset      = file_exists( $asset_path )
+			? require $asset_path
+			: array(
+				'dependencies' => array(),
+				'version'      => CORTEXT_VERSION,
+			);
+
+		wp_enqueue_script(
+			'cortext-frontend',
+			CORTEXT_URL . 'build/frontend.js',
+			$asset['dependencies'] ?? array(),
+			$asset['version'] ?? CORTEXT_VERSION,
+			true
+		);
+
+		wp_enqueue_style(
+			'cortext-frontend',
+			CORTEXT_URL . 'build/frontend.css',
+			array( 'wp-block-library', 'wp-components' ),
+			$asset['version'] ?? CORTEXT_VERSION
+		);
+	}
 }

--- a/includes/PostType/DocumentIdentity.php
+++ b/includes/PostType/DocumentIdentity.php
@@ -73,8 +73,10 @@ final class DocumentIdentity {
 	 * architectural fix that drops the block from content entirely.
 	 */
 	public static function header_blocks_markup(): string {
-		$lock = array(
-			'lock' => array(
+		$attrs = array(
+			// Render the title as the page <h1>; the block defaults to <h2>.
+			'level' => 1,
+			'lock'  => array(
 				'move'   => true,
 				'remove' => true,
 			),
@@ -83,7 +85,7 @@ final class DocumentIdentity {
 		$blocks = array(
 			array(
 				'blockName'    => 'core/post-title',
-				'attrs'        => $lock,
+				'attrs'        => $attrs,
 				'innerBlocks'  => array(),
 				'innerHTML'    => '',
 				'innerContent' => array(),

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -1,8 +1,9 @@
 /**
  * Frontend entry point for public Cortext pages.
  *
- * Hydrates interactive DataViews instances into containers rendered by
- * the cortext/data-view block's PHP render callback.
+ * Hydrates interactive DataViews instances into containers rendered by the
+ * cortext/data-view block's PHP render callback, and fills WordPress-icon
+ * document glyphs that PHP can't render server-side.
  */
 import './frontend.scss';
 
@@ -12,6 +13,29 @@ import PublicDataView, {
 	PublicDataViewErrorBoundary,
 	PublicDataViewErrorFallback,
 } from './components/PublicDataView';
+
+// The document-icon block's `wp` variant emits an empty marker because
+// @wordpress/icons is JS-only. Render the glyph into each marker; the color
+// rides on the span's inline style (the glyph uses currentColor). The icon
+// namespace is heavy, so load it only when a page actually has a wp glyph.
+const wpIconMarkers = document.querySelectorAll(
+	'.cortext-document-icon--wp[data-icon]'
+);
+if ( wpIconMarkers.length ) {
+	import(
+		/* webpackChunkName: "document-icon-wp" */ './components/DocumentIconWp'
+	).then( ( { default: DocumentIconWp } ) => {
+		wpIconMarkers.forEach( ( el ) => {
+			const name = el.getAttribute( 'data-icon' );
+			if ( ! name ) {
+				return;
+			}
+			createRoot( el ).render(
+				<DocumentIconWp name={ name } size={ 44 } />
+			);
+		} );
+	} );
+}
 
 document.querySelectorAll( '[data-cortext-data-view]' ).forEach( ( el ) => {
 	const script = el.querySelector( '.cortext-dv-init' );

--- a/src/frontend.scss
+++ b/src/frontend.scss
@@ -4,9 +4,10 @@
  * Enqueued only on singular crtxt_document views. Intentionally minimal,
  * core block styles come from wp-block-library, enqueued separately.
  *
- * Heads-up: cover and icon styles still only load in admin/editor
- * bundles, so the PHP-rendered cover/icon markup is unstyled here.
- * See tech-debt.md#td-frontend-cover-icon-styles.
+ * Cover and icon styles for the PHP-rendered document-identity markup live
+ * in the "Document identity" section below, scoped to the persisted classes
+ * the render callbacks emit. The editor styles the same classes from its
+ * block edit partials.
  */
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
@@ -36,11 +37,13 @@
 	padding: 2rem 2rem 4rem;
 }
 
-.cortext-public-page__title {
+// The page title is the core/post-title block at the top of the content
+// (the template renders no separate the_title()). Give it the page-title look.
+.cortext-public-page .wp-block-post-title {
 	font-size: 2.5rem;
 	font-weight: 700;
 	line-height: 1.2;
-	margin: 2rem 0 1.5rem;
+	margin-block: 2rem 1.5rem;
 }
 
 .cortext-public-page__body {
@@ -57,6 +60,83 @@
 
 	> .alignfull {
 		max-width: none;
+	}
+}
+
+// -- Document identity: cover and icon (PHP-rendered markup) -------------
+// The cover/icon render callbacks emit these persisted classes on the public
+// page. The editor styles the same classes from its block edit partials; the
+// front end doesn't load those bundles, so the layout rules live here too.
+
+.cortext-document-cover-block {
+	position: relative;
+	height: clamp(140px, 26vh, 260px);
+	margin: 0;
+
+	&__image,
+	img {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+}
+
+.cortext-document-icon-block {
+	display: flex;
+	align-items: flex-end;
+	justify-content: flex-start;
+	max-width: var(--wp--style--global--content-size, 840px);
+	width: 100%;
+	margin: $grid-unit-10 auto;
+	padding: 0 $grid-unit-20;
+}
+
+// Pull the icon up over the cover when one immediately follows the other,
+// mirroring the editor overlap.
+.cortext-document-cover-block + .cortext-document-icon-block {
+	position: relative;
+	z-index: 1;
+	margin-block-start: -28px;
+	margin-block-end: 0;
+}
+
+.cortext-document-icon {
+	--cortext-document-icon-glyph-size: 44px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	line-height: 1;
+	vertical-align: middle;
+
+	&--emoji {
+		// prettier-ignore
+		font-family:
+			"Apple Color Emoji",
+			"Segoe UI Emoji",
+			"Noto Color Emoji",
+			"Twemoji Mozilla",
+			sans-serif;
+		font-size: 48px;
+	}
+
+	&--image {
+		width: 56px;
+		height: 56px;
+		object-fit: cover;
+		border-radius: 3px;
+	}
+
+	&--wp svg {
+		width: var(--cortext-document-icon-glyph-size);
+		min-width: var(--cortext-document-icon-glyph-size);
+		height: var(--cortext-document-icon-glyph-size);
+		flex: 0 0 var(--cortext-document-icon-glyph-size);
+		max-width: none;
+		// Admin themes svg fill to currentColor globally; the public page
+		// doesn't, so the saved icon color wouldn't reach the glyph otherwise.
+		fill: currentcolor;
 	}
 }
 
@@ -130,11 +210,19 @@
 	overflow-x: auto;
 
 	.dataviews-view-table {
-		// Let the table grow beyond the container so columns keep
-		// their natural width instead of collapsing. The parent's
-		// overflow-x: auto provides the scrollbar.
+		// Size columns to their content and scroll horizontally (the parent's
+		// overflow-x provides the scrollbar) instead of cramming every column
+		// into the content width. Per-cell min/max stops a shrinkable text
+		// column (e.g. a relation list) from collapsing to a few pixels and
+		// wrapping a word per line, or one column from eating the whole table.
 		table-layout: auto;
-		min-width: 600px;
+		min-width: 100%;
+
+		th,
+		td {
+			min-width: 7rem;
+			max-width: 24rem;
+		}
 
 		/* stylelint-disable-next-line no-descending-specificity */
 		tbody .dataviews-view-table__cell-content-wrapper {
@@ -142,6 +230,14 @@
 			width: 100%;
 			min-width: 0;
 			max-width: 100%;
+			// Cap row height: a relation or multi-value cell would otherwise
+			// wrap into a very tall row. Keep a few lines and clip the rest;
+			// the full value lives on the row's own page. Top-align so the clip
+			// keeps the start of the value (DataViews centers the cell, which
+			// would otherwise show a meaningless middle slice).
+			align-items: flex-start;
+			max-height: 4.5em;
+			overflow: hidden;
 		}
 	}
 

--- a/templates/single-crtxt_document.php
+++ b/templates/single-crtxt_document.php
@@ -29,13 +29,11 @@ defined( 'ABSPATH' ) || exit;
 		?>
 		<article id="post-<?php the_ID(); ?>">
 			<?php
-			// `the_title()` is the authoritative render; the same string also
-			// resolves a second time inside `the_content()` for any page
-			// whose `post_content` carries the locked `core/post-title`
-			// block prepended by `DocumentIdentity::prepend_header_blocks`.
-			// See tech-debt.md#td-public-title-double-render.
+			// The title comes from the locked `core/post-title` block that
+			// `DocumentIdentity::prepend_header_blocks` keeps at the top of
+			// `post_content`, so `the_content()` renders it. The template
+			// adds no separate `the_title()`; that would print it twice.
 			?>
-			<h1 class="cortext-public-page__title"><?php the_title(); ?></h1>
 			<div class="cortext-public-page__body is-layout-constrained">
 				<?php the_content(); ?>
 			</div>


### PR DESCRIPTION
## What

Published Cortext pages now render the title once, at the page-title size, instead of twice. They also style the cover image and the document icon, including the emoji, image, and WordPress-icon variants, with the WordPress-icon glyph in its saved color. Embedded collection tables size their columns and cap row height, so a long relation cell no longer wraps a word per line and stretches the row.

## Why

This content already rendered on public pages but with problems: the title printed twice, covers showed at full size, icons were unstyled, the WordPress-icon variant came out blank, and relation-heavy tables looked broken.

## How

- Loading the WordPress icon glyph on a public page only when that page actually uses one.

## Testing Instructions

1. Create and publish a Cortext page, then open its public URL and confirm the title appears once and looks like a page title.
2. Add a cover and an icon to a page, trying the emoji, image, and WordPress-icon options, and give the WordPress icon a color. Publish it, open the public URL, and confirm the cover is sized, the icon shows at a sensible size, and the WordPress icon appears in its color.
3. Publish a collection with several columns and a relation field, open its public page, and confirm the columns are readable and rows have a uniform height with no word-per-line wrapping.

## Screenshot
<img width="1859" height="1079" alt="image" src="https://github.com/user-attachments/assets/3d01dc2e-c8cd-4a72-bf3a-f6e4bf810c52" />

Note the bug in rendering the due range date that says `[Object Object]`; that's addressed in #334
