### PR TITLE
Stop public pages rendering the title twice

### DIFF
--- a/includes/Frontend/Template.php
+++ b/includes/Frontend/Template.php
@@ -22,8 +22,34 @@ final class Template {
 		// block editor documents whose locked data-view block renders via
 		// DataView::render().
 		if ( is_singular( Document::POST_TYPE ) ) {
+			add_filter( 'render_block', array( $this, 'suppress_duplicate_title' ), 10, 2 );
 			return CORTEXT_PATH . 'templates/single-crtxt_document.php';
 		}
 		return $template;
+	}
+
+	/**
+	 * Drops the locked `core/post-title` block from a Cortext document's
+	 * public render.
+	 *
+	 * The template prints `the_title()` as the single authoritative title.
+	 * `DocumentIdentity::prepend_header_blocks` keeps a matching
+	 * `core/post-title` in `post_content` so the editor canvas can show the
+	 * title inline, but `the_content()` would otherwise resolve it to the same
+	 * `post_title` and render the title a second time. Cortext documents never
+	 * carry a second post-title block (the header boundary blocks inserting one
+	 * in the body), so suppressing it here is safe for pages saved with and
+	 * without the block. Scoped to the public document render: this filter is
+	 * only attached while serving the Cortext template, so it never reaches the
+	 * admin or REST. See tech-debt.md#td-public-title-double-render.
+	 *
+	 * @param string $block_content Rendered block HTML.
+	 * @param array  $block         Parsed block, including `blockName`.
+	 */
+	public function suppress_duplicate_title( string $block_content, array $block ): string {
+		if ( 'core/post-title' === ( $block['blockName'] ?? '' ) ) {
+			return '';
+		}
+		return $block_content;
 	}
 }


### PR DESCRIPTION
## What

Cortext pages keep the title as a locked block inside their content, and the public template also prints the title, so every published page showed its title twice. The public render now shows it once.

## Testing Instructions

1. Create and publish a Cortext page, then open its public URL and confirm the title appears once.
2. Open a page created before this change (its content has no title block) and confirm its title still appears once.
