### PR TITLE
Fix: stopgap hide the publish toggle for collection rows

### DIFF
--- a/src/components/DocumentPublishToggle.js
+++ b/src/components/DocumentPublishToggle.js
@@ -12,7 +12,7 @@ import { useCallback, useState } from '@wordpress/element';
 
 import PublishToggle from './PublishToggle';
 import useCollectionDependentPages from '../hooks/useCollectionDependentPages';
-import { definesTrait } from '../documents/capabilities';
+import { definesTrait, hasTrait } from '../documents/capabilities';
 import { isPublicWebAffordancesEnabled } from '../settings';
 
 const CASCADE_PUBLISH_ERROR_NOTICE_ID = 'cortext-document-publish-error';
@@ -41,27 +41,36 @@ export default function DocumentPublishToggle( { disabled = false, postId } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, removeNotice } = useDispatch( noticesStore );
 
-	const { status, link, title, isSaving, isLocked, blocks, isCollection } =
-		useSelect(
-			( select ) => {
-				const editor = select( editorStore );
-				const record = select( coreStore ).getEntityRecord(
-					'postType',
-					'crtxt_document',
-					postId
-				);
-				return {
-					status: editor.getEditedPostAttribute( 'status' ),
-					link: editor.getEditedPostAttribute( 'link' ),
-					title: editor.getEditedPostAttribute( 'title' ),
-					isSaving: editor.isSavingPost(),
-					isLocked: editor.isPostLocked?.() ?? false,
-					blocks: select( blockEditorStore ).getBlocks(),
-					isCollection: definesTrait( record ),
-				};
-			},
-			[ postId ]
-		);
+	const {
+		status,
+		link,
+		title,
+		isSaving,
+		isLocked,
+		blocks,
+		isCollection,
+		carriesTrait,
+	} = useSelect(
+		( select ) => {
+			const editor = select( editorStore );
+			const record = select( coreStore ).getEntityRecord(
+				'postType',
+				'crtxt_document',
+				postId
+			);
+			return {
+				status: editor.getEditedPostAttribute( 'status' ),
+				link: editor.getEditedPostAttribute( 'link' ),
+				title: editor.getEditedPostAttribute( 'title' ),
+				isSaving: editor.isSavingPost(),
+				isLocked: editor.isPostLocked?.() ?? false,
+				blocks: select( blockEditorStore ).getBlocks(),
+				isCollection: definesTrait( record ),
+				carriesTrait: hasTrait( record ),
+			};
+		},
+		[ postId ]
+	);
 
 	const isPublic = status === 'publish';
 	const isDisabled = disabled || isLocked;
@@ -70,6 +79,11 @@ export default function DocumentPublishToggle( { disabled = false, postId } ) {
 	// term (`cortext_defines_trait`), true even for a collection with no custom
 	// fields, so the dependency check keys off that, not a field count.
 	const isReferenceable = isCollection;
+	// A row (carries a trait term but doesn't define one) has no public
+	// properties render yet, so publishing one strands a page with no fields.
+	// Hide the publish affordance for a not-yet-public row. A row that is
+	// already public keeps the control so it can still be unpublished.
+	const isRow = carriesTrait && ! isCollection;
 
 	const [ isConfirming, setIsConfirming ] = useState( false );
 	const { isLoading, dependentPages, error } = useCollectionDependentPages(
@@ -128,7 +142,11 @@ export default function DocumentPublishToggle( { disabled = false, postId } ) {
 		togglePublishStatus();
 	}, [ togglePublishStatus ] );
 
-	if ( ! publicWebAffordances || status === 'draft' ) {
+	if (
+		! publicWebAffordances ||
+		status === 'draft' ||
+		( isRow && ! isPublic )
+	) {
 		return null;
 	}
 

--- a/tests/js/components/DocumentPublishToggle.test.js
+++ b/tests/js/components/DocumentPublishToggle.test.js
@@ -176,4 +176,47 @@ describe( 'DocumentPublishToggle', () => {
 		} );
 		expect( editorDispatch.savePost ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'hides publishing for an unpublished row (carries a trait, does not define one)', () => {
+		record = {
+			id: 7,
+			cortext_defines_trait: false,
+			crtxt_trait: [ 12 ],
+		};
+		editorState.status = 'private';
+
+		const { container } = render( <DocumentPublishToggle postId={ 7 } /> );
+
+		expect( screen.queryByRole( 'button' ) ).toBeNull();
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'keeps the unpublish control for an already-public row', () => {
+		record = {
+			id: 7,
+			cortext_defines_trait: false,
+			crtxt_trait: [ 12 ],
+		};
+		editorState.status = 'publish';
+
+		render( <DocumentPublishToggle postId={ 7 } /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Unpublish' } )
+		).toBeTruthy();
+	} );
+
+	it( 'keeps publishing for a collection (defines its own trait)', () => {
+		record = {
+			id: 7,
+			cortext_defines_trait: true,
+			crtxt_trait: [ 7 ],
+		};
+
+		render( <DocumentPublishToggle postId={ 7 } /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Publish' } )
+		).toBeTruthy();
+	} );
 } );


### PR DESCRIPTION
## What

Refs #155.

A collection row can be opened as its own document, but rows have no public properties view yet, so publishing one would strand a page with no fields. The publish toggle is now hidden for a row that isn't public. A row that is already public keeps the control so it can still be unpublished.

## Testing Instructions

1. Open a collection row as a document and confirm there is no publish toggle.
2. Open a page or a full-page collection and confirm the publish toggle still appears.
3. If you have a row that is already public, open it and confirm the unpublish control is still available.
