### PR TITLE
Fix: dark-mode canvas loading flicker

### DIFF
--- a/src/components/WorkspaceTopBar.scss
+++ b/src/components/WorkspaceTopBar.scss
@@ -22,7 +22,7 @@
 	}
 }
 
-.cortext-workspace[data-target-kind="collection"] {
+.cortext-workspace[data-target-kind="document"] {
 	background: var(--cortext-canvas-surface);
 }
 
@@ -46,8 +46,10 @@
 	z-index: 1;
 }
 
-.cortext-workspace[data-target-kind="collection"]
-.cortext-workspace__pane[data-active="true"] {
+// Documents, rows, and full-page collection views all render light content.
+// Keep their active pane on the canvas surface; published, import, and empty
+// panes can use the frame.
+.cortext-workspace[data-target-kind="document"] .cortext-workspace__pane[data-active="true"] {
 	background: var(--cortext-canvas-surface);
 }
 

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -57,6 +57,7 @@ function LoadingPane( { active } ) {
 	return (
 		<div className="cortext-canvas__loading cortext-canvas__loading--document">
 			{ showProgress ? <CanvasProgressBar /> : null }
+			<CanvasSkeleton />
 		</div>
 	);
 }

--- a/src/styles/global/_view-transitions.scss
+++ b/src/styles/global/_view-transitions.scss
@@ -1,17 +1,13 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
-// Leave the default root snapshot out so the sidebar and topbar stay live
-// during the swap. Only the canvas opts in below. The fallback canvas surface
-// also lives here because view-transition pseudos cannot read shell tokens
-// from .cortext-root; :has() handles dark mode.
+// Keep the root out of the transition so the sidebar and topbar stay live.
+// The pseudos read from :root, not .cortext-root. Since the editor canvas is
+// still light-only, its transition backdrop stays white in dark mode.
 :root {
 	view-transition-name: none;
 	--cortext-canvas-frame-surface-root: #{$white};
-}
-
-:root:has(.cortext-root[data-theme="dark"]) {
-	--cortext-canvas-frame-surface-root: #2a2a2a;
+	--cortext-canvas-transition-surface-root: #{$white};
 }
 
 // During the cross-fade, both snapshots briefly dip to about 50% opacity. The
@@ -21,7 +17,7 @@
 ::view-transition-image-pair(cortext-canvas),
 ::view-transition-old(cortext-canvas),
 ::view-transition-new(cortext-canvas) {
-	background: var(--cortext-canvas-frame-surface-root, #fff);
+	background: var(--cortext-canvas-transition-surface-root, #fff);
 }
 
 // Keep the canvas layer below the side peek so the canvas cross-fade never

--- a/tests/e2e/specs/navigation-lifecycle.spec.js
+++ b/tests/e2e/specs/navigation-lifecycle.spec.js
@@ -14,6 +14,7 @@ const HISTORY_SECOND_PAGE_TITLE = `E2E History Page B ${ SUFFIX }`;
 const HISTORY_COLLECTION_TITLE = `E2E History Collection ${ SUFFIX }`;
 const NO_FLASH_FIRST_PAGE_TITLE = `E2E No Flash Page A ${ SUFFIX }`;
 const NO_FLASH_SECOND_PAGE_TITLE = `E2E No Flash Page B ${ SUFFIX }`;
+const DARK_LOADING_FIRST_PAGE_TITLE = `E2E Dark Loading Page A ${ SUFFIX }`;
 const COVER_FIRST_PAGE_TITLE = `E2E Cover Page A ${ SUFFIX }`;
 const COVER_SECOND_PAGE_TITLE = `E2E Cover Page B ${ SUFFIX }`;
 const COVER_PNG = Buffer.from(
@@ -198,6 +199,51 @@ async function waitForTransitionModeToClear( page ) {
 	await page.waitForFunction(
 		() => ! document.documentElement.dataset.cortextViewTransition
 	);
+}
+
+async function canvasSurfaceState( page ) {
+	return page.evaluate( () => {
+		const root = document.documentElement;
+		const rootStyle = window.getComputedStyle( root );
+		const workspace = document.querySelector( '.cortext-workspace' );
+		const activePane = document.querySelector(
+			'.cortext-workspace__pane[data-active="true"]'
+		);
+		const styleFor = ( element ) =>
+			element ? window.getComputedStyle( element ) : null;
+		return {
+			activePaneBackground: styleFor( activePane )?.backgroundColor || '',
+			hasLoadingPane: Boolean(
+				activePane?.querySelector( '.cortext-canvas__loading' )
+			),
+			hasSkeleton: Boolean(
+				activePane?.querySelector( '.cortext-canvas-skeleton' )
+			),
+			rootTheme:
+				document
+					.getElementById( 'cortext-root' )
+					?.getAttribute( 'data-theme' ) || '',
+			transitionBackgrounds: {
+				group: window.getComputedStyle(
+					root,
+					'::view-transition-group(cortext-canvas)'
+				).backgroundColor,
+				new: window.getComputedStyle(
+					root,
+					'::view-transition-new(cortext-canvas)'
+				).backgroundColor,
+				old: window.getComputedStyle(
+					root,
+					'::view-transition-old(cortext-canvas)'
+				).backgroundColor,
+			},
+			transitionSurface: rootStyle
+				.getPropertyValue( '--cortext-canvas-transition-surface-root' )
+				.trim(),
+			workspaceBackground: styleFor( workspace )?.backgroundColor || '',
+			workspaceKind: workspace?.getAttribute( 'data-target-kind' ) || '',
+		};
+	} );
 }
 
 async function resetViewTransitionProbe( page ) {
@@ -575,6 +621,94 @@ test.describe( 'Navigation lifecycle', () => {
 				fixture.secondPage &&
 					`/wp/v2/crtxt_documents/${ fixture.secondPage.id }`
 			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.firstPage &&
+					`/wp/v2/crtxt_documents/${ fixture.firstPage.id }`
+			);
+		}
+	} );
+
+	test( 'loads a dark-mode document on the light canvas', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		let releaseFirstLocator = () => {};
+
+		try {
+			fixture.firstPage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: DARK_LOADING_FIRST_PAGE_TITLE,
+					status: 'private',
+				},
+			} );
+
+			await page.addInitScript( () => {
+				window.localStorage.setItem( 'cortext.colorScheme', 'dark' );
+			} );
+
+			const firstLocatorGate = new Promise( ( resolve ) => {
+				releaseFirstLocator = resolve;
+			} );
+			await page.route(
+				`**/wp-json/cortext/v1/documents/${ fixture.firstPage.id }`,
+				async ( route ) => {
+					await firstLocatorGate;
+					await route.continue();
+				}
+			);
+			const firstLocatorRequest = page.waitForRequest( ( request ) =>
+				request
+					.url()
+					.includes(
+						`/wp-json/cortext/v1/documents/${ fixture.firstPage.id }`
+					)
+			);
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ fixture.firstPage.id }`
+			);
+			await firstLocatorRequest;
+
+			await expect( page.locator( '#cortext-root' ) ).toHaveAttribute(
+				'data-theme',
+				'dark'
+			);
+			await expect( page.locator( '.cortext-workspace' ) ).toHaveCSS(
+				'background-color',
+				'rgb(255, 255, 255)'
+			);
+			await expect(
+				page.locator( '.cortext-workspace__pane[data-active="true"]' )
+			).toHaveCSS( 'background-color', 'rgb(255, 255, 255)' );
+
+			const loadingSurface = await canvasSurfaceState( page );
+			expect( loadingSurface ).toEqual(
+				expect.objectContaining( {
+					activePaneBackground: 'rgb(255, 255, 255)',
+					hasLoadingPane: true,
+					hasSkeleton: true,
+					rootTheme: 'dark',
+					transitionSurface: '#fff',
+					workspaceBackground: 'rgb(255, 255, 255)',
+					workspaceKind: 'document',
+				} )
+			);
+			expect( loadingSurface.transitionBackgrounds ).toEqual( {
+				group: 'rgb(255, 255, 255)',
+				new: 'rgb(255, 255, 255)',
+				old: 'rgb(255, 255, 255)',
+			} );
+
+			releaseFirstLocator();
+			await waitForEditorPost( page, fixture.firstPage.id );
+		} finally {
+			releaseFirstLocator();
 			await deleteIfCreated(
 				requestUtils,
 				fixture.firstPage &&


### PR DESCRIPTION
## What

Keeps the document canvas white in dark mode while Cortext is loading or switching documents. The loader now has a light skeleton under the progress bar, so refreshes and slow document loads do not leave a blank-looking canvas or flash against the dark shell.

## Why

The shell supports dark mode, but the editor canvas is still light. This keeps the loading state honest to that behavior instead of briefly showing the wrong surface.

## Testing Instructions

1. Switch Cortext to dark mode.
2. Open a document in the Cortext admin screen.
3. Refresh the page, ideally with slow network enabled.
4. Confirm the sidebar and topbar stay dark while the canvas, loader, and skeleton stay white.
5. Navigate to another document and confirm the canvas does not flash dark during the transition.