### PR TITLE
Fix: Format rollup values in the public table

### DIFF
--- a/src/hooks/publicFieldMapping.js
+++ b/src/hooks/publicFieldMapping.js
@@ -163,6 +163,22 @@ function formatPublicDisplay( value, type, elements ) {
 	if ( type === 'relation' ) {
 		return formatPublicRelation( value );
 	}
+	if ( type === 'rollup' ) {
+		// Date-range rollups arrive as a { start, end } object.
+		if (
+			value &&
+			typeof value === 'object' &&
+			! Array.isArray( value ) &&
+			( 'start' in value || 'end' in value )
+		) {
+			return formatDisplay( value, 'rollup-date-range' );
+		}
+		// Other rollups are a scalar or an array of the target field's
+		// values. An array can hold relation references (objects), which
+		// formatDisplay stringifies to "[object Object]". textValue reads
+		// their titles instead.
+		return textValue( value );
+	}
 	return formatDisplay( value, type, elements );
 }
 


### PR DESCRIPTION
## What

Some rollup columns showed "[object Object]" in the public collection table. A date-range rollup comes back as a `{ start, end }` object and a "show values" rollup as a list of references, and neither had a public formatter, so they got stringified. Those cells now show real values: a date range as "05/10/2026 - 05/14/2026", and a reference list as its titles.

## Testing Instructions

1. Publish a collection that has rollup fields with values (a date-range rollup, like a "due range" aggregating dates from related rows, is the clearest case).
2. Open its public page and confirm the rollup columns show readable values, with no "[object Object]".
