### PR TITLE
Fix: Desktop app visually broken on first load

### DIFF
--- a/apps/desktop/scripts/build-snapshot.mjs
+++ b/apps/desktop/scripts/build-snapshot.mjs
@@ -36,6 +36,7 @@ const PLUGIN_INCLUDES = [
 	'readme.txt',
 	'LICENSE',
 	'includes',
+	'assets/brand',
 	'build',
 	'templates',
 	'src/blocks',

--- a/src/components/Canvas.scss
+++ b/src/components/Canvas.scss
@@ -46,6 +46,10 @@
 		min-height: 0;
 	}
 
+	&.interface-interface-skeleton {
+		left: 0;
+	}
+
 	&__visual {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
## What

Fixes two desktop-only rough edges: the Cortext icon now shows up in the sidebar, and document pages no longer start with an odd blank gap before the canvas.

## Why

The desktop app runs from its packaged snapshot, not straight from the repo. That snapshot was missing the brand image files, and Gutenberg was adding a small left offset inside the app shell.

## Testing Instructions

1. Launch the desktop app from a fresh local desktop site.
2. Open the Library page.
3. Check that the Cortext icon appears in the sidebar header.
4. Check that the document canvas starts flush with the main column, with no extra white gap.

## Screenshots

| Before | After |
| --- | --- |
|<img width="805" height="792" alt="image" src="https://github.com/user-attachments/assets/d3357ea8-c333-4a28-81fa-ff62380917ca" /> | <img width="582" height="796" alt="image" src="https://github.com/user-attachments/assets/b77f362e-0b69-49fc-836e-acc873e80942" /> |
