### PR TITLE
Tooling: Harden shipped code for the WordPress.org submission

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,43 @@
+name: Plugin Check
+
+# Run on demand (e.g. before a WordPress.org submission). Plugin Check is slow,
+# so it is not wired to every push or PR.
+on:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    plugin-check:
+        name: Plugin Check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: 11.0.8
+                  standalone: true
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '24.15'
+                  cache: 'pnpm'
+
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+                  tools: composer:v2
+                  coverage: none
+
+            # Build the same tree the release ZIP ships, so Plugin Check sees
+            # exactly what WordPress.org reviews (no src/tests/dev files).
+            - name: Build the plugin
+              run: ./scripts/build-zip.sh
+
+            - name: Plugin Check
+              uses: WordPress/plugin-check-action@v1.1.6
+              with:
+                  build-dir: ./dist/cortext
+                  exclude-directories: vendor

--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -15,6 +15,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Admin;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Runtime\Features;
 use Cortext\Theming\Preferences;
 

--- a/includes/Block/DataView.php
+++ b/includes/Block/DataView.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Block;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Frontend\Assets;
 use Cortext\PostType\Document;
 

--- a/includes/Block/DataView.php
+++ b/includes/Block/DataView.php
@@ -62,11 +62,14 @@ final class DataView {
 
 		Assets::enqueue_frontend_runtime();
 
+		// Escape <, >, and & so a `view` attribute containing `</script>` can't
+		// break out of the inline JSON island below.
 		$init_data = wp_json_encode(
 			array(
 				'collectionId' => $collection_id,
 				'view'         => $attributes['view'] ?? array(),
-			)
+			),
+			JSON_HEX_TAG | JSON_HEX_AMP
 		);
 
 		$wrapper_attributes = get_block_wrapper_attributes(

--- a/includes/CLI/BackfillMedia.php
+++ b/includes/CLI/BackfillMedia.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 
 namespace Cortext\CLI;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Media\CortextMedia;
 use WP_CLI;
 use WP_CLI_Command;

--- a/includes/CLI/FieldValues.php
+++ b/includes/CLI/FieldValues.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\CLI;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\FieldValues\FieldValueIndex;
 use Cortext\PostType\Document;
 use Cortext\PostType\Field;

--- a/includes/CLI/PerfBench.php
+++ b/includes/CLI/PerfBench.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\CLI;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\FieldValues\FieldValueIndex;
 use Cortext\FieldValues\FieldValueStore;
 use Cortext\PostType\Document;

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\CLI;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Media\CortextMedia;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;

--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -19,6 +19,8 @@ declare( strict_types=1 );
 
 namespace Cortext;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Documents\DocumentDuplicator;
 use Cortext\Relations;
 use Cortext\Fields\FieldTypeRegistry;

--- a/includes/Documents/DocumentDuplicator.php
+++ b/includes/Documents/DocumentDuplicator.php
@@ -14,6 +14,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Documents;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Documents;
 use Cortext\PostType\Document;
 use Cortext\PostType\Field;

--- a/includes/Editor/DocumentCoverBlock.php
+++ b/includes/Editor/DocumentCoverBlock.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Editor;
 
+defined( 'ABSPATH' ) || exit;
+
 final class DocumentCoverBlock {
 
 	public const BLOCK_NAME = 'cortext/document-cover';

--- a/includes/Editor/DocumentIconBlock.php
+++ b/includes/Editor/DocumentIconBlock.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Editor;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Frontend\Assets;
 use Cortext\PostType\DocumentIdentity;
 

--- a/includes/Editor/DocumentPropertiesBlock.php
+++ b/includes/Editor/DocumentPropertiesBlock.php
@@ -14,6 +14,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Editor;
 
+defined( 'ABSPATH' ) || exit;
+
 final class DocumentPropertiesBlock {
 
 	public const BLOCK_NAME = 'cortext/document-properties';

--- a/includes/Editor/RevisionThrottle.php
+++ b/includes/Editor/RevisionThrottle.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Editor;
 
+defined( 'ABSPATH' ) || exit;
+
 use WP_Post;
 
 final class RevisionThrottle {

--- a/includes/FieldValues/FieldValueIndex.php
+++ b/includes/FieldValues/FieldValueIndex.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\FieldValues;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 use Cortext\PostType\Field;
 use Cortext\Taxonomy\TraitTaxonomy;

--- a/includes/FieldValues/FieldValueReadQuery.php
+++ b/includes/FieldValues/FieldValueReadQuery.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\FieldValues;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 use Cortext\Relations;
 use Cortext\Taxonomy\TraitTaxonomy;

--- a/includes/FieldValues/FieldValueStore.php
+++ b/includes/FieldValues/FieldValueStore.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\FieldValues;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Relations;
 
 final class FieldValueStore {

--- a/includes/Fields/FieldDefaults.php
+++ b/includes/Fields/FieldDefaults.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Fields;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\FieldValues\FieldValueStore;
 use Cortext\Relations;
 

--- a/includes/Fields/FieldTypeConverter.php
+++ b/includes/Fields/FieldTypeConverter.php
@@ -14,6 +14,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Fields;
 
+defined( 'ABSPATH' ) || exit;
+
 final class FieldTypeConverter {
 
 	public const STATUS_DISPLAYS = 'displays';

--- a/includes/Fields/FieldTypeRegistry.php
+++ b/includes/Fields/FieldTypeRegistry.php
@@ -16,6 +16,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Fields;
 
+defined( 'ABSPATH' ) || exit;
+
 final class FieldTypeRegistry {
 
 	private const TEXT_OPERATORS = array(

--- a/includes/Frontend/AdminBar.php
+++ b/includes/Frontend/AdminBar.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Frontend;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 
 final class AdminBar {

--- a/includes/Frontend/Assets.php
+++ b/includes/Frontend/Assets.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Frontend;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 
 final class Assets {

--- a/includes/Frontend/Template.php
+++ b/includes/Frontend/Template.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Frontend;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 
 final class Template {

--- a/includes/Media/CortextMedia.php
+++ b/includes/Media/CortextMedia.php
@@ -22,6 +22,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Media;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 use WP_Post;
 use WP_REST_Request;

--- a/includes/Notion/Client.php
+++ b/includes/Notion/Client.php
@@ -13,6 +13,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Notion;
 
+defined( 'ABSPATH' ) || exit;
+
 use WP_Error;
 
 final class Client {

--- a/includes/Notion/Importer.php
+++ b/includes/Notion/Importer.php
@@ -30,6 +30,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Notion;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Documents;
 use Cortext\PostType\Document;
 use Cortext\PostType\Field;

--- a/includes/OptionPalette.php
+++ b/includes/OptionPalette.php
@@ -14,6 +14,8 @@ declare( strict_types=1 );
 
 namespace Cortext;
 
+defined( 'ABSPATH' ) || exit;
+
 final class OptionPalette {
 
 	private const NAMES = array(

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Admin\Screen;
 use Cortext\Block\DataView;
 use Cortext\Editor\DocumentCoverBlock;

--- a/includes/PostType/Document.php
+++ b/includes/PostType/Document.php
@@ -18,6 +18,8 @@ declare( strict_types=1 );
 
 namespace Cortext\PostType;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Documents;
 use Cortext\Fields\FieldTypeRegistry;
 use Cortext\FieldValues\FieldValueIndex;

--- a/includes/PostType/DocumentIdentity.php
+++ b/includes/PostType/DocumentIdentity.php
@@ -15,6 +15,8 @@ declare( strict_types=1 );
 
 namespace Cortext\PostType;
 
+defined( 'ABSPATH' ) || exit;
+
 final class DocumentIdentity {
 
 	/**

--- a/includes/PostType/Field.php
+++ b/includes/PostType/Field.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\PostType;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Fields\FieldDefaults;
 use Cortext\Fields\FieldTypeRegistry;
 use WP_Error;

--- a/includes/PostType/TrashCascade.php
+++ b/includes/PostType/TrashCascade.php
@@ -24,6 +24,8 @@ declare( strict_types=1 );
 
 namespace Cortext\PostType;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Relations;
 use Cortext\Taxonomy\TraitTaxonomy;
 use WP_Post;

--- a/includes/Relations.php
+++ b/includes/Relations.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\FieldValues\FieldValueIndex;
 use Cortext\PostType\Document;
 use Cortext\PostType\Field;

--- a/includes/Rest/DocumentLocatorController.php
+++ b/includes/Rest/DocumentLocatorController.php
@@ -17,6 +17,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 use Cortext\Taxonomy\TraitTaxonomy;
 use WP_Error;

--- a/includes/Rest/DocumentsController.php
+++ b/includes/Rest/DocumentsController.php
@@ -16,6 +16,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Documents;
 use Cortext\PostType\Document;
 use Cortext\PostType\TrashCascade;

--- a/includes/Rest/FavoritesController.php
+++ b/includes/Rest/FavoritesController.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Documents;
 use WP_Error;
 use WP_REST_Request;

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Fields\FieldDefaults;
 use Cortext\Fields\FieldTypeConverter;
 use Cortext\Fields\FieldTypeRegistry;

--- a/includes/Rest/NotionController.php
+++ b/includes/Rest/NotionController.php
@@ -30,6 +30,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Notion\Client;
 use Cortext\Notion\Importer;
 use WP_Error;

--- a/includes/Rest/PostLocksController.php
+++ b/includes/Rest/PostLocksController.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use WP_Error;
 use WP_Post;
 use WP_REST_Request;

--- a/includes/Rest/RecentsController.php
+++ b/includes/Rest/RecentsController.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Documents;
 use WP_Error;
 use WP_REST_Request;

--- a/includes/Rest/RowFormatContext.php
+++ b/includes/Rest/RowFormatContext.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Holds field metadata for one `get_rows()` call. The controller passes this
  * object through the formatter instead of keeping cache state on itself.

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -17,6 +17,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Fields\FieldDefaults;
 use Cortext\Fields\FieldTypeConverter;
 use Cortext\FieldValues\FieldValueReadQuery;

--- a/includes/Rest/RowsFilterQuery.php
+++ b/includes/Rest/RowsFilterQuery.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Fields\FieldTypeRegistry;
 use WP_Error;
 

--- a/includes/Rest/RowsManualOrder.php
+++ b/includes/Rest/RowsManualOrder.php
@@ -13,6 +13,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 use Cortext\Relations;
 use Cortext\Taxonomy\TraitTaxonomy;

--- a/includes/Rest/RowsMetaQuery.php
+++ b/includes/Rest/RowsMetaQuery.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use WP_Meta_Query;
 
 final class RowsMetaQuery extends WP_Meta_Query {

--- a/includes/Rest/RowsQueryScope.php
+++ b/includes/Rest/RowsQueryScope.php
@@ -14,6 +14,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use WP_Query;
 
 final class RowsQueryScope {

--- a/includes/Rest/WorkspaceHomeController.php
+++ b/includes/Rest/WorkspaceHomeController.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Rest;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\Documents;
 use WP_Error;
 use WP_REST_Request;

--- a/includes/Runtime/Features.php
+++ b/includes/Runtime/Features.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Runtime;
 
+defined( 'ABSPATH' ) || exit;
+
 final class Features {
 
 	public function is_desktop(): bool {

--- a/includes/Taxonomy/TraitTaxonomy.php
+++ b/includes/Taxonomy/TraitTaxonomy.php
@@ -39,6 +39,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Taxonomy;
 
+defined( 'ABSPATH' ) || exit;
+
 use Cortext\PostType\Document;
 use WP_Post;
 

--- a/includes/Theming/Preferences.php
+++ b/includes/Theming/Preferences.php
@@ -18,6 +18,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Theming;
 
+defined( 'ABSPATH' ) || exit;
+
 final class Preferences {
 
 	public function register(): void {


### PR DESCRIPTION
## What

Part of #285.

Hardening and tooling over the shipped code, ahead of the wp.org submission:

- Escapes the data-view block's inline JSON so a `view` containing `</script>` can't break out of the script tag.
- Adds a direct-access guard to every PHP file under `includes/`, which is what Plugin Check looks for.
- Adds an on-demand Plugin Check workflow that builds the plugin and runs the WordPress.org Plugin Check against the shipped tree.

## Testing Instructions

1. Open a published page with a collection (data-view) block on the front end and confirm it still renders.
2. View the page source and confirm the inline JSON in the data-view's script tag has no raw angle brackets (they're escaped), so a `</script>` inside a view can't close the tag early.
3. From the Actions tab, run the "Plugin Check" workflow and confirm it completes.
