### PR TITLE
Fix: Stop row detail from flashing on open

### DIFF
--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -598,6 +598,8 @@ export default function RowDetailView( {
 								meta: paneRowMeta,
 								cortext_hydrated_meta: paneRowHydratedMeta,
 							};
+							const shouldAcquirePostLock =
+								pane.state === 'preparing' || isApiActive;
 
 							return (
 								<div
@@ -659,6 +661,9 @@ export default function RowDetailView( {
 										}
 										row={ paneRow }
 										rowId={ pane.detail.rowId }
+										shouldAcquirePostLock={
+											shouldAcquirePostLock
+										}
 									/>
 								</div>
 							);

--- a/src/components/RowDetailView.scss
+++ b/src/components/RowDetailView.scss
@@ -1419,7 +1419,7 @@
 	border-left: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
 	box-shadow: -18px 0 36px rgba(0, 0, 0, 0.12);
 	overflow: hidden;
-	will-change: width;
+	will-change: transform;
 	view-transition-name: cortext-row-detail-sidebar;
 	animation:
 		cortext-row-detail-sidebar-open 300ms
@@ -1482,26 +1482,22 @@ body.cortext-row-detail-sidebar-resizing {
 @keyframes cortext-row-detail-sidebar-open {
 
 	from {
-		flex-basis: 0;
-		width: 0;
+		transform: translateX(100%);
 	}
 
 	to {
-		flex-basis: var(--cortext-row-detail-sidebar-width, 560px);
-		width: var(--cortext-row-detail-sidebar-width, 560px);
+		transform: translateX(0);
 	}
 }
 
 @keyframes cortext-row-detail-sidebar-close {
 
 	from {
-		flex-basis: var(--cortext-row-detail-sidebar-width, 560px);
-		width: var(--cortext-row-detail-sidebar-width, 560px);
+		transform: translateX(0);
 	}
 
 	to {
-		flex-basis: 0;
-		width: 0;
+		transform: translateX(100%);
 	}
 }
 

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -6,7 +6,7 @@
 // renders synchronously; only this inner stack suspends on first row open.
 import { useDispatch } from '@wordpress/data';
 import { EditorProvider, store as editorStore } from '@wordpress/editor';
-import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 
 import useAutosave from '../hooks/useAutosave';
@@ -120,16 +120,35 @@ function DetailPaneContent( {
 	propertiesVisible,
 	row,
 	rowId,
+	shouldAcquirePostLock,
 } ) {
-	const handleReady = useCallback(
-		() => onPaneReady( detailKey ),
-		[ detailKey, onPaneReady ]
-	);
 	const postLock = usePostLock( {
 		postId: row?.id ?? rowId,
 		postType,
-		enabled: isActive && ! isHidden,
+		enabled: shouldAcquirePostLock,
 	} );
+	const [ isEditorReady, setIsEditorReady ] = useState( false );
+	const notifiedReadyKeyRef = useRef( null );
+	const handleReady = useCallback( () => setIsEditorReady( true ), [] );
+	const isPostLockSettled =
+		! postLock.isReadOnly || postLock.isFailed || postLock.isLocked;
+
+	useEffect( () => {
+		setIsEditorReady( false );
+		notifiedReadyKeyRef.current = null;
+	}, [ detailKey ] );
+
+	useEffect( () => {
+		if (
+			! isEditorReady ||
+			! isPostLockSettled ||
+			notifiedReadyKeyRef.current === detailKey
+		) {
+			return;
+		}
+		notifiedReadyKeyRef.current = detailKey;
+		onPaneReady( detailKey );
+	}, [ detailKey, isEditorReady, isPostLockSettled, onPaneReady ] );
 
 	const content = (
 		<DocumentPropertiesProvider
@@ -218,6 +237,7 @@ export default function RowEditor( {
 	propertiesVisible,
 	row,
 	rowId,
+	shouldAcquirePostLock = false,
 } ) {
 	return (
 		<EditorProvider
@@ -252,6 +272,7 @@ export default function RowEditor( {
 						propertiesVisible={ propertiesVisible }
 						row={ row }
 						rowId={ rowId }
+						shouldAcquirePostLock={ shouldAcquirePostLock }
 					/>
 				</EditorSurfaceProvider>
 			</SlotFillProvider>

--- a/tests/js/components/RowDetailViewStyles.test.js
+++ b/tests/js/components/RowDetailViewStyles.test.js
@@ -1,0 +1,41 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+function keyframeBody( stylesheet, name ) {
+	const start = stylesheet.indexOf( `@keyframes ${ name }` );
+	if ( start < 0 ) {
+		return '';
+	}
+	const nextKeyframe = stylesheet.indexOf( '@keyframes ', start + 1 );
+	const nextMedia = stylesheet.indexOf( '@media ', start + 1 );
+	const endCandidates = [ nextKeyframe, nextMedia ].filter(
+		( index ) => index > start
+	);
+	const end =
+		endCandidates.length > 0
+			? Math.min( ...endCandidates )
+			: stylesheet.length;
+	return stylesheet.slice( start, end );
+}
+
+describe( 'RowDetailView styles', () => {
+	it( 'slides the side peek without squeezing the editor', () => {
+		const stylesheet = readFileSync(
+			join( process.cwd(), 'src/components/RowDetailView.scss' ),
+			'utf8'
+		);
+		const openAnimation = keyframeBody(
+			stylesheet,
+			'cortext-row-detail-sidebar-open'
+		);
+		const closeAnimation = keyframeBody(
+			stylesheet,
+			'cortext-row-detail-sidebar-close'
+		);
+		const sidebarAnimations = `${ openAnimation }\n${ closeAnimation }`;
+
+		expect( sidebarAnimations ).toContain( 'transform: translateX' );
+		expect( sidebarAnimations ).not.toContain( 'width:' );
+		expect( sidebarAnimations ).not.toContain( 'flex-basis:' );
+	} );
+} );

--- a/tests/js/components/RowEditor.test.js
+++ b/tests/js/components/RowEditor.test.js
@@ -2,6 +2,7 @@ import { act, render } from '@testing-library/react';
 
 import RowEditor from '../../../src/components/RowEditor';
 import EditorBody from '../../../src/components/EditorBody';
+import usePostLock from '../../../src/hooks/usePostLock';
 
 jest.mock( '@wordpress/components', () => ( {
 	SlotFillProvider: ( { children } ) => <>{ children }</>,
@@ -61,16 +62,82 @@ jest.mock( '../../../src/hooks/usePostLock', () =>
 	} ) )
 );
 
+const unlockedPostLock = {
+	error: null,
+	isAcquiring: false,
+	isFailed: false,
+	isLocked: false,
+	isReadOnly: false,
+	isTakeover: false,
+	isTakingOver: false,
+	retry: jest.fn(),
+	takeOver: jest.fn(),
+	user: null,
+};
+
+function renderRowEditor( overrides = {} ) {
+	return render(
+		<RowEditor
+			collectionId={ 10 }
+			detailKey="crtxt_tasks:20"
+			fields={ [] }
+			isActive
+			isHidden={ false }
+			onApi={ jest.fn() }
+			onPaneReady={ jest.fn() }
+			onRestored={ jest.fn() }
+			onSaved={ jest.fn() }
+			onTogglePropertiesVisible={ jest.fn() }
+			post={ { id: 20, type: 'crtxt_tasks' } }
+			postType="crtxt_tasks"
+			propertiesVisible
+			row={ { id: 20 } }
+			rowId={ 20 }
+			shouldAcquirePostLock
+			{ ...overrides }
+		/>
+	);
+}
+
 describe( 'RowEditor', () => {
 	beforeEach( () => {
 		EditorBody.mockClear();
+		usePostLock.mockReturnValue( unlockedPostLock );
 		window.cortextEditorSettings = {};
 	} );
 
-	it( 'waits for the editor body paint signal before marking the pane ready', () => {
+	it( 'marks the pane ready after the editor body has painted', () => {
 		const onPaneReady = jest.fn();
 
-		render(
+		renderRowEditor( { onPaneReady } );
+
+		expect( onPaneReady ).not.toHaveBeenCalled();
+
+		act( () => {
+			EditorBody.mock.calls[ 0 ][ 0 ].onReady();
+		} );
+
+		expect( onPaneReady ).toHaveBeenCalledWith( 'crtxt_tasks:20' );
+	} );
+
+	it( 'keeps the pane hidden while the first post-lock check runs', () => {
+		const onPaneReady = jest.fn();
+		usePostLock.mockReturnValue( {
+			...unlockedPostLock,
+			isAcquiring: true,
+			isReadOnly: true,
+		} );
+
+		const { rerender } = renderRowEditor( { onPaneReady } );
+
+		act( () => {
+			EditorBody.mock.calls[ 0 ][ 0 ].onReady();
+		} );
+
+		expect( onPaneReady ).not.toHaveBeenCalled();
+
+		usePostLock.mockReturnValue( unlockedPostLock );
+		rerender(
 			<RowEditor
 				collectionId={ 10 }
 				detailKey="crtxt_tasks:20"
@@ -87,14 +154,9 @@ describe( 'RowEditor', () => {
 				propertiesVisible
 				row={ { id: 20 } }
 				rowId={ 20 }
+				shouldAcquirePostLock
 			/>
 		);
-
-		expect( onPaneReady ).not.toHaveBeenCalled();
-
-		act( () => {
-			EditorBody.mock.calls[ 0 ][ 0 ].onReady();
-		} );
 
 		expect( onPaneReady ).toHaveBeenCalledWith( 'crtxt_tasks:20' );
 	} );


### PR DESCRIPTION
## What

Regression introduced #308.

Fixes a row detail glitch where the side peek could show the row, shift it, then settle a moment later. The pane now waits until the editor and the first lock check are ready, so the title, identity controls, and properties appear in one stable position.

## Why

It made the row feel like it opened twice, especially from embedded collection tables.

## How

- Waiting to reveal the pane until the first lock check finishes.
- Sliding the side peek with `transform` instead of animating its width.

## Testing Instructions

1. Open a page with an embedded collection table.
2. Hover a row and click Open.
3. Watch the side peek as it opens. The row title should stay put, without a flicker or downward jump.
4. Close it, open another row, and confirm it stays stable.

## Screen recording

Before:

https://github.com/user-attachments/assets/c2a0687d-bcc0-4172-94d6-0f62a204a0fe

After:

https://github.com/user-attachments/assets/a4c1ddc4-89d6-4eaf-bb94-82f4f8ca54b5
