### PR TITLE
Tooling: Fix Plugin Check startup

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -41,3 +41,4 @@ jobs:
               with:
                   build-dir: ./dist/cortext
                   exclude-directories: vendor
+                  wp-version: trunk


### PR DESCRIPTION
## What

Part of #285.

Follow-up to #337.

Fixes the Plugin Check workflow so wp-env starts with a real WordPress source instead of `core: null`. The workflow was failing before Plugin Check could inspect Cortext.

## Testing Instructions

1. Run the Plugin Check workflow from GitHub Actions.
2. Confirm the job gets past wp-env startup and reaches the Plugin Check step.

