### PR TITLE
Code Quality: address Plugin Check submission findings

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,9 +3,9 @@
 # deploy action.
 #
 # This mirrors the runtime allowlist in scripts/build-zip.sh as a denylist:
-# anything not listed here can ship to users. The public plugin should contain
-# cortext.php, readme.txt, LICENSE, includes/, templates/, build/,
-# seed-assets/, assets/brand/, and vendor/ without dev dependencies.
+# anything not listed here can ship to users. The plugin ZIP should contain
+# cortext.php, readme.txt, LICENSE, composer.json, includes/, templates/,
+# build/, seed-assets/, assets/brand/, and vendor/ without dev dependencies.
 #
 # Note: .distignore does not respect .gitignore, but build/ and vendor/ are
 # gitignored. If a deploy relies on this file, run `pnpm run build` and
@@ -32,7 +32,6 @@
 /package.json
 /pnpm-lock.yaml
 /pnpm-workspace.yaml
-/composer.json
 /composer.lock
 
 # Local dev environment (wp-env) and its generated auto-login helpers

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -36,9 +36,164 @@ jobs:
             - name: Build the plugin
               run: ./scripts/build-zip.sh
 
-            - name: Plugin Check
-              uses: WordPress/plugin-check-action@v1.1.6
+            - name: Configure Plugin Check environment
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  plugin_dir="$(realpath ./dist/cortext)"
+                  plugin_slug="$(basename "$plugin_dir")"
+
+                  echo "PLUGIN_SLUG=$plugin_slug" >> "$GITHUB_ENV"
+
+                  cat > .wp-env.plugin-check.json <<EOF
+                  {
+                    "core": "WordPress/WordPress#master",
+                    "port": 8880,
+                    "testsEnvironment": false,
+                    "mappings": {
+                      "wp-content/plugins/${plugin_slug}": "${plugin_dir}"
+                    }
+                  }
+                  EOF
+
+            # The official Plugin Check action currently breaks on GitHub's
+            # ubuntu-24.04 runner when plugin-check.zip is loaded through
+            # .wp-env.json. Keep the env local, then install Plugin Check with
+            # WP-CLI once WordPress is running.
+            - name: Start wp-env
+              uses: nick-fields/retry@v4
               with:
-                  build-dir: ./dist/cortext
-                  exclude-directories: vendor
-                  wp-version: trunk
+                  timeout_minutes: 10
+                  max_attempts: 3
+                  shell: bash
+                  command: |
+                      ./node_modules/.bin/wp-env --config .wp-env.plugin-check.json start
+                      ./node_modules/.bin/wp-env --config .wp-env.plugin-check.json run cli wp cli info
+
+            - name: Run Plugin Check
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  wp_env=( ./node_modules/.bin/wp-env --config .wp-env.plugin-check.json )
+
+                  echo "::group::Debugging information"
+                  "${wp_env[@]}" run cli wp plugin list
+                  echo "::endgroup::"
+
+                  echo "::group::Install Plugin Check"
+                  "${wp_env[@]}" run cli wp plugin install plugin-check --activate
+                  "${wp_env[@]}" run cli wp plugin list-checks
+                  "${wp_env[@]}" run cli wp plugin list-check-categories
+                  echo "::endgroup::"
+
+                  echo "::group::Install plugin dependencies"
+                  dependencies="$( "${wp_env[@]}" run cli wp plugin get "$PLUGIN_SLUG" --field=requires_plugins | tr ',' ' ' | xargs )"
+                  if [ -n "$dependencies" ]; then
+                    echo "Installing plugin dependencies: $dependencies"
+                    "${wp_env[@]}" run cli wp plugin install --activate $dependencies
+                  else
+                    echo "Plugin has no dependencies"
+                  fi
+                  echo "::endgroup::"
+
+                  "${wp_env[@]}" run cli wp plugin activate "$PLUGIN_SLUG"
+
+                  echo "::group::Run Plugin Check"
+                  results="$RUNNER_TEMP/plugin-check-results.txt"
+                  set +e
+                  "${wp_env[@]}" run cli wp plugin check "$PLUGIN_SLUG" \
+                    --format=json \
+                    --exclude-directories=vendor \
+                    --require=./wp-content/plugins/plugin-check/cli.php \
+                    | tee "$results"
+                  status="${PIPESTATUS[0]}"
+                  set -e
+                  echo "::endgroup::"
+
+                  exit "$status"
+
+            - name: Process Plugin Check results
+              shell: bash
+              run: |
+                  node <<'NODE'
+                  const fs = require( 'fs' );
+
+                  const resultsPath = `${ process.env.RUNNER_TEMP }/plugin-check-results.txt`;
+                  const content = fs.existsSync( resultsPath ) ? fs.readFileSync( resultsPath, 'utf8' ) : '';
+                  const lines = content.split( /\r?\n/ );
+
+                  const escapeData = ( value ) =>
+                    String( value )
+                      .replace( /%/g, '%25' )
+                      .replace( /\r/g, '%0D' )
+                      .replace( /\n/g, '%0A' );
+
+                  const escapeProperty = ( value ) =>
+                    escapeData( value ).replace( /:/g, '%3A' ).replace( /,/g, '%2C' );
+
+                  const decodeHtmlEntities = ( value ) =>
+                    String( value )
+                      .replace( /&quot;/g, '"' )
+                      .replace( /&#039;/g, "'" )
+                      .replace( /&lt;/g, '<' )
+                      .replace( /&gt;/g, '>' )
+                      .replace( /&amp;/g, '&' );
+
+                  const annotate = ( command, properties, message ) => {
+                    const props = Object.entries( properties )
+                      .filter( ( [ , value ] ) => value !== undefined && value !== null && value !== '' )
+                      .map( ( [ key, value ] ) => `${ key }=${ escapeProperty( value ) }` )
+                      .join( ',' );
+
+                    console.log( `::${ command } ${ props }::${ escapeData( decodeHtmlEntities( message ) ) }` );
+                  };
+
+                  let errors = 0;
+                  let warnings = 0;
+
+                  for ( let index = 0; index < lines.length - 1; index++ ) {
+                    const line = lines[ index ];
+
+                    if ( ! line.startsWith( 'FILE: ' ) ) {
+                      continue;
+                    }
+
+                    const file = line.slice( 6 );
+                    const results = JSON.parse( lines[ ++index ] || '[]' );
+
+                    for ( const result of results ) {
+                      if ( result.type === 'ERROR' ) {
+                        errors++;
+                      } else if ( result.type === 'WARNING' ) {
+                        warnings++;
+                      }
+
+                      annotate(
+                        result.type === 'ERROR' ? 'error' : 'warning',
+                        {
+                          file,
+                          line: result.line > 0 ? result.line : undefined,
+                          col: result.column > 0 ? result.column : undefined,
+                          title: result.code,
+                        },
+                        result.message
+                      );
+                    }
+                  }
+
+                  console.log( `Plugin Check found ${ errors } error(s) and ${ warnings } warning(s).` );
+
+                  if ( errors > 0 ) {
+                    process.exit( 1 );
+                  }
+                  NODE
+
+            - name: Upload Plugin Check results
+              if: ${{ always() }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: plugin-check-results
+                  path: ${{ runner.temp }}/plugin-check-results.txt
+                  if-no-files-found: ignore

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -162,6 +162,7 @@ jobs:
                   required_paths=(
                     cortext/cortext.php
                     cortext/readme.txt
+                    cortext/composer.json
                     cortext/vendor/autoload.php
                     cortext/build/index.js
                   )
@@ -177,7 +178,7 @@ jobs:
                   # catches local dev helpers, desktop-only files, WordPress
                   # core copies, and other files that should stay out of a
                   # plugin release.
-                  allowed='^cortext/(cortext\.php|readme\.txt|LICENSE)$|^cortext/(includes|templates|build|seed-assets|vendor|assets/brand)/'
+                  allowed='^cortext/(cortext\.php|readme\.txt|LICENSE|composer\.json)$|^cortext/(includes|templates|build|seed-assets|vendor|assets/brand)/'
                   if grep -v '/$' release-zip-contents.txt | grep -vE "$allowed" > release-zip-unexpected.txt; then
                     echo "::error::Release ZIP contains files outside the runtime allowlist"
                     cat release-zip-unexpected.txt

--- a/includes/FieldValues/FieldValueIndex.php
+++ b/includes/FieldValues/FieldValueIndex.php
@@ -625,7 +625,7 @@ final class FieldValueIndex {
 
 		$table = $this->table_name();
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Benchmark reads hit the derived index directly; the table name comes from this plugin.
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT n.row_id
@@ -662,7 +662,7 @@ final class FieldValueIndex {
 
 		$table = $this->table_name();
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Benchmark reads hit the derived index directly; the table name comes from this plugin.
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT row_id
@@ -690,7 +690,7 @@ final class FieldValueIndex {
 
 		$table = $this->table_name();
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Benchmark reads hit the derived index directly; the table name comes from this plugin.
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT row_id
@@ -727,7 +727,7 @@ final class FieldValueIndex {
 
 		$table = $this->table_name();
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Benchmark reads hit the derived index directly; the table name comes from this plugin.
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT d.row_id
@@ -776,7 +776,7 @@ final class FieldValueIndex {
 		$args         = array_merge( array( $collection_id ), $field_ids, array( $like, $limit ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Benchmark reads hit the derived index directly; the table name comes from this plugin.
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT DISTINCT row_id
@@ -820,7 +820,7 @@ final class FieldValueIndex {
 		$args         = array_merge( array( $collection_id ), $field_ids, array( $like, $number_field_id, $minimum, $select_field_id, $select_value, $limit ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Benchmark reads hit the derived index directly; the table name comes from this plugin.
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT DISTINCT t.row_id
@@ -855,7 +855,7 @@ final class FieldValueIndex {
 		$function = 'count' === $operation ? 'COUNT(value_number)' : 'COALESCE(SUM(value_number), 0)';
 		$table    = $this->table_name();
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Benchmark reads hit the derived index directly; table and aggregate SQL come from fixed plugin code.
 		$value = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT {$function}
@@ -880,7 +880,7 @@ final class FieldValueIndex {
 
 		$table = $this->table_name();
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Benchmark reads directly from the derived index.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Benchmark reads hit the derived index directly; the table name comes from this plugin.
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*)
@@ -1111,7 +1111,7 @@ final class FieldValueIndex {
 
 		$table = $this->table_name();
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Verification compares the derived index to the postmeta source of truth.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Verification compares the derived index with postmeta; the table name comes from this plugin.
 		return $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT row_id, collection_id, field_id, value_seq, value_text, value_number, value_date, post_status

--- a/includes/FieldValues/FieldValueReadQuery.php
+++ b/includes/FieldValues/FieldValueReadQuery.php
@@ -571,7 +571,7 @@ final class FieldValueReadQuery {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$count_sql = "SELECT COUNT(DISTINCT p.ID) FROM {$from} {$joins} WHERE {$where}";
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Reads from the field-value index by design.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Reads through the field-value index; build_plan prepares the WHERE/JOIN pieces.
 		$total = $wpdb->get_var( $count_sql );
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( null === $total && '' !== $wpdb->last_error ) {
@@ -595,7 +595,7 @@ final class FieldValueReadQuery {
 			$per_page,
 			$offset
 		);
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Reads from the field-value index by design.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Reads through the field-value index; build_plan prepares the WHERE/JOIN pieces.
 		$ids = $wpdb->get_col( $id_sql );
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( ! is_array( $ids ) && '' !== $wpdb->last_error ) {
@@ -618,7 +618,7 @@ final class FieldValueReadQuery {
 				'post__in'         => $ids,
 				'orderby'          => 'post__in',
 				'posts_per_page'   => count( $ids ),
-				'suppress_filters' => true,
+				'suppress_filters' => false,
 			)
 		);
 

--- a/includes/PostType/Document.php
+++ b/includes/PostType/Document.php
@@ -786,7 +786,7 @@ final class Document {
 		if ( null !== $no_collections && '' !== (string) $no_collections && '0' !== (string) $no_collections ) {
 			$ids = TraitTaxonomy::all_trait_ids();
 			if ( array() !== $ids ) {
-				$args['post__not_in'] = array_merge( $args['post__not_in'] ?? array(), $ids );
+				$args['post__not_in'] = array_merge( $args['post__not_in'] ?? array(), $ids ); // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in -- Trait ids are one per collection, so this stays bounded.
 			}
 		}
 

--- a/includes/Relations.php
+++ b/includes/Relations.php
@@ -265,7 +265,7 @@ final class Relations {
 			if ( count( $removed ) > 0 ) {
 				$placeholders = implode( ',', array_fill( 0, count( $removed ), '%d' ) );
 				$args         = array_merge( array( $row_id, $key ), array_map( 'strval', $removed ) );
-				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders, PluginCheck.Security.DirectDB.UnescapedDBParameter
 				$wpdb->query(
 					$wpdb->prepare(
 						"DELETE FROM {$wpdb->postmeta}
@@ -287,7 +287,7 @@ final class Relations {
 					$args[] = $key;
 					$args[] = (string) $value;
 				}
-				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders, PluginCheck.Security.DirectDB.UnescapedDBParameter
 				$wpdb->query(
 					$wpdb->prepare(
 						"INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value) VALUES {$placeholders}",
@@ -424,7 +424,7 @@ final class Relations {
 		$placeholders = implode( ',', array_fill( 0, count( $targets ), '%d' ) );
 		$args         = array_merge( array( $key, (string) $row_id ), $targets );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->postmeta}
@@ -464,7 +464,7 @@ final class Relations {
 			// so the (target, reverse_key, row_id) row is the only one left.
 			$placeholders = implode( ',', array_fill( 0, count( $targets ), '%d' ) );
 			$args         = array_merge( array( $key ), $targets );
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders, PluginCheck.Security.DirectDB.UnescapedDBParameter
 			$wpdb->query(
 				$wpdb->prepare(
 					"DELETE FROM {$wpdb->postmeta}
@@ -501,7 +501,7 @@ final class Relations {
 			$args[] = $value;
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQLPlaceholders, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$wpdb->query(
 			$wpdb->prepare(
 				"INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value) VALUES {$placeholders}",

--- a/scripts/build-zip.sh
+++ b/scripts/build-zip.sh
@@ -45,7 +45,7 @@ composer install \
 	--optimize-autoloader \
 	--no-interaction
 
-rm -f "${stage_dir}/composer.json" "${stage_dir}/composer.lock"
+rm -f "${stage_dir}/composer.lock"
 
 (
 	cd "$dist_dir"


### PR DESCRIPTION
## What

Part of #285.

Follow-up to #332, #337, and #339. Addresses the findings from [Plugin Check run 26818501074](https://github.com/Automattic/cortext/actions/runs/26818501074), specifically the [Plugin Check job](https://github.com/Automattic/cortext/actions/runs/26818501074/job/79066403183).

The plugin ZIP now keeps `composer.json` alongside `vendor/`, indexed row hydration no longer skips WordPress filters, and the remaining SQL findings are documented where the queries are already prepared.

## Why

This clears the last Plugin Check findings from the WordPress.org submission pass without changing the indexed reads themselves.

## How

- Keeping `composer.json` in the release ZIP and allowlist.
- Switching indexed row hydration to `suppress_filters => false`.
- Adding targeted PHPCS ignores for prepared SQL patterns Plugin Check cannot infer.

## Testing Instructions

1. Open the Plugin Check workflow in GitHub Actions.
2. Run it against `priethor/fix/plugin-check-results`.
3. Confirm it completes with no Plugin Check findings.

