### PR TITLE
Fix: properly quit desktop app on close

### DIFF
--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -116,9 +116,7 @@ app.whenReady().then( () => {
 app.on( 'window-all-closed', () => {
 	quitting = true;
 	stopRuntime( runtimeHandle );
-	if ( process.platform !== 'darwin' ) {
-		app.quit();
-	}
+	app.quit();
 } );
 
 app.on( 'before-quit', () => {

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -1,8 +1,8 @@
 /**
- * Smoke test for desktop startup.
+ * Smoke test for desktop launch.
  *
- * This only checks the path a user hits on launch: extract the snapshot,
- * start PHP, open BrowserWindow, and mount the Cortext shell. Editor flows
+ * This follows the first thing a user sees: extract the snapshot, start PHP,
+ * open the window, and paint the first Cortext document. Deeper editor flows
  * can move here once the desktop surface settles.
  *
  * Requires `apps/desktop/snapshot.zip` to exist before running. CI builds
@@ -46,27 +46,88 @@ test.beforeAll( () => {
 	}
 } );
 
-test( 'launches and loads the Cortext shell', async () => {
-	const app = await electron.launch( {
+function launchDesktopApp() {
+	return electron.launch( {
 		args: [ APP_PATH ],
 		env: {
 			...process.env,
 			CORTEXT_DEVTOOLS: '0',
 		},
 	} );
+}
+
+async function waitForCortextShell( app ) {
+	const window = await app.firstWindow();
+	// The window starts on `loading.html`, then moves to wp-admin once PHP is
+	// ready. Wait for that hop before reading the DOM.
+	await window.waitForURL( /admin\.php\?page=cortext/, {
+		timeout: 90 * 1000,
+	} );
+	await expect( window.locator( '#cortext-root' ) ).toBeVisible( {
+		timeout: 30 * 1000,
+	} );
+	await expect(
+		window.locator(
+			'.cortext-workspace__pane[data-active="true"] .cortext-canvas__loading'
+		)
+	).toHaveCount( 0, { timeout: 30 * 1000 } );
+	await expect(
+		window.locator(
+			'.cortext-workspace__pane[data-active="true"] .cortext-canvas'
+		)
+	).toBeVisible( { timeout: 30 * 1000 } );
+	return window;
+}
+
+function waitForProcessExit( app, timeoutMs = 10000 ) {
+	const child = app.process();
+	return new Promise( ( resolve, reject ) => {
+		if ( child.exitCode !== null || child.signalCode !== null ) {
+			resolve();
+			return;
+		}
+
+		const onExit = () => {
+			clearTimeout( timer );
+			resolve();
+		};
+		const timer = setTimeout( () => {
+			child.off( 'exit', onExit );
+			reject(
+				new Error(
+					`Electron stayed open for more than ${ timeoutMs }ms.`
+				)
+			);
+		}, timeoutMs );
+
+		child.once( 'exit', onExit );
+	} );
+}
+
+test( 'opens the first Cortext document', async () => {
+	const app = await launchDesktopApp();
 
 	try {
-		const window = await app.firstWindow();
-		// The window starts on `loading.html`. After PHP comes up, main.js
-		// sends it to wp-admin. Wait for that navigation before reading the DOM.
-		await window.waitForURL( /admin\.php\?page=cortext/, {
-			timeout: 90 * 1000,
-		} );
-		await expect( window.locator( '#cortext-root' ) ).toBeVisible( {
-			timeout: 30 * 1000,
-		} );
+		const window = await waitForCortextShell( app );
 		await expect.poll( () => window.title() ).toBe( 'Cortext' );
 	} finally {
 		await app.close();
+	}
+} );
+
+test( 'exits after closing its only window', async () => {
+	const app = await launchDesktopApp();
+	let didExit = false;
+
+	try {
+		const window = await waitForCortextShell( app );
+		const exitPromise = waitForProcessExit( app );
+		await window.close();
+		await exitPromise;
+		didExit = true;
+	} finally {
+		if ( ! didExit ) {
+			await app.close();
+		}
 	}
 } );


### PR DESCRIPTION
## What

Part of #196.

Closing the last Cortext desktop window now quits the app instead of leaving it running in the background.

## Testing Instructions

1. Open the desktop app.
2. Close the Cortext window.
3. Check that the app has quit.
