### PR TITLE
Tooling: Fix desktop app release job

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -120,7 +120,7 @@ jobs:
               if: ${{ inputs.dry_run }}
               uses: actions/upload-artifact@v4
               with:
-                  name: cortext-desktop-dmg-${{ inputs.version }}
+                  name: cortext-desktop-dmg-${{ inputs.version }}-dry-run
                   path: apps/desktop/dist/*.dmg
                   if-no-files-found: error
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -94,6 +94,8 @@ jobs:
 
             - name: Build bundled arm64 PHP
               working-directory: apps/desktop
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
               run: npm run runtime:php
 
             - name: Cache snapshot downloads (WP core + wp-cli + SQLite plugin)

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -121,7 +121,7 @@ jobs:
 
                   ## Opening the macOS app
 
-                  This DMG isn't signed yet, so macOS warns you the first time you open it. Move Cortext to Applications, then open it from System Settings > Privacy & Security > "Open Anyway", or run `xattr -dr com.apple.quarantine /Applications/Cortext.app` once.
+                  This DMG is unsigned, so macOS may show a "Cortext is damaged" warning the first time you open it. Move Cortext to Applications. If that warning appears, click Cancel, open Terminal, and run `xattr -dr com.apple.quarantine /Applications/Cortext.app && open /Applications/Cortext.app`.
                   EOF
 
             - name: Build plugin ZIP

--- a/apps/desktop/scripts/install-runtime.mjs
+++ b/apps/desktop/scripts/install-runtime.mjs
@@ -116,6 +116,16 @@ function platformKey() {
 	throw new Error( `Unsupported macOS architecture: ${ process.arch }.` );
 }
 
+function spcPackageRoot() {
+	if ( process.arch === 'arm64' ) {
+		return 'aarch64-darwin';
+	}
+	if ( process.arch === 'x64' ) {
+		return 'x86_64-darwin';
+	}
+	throw new Error( `Unsupported macOS architecture: ${ process.arch }.` );
+}
+
 function frankenPlatformName() {
 	return platformKey() === 'macos-aarch64' ? 'mac-arm64' : 'mac-x86_64';
 }
@@ -331,6 +341,16 @@ async function installPhp( options ) {
 	}
 
 	if ( ! existsSync( builtPhp ) || options.rebuild ) {
+		const pkgConfig = resolve(
+			spcDir,
+			'pkgroot',
+			spcPackageRoot(),
+			'bin/pkg-config'
+		);
+		if ( ! existsSync( pkgConfig ) ) {
+			run( spcBin, [ 'install-pkg', 'pkg-config' ], { cwd: spcDir } );
+		}
+
 		const extensionList = phpExtensions().join( ',' );
 		const buildArgs = [ 'build', extensionList, '--build-cli' ];
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -123,9 +123,10 @@ that already exists.
 ## Desktop app
 
 The desktop release builds a macOS DMG with electron-builder and attaches it to
-the same Release as the plugin ZIP. It is arm64 only and unsigned for now.
-Because it is unsigned, macOS warns on first launch, so the release notes tell
-people to open it from System Settings > Privacy & Security > "Open Anyway", or
-to run `xattr -dr com.apple.quarantine /Applications/Cortext.app` once. The
-installed app checks GitHub Releases on launch and links to the download when a
-newer version exists, but it does not update itself.
+the same Release as the plugin ZIP. The build is arm64-only and unsigned for
+now, so macOS may show a "Cortext is damaged" warning the first time it opens.
+Release notes should tell people to move Cortext to Applications. If the warning
+appears, they should click Cancel, open Terminal, and run
+`xattr -dr com.apple.quarantine /Applications/Cortext.app && open /Applications/Cortext.app`.
+The installed app checks GitHub Releases on launch and links to the download
+when a newer version exists, but it does not update itself.


### PR DESCRIPTION
## What

Part of #196.

Fix the desktop release job on fresh macOS runners that happened in https://github.com/Automattic/cortext/actions/runs/26823593548/job/79084671451

The PHP runtime build now has what it needs to download and build cleanly. This also labels dry-run DMGs clearly and updates the beta install note for the unsigned macOS app.

## How

- Pass the workflow token to static-php-cli downloads.
- Install static-php-cli's `pkg-config` package when it is missing.
- Add `-dry-run` to dry-run DMG artifact names.

## Testing Instructions

1. Run Prepare release from this branch with `dry_run` enabled.
2. Confirm both jobs pass and the desktop dry-run artifact includes `-dry-run` in its name.
3. Download the DMG, move Cortext to Applications, and use the release-note command if macOS shows the damaged-app warning.

