### PR TITLE
Fix: media picker in Playground

### DIFF
--- a/src/components/MediaPicker.js
+++ b/src/components/MediaPicker.js
@@ -1,18 +1,46 @@
 import { useCallback } from '@wordpress/element';
 import { MediaUploadCheck } from '@wordpress/block-editor';
 
-// Resolves to the host document's `wp` global. Inside the BlockCanvas iframe
-// `window.wp.media` is undefined (wp_enqueue_media() only loads media-views in
-// the parent), so we walk up to `window.parent` when needed. Returns null when
-// the host has not loaded media-views (for example a screen that did not call
-// wp_enqueue_media()); callers should treat the trigger as a no-op.
-function getHostWp() {
-	if ( typeof window === 'undefined' ) {
+function readWindowWp( candidate ) {
+	try {
+		return candidate?.wp ?? null;
+	} catch {
 		return null;
 	}
-	const host =
-		window.parent && window.parent !== window ? window.parent : window;
-	return host?.wp ?? null;
+}
+
+function readWindowParent( candidate ) {
+	try {
+		return candidate?.parent ?? null;
+	} catch {
+		return null;
+	}
+}
+
+// Find the closest window that actually has wp.media. In the block canvas that
+// is usually the parent; in Playground it can be the current wp-admin iframe.
+export function getHostWp(
+	startWindow = typeof window === 'undefined' ? null : window
+) {
+	let candidate = startWindow;
+	const visited = new Set();
+
+	while ( candidate && ! visited.has( candidate ) ) {
+		visited.add( candidate );
+
+		const wp = readWindowWp( candidate );
+		if ( wp?.media ) {
+			return wp;
+		}
+
+		const parent = readWindowParent( candidate );
+		if ( ! parent || parent === candidate ) {
+			break;
+		}
+		candidate = parent;
+	}
+
+	return null;
 }
 
 // Drop-in alternative to `<MediaUpload>` from `@wordpress/block-editor`

--- a/tests/js/components/MediaPicker.test.js
+++ b/tests/js/components/MediaPicker.test.js
@@ -1,0 +1,45 @@
+jest.mock( '@wordpress/block-editor', () => ( {
+	MediaUploadCheck: ( { children } ) => children,
+} ) );
+
+import { getHostWp } from '../../../src/components/MediaPicker';
+
+describe( 'getHostWp', () => {
+	it( 'uses media from the current window first', () => {
+		const currentWp = { media: jest.fn() };
+		const parentWp = { media: jest.fn() };
+		const parentWindow = { wp: parentWp };
+		parentWindow.parent = parentWindow;
+
+		const currentWindow = {
+			wp: currentWp,
+			parent: parentWindow,
+		};
+
+		expect( getHostWp( currentWindow ) ).toBe( currentWp );
+	} );
+
+	it( 'falls back to the parent window', () => {
+		const parentWp = { media: jest.fn() };
+		const parentWindow = { wp: parentWp };
+		parentWindow.parent = parentWindow;
+
+		const currentWindow = {
+			wp: {},
+			parent: parentWindow,
+		};
+
+		expect( getHostWp( currentWindow ) ).toBe( parentWp );
+	} );
+
+	it( 'does not crash on cross-origin parents', () => {
+		const currentWindow = {
+			wp: {},
+			get parent() {
+				throw new Error( 'Cross-origin parent' );
+			},
+		};
+
+		expect( getHostWp( currentWindow ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
## What

Part of #284.

Fixes the cover and icon image picker when Cortext is running in WordPress Playground.

The picker now opens the media library in Playground and still works from the block editor iframe.

## Why

Playground wraps wp-admin in its own iframe, so the old lookup could end up checking the wrong window for `wp.media`.

## Testing Instructions

1. Open Cortext in WordPress Playground: https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/cortext/main/playground/blueprint.json
2. Click Add cover and confirm the media library opens.
3. Click Add icon, switch to Upload, and confirm Open media library opens the picker.

