### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
-    groups:
-      actions-minor-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-      actions-major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
-    cooldown:
-      default-days: 7
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+      open-pull-requests-limit: 10
+      groups:
+          actions-minor-patch:
+              patterns:
+                  - '*'
+              update-types:
+                  - 'minor'
+                  - 'patch'
+          actions-major:
+              patterns:
+                  - '*'
+              update-types:
+                  - 'major'
+      cooldown:
+          default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -56,7 +56,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.3'
                   extensions: pdo_sqlite, sqlite3, mbstring, json, curl, openssl
@@ -70,7 +70,7 @@ jobs:
 
             - run: composer install --no-interaction --prefer-dist --no-dev
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.1'
                   tools: composer:v2
@@ -69,7 +69,7 @@ jobs:
 
             - run: composer install --no-interaction --prefer-dist --no-dev
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true

--- a/.github/workflows/perf-bench.yml
+++ b/.github/workflows/perf-bench.yml
@@ -29,7 +29,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.1'
                   tools: composer:v2
@@ -40,7 +40,7 @@ jobs:
                   path: ~/.composer/cache
                   key: composer-${{ hashFiles('composer.lock') }}
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -15,7 +15,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true
@@ -25,7 +25,7 @@ jobs:
                   node-version: '24.15'
                   cache: 'pnpm'
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.1'
                   tools: composer:v2
@@ -62,7 +62,7 @@ jobs:
             # .wp-env.json. Keep the env local, then install Plugin Check with
             # WP-CLI once WordPress is running.
             - name: Start wp-env
-              uses: nick-fields/retry@v4
+              uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
               with:
                   timeout_minutes: 10
                   max_attempts: 3

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -45,7 +45,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true
@@ -55,7 +55,7 @@ jobs:
                   node-version: '24.15'
                   cache: 'pnpm'
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.1'
                   tools: composer:v2
@@ -128,7 +128,7 @@ jobs:
             # the plugin workflow stays the owner of the Release title and notes.
             - name: Attach DMG to draft GitHub Release
               if: ${{ ! inputs.dry_run }}
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
               with:
                   tag_name: ${{ inputs.version }}
                   draft: true

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -46,7 +46,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true
@@ -56,7 +56,7 @@ jobs:
                   node-version: '24.15'
                   cache: 'pnpm'
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.1'
                   tools: composer:v2
@@ -231,7 +231,7 @@ jobs:
 
             - name: Create or update draft GitHub Release
               if: ${{ ! inputs.dry_run }}
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
               with:
                   tag_name: ${{ inputs.version }}
                   name: ${{ inputs.version }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,7 +16,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true
@@ -37,7 +37,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.1'
                   tools: composer:v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -63,7 +63,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: shivammathur/setup-php@v2
+            - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '8.1'
                   tools: composer:v2
@@ -86,7 +86,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 11.0.8
                   standalone: true


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

Tracking: DEVPROD-1072

Changes:
- Pins 4 distinct third-party action refs to full commit SHAs with readable version comments.
- Updates: .github/dependabot.yml, .github/workflows/build.yml, .github/workflows/desktop-e2e.yml, .github/workflows/e2e.yml, .github/workflows/perf-bench.yml, .github/workflows/plugin-check.yml, .github/workflows/release-desktop.yml, .github/workflows/release-plugin.yml, .github/workflows/static.yml, .github/workflows/unit-tests.yml
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)

Verification commands:

```bash
# nick-fields/retry # v4.0.0 -> ad984534de44a9489a53aefd81eb77f87c70dc60
gh api repos/nick-fields/retry/commits/v4.0.0 --jq '.sha'
# expected: ad984534de44a9489a53aefd81eb77f87c70dc60

# pnpm/action-setup # v4.3.0 -> b906affcce14559ad1aafd4ab0e942779e9f58b1
gh api repos/pnpm/action-setup/commits/v4.3.0 --jq '.sha'
# expected: b906affcce14559ad1aafd4ab0e942779e9f58b1

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# softprops/action-gh-release # v2.6.2 -> 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
gh api repos/softprops/action-gh-release/commits/v2.6.2 --jq '.sha'
# expected: 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
```
