### PR TITLE
Offer demo content from an empty workspace

### DIFF
--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -17,10 +17,8 @@ use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
 use Cortext\Relations;
 use Cortext\Taxonomy\TraitTaxonomy;
-use WP_CLI;
-use WP_CLI_Command;
 
-final class SeedDummyCollections extends WP_CLI_Command {
+final class SeedDummyCollections {
 
 	private const WORKSPACE_HOME_META_KEY = 'cortext_workspace_home';
 	private const FAVORITES_META_KEY      = 'cortext_favorites';
@@ -29,6 +27,20 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 	private bool $seed_full_dataset = false;
 	private bool $fetch_real_images = false;
+	private array $messages         = array();
+
+	/**
+	 * Runs the compact offline sample seed and returns log messages for
+	 * non-CLI callers such as the onboarding REST endpoint.
+	 *
+	 * @return array<int,array{level:string,message:string}>
+	 */
+	public function seed_sample_content(): array {
+		$this->messages = array();
+		$this->__invoke( array(), array() );
+
+		return $this->messages;
+	}
 
 	/**
 	 * Seeds connected sample collections (books/authors/publishers,
@@ -96,19 +108,19 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
-		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'prefetch-icons', false ) ) {
-			$this->seed_full_dataset = WP_CLI\Utils\get_flag_value( $assoc_args, 'full', false );
+		if ( self::get_flag_value( $assoc_args, 'prefetch-icons', false ) ) {
+			$this->seed_full_dataset = self::get_flag_value( $assoc_args, 'full', false );
 			$this->prefetch_icons();
 			return;
 		}
 
-		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'prefetch-covers', false ) ) {
-			$this->seed_full_dataset = WP_CLI\Utils\get_flag_value( $assoc_args, 'full', false );
+		if ( self::get_flag_value( $assoc_args, 'prefetch-covers', false ) ) {
+			$this->seed_full_dataset = self::get_flag_value( $assoc_args, 'full', false );
 			$this->prefetch_covers();
 			return;
 		}
 
-		$this->fetch_real_images = WP_CLI\Utils\get_flag_value( $assoc_args, 'with-real-images', false );
+		$this->fetch_real_images = self::get_flag_value( $assoc_args, 'with-real-images', false );
 
 		// Run as an administrator so seeded entries get a real `post_author`
 		// (otherwise CLI's user-0 context produces empty Created by /
@@ -117,12 +129,12 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		$seed_user_id = $this->default_seed_user_id();
 		wp_set_current_user( $seed_user_id );
 
-		$this->seed_full_dataset = WP_CLI\Utils\get_flag_value( $assoc_args, 'full', false );
+		$this->seed_full_dataset = self::get_flag_value( $assoc_args, 'full', false );
 
-		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'reset', false ) ) {
-			WP_CLI::confirm(
+		if ( self::get_flag_value( $assoc_args, 'reset', false ) ) {
+			$this->confirm(
 				'This will delete all Cortext collections, fields, entries, pages, workspace home preferences, and sidebar favorites. Continue?',
-				array( 'yes' => WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false ) )
+				array( 'yes' => self::get_flag_value( $assoc_args, 'force', false ) )
 			);
 			$this->reset();
 		}
@@ -133,15 +145,15 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			$this->work_collections()
 		);
 		if ( $this->seed_full_dataset ) {
-			WP_CLI::log( 'Seeding full sample dataset.' );
+			$this->log( 'Seeding full sample dataset.' );
 		} else {
-			WP_CLI::log( 'Seeding compact sample dataset. Pass --full to include every sample row.' );
+			$this->log( 'Seeding compact sample dataset. Pass --full to include every sample row.' );
 			$collections = $this->compact_collection_entries( $collections );
 		}
 		if ( $this->fetch_real_images ) {
-			WP_CLI::log( 'Row images: bundle first, then live Wikimedia Commons / Open Library / Cover Art Archive for misses (per-file license, see each source).' );
+			$this->log( 'Row images: bundle first, then live Wikimedia Commons / Open Library / Cover Art Archive for misses (per-file license, see each source).' );
 		} else {
-			WP_CLI::log( 'Row images: bundle only (offline). Pass --with-real-images for live Wikimedia / Open Library / Cover Art Archive lookups, or --prefetch-icons to extend the bundle.' );
+			$this->log( 'Row images: bundle only (offline). Pass --with-real-images for live Wikimedia / Open Library / Cover Art Archive lookups, or --prefetch-icons to extend the bundle.' );
 		}
 
 		$collection_ids = array();
@@ -164,7 +176,83 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		$this->seed_workspace_home( $seed_user_id, $workspace_page_id );
 		$this->seed_favorites( $seed_user_id, $workspace_page_id );
 
-		WP_CLI::success( 'Seeding complete.' );
+		$this->success( 'Seeding complete.' );
+	}
+
+	/**
+	 * Lightweight flag reader so the seeder can run both under WP-CLI and REST.
+	 *
+	 * @param array<string,mixed> $assoc_args Associative arguments.
+	 * @param string              $name       Flag name.
+	 * @param mixed               $fallback   Fallback value.
+	 */
+	private static function get_flag_value( array $assoc_args, string $name, mixed $fallback = false ): mixed {
+		if ( function_exists( 'WP_CLI\\Utils\\get_flag_value' ) ) {
+			return \WP_CLI\Utils\get_flag_value( $assoc_args, $name, $fallback );
+		}
+
+		return array_key_exists( $name, $assoc_args ) ? $assoc_args[ $name ] : $fallback;
+	}
+
+	/**
+	 * Confirms destructive CLI-only actions.
+	 *
+	 * @param string              $message Confirmation message.
+	 * @param array<string,mixed> $options Confirmation options.
+	 * @throws \RuntimeException When confirmation is required outside WP-CLI.
+	 */
+	private function confirm( string $message, array $options = array() ): void {
+		if ( class_exists( '\WP_CLI' ) ) {
+			\WP_CLI::confirm( $message, $options );
+			return;
+		}
+
+		if ( empty( $options['yes'] ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message is returned to REST/CLI callers, not rendered here.
+			throw new \RuntimeException( $message );
+		}
+	}
+
+	private function log( string $message ): void {
+		$this->messages[] = array(
+			'level'   => 'info',
+			'message' => $message,
+		);
+
+		if ( class_exists( '\WP_CLI' ) ) {
+			\WP_CLI::log( $message );
+		}
+	}
+
+	private function warning( string $message ): void {
+		$this->messages[] = array(
+			'level'   => 'warning',
+			'message' => $message,
+		);
+
+		if ( class_exists( '\WP_CLI' ) ) {
+			\WP_CLI::warning( $message );
+		}
+	}
+
+	private function success( string $message ): void {
+		$this->messages[] = array(
+			'level'   => 'success',
+			'message' => $message,
+		);
+
+		if ( class_exists( '\WP_CLI' ) ) {
+			\WP_CLI::success( $message );
+		}
+	}
+
+	private function error( string $message ): void {
+		if ( class_exists( '\WP_CLI' ) ) {
+			\WP_CLI::error( $message );
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message is returned to REST/CLI callers, not rendered here.
+		throw new \RuntimeException( $message );
 	}
 
 	/**
@@ -220,6 +308,11 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	 * have a recognizable `post_author` and `_modified_by`.
 	 */
 	private function default_seed_user_id(): int {
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id > 0 ) {
+			return $current_user_id;
+		}
+
 		$users = get_users(
 			array(
 				'role'   => 'administrator',
@@ -3611,7 +3704,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		$page_id          = $this->find_seed_page_tree_candidate( $candidate_titles, $parent_id );
 
 		if ( $page_id > 0 ) {
-			WP_CLI::log( "Page '{$node['title']}' already exists (ID {$page_id})." );
+			$this->log( "Page '{$node['title']}' already exists (ID {$page_id})." );
 
 			$page            = get_post( $page_id );
 			$content_version = (string) get_post_meta( $page_id, '_cortext_seed_content_version', true );
@@ -3630,7 +3723,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 					$update['post_content'] = $node['content'];
 				}
 				wp_update_post( $update );
-				WP_CLI::log( "Updated page '{$node['title']}' with current sample content." );
+				$this->log( "Updated page '{$node['title']}' with current sample content." );
 			}
 		} else {
 			$page_id = wp_insert_post(
@@ -3645,10 +3738,10 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			);
 
 			if ( is_wp_error( $page_id ) ) {
-				WP_CLI::error( "Failed to create page '{$node['title']}': " . $page_id->get_error_message() );
+				$this->error( "Failed to create page '{$node['title']}': " . $page_id->get_error_message() );
 			}
 
-			WP_CLI::log( "Created page '{$node['title']}' (ID {$page_id})." );
+			$this->log( "Created page '{$node['title']}' (ID {$page_id})." );
 		}
 
 		if ( ! empty( $node['icon'] ) ) {
@@ -3748,7 +3841,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 					continue;
 				}
 				wp_trash_post( $id );
-				WP_CLI::log( "Moved obsolete sample page '{$title}' to trash (ID {$id})." );
+				$this->log( "Moved obsolete sample page '{$title}' to trash (ID {$id})." );
 			}
 		}
 	}
@@ -3806,13 +3899,13 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 		$current = get_user_meta( $user_id, self::WORKSPACE_HOME_META_KEY, true );
 		if ( is_string( $current ) && '' !== $current && $this->workspace_home_exists( $current ) ) {
-			WP_CLI::log( 'Workspace home already exists. Skipping.' );
+			$this->log( 'Workspace home already exists. Skipping.' );
 			return;
 		}
 
 		update_user_meta( $user_id, self::WORKSPACE_HOME_META_KEY, "page:{$page_id}" );
 		$page_title = get_the_title( $page_id );
-		WP_CLI::log( "Set workspace home to page '{$page_title}' (ID {$page_id})." );
+		$this->log( "Set workspace home to page '{$page_title}' (ID {$page_id})." );
 	}
 
 	private function workspace_home_exists( string $raw ): bool {
@@ -3849,7 +3942,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	private function seed_favorites( int $user_id, int $workspace_page_id ): void {
 		$current = get_user_meta( $user_id, self::FAVORITES_META_KEY, true );
 		if ( $this->favorites_exist( $current ) ) {
-			WP_CLI::log( 'Favorites already exist. Skipping.' );
+			$this->log( 'Favorites already exist. Skipping.' );
 			return;
 		}
 
@@ -3878,12 +3971,12 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		if ( ! $favorites ) {
-			WP_CLI::warning( 'No valid favorites were found to seed.' );
+			$this->warning( 'No valid favorites were found to seed.' );
 			return;
 		}
 
 		update_user_meta( $user_id, self::FAVORITES_META_KEY, $favorites );
-		WP_CLI::log( sprintf( 'Seeded %d sidebar favorites.', count( $favorites ) ) );
+		$this->log( sprintf( 'Seeded %d sidebar favorites.', count( $favorites ) ) );
 	}
 
 	/**
@@ -4080,7 +4173,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 		$tmp = download_url( $url, 30 );
 		if ( is_wp_error( $tmp ) ) {
-			WP_CLI::warning( "Failed to download icon from {$url}: " . $tmp->get_error_message() );
+			$this->warning( "Failed to download icon from {$url}: " . $tmp->get_error_message() );
 			return 0;
 		}
 
@@ -4179,7 +4272,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	private function prefetch_icons(): void {
 		$bundle_dir = CORTEXT_PATH . 'seed-assets/icons';
 		if ( ! is_dir( $bundle_dir ) && ! wp_mkdir_p( $bundle_dir ) ) {
-			WP_CLI::error( "Failed to create {$bundle_dir}" );
+			$this->error( "Failed to create {$bundle_dir}" );
 		}
 
 		$collections = array_merge(
@@ -4216,7 +4309,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				}
 				$tmp = download_url( $url, 30 );
 				if ( is_wp_error( $tmp ) ) {
-					WP_CLI::warning( "Failed to download icon for {$slug}/{$title}: " . $tmp->get_error_message() );
+					$this->warning( "Failed to download icon for {$slug}/{$title}: " . $tmp->get_error_message() );
 					++$missed;
 					continue;
 				}
@@ -4224,18 +4317,18 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				if ( ! @copy( $tmp, $dest ) ) {
 					// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
 					@unlink( $tmp );
-					WP_CLI::warning( "Failed to write {$dest}" );
+					$this->warning( "Failed to write {$dest}" );
 					++$missed;
 					continue;
 				}
 				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
 				@unlink( $tmp );
 				++$downloaded;
-				WP_CLI::log( "Bundled {$slug}/{$title} -> " . basename( $dest ) );
+				$this->log( "Bundled {$slug}/{$title} -> " . basename( $dest ) );
 			}
 		}
 
-		WP_CLI::success(
+		$this->success(
 			sprintf(
 				'Prefetched %d / %d icons (%d already bundled, %d failed). Bundle directory: %s',
 				$downloaded,
@@ -4257,7 +4350,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	private function prefetch_covers(): void {
 		$bundle_dir = CORTEXT_PATH . 'seed-assets/covers';
 		if ( ! is_dir( $bundle_dir ) && ! wp_mkdir_p( $bundle_dir ) ) {
-			WP_CLI::error( "Failed to create {$bundle_dir}" );
+			$this->error( "Failed to create {$bundle_dir}" );
 		}
 
 		$collections = array_merge(
@@ -4297,7 +4390,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				}
 				$tmp = download_url( $url, 30 );
 				if ( is_wp_error( $tmp ) ) {
-					WP_CLI::warning( "Failed to download cover for {$slug}/{$title}: " . $tmp->get_error_message() );
+					$this->warning( "Failed to download cover for {$slug}/{$title}: " . $tmp->get_error_message() );
 					++$missed;
 					continue;
 				}
@@ -4305,18 +4398,18 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				if ( ! @copy( $tmp, $dest ) ) {
 					// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
 					@unlink( $tmp );
-					WP_CLI::warning( "Failed to write {$dest}" );
+					$this->warning( "Failed to write {$dest}" );
 					++$missed;
 					continue;
 				}
 				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
 				@unlink( $tmp );
 				++$downloaded;
-				WP_CLI::log( "Bundled cover {$slug}/{$title} -> " . basename( $dest ) );
+				$this->log( "Bundled cover {$slug}/{$title} -> " . basename( $dest ) );
 			}
 		}
 
-		WP_CLI::success(
+		$this->success(
 			sprintf(
 				'Prefetched %d / %d covers (%d already bundled, %d failed).',
 				$downloaded,
@@ -4602,7 +4695,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				);
 				if ( '' !== $icon_meta ) {
 					update_post_meta( $entry_id, DocumentIdentity::META_KEY, $icon_meta );
-					WP_CLI::log( sprintf( '  Icon (bundle) attached to entry %d.', $entry_id ) );
+					$this->log( sprintf( '  Icon (bundle) attached to entry %d.', $entry_id ) );
 				}
 				return;
 			}
@@ -4629,7 +4722,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		if ( '' !== $icon_meta ) {
 			update_post_meta( $entry_id, DocumentIdentity::META_KEY, $icon_meta );
 			$source = $this->row_icon_source_label( $icon_url );
-			WP_CLI::log( sprintf( '  Icon (%s) attached to entry %d.', $source, $entry_id ) );
+			$this->log( sprintf( '  Icon (%s) attached to entry %d.', $source, $entry_id ) );
 		}
 	}
 
@@ -4696,7 +4789,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			$cover_id = $this->ensure_attachment_from_path( $path );
 			if ( $cover_id > 0 ) {
 				update_post_meta( $entry_id, '_thumbnail_id', $cover_id );
-				WP_CLI::log( sprintf( '  Cover (bundle) attached to entry %d.', $entry_id ) );
+				$this->log( sprintf( '  Cover (bundle) attached to entry %d.', $entry_id ) );
 			}
 			return;
 		}
@@ -4714,7 +4807,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		if ( $cover_id > 0 ) {
 			update_post_meta( $entry_id, '_thumbnail_id', $cover_id );
 			$source = false !== strpos( $url, 'openlibrary.org' ) ? 'open-library' : 'cover-art-archive';
-			WP_CLI::log( sprintf( '  Cover (%s) attached to entry %d.', $source, $entry_id ) );
+			$this->log( sprintf( '  Cover (%s) attached to entry %d.', $source, $entry_id ) );
 			return;
 		}
 
@@ -4744,7 +4837,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		$cover_id = $this->ensure_attachment_from_path( $path );
 		if ( $cover_id > 0 ) {
 			update_post_meta( $entry_id, '_thumbnail_id', $cover_id );
-			WP_CLI::log( sprintf( '  Cover (album icon bundle) attached to entry %d.', $entry_id ) );
+			$this->log( sprintf( '  Cover (album icon bundle) attached to entry %d.', $entry_id ) );
 		}
 	}
 
@@ -5160,7 +5253,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 		if ( $existing ) {
 			$collection_id = $existing[0]->ID;
-			WP_CLI::log( "Collection '{$spec['title']}' already exists (ID {$collection_id})." );
+			$this->log( "Collection '{$spec['title']}' already exists (ID {$collection_id})." );
 		} else {
 			$collection_id = wp_insert_post(
 				array(
@@ -5172,11 +5265,11 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			);
 
 			if ( is_wp_error( $collection_id ) ) {
-				WP_CLI::error( "Failed to create collection '{$spec['title']}': " . $collection_id->get_error_message() );
+				$this->error( "Failed to create collection '{$spec['title']}': " . $collection_id->get_error_message() );
 			}
 
 			update_post_meta( $collection_id, 'cortext_seed_slug', $slug );
-			WP_CLI::log( "Created collection '{$spec['title']}' (ID {$collection_id})." );
+			$this->log( "Created collection '{$spec['title']}' (ID {$collection_id})." );
 		}
 
 		// In the universal-document model rows live in `crtxt_document`, which
@@ -5214,7 +5307,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 					delete_post_meta( $found, 'number_format' );
 				}
 				$field_ids[ $title ] = $found;
-				WP_CLI::log( "Field '{$title}' already exists (ID {$found}); refreshed seed metadata." );
+				$this->log( "Field '{$title}' already exists (ID {$found}); refreshed seed metadata." );
 				continue;
 			}
 
@@ -5228,7 +5321,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			);
 
 			if ( is_wp_error( $field_id ) ) {
-				WP_CLI::error( "Failed to create field '{$title}': " . $field_id->get_error_message() );
+				$this->error( "Failed to create field '{$title}': " . $field_id->get_error_message() );
 			}
 
 			update_post_meta( $field_id, 'type', $type );
@@ -5240,7 +5333,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			}
 			add_post_meta( $collection_id, 'cortext_fields', $field_id );
 			$field_ids[ $title ] = $field_id;
-			WP_CLI::log( "Created field '{$title}' (ID {$field_id}, type: {$type})." );
+			$this->log( "Created field '{$title}' (ID {$field_id}, type: {$type})." );
 		}
 
 		// 4. Register field meta on the entry CPT (safe to call repeatedly).
@@ -5312,7 +5405,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				$this->update_entry_content( $existing_entry_id, $entry_content );
 				$this->maybe_apply_row_icon( $existing_entry_id, $spec['slug'], $entry_title );
 				$this->maybe_apply_row_cover( $existing_entry_id, $spec['slug'], $entry_title );
-				WP_CLI::log( "Entry '{$entry_title}' already exists. Skipping." );
+				$this->log( "Entry '{$entry_title}' already exists. Skipping." );
 				continue;
 			}
 
@@ -5327,7 +5420,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			);
 
 			if ( is_wp_error( $entry_id ) ) {
-				WP_CLI::error( "Failed to create entry '{$entry_title}': " . $entry_id->get_error_message() );
+				$this->error( "Failed to create entry '{$entry_title}': " . $entry_id->get_error_message() );
 			}
 
 			$trait_term_id = Relations::trait_term_id_for_collection( (int) $collection_id );
@@ -5358,7 +5451,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 				update_post_meta( $entry_id, "field-{$field_id}", $value );
 			}
 
-			WP_CLI::log( "Created entry '{$entry_title}' (ID {$entry_id})." );
+			$this->log( "Created entry '{$entry_title}' (ID {$entry_id})." );
 		}
 
 		return (int) $collection_id;
@@ -5390,7 +5483,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		if ( $removed > 0 ) {
-			WP_CLI::log( sprintf( 'Removed %d seeded Icon field(s).', $removed ) );
+			$this->log( sprintf( 'Removed %d seeded Icon field(s).', $removed ) );
 		}
 
 		return get_post_meta( $collection_id, 'cortext_fields', false );
@@ -6096,7 +6189,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			$reverse_multiple
 		);
 
-		WP_CLI::log(
+		$this->log(
 			sprintf(
 				"Seeded relation '%s' (ID %d) <-> '%s' (ID %d).",
 				$source_title,
@@ -6147,7 +6240,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			delete_post_meta( $field_id, 'rollup_target_field_id' );
 		}
 
-		WP_CLI::log(
+		$this->log(
 			sprintf(
 				"Seeded rollup '%s' (ID %d, aggregator: %s).",
 				$title,
@@ -6226,11 +6319,11 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		);
 
 		if ( is_wp_error( $field_id ) ) {
-			WP_CLI::error( "Failed to create field '{$title}': " . $field_id->get_error_message() );
+			$this->error( "Failed to create field '{$title}': " . $field_id->get_error_message() );
 		}
 
 		add_post_meta( $collection_id, 'cortext_fields', (string) $field_id );
-		WP_CLI::log( "Created field '{$title}' (ID {$field_id})." );
+		$this->log( "Created field '{$title}' (ID {$field_id})." );
 
 		return (int) $field_id;
 	}
@@ -6444,7 +6537,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 	): void {
 		$source_id = $this->entry_id_by_title( $source_slug, $source_title );
 		if ( $source_id < 1 ) {
-			WP_CLI::warning( "Could not seed relation for missing row '{$source_title}'." );
+			$this->warning( "Could not seed relation for missing row '{$source_title}'." );
 			return;
 		}
 
@@ -6455,7 +6548,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		foreach ( $target_titles as $target_title ) {
 			$target_id = $this->entry_id_by_title( $target_slug, $target_title );
 			if ( $target_id < 1 ) {
-				WP_CLI::warning( "Could not seed relation target '{$target_title}'." );
+				$this->warning( "Could not seed relation target '{$target_title}'." );
 				continue;
 			}
 			$target_ids[] = $target_id;
@@ -6463,7 +6556,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 
 		$result = Relations::sync_relation_value( $source_id, $field_id, $target_ids );
 		if ( is_wp_error( $result ) ) {
-			WP_CLI::warning(
+			$this->warning(
 				sprintf(
 					"Could not seed relation for '%s': %s",
 					$source_title,
@@ -6563,7 +6656,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 			}
 
 			if ( $entries ) {
-				WP_CLI::log( sprintf( 'Deleted %d entries from "%s".', count( $entries ), $collection->post_title ) );
+				$this->log( sprintf( 'Deleted %d entries from "%s".', count( $entries ), $collection->post_title ) );
 			}
 		}
 
@@ -6582,7 +6675,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		if ( $fields ) {
-			WP_CLI::log( sprintf( 'Deleted %d fields.', count( $fields ) ) );
+			$this->log( sprintf( 'Deleted %d fields.', count( $fields ) ) );
 		}
 
 		// 3. Delete all collections.
@@ -6591,7 +6684,7 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		if ( $collections ) {
-			WP_CLI::log( sprintf( 'Deleted %d collections.', count( $collections ) ) );
+			$this->log( sprintf( 'Deleted %d collections.', count( $collections ) ) );
 		}
 
 		// 4. Delete all pages, including trashed ones. WP_Query's 'any'
@@ -6610,18 +6703,18 @@ final class SeedDummyCollections extends WP_CLI_Command {
 		}
 
 		if ( $pages ) {
-			WP_CLI::log( sprintf( 'Deleted %d pages.', count( $pages ) ) );
+			$this->log( sprintf( 'Deleted %d pages.', count( $pages ) ) );
 		}
 
 		if ( delete_metadata( 'user', 0, self::WORKSPACE_HOME_META_KEY, '', true ) ) {
-			WP_CLI::log( 'Deleted workspace home preferences.' );
+			$this->log( 'Deleted workspace home preferences.' );
 		}
 
 		if ( delete_metadata( 'user', 0, self::FAVORITES_META_KEY, '', true ) ) {
-			WP_CLI::log( 'Deleted sidebar favorites.' );
+			$this->log( 'Deleted sidebar favorites.' );
 		}
 
-		WP_CLI::success( 'Reset complete.' );
+		$this->success( 'Reset complete.' );
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -35,6 +35,7 @@ use Cortext\Rest\NotionController;
 use Cortext\Rest\PostLocksController;
 use Cortext\Rest\RecentsController;
 use Cortext\Rest\RowsController;
+use Cortext\Rest\SampleContentController;
 use Cortext\Rest\WorkspaceHomeController;
 use Cortext\Taxonomy\TraitTaxonomy;
 use Cortext\Theming\Preferences;
@@ -74,6 +75,7 @@ final class Plugin {
 		( new PostLocksController() )->register();
 		( new RecentsController() )->register();
 		( new RowsController() )->register();
+		( new SampleContentController() )->register();
 		( new WorkspaceHomeController() )->register();
 		( new NotionController() )->register();
 		( new NotionImporter() )->register();

--- a/includes/Rest/SampleContentController.php
+++ b/includes/Rest/SampleContentController.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * REST endpoint for seeding optional Cortext sample content.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\CLI\SeedDummyCollections;
+use Cortext\PostType\Document;
+use WP_Error;
+use WP_REST_Response;
+
+final class SampleContentController {
+
+	private const NAMESPACE = 'cortext/v1';
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/sample-content/seed',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'seed' ),
+					'permission_callback' => array( $this, 'can_seed' ),
+				),
+			)
+		);
+	}
+
+	public function can_seed(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	public function seed(): WP_REST_Response|WP_Error {
+		$before = $this->counts();
+
+		try {
+			( new SeedDummyCollections() )->seed_sample_content();
+		} catch ( \Throwable $exception ) {
+			return new WP_Error(
+				'cortext_sample_seed_failed',
+				$exception->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$after = $this->counts();
+
+		return new WP_REST_Response(
+			array(
+				'message' => __( 'Sample content is ready.', 'cortext' ),
+				'counts'  => $after,
+				'created' => array(
+					'pages'       => max( 0, $after['pages'] - $before['pages'] ),
+					'collections' => max( 0, $after['collections'] - $before['collections'] ),
+					'entries'     => max( 0, $after['entries'] - $before['entries'] ),
+				),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Counts seeded sample content by kind.
+	 *
+	 * @return array{pages:int,collections:int,entries:int}
+	 */
+	private function counts(): array {
+		return array(
+			'pages'       => $this->count_seeded_documents( '_cortext_seed_content_version' ),
+			'collections' => $this->count_seeded_documents( 'cortext_seed_slug' ),
+			'entries'     => $this->count_seeded_documents( '_cortext_seed_entry_content_version' ),
+		);
+	}
+
+	private function count_seeded_documents( string $meta_key ): int {
+		$posts = get_posts(
+			array(
+				'post_type'      => Document::POST_TYPE,
+				'post_status'    => array( 'draft', 'private', 'publish', 'pending', 'future', 'trash' ),
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'       => $meta_key,
+			)
+		);
+
+		return count( $posts );
+	}
+}

--- a/src/hooks/useSeedSampleContent.js
+++ b/src/hooks/useSeedSampleContent.js
@@ -1,0 +1,42 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Seeds the optional sample content via REST and reloads once it lands.
+ *
+ * The reload lets EntityRoute pick up the freshly created pages and route to
+ * the first document, and drops the empty-state CTA because the workspace is
+ * no longer empty. The seed endpoint is idempotent, so a retry after a
+ * partial failure reuses what already exists instead of duplicating it.
+ *
+ * @return {{seed: Function, isSeeding: boolean, error: string}} Seed handler and status.
+ */
+export default function useSeedSampleContent() {
+	const [ isSeeding, setIsSeeding ] = useState( false );
+	const [ error, setError ] = useState( '' );
+
+	const seed = useCallback( async () => {
+		if ( isSeeding ) {
+			return;
+		}
+
+		setIsSeeding( true );
+		setError( '' );
+
+		try {
+			await apiFetch( {
+				path: '/cortext/v1/sample-content/seed',
+				method: 'POST',
+			} );
+			window.location.reload();
+		} catch ( err ) {
+			setError(
+				err?.message || __( "Couldn't add demo content.", 'cortext' )
+			);
+			setIsSeeding( false );
+		}
+	}, [ isSeeding ] );
+
+	return { seed, isSeeding, error };
+}

--- a/src/router/EmptyState.js
+++ b/src/router/EmptyState.js
@@ -1,9 +1,52 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default function EmptyState() {
+import useSeedSampleContent from '../hooks/useSeedSampleContent';
+
+// Two empty-state faces share one pane. With content present, this is the
+// "nothing selected" placeholder. On a fresh install with no documents at all,
+// it becomes the onboarding surface that offers sample content. The CTA is
+// driven purely by `isWorkspaceEmpty`, so it disappears on its own once the
+// first document exists; there is no persisted "onboarding done" flag.
+export default function EmptyState( { isWorkspaceEmpty = false } ) {
+	const { seed, isSeeding, error } = useSeedSampleContent();
+
+	if ( ! isWorkspaceEmpty ) {
+		return (
+			<div className="cortext-canvas__empty">
+				<p>{ __( 'Choose something to edit.', 'cortext' ) }</p>
+			</div>
+		);
+	}
+
 	return (
 		<div className="cortext-canvas__empty">
-			<p>{ __( 'Choose something to edit.', 'cortext' ) }</p>
+			<h2 className="cortext-canvas__empty-title">
+				{ __( 'Your workspace is empty', 'cortext' ) }
+			</h2>
+			<p className="cortext-canvas__empty-text">
+				{ __(
+					'Add some sample collections and pages to see how Cortext works, or create your first collection from scratch.',
+					'cortext'
+				) }
+			</p>
+			<div className="cortext-canvas__empty-actions">
+				<Button
+					variant="primary"
+					isBusy={ isSeeding }
+					disabled={ isSeeding }
+					onClick={ seed }
+				>
+					{ isSeeding
+						? __( 'Adding demo content…', 'cortext' )
+						: __( 'Add demo content', 'cortext' ) }
+				</Button>
+			</div>
+			{ error && (
+				<p className="cortext-canvas__empty-error" role="alert">
+					{ error }
+				</p>
+			) }
 		</div>
 	);
 }

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -118,6 +118,11 @@ export default function EntityRoute( { history } ) {
 		ACTIVE_PAGES_QUERY
 	);
 
+	// `pages` spans every non-row document (pages and collections), so an empty
+	// list once resolved means a fresh install with nothing created yet. That is
+	// the only state where the empty pane offers to seed sample content.
+	const isWorkspaceEmpty = ! isResolvingPages && ( pages?.length ?? 0 ) === 0;
+
 	const [ state, rawDispatch ] = useReducer( reducer, target, init );
 	const { active, mountedDocumentId, displayedDocumentId } = state;
 
@@ -428,7 +433,7 @@ export default function EntityRoute( { history } ) {
 					<ImportPane />
 				</WorkspacePane>
 				<WorkspacePane active={ active.kind === 'empty' }>
-					<EmptyState />
+					<EmptyState isWorkspaceEmpty={ isWorkspaceEmpty } />
 				</WorkspacePane>
 				<WorkspacePane active={ active.kind === 'document-not-found' }>
 					<NotFoundPane />

--- a/src/styles/global/_shell-root.scss
+++ b/src/styles/global/_shell-root.scss
@@ -206,10 +206,29 @@ body.cortext-fullscreen {
 	overflow: auto;
 }
 
+.cortext-canvas__empty-title {
+	margin: 0;
+	color: var(--cortext-text-strong);
+}
+
 .cortext-canvas__empty-text {
-	color: $gray-700;
+	color: var(--cortext-text-muted);
 	text-align: center;
 	padding: $grid-unit-30 0;
+	max-width: 460px;
+}
+
+.cortext-canvas__empty-actions {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: $grid-unit-10;
+}
+
+.cortext-canvas__empty-error {
+	color: $alert-red;
+	text-align: center;
+	margin-top: $grid-unit-15;
 }
 
 // Identity-action affordances render inside the BlockCanvas iframe via


### PR DESCRIPTION
## What

When a Cortext workspace has no documents, the empty state offers an `Add demo content`action that loads a small set of sample collections and pages. The action only shows while the workspace is empty, so it disappears once you add anything of your own.

## Why

Desktop and Playground arrive already seeded, but a plain plugin install starts empty, with no way to load the sample content from inside the app. Now those installs can try Cortext with real content without dropping to the command line.

## How

- Adding a seed endpoint, behind an edit-access check, that the empty-state action calls.
- Sharing the seed with the existing `wp cortext seed` command and keeping it idempotent, so a repeat run reuses content instead of duplicating it.
- Reading whether to show the offer from the workspace's own documents rather than a stored flag, so it clears itself.

## Testing Instructions

1. On an install with no Cortext content, open Cortext. The main area shows an **Add demo content** action.
2. Click **Add demo content**. Sample collections and pages are created, and the first document opens.
3. Reload Cortext. It opens straight to a document, and the **Add demo content** action no longer appears.
4. On an empty install, switch the color scheme to Dark (bottom of the sidebar) and confirm the empty-state heading is readable.

## Screen recording

https://github.com/user-attachments/assets/24568e43-92d8-49b0-bb2c-9d1d85c8a4c0

