### PR TITLE
Chore: Label Dependabot PRs as tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
       schedule:
           interval: 'weekly'
           day: 'monday'
+      labels:
+          - 'type: tooling'
+          - 'dependencies'
+          - 'github_actions'
       open-pull-requests-limit: 10
       groups:
           actions-minor-patch:


### PR DESCRIPTION
## What

Follow-up to #350 and #354.

This updates the GitHub Actions Dependabot config so new Dependabot PRs come in with the labels they need: `type: tooling`, `dependencies`, and `github_actions`.

## Why

After #350, Dependabot opened #354 without a `type:*` label, which made the label check fail. This makes the label automatic instead of something we have to fix by hand on each Dependabot PR.