### PR TITLE
Tooling: Group release notes by area

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -44,8 +44,10 @@ Use `release: skip` for PRs that should not be assigned to the active release
 milestone. It only skips milestone assignment; the PR still needs one `type:*`
 label.
 
-Area labels are optional and do not affect release automation. Add them when
-they make planning or filtering easier:
+Area labels are optional and group release notes within each `type:*` section.
+PRs without exactly one supported area label appear under `Other`, so missing or
+ambiguous areas do not block releases. Add area labels when they make planning,
+filtering, or release notes easier:
 
 -   `area: canvas` for the block editor canvas, blocks, inspector, covers, and
     icons
@@ -76,7 +78,8 @@ fails if a ready PR has zero `type:*` labels or more than one.
 
 By default, release notes are the public changelog. They include user-facing
 enhancements and bug fixes, and leave docs, tooling, and code quality changes
-out of the published notes.
+out of the published notes. Notes are grouped by `type:*` first, then by
+`area:*`, with unclassified entries under `Other`.
 
 Preview the changelog locally:
 

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const TYPE_LABELS = new Map( [
 	[ 'type: enhancement', 'Enhancements' ],
@@ -17,6 +19,27 @@ const TYPE_ORDER = [
 	'Documentation',
 	'Tooling',
 	'Code quality',
+];
+
+const AREA_LABELS = new Map( [
+	[ 'area: canvas', 'Canvas' ],
+	[ 'area: collections', 'Collections' ],
+	[ 'area: desktop', 'Desktop' ],
+	[ 'area: performance', 'Performance' ],
+	[ 'area: publishing', 'Publishing' ],
+	[ 'area: shell', 'Shell' ],
+] );
+
+const OTHER_AREA = 'Other';
+
+const AREA_ORDER = [
+	'Canvas',
+	'Collections',
+	'Desktop',
+	'Performance',
+	'Publishing',
+	'Shell',
+	OTHER_AREA,
 ];
 
 function parseArgs() {
@@ -106,6 +129,21 @@ function getTypeLabels( pr ) {
 		.filter( ( name ) => TYPE_LABELS.has( name.toLowerCase() ) );
 }
 
+function getArea( pr ) {
+	const areaLabels = pr.labels
+		.map( ( label ) => label.name )
+		.filter( ( name ) => name.toLowerCase().startsWith( 'area:' ) );
+	const supportedAreaLabels = areaLabels.filter( ( name ) =>
+		AREA_LABELS.has( name.toLowerCase() )
+	);
+
+	if ( areaLabels.length !== 1 || supportedAreaLabels.length !== 1 ) {
+		return OTHER_AREA;
+	}
+
+	return AREA_LABELS.get( supportedAreaLabels[ 0 ].toLowerCase() );
+}
+
 function getIncludedTypeLabels( options ) {
 	if ( options.full ) {
 		return new Set( TYPE_LABELS.keys() );
@@ -121,9 +159,106 @@ function getTypeOrder( includedTypeLabels ) {
 	);
 }
 
+function getAreaGroups() {
+	return new Map( AREA_ORDER.map( ( area ) => [ area, [] ] ) );
+}
+
 function formatPr( pr ) {
 	const title = sentence( normalizeTitle( pr.title ) );
 	return `- ${ title } ([#${ pr.number }](${ pr.html_url || pr.url }))`;
+}
+
+export function buildReleaseNotes( pullRequests, options ) {
+	const errors = [];
+	const includedTypeLabels = getIncludedTypeLabels( options );
+	const typeOrder = getTypeOrder( includedTypeLabels );
+	const grouped = new Map(
+		typeOrder.map( ( type ) => [ type, getAreaGroups() ] )
+	);
+	const includedPullRequests = [];
+
+	for ( const pr of pullRequests ) {
+		const typeLabels = getTypeLabels( pr );
+		if ( typeLabels.length !== 1 ) {
+			errors.push(
+				`#${ pr.number } needs exactly one type:* label; found ${
+					typeLabels.length ? typeLabels.join( ', ' ) : 'none'
+				}.`
+			);
+			continue;
+		}
+
+		const typeLabel = typeLabels[ 0 ].toLowerCase();
+		if ( ! includedTypeLabels.has( typeLabel ) ) {
+			continue;
+		}
+
+		const section = TYPE_LABELS.get( typeLabel );
+		const area = getArea( pr );
+		grouped.get( section ).get( area ).push( pr );
+		includedPullRequests.push( pr );
+	}
+
+	if ( errors.length && options.strict ) {
+		throw new Error(
+			`Release note classification failed:\n${ errors.join( '\n' ) }`
+		);
+	}
+
+	const title = options.version
+		? `# Cortext ${ options.version }`
+		: `# ${ options.milestone }`;
+	let notes = `${ title }\n\n`;
+
+	if ( ! pullRequests.length ) {
+		notes += 'No pull requests were found for this milestone.\n';
+	} else if ( ! includedPullRequests.length ) {
+		notes += options.full
+			? 'No release note entries were found for this milestone.\n'
+			: 'No public changelog entries were found for this milestone.\n';
+	} else {
+		for ( const section of typeOrder ) {
+			const areaGroups = grouped.get( section );
+			const hasPrs = Array.from( areaGroups.values() ).some(
+				( prs ) => prs.length
+			);
+			if ( ! hasPrs ) {
+				continue;
+			}
+			notes += `## ${ section }\n\n`;
+			for ( const area of AREA_ORDER ) {
+				const prs = areaGroups.get( area );
+				if ( ! prs.length ) {
+					continue;
+				}
+				notes += `### ${ area }\n\n`;
+				notes += `${ prs.map( formatPr ).join( '\n' ) }\n\n`;
+			}
+		}
+	}
+
+	const contributors = [
+		...new Set(
+			includedPullRequests
+				.map( ( pr ) => pr.user?.login )
+				.filter( Boolean )
+				.filter( ( login ) => ! login.endsWith( '[bot]' ) )
+		),
+	].sort( ( a, b ) => a.localeCompare( b ) );
+
+	if ( contributors.length ) {
+		notes += '## Contributors\n\n';
+		notes += contributors.map( ( login ) => `@${ login }` ).join( ' ' );
+		notes += '\n\n';
+	}
+
+	if ( errors.length ) {
+		notes += '## Release note warnings\n\n';
+		notes += errors.map( ( error ) => `- ${ error }` ).join( '\n' );
+		notes += '\n';
+	}
+
+	return notes;
 }
 
 async function main() {
@@ -168,86 +303,15 @@ async function main() {
 		.filter( ( item ) => item.pull_request?.merged_at )
 		.sort( ( a, b ) => a.number - b.number );
 
-	const errors = [];
-	const includedTypeLabels = getIncludedTypeLabels( options );
-	const typeOrder = getTypeOrder( includedTypeLabels );
-	const grouped = new Map( typeOrder.map( ( type ) => [ type, [] ] ) );
-	const includedPullRequests = [];
-
-	for ( const pr of pullRequests ) {
-		const typeLabels = getTypeLabels( pr );
-		if ( typeLabels.length !== 1 ) {
-			errors.push(
-				`#${ pr.number } needs exactly one type:* label; found ${
-					typeLabels.length ? typeLabels.join( ', ' ) : 'none'
-				}.`
-			);
-			continue;
-		}
-
-		const typeLabel = typeLabels[ 0 ].toLowerCase();
-		if ( ! includedTypeLabels.has( typeLabel ) ) {
-			continue;
-		}
-
-		const section = TYPE_LABELS.get( typeLabel );
-		grouped.get( section ).push( pr );
-		includedPullRequests.push( pr );
-	}
-
-	if ( errors.length && options.strict ) {
-		throw new Error(
-			`Release note classification failed:\n${ errors.join( '\n' ) }`
-		);
-	}
-
-	const title = options.version
-		? `# Cortext ${ options.version }`
-		: `# ${ options.milestone }`;
-	let notes = `${ title }\n\n`;
-
-	if ( ! pullRequests.length ) {
-		notes += 'No pull requests were found for this milestone.\n';
-	} else if ( ! includedPullRequests.length ) {
-		notes += options.full
-			? 'No release note entries were found for this milestone.\n'
-			: 'No public changelog entries were found for this milestone.\n';
-	} else {
-		for ( const section of typeOrder ) {
-			const prs = grouped.get( section );
-			if ( ! prs.length ) {
-				continue;
-			}
-			notes += `## ${ section }\n\n`;
-			notes += `${ prs.map( formatPr ).join( '\n' ) }\n\n`;
-		}
-	}
-
-	const contributors = [
-		...new Set(
-			includedPullRequests
-				.map( ( pr ) => pr.user?.login )
-				.filter( Boolean )
-				.filter( ( login ) => ! login.endsWith( '[bot]' ) )
-		),
-	].sort( ( a, b ) => a.localeCompare( b ) );
-
-	if ( contributors.length ) {
-		notes += '## Contributors\n\n';
-		notes += contributors.map( ( login ) => `@${ login }` ).join( ' ' );
-		notes += '\n\n';
-	}
-
-	if ( errors.length ) {
-		notes += '## Release note warnings\n\n';
-		notes += errors.map( ( error ) => `- ${ error }` ).join( '\n' );
-		notes += '\n';
-	}
-
-	process.stdout.write( notes );
+	process.stdout.write( buildReleaseNotes( pullRequests, options ) );
 }
 
-main().catch( ( error ) => {
-	console.error( error.message );
-	process.exit( 1 );
-} );
+if (
+	process.argv[ 1 ] &&
+	resolve( process.argv[ 1 ] ) === fileURLToPath( import.meta.url )
+) {
+	main().catch( ( error ) => {
+		console.error( error.message );
+		process.exit( 1 );
+	} );
+}

--- a/tests/node/release-notes.test.mjs
+++ b/tests/node/release-notes.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildReleaseNotes } from '../../scripts/release-notes.mjs';
+
+const baseOptions = {
+	milestone: '0.2.0',
+	version: '0.2.0',
+	strict: false,
+	full: false,
+};
+
+function pullRequest( number, title, labels, login = 'github-actions[bot]' ) {
+	return {
+		number,
+		title,
+		html_url: `https://github.com/Automattic/cortext/pull/${ number }`,
+		labels: labels.map( ( name ) => ( { name } ) ),
+		user: { login },
+	};
+}
+
+describe( 'release notes', () => {
+	it( 'groups public release notes by type and area', () => {
+		const notes = buildReleaseNotes(
+			[
+				pullRequest(
+					10,
+					'feat: add relation field',
+					[ 'type: enhancement', 'area: collections' ],
+					'zed'
+				),
+				pullRequest(
+					11,
+					'fix: restore sidebar trash',
+					[ 'type: bug', 'area: shell' ],
+					'amy'
+				),
+				pullRequest(
+					12,
+					'docs: update release process',
+					[ 'type: docs', 'area: publishing' ],
+					'amy'
+				),
+			],
+			{ ...baseOptions, strict: true }
+		);
+
+		assert.equal(
+			notes,
+			`# Cortext 0.2.0
+
+## Enhancements
+
+### Collections
+
+- Add relation field. ([#10](https://github.com/Automattic/cortext/pull/10))
+
+## Bug fixes
+
+### Shell
+
+- Restore sidebar trash. ([#11](https://github.com/Automattic/cortext/pull/11))
+
+## Contributors
+
+@amy @zed
+
+`
+		);
+	} );
+
+	it( 'puts entries without exactly one supported area under Other without failing strict mode', () => {
+		const notes = buildReleaseNotes(
+			[
+				pullRequest( 20, 'feat: add unclassified change', [
+					'type: enhancement',
+				] ),
+				pullRequest( 21, 'feat: handle unknown area', [
+					'type: enhancement',
+					'area: mobile',
+				] ),
+				pullRequest( 22, 'feat: handle duplicate areas', [
+					'type: enhancement',
+					'area: canvas',
+					'area: shell',
+				] ),
+				pullRequest( 23, 'feat: handle mixed known and unknown areas', [
+					'type: enhancement',
+					'area: collections',
+					'area: mobile',
+				] ),
+			],
+			{ ...baseOptions, strict: true }
+		);
+
+		assert.equal(
+			notes,
+			`# Cortext 0.2.0
+
+## Enhancements
+
+### Other
+
+- Add unclassified change. ([#20](https://github.com/Automattic/cortext/pull/20))
+- Handle unknown area. ([#21](https://github.com/Automattic/cortext/pull/21))
+- Handle duplicate areas. ([#22](https://github.com/Automattic/cortext/pull/22))
+- Handle mixed known and unknown areas. ([#23](https://github.com/Automattic/cortext/pull/23))
+
+`
+		);
+	} );
+
+	it( 'groups full release notes by type and area', () => {
+		const notes = buildReleaseNotes(
+			[
+				pullRequest( 30, 'docs: clarify publishing setup', [
+					'type: docs',
+					'area: publishing',
+				] ),
+				pullRequest( 31, 'build: update desktop packaging', [
+					'type: tooling',
+					'area: desktop',
+				] ),
+				pullRequest( 32, 'internal: speed up perf fixtures', [
+					'type: code quality',
+					'area: performance',
+				] ),
+			],
+			{ ...baseOptions, full: true, strict: true }
+		);
+
+		assert.match( notes, /## Documentation\n\n### Publishing/ );
+		assert.match( notes, /## Tooling\n\n### Desktop/ );
+		assert.match( notes, /## Code quality\n\n### Performance/ );
+		assert.doesNotMatch( notes, /No public changelog entries/ );
+	} );
+
+	it( 'keeps strict mode focused on type labels', () => {
+		assert.throws(
+			() =>
+				buildReleaseNotes(
+					[
+						pullRequest( 40, 'feat: miss type', [ 'area: shell' ] ),
+						pullRequest( 41, 'feat: duplicate type', [
+							'type: enhancement',
+							'type: bug',
+							'area: shell',
+						] ),
+					],
+					{ ...baseOptions, strict: true }
+				),
+			( error ) => {
+				assert.match(
+					error.message,
+					/#40 needs exactly one type:\* label; found none\./
+				);
+				assert.match(
+					error.message,
+					/#41 needs exactly one type:\* label; found type: enhancement, type: bug\./
+				);
+				return true;
+			}
+		);
+	} );
+} );


### PR DESCRIPTION
## What

Part of #283.

Release notes now keep the existing type sections, then split each section by area. If a PR does not have one recognized `area:*` label, it goes under `Other` instead of blocking the release.

## How

The release notes command and release workflow stay the same. `--strict` still only checks `type:*` labels.

## Testing Instructions

1. Run `pnpm run release:notes -- --milestone 0.1.0 --version 0.1.0 --strict`.
2. Check that entries are grouped by type first, then by area.
3. Check that entries without one supported `area:*` label show up under `Other`.
