### PR TITLE
Chore: Strip emoji-mart's jsDelivr CDN URLs from the built bundle

### DIFF
--- a/scripts/strip-emoji-cdn-loader.js
+++ b/scripts/strip-emoji-cdn-loader.js
@@ -1,0 +1,18 @@
+/**
+ * Webpack loader that strips emoji-mart's hardcoded jsDelivr CDN URLs.
+ *
+ * emoji-mart only reaches those URLs when it has to fetch emoji data (no
+ * `data` prop) or render a non-native image set. Cortext always passes the
+ * bundled `@emoji-mart/data` and renders native emoji, so the fetches are
+ * dead code. Blanking the URLs keeps the shipped bundle free of remote-asset
+ * references, which the WordPress.org plugin guidelines disallow.
+ *
+ * The match runs to the surrounding string delimiter, so each literal is left
+ * as an empty string rather than a dangling path fragment.
+ *
+ * @param {string} source Module source.
+ * @return {string} Source with the CDN URLs removed.
+ */
+module.exports = function ( source ) {
+	return source.replace( /https:\/\/cdn\.jsdelivr\.net[^`"']*/g, '' );
+};

--- a/scripts/strip-emoji-cdn-loader.js
+++ b/scripts/strip-emoji-cdn-loader.js
@@ -4,8 +4,8 @@
  * emoji-mart only reaches those URLs when it has to fetch emoji data (no
  * `data` prop) or render a non-native image set. Cortext always passes the
  * bundled `@emoji-mart/data` and renders native emoji, so the fetches are
- * dead code. Blanking the URLs keeps the shipped bundle free of remote-asset
- * references, which the WordPress.org plugin guidelines disallow.
+ * dead code. Stripping the URLs keeps them out of the shipped bundle, which
+ * the WordPress.org plugin guidelines disallow.
  *
  * The match runs to the surrounding string delimiter, so each literal is left
  * as an empty string rather than a dangling path fragment.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,25 @@ module.exports = {
 		// numeric-only chunk names.
 		chunkFilename: '[name].js?ver=[chunkhash]',
 	},
+	module: {
+		...defaultConfig.module,
+		rules: [
+			...defaultConfig.module.rules,
+			// emoji-mart hardcodes jsDelivr CDN URLs for the emoji data and
+			// image sets it only reaches when no `data` prop is passed or a
+			// non-native set is rendered. Cortext always passes bundled
+			// `@emoji-mart/data` and renders native emoji, so those fetches
+			// never run. Blank them so the shipped bundle carries no
+			// remote-asset references.
+			{
+				test: /[\\/]emoji-mart[\\/]dist[\\/].*\.js$/,
+				loader: path.resolve(
+					__dirname,
+					'scripts/strip-emoji-cdn-loader.js'
+				),
+			},
+		],
+	},
 	optimization: {
 		...defaultConfig.optimization,
 		chunkIds: 'named',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,8 +48,7 @@ module.exports = {
 			// image sets it only reaches when no `data` prop is passed or a
 			// non-native set is rendered. Cortext always passes bundled
 			// `@emoji-mart/data` and renders native emoji, so those fetches
-			// never run. Blank them so the shipped bundle carries no
-			// remote-asset references.
+			// never run. Strip them so they stay out of the shipped bundle.
 			{
 				test: /[\\/]emoji-mart[\\/]dist[\\/].*\.js$/,
 				loader: path.resolve(


### PR DESCRIPTION
## What

Part of #285.

The built JavaScript no longer contains `emoji-mart`'s hardcoded `jsDelivr` CDN URLs. The emoji picker behaves exactly as before: it already rendered from the bundled data with native emoji, and the URLs were unused fallback paths.

## Why

A WordPress.org plugin review flagged the built file for pointing at a remote CDN (`jsDelivr`). `emoji-mart` hardcodes those URLs to fetch emoji data and image sets, but Cortext passes the bundled data and renders native emoji, so they never run. The review scans for the strings either way, so they had to leave the bundle.

## How

- Stripping the CDN URLs from `emoji-mart` during the build.

## Testing Instructions

1. In a build of the plugin, confirm `build/emoji-mart-react.js` contains no `jsDelivr` URLs.
2. Open the document icon's emoji picker, pick an emoji, and confirm it works with no request to a CDN (watch the network panel).

