### PR TITLE
Lower the Cortext admin menu below the core items

### DIFF
--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -46,7 +46,7 @@ final class Screen {
 			self::MENU_SLUG,
 			array( $this, 'render' ),
 			'dashicons-welcome-write-blog',
-			3
+			'58.5'
 		);
 	}
 


### PR DESCRIPTION
## What

Part of #285.

The Cortext admin menu no longer sits near the top of the sidebar above Posts. It now appears below the core content items, lower in the menu.

## Why

A WordPress.org plugin review flagged the menu for using a very high position that placed it above core WordPress items. The guidelines ask plugins to integrate with the admin menu rather than compete with core for the top of it.

## Testing Instructions

1. Open wp-admin and confirm the Cortext menu appears below the core content items (below Comments, above Appearance), not above Posts.

