### PR TITLE
Fix: row reorder missing the first drag in scrolled collections

### DIFF
--- a/src/components/DataViewRowReorder.js
+++ b/src/components/DataViewRowReorder.js
@@ -662,6 +662,19 @@ function useRenderedRows( wrapperRef, view, rows, isDragging ) {
 		wrapper.addEventListener( 'scroll', sync, true );
 		window.addEventListener( 'resize', sync );
 		window.addEventListener( 'scroll', sync, true );
+		// `window` is the parent frame, but the wrapper lives in the editor
+		// canvas iframe, which scrolls on its own. The parent never sees that
+		// scroll, so without the iframe listeners below the gap snapshot keeps
+		// its pre-scroll positions: the first drag onto a table lower down
+		// finds the fixed drop zones sitting the scroll distance below the
+		// rows, with nothing under the pointer. Later drags re-sync, so only
+		// the first one misses.
+		const ownerWindow = wrapper.ownerDocument?.defaultView;
+		const watchesOwnerWindow = ownerWindow && ownerWindow !== window;
+		if ( watchesOwnerWindow ) {
+			ownerWindow.addEventListener( 'scroll', sync, true );
+			ownerWindow.addEventListener( 'resize', sync );
+		}
 
 		// Leave decoration classes in place between subscriptions. Sort changes
 		// and refetches can re-run this effect during the drop freeze; removing
@@ -677,6 +690,10 @@ function useRenderedRows( wrapperRef, view, rows, isDragging ) {
 			wrapper.removeEventListener( 'scroll', sync, true );
 			window.removeEventListener( 'resize', sync );
 			window.removeEventListener( 'scroll', sync, true );
+			if ( watchesOwnerWindow ) {
+				ownerWindow.removeEventListener( 'scroll', sync, true );
+				ownerWindow.removeEventListener( 'resize', sync );
+			}
 		};
 	}, [ wrapperRef, view, rows, isLinear ] );
 

--- a/src/components/RowDragHandle.js
+++ b/src/components/RowDragHandle.js
@@ -11,13 +11,23 @@ const ROW_DRAGGING_CLASS = 'cortext-row-dragging';
 const ROW_SUPPRESS_HOVER_CLASS = 'cortext-row-reorder-suppress-hover';
 const HOVER_SUPPRESSION_PRIME_TIMEOUT = 800;
 
-function primeRowHoverSuppression() {
-	document.body.classList.add( ROW_SUPPRESS_HOVER_CLASS );
-	window.setTimeout( () => {
-		if ( ! document.body.classList.contains( ROW_DRAGGING_CLASS ) ) {
-			document.body.classList.remove( ROW_SUPPRESS_HOVER_CLASS );
+function primeRowHoverSuppression( ownerDocument = document ) {
+	const body = ownerDocument?.body ?? document.body;
+	const ownerWindow = ownerDocument?.defaultView ?? window;
+	body.classList.add( ROW_SUPPRESS_HOVER_CLASS );
+	ownerWindow.setTimeout( () => {
+		if ( ! body.classList.contains( ROW_DRAGGING_CLASS ) ) {
+			body.classList.remove( ROW_SUPPRESS_HOVER_CLASS );
 		}
 	}, HOVER_SUPPRESSION_PRIME_TIMEOUT );
+}
+
+function capturePointer( event ) {
+	const pointerId = event.pointerId ?? event.nativeEvent?.pointerId;
+	if ( pointerId === undefined ) {
+		return;
+	}
+	event.currentTarget?.setPointerCapture?.( pointerId );
 }
 
 export default function RowDragHandle( { row, keyboardFocusable = true } ) {
@@ -67,7 +77,7 @@ export default function RowDragHandle( { row, keyboardFocusable = true } ) {
 	}, [] );
 
 	const stopInteractionStart = useCallback( ( event ) => {
-		primeRowHoverSuppression();
+		primeRowHoverSuppression( event.currentTarget?.ownerDocument );
 		event.stopPropagation();
 	}, [] );
 
@@ -84,7 +94,12 @@ export default function RowDragHandle( { row, keyboardFocusable = true } ) {
 								eventName === 'onTouchStart' ||
 								eventName === 'onKeyDown'
 							) {
-								primeRowHoverSuppression();
+								primeRowHoverSuppression(
+									event.currentTarget?.ownerDocument
+								);
+							}
+							if ( eventName === 'onPointerDown' ) {
+								capturePointer( event );
 							}
 							event.stopPropagation();
 							handler?.( event );

--- a/tests/js/components/DataViewRowReorder.test.js
+++ b/tests/js/components/DataViewRowReorder.test.js
@@ -146,8 +146,8 @@ afterEach( () => {
 	);
 } );
 
-function createWrapper( heights = [ 40, 40, 40 ] ) {
-	const wrapper = document.createElement( 'div' );
+function createWrapper( heights = [ 40, 40, 40 ], ownerDocument = document ) {
+	const wrapper = ownerDocument.createElement( 'div' );
 	wrapper.innerHTML = `
 		<table class="dataviews-view-table">
 			<tbody>
@@ -172,7 +172,7 @@ function createWrapper( heights = [ 40, 40, 40 ] ) {
 			bottom: rowTop + height,
 		} );
 	} );
-	document.body.appendChild( wrapper );
+	ownerDocument.body.appendChild( wrapper );
 	return wrapper;
 }
 
@@ -237,7 +237,9 @@ function draggableDataFor( rowId ) {
 }
 
 async function renderReorder( props = {}, options = {} ) {
-	const wrapperRef = { current: createWrapper( options.rowHeights ) };
+	const wrapperRef = {
+		current: createWrapper( options.rowHeights, options.ownerDocument ),
+	};
 	const onChangeView = jest.fn();
 	const onReordered = jest.fn();
 	const mutateRows = jest.fn();
@@ -1311,5 +1313,44 @@ describe( 'DataViewRowReorder', () => {
 			'cortext-row-reorder-suppress-hover'
 		);
 		expect( document.body ).not.toHaveClass( 'cortext-row-dragging' );
+	} );
+
+	it( 'suppresses row hover in the row document', async () => {
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const iframeDocument = iframe.contentDocument;
+		mockDraggableListeners = { onPointerDown: jest.fn() };
+
+		await renderReorder( {}, { ownerDocument: iframeDocument } );
+
+		fireEvent.pointerDown(
+			within( iframeDocument.body ).getByRole( 'button', {
+				name: 'Reorder: One',
+			} )
+		);
+
+		expect( iframeDocument.body ).toHaveClass(
+			'cortext-row-reorder-suppress-hover'
+		);
+		expect( document.body ).not.toHaveClass(
+			'cortext-row-reorder-suppress-hover'
+		);
+	} );
+
+	it( 'captures the pointer on the drag handle before activation', async () => {
+		mockDraggableListeners = { onPointerDown: jest.fn() };
+
+		await renderReorder();
+
+		const handle = screen.getByRole( 'button', { name: 'Reorder: One' } );
+		handle.setPointerCapture = jest.fn();
+		const event = new window.MouseEvent( 'pointerdown', {
+			bubbles: true,
+		} );
+		Object.defineProperty( event, 'pointerId', { value: 42 } );
+
+		fireEvent( handle, event );
+
+		expect( handle.setPointerCapture ).toHaveBeenCalledWith( 42 );
 	} );
 } );


### PR DESCRIPTION
## What

In a page with multiple collections or a very long one, reordering rows after scrolling would fail on the first try. This PR fixes it so drag and drop works on the first try even after scrolling.

## How

- Tracking the canvas iframe's own scroll, so the drop targets follow the rows when you scroll to a collection. They used to watch only the parent frame and stayed where the rows had been.
- Capturing the pointer on the drag handle, so the drag keeps following the cursor once it moves off the handle.
- Suppressing the row hover inside the canvas document, where it actually applies during an editor drag.

## Testing Instructions

Following the editor canvas iframe’s own scroll and pointer instead of only the parent frame’s, so the drop targets stay aligned with the rows, and the drag keeps tracking after you scroll.

## Screen recording
Before:

https://github.com/user-attachments/assets/8ae9b903-ff59-47b7-8ef9-ba81f5a5b0cd


After:

https://github.com/user-attachments/assets/0d081b54-cce1-4292-9542-b426ef5acf37

