### PR TITLE
Chore: Prepare the 0.1.1 release

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cortext-desktop",
-	"version": "0.0.1",
+	"version": "0.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cortext-desktop",
-			"version": "0.0.1",
+			"version": "0.1.1",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cortext-desktop",
-	"version": "0.0.1",
+	"version": "0.1.1",
 	"description": "Cortext desktop app: Electron shell that runs Cortext on native PHP.",
 	"private": true,
 	"license": "GPL-2.0-or-later",

--- a/cortext.php
+++ b/cortext.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Cortext
  * Plugin URI:        https://github.com/Automattic/cortext
  * Description:       Build a WordPress-native knowledge base with pages, typed collections, views, and public publishing.
- * Version:           0.1.0
+ * Version:           0.1.1
  * Requires at least: 6.9
  * Requires PHP:      8.1
  * Author:            Héctor Prieto, Miguel Fonseca
@@ -16,7 +16,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CORTEXT_VERSION', '0.1.0' );
+define( 'CORTEXT_VERSION', '0.1.1' );
 define( 'CORTEXT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CORTEXT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cortext",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Knowledge base inside WordPress.",
 	"engines": {
 		"node": "^24.15",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: knowledge-base, collections, custom-post-types, block-editor, publishing
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -76,6 +76,15 @@ Notion's Terms of Service (https://www.notion.so/28ffdd083dc3473e9c2da6ec011b58a
 1. The Cortext workspace showing a seeded Library page with a catalog table and detail panel.
 
 == Changelog ==
+
+= 0.1.1 =
+Patch release for the 0.1 beta line. In this release:
+
+* Added richer demo content entry points for empty workspaces.
+* Fixed row reordering so the first drag works in scrolled collections.
+* Fixed canvas flicker when opening or leaving row documents.
+* Moved the Cortext admin menu below the core WordPress items.
+* Improved release packaging and automation for distributed builds.
 
 = 0.1.0 =
 First public beta. In this release you can:


### PR DESCRIPTION
## What

Part of #283.

Bumps Cortext to `0.1.1` in the plugin metadata, root package, and desktop package. Also adds the `0.1.1` changelog entry to `readme.txt`.
