### PR TITLE
Docs: Point Cortext installs to WordPress.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Cortext
 
-[Try in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/cortext/main/playground/blueprint.json)
+[Try in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/cortext/main/assets/wordpress-org/blueprints/blueprint.json)
 
 > [!WARNING]
 > Cortext is an early beta. Try it somewhere low-stakes first.

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ Cortext stores documents, collection definitions, fields, and collection rows as
 
 ## Try the beta
 
-You do not need to build from source to try Cortext.
+The easiest way to try Cortext is from the WordPress plugin directory.
 
-1. Download the latest `cortext.zip` from the [Releases page](https://github.com/Automattic/cortext/releases).
-2. In wp-admin, go to Plugins, then Add New, then Upload Plugin, and choose the ZIP.
-3. Install and activate Cortext, then open "Cortext" from the admin menu.
+1. In wp-admin, go to Plugins, then Add New.
+2. Search for "Cortext", install it, and activate it.
+3. Open "Cortext" from the admin menu.
 
 New to Cortext? [Using Cortext](docs/using-cortext.md) walks through the main pieces and the basic tasks.
 
-Cortext needs WordPress 6.9+ and PHP 8.1+. Once the listing is live, you will also be able to install it from the WordPress.org plugin directory.
+Cortext needs WordPress 6.9+ and PHP 8.1+. If you prefer a ZIP, download it from the [WordPress.org plugin page](https://wordpress.org/plugins/cortext/) or from [GitHub Releases](https://github.com/Automattic/cortext/releases).
 
 ## Docs
 

--- a/assets/wordpress-org/blueprints/blueprint.json
+++ b/assets/wordpress-org/blueprints/blueprint.json
@@ -20,12 +20,11 @@
 		{
 			"step": "installPlugin",
 			"pluginData": {
-				"resource": "url",
-				"url": "https://github.com/Automattic/cortext/releases/latest/download/cortext.zip"
+				"resource": "wordpress.org/plugins",
+				"slug": "cortext"
 			},
 			"options": {
-				"activate": true,
-				"targetFolderName": "cortext"
+				"activate": true
 			}
 		},
 		{

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -2,8 +2,9 @@
 
 Cortext has two WordPress Playground blueprints:
 
--   `playground/blueprint.json` powers the demo linked from the README. It
-    installs `cortext.zip` from the latest GitHub Release.
+-   `assets/wordpress-org/blueprints/blueprint.json` is the demo linked from the
+    README and the blueprint copied to WordPress.org for the plugin Preview
+    button. It installs the latest stable Cortext release from WordPress.org.
 -   `playground/gallery/blueprint.json` is for the `WordPress/blueprints` gallery
     PR. It installs a bundled `./cortext.zip`, because gallery submissions need to
     include every file they reference.
@@ -13,17 +14,29 @@ Cortext has two WordPress Playground blueprints:
 The README link loads:
 
 ```text
-https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/cortext/main/playground/blueprint.json
+https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/cortext/main/assets/wordpress-org/blueprints/blueprint.json
 ```
 
-That blueprint downloads the current release asset:
+That link loads `assets/wordpress-org/blueprints/blueprint.json`, which installs
+Cortext from the WordPress.org plugin directory:
 
 ```text
-https://github.com/Automattic/cortext/releases/latest/download/cortext.zip
+pluginData.resource: wordpress.org/plugins
+pluginData.slug: cortext
 ```
 
-The link starts working after a GitHub Release includes `cortext.zip`. To update
-the demo later, publish a new release with a fresh ZIP.
+The demo follows whatever version is currently stable on WordPress.org.
+
+## WordPress.org preview
+
+The plugin directory looks for a blueprint at
+`assets/blueprints/blueprint.json` in the WordPress.org SVN repository. In this
+repo, that source file lives at
+`assets/wordpress-org/blueprints/blueprint.json` and is deployed with the other
+WordPress.org assets.
+
+After the file is live, enable the public Preview button from the plugin's
+Advanced view.
 
 ## Gallery submission
 
@@ -48,7 +61,7 @@ gallery PR.
 Validate the blueprints:
 
 ```bash
-jq empty playground/blueprint.json playground/gallery/blueprint.json
+jq empty assets/wordpress-org/blueprints/blueprint.json playground/gallery/blueprint.json
 ```
 
 The release workflow checks the ZIP contents in its run summary. For a local

--- a/docs/release.md
+++ b/docs/release.md
@@ -137,6 +137,32 @@ desktop run only uploads the DMG. You can also run either workflow on its own
 from the Actions tab, which is handy for rebuilding just the DMG against a draft
 that already exists.
 
+## Deploying to WordPress.org
+
+After the GitHub Release is published, deploy that exact ZIP to the
+WordPress.org SVN repository. SVN is only the distribution channel; GitHub stays
+the source of truth.
+
+```bash
+svn checkout https://plugins.svn.wordpress.org/cortext .context/wporg-svn/cortext
+gh release download <version> --repo Automattic/cortext --pattern cortext.zip --dir .context/wporg-release/<version>
+unzip .context/wporg-release/<version>/cortext.zip -d .context/wporg-release/<version>/unpacked
+rsync -a --delete .context/wporg-release/<version>/unpacked/cortext/ .context/wporg-svn/cortext/trunk/
+rsync -a --delete assets/wordpress-org/ .context/wporg-svn/cortext/assets/
+svn status .context/wporg-svn/cortext/trunk .context/wporg-svn/cortext/assets | awk '/^!/ { print substr($0, 9) }' | while IFS= read -r path; do
+    svn rm "$path"
+done
+svn add --force .context/wporg-svn/cortext/trunk .context/wporg-svn/cortext/assets
+svn copy .context/wporg-svn/cortext/trunk .context/wporg-svn/cortext/tags/<version>
+svn commit .context/wporg-svn/cortext -m "Release Cortext <version>" --username <wporg-user>
+```
+
+Before committing, check that `trunk/readme.txt` and
+`tags/<version>/readme.txt` both point to the release stable tag, the plugin
+header and `CORTEXT_VERSION` match the release, and the SVN tree contains only
+runtime files plus WordPress.org assets. The Preview button blueprint comes from
+`assets/wordpress-org/blueprints/blueprint.json`.
+
 When a release succeeds, the workflow closes the released milestone. If it is a
 non-patch release, it also creates the next non-patch milestone if it does not
 already exist. For example, `2.0.0` creates `2.1.0` and `0.2.0` creates

--- a/readme.txt
+++ b/readme.txt
@@ -28,14 +28,12 @@ Behind the scenes, Cortext stores documents, collection definitions, fields, and
 
 == Installation ==
 
-During the beta, install Cortext from a ZIP:
+Install Cortext from the WordPress plugin directory:
 
-1. Download `cortext.zip` from the Releases page at https://github.com/Automattic/cortext/releases.
-2. In wp-admin, go to Plugins, then Add New, then Upload Plugin, and choose the ZIP.
+1. In wp-admin, go to Plugins, then Add New.
+2. Search for "Cortext".
 3. Install and activate Cortext, then open "Cortext" from the admin menu.
 4. Try the workspace with sample content first.
-
-Once Cortext is listed on WordPress.org, you can also install it from Plugins, then Add New.
 
 It is beta software, so install it somewhere you can experiment first.
 


### PR DESCRIPTION
## What

Part of #285.

Now that Cortext is live on WordPress.org, this updates the docs and Playground setup to use that path first. The README and plugin readme send people through wp-admin plugin search, the Playground demo installs Cortext by its WordPress.org slug, and the wp.org assets include the blueprint for the Preview button.

## Why

The old copy still treated the GitHub release ZIP as the normal install path. That was useful before approval, but it now makes the published plugin feel half-launched.

## How

- Installing the Playground demo from the `cortext` WordPress.org plugin slug.
- Using the WordPress.org Preview blueprint as the single Playground demo blueprint.
- Capturing the manual SVN deploy flow from the first publish.

## Testing Instructions

1. Read the “Try the beta” section in `README.md` and the “Installation” section in `readme.txt`.
2. Load the README Playground link and confirm it installs and opens Cortext.
3. Check that `assets/wordpress-org/blueprints/blueprint.json` is the only README/Preview blueprint.