### PR TITLE
Tooling: Give dependency PRs their own type label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,44 @@
 version: 2
 updates:
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+      labels:
+          - 'type: dependencies'
+      open-pull-requests-limit: 0
+    - package-ecosystem: 'npm'
+      directory: '/apps/desktop'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+      labels:
+          - 'type: dependencies'
+      open-pull-requests-limit: 0
+    - package-ecosystem: 'bundler'
+      directory: '/apps/desktop'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+      labels:
+          - 'type: dependencies'
+      open-pull-requests-limit: 0
+    - package-ecosystem: 'composer'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+      labels:
+          - 'type: dependencies'
+      open-pull-requests-limit: 0
     - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:
           interval: 'weekly'
           day: 'monday'
       labels:
-          - 'type: tooling'
-          - 'dependencies'
+          - 'type: dependencies'
           - 'github_actions'
       open-pull-requests-limit: 10
       groups:

--- a/.github/workflows/assign-release-milestone.yml
+++ b/.github/workflows/assign-release-milestone.yml
@@ -25,6 +25,7 @@ jobs:
                         'type: bug',
                         'type: docs',
                         'type: tooling',
+                        'type: dependencies',
                         'type: code quality',
                       ];
 

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -23,7 +23,7 @@ jobs:
               with:
                   mode: exactly
                   count: 1
-                  labels: '^(type: enhancement|type: bug|type: docs|type: tooling|type: code quality)$'
+                  labels: '^(type: enhancement|type: bug|type: docs|type: tooling|type: dependencies|type: code quality)$'
                   use_regex: true
                   add_comment: true
                   message: |
@@ -31,5 +31,5 @@ jobs:
 
                       Add exactly one `type:*` label before merging this PR.
 
-                      Use one of: `type: enhancement`, `type: bug`, `type: docs`, `type: tooling`, `type: code quality`.
+                      Use one of: `type: enhancement`, `type: bug`, `type: docs`, `type: tooling`, `type: dependencies`, `type: code quality`.
                   exit_type: failure

--- a/docs/release.md
+++ b/docs/release.md
@@ -42,13 +42,16 @@ Every PR needs exactly one `type:*` label:
     improvements to existing behavior
 -   `type: bug`
 -   `type: docs`
--   `type: tooling` for CI, release, packaging, scripts, dependencies, and
-    repo automation
+-   `type: tooling` for CI, release, packaging, scripts, and repo automation
+-   `type: dependencies` for dependency updates
 -   `type: code quality` for refactors, cleanup, tests, and internal structure
 
 Use `release: skip` for PRs that should not be assigned to the active release
 milestone. It only skips milestone assignment; the PR still needs one `type:*`
 label.
+
+Dependabot adds `type: dependencies` to its PRs, which groups them under the
+Dependencies section in release notes.
 
 Area labels are optional and group release notes within each `type:*` section.
 PRs without exactly one supported area label appear under `Other`, so missing or
@@ -79,7 +82,7 @@ on the PR and fails. Patch and hotfix PRs should be assigned to their patch
 milestone manually before merge.
 
 `.github/workflows/enforce-pr-labels.yml` also checks open PRs before merge. It
-fails if a ready PR has zero `type:*` labels or more than one.
+fails if a ready PR has zero release-note type labels or more than one.
 
 ## Changelog preview
 

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -8,6 +8,7 @@ const TYPE_LABELS = new Map( [
 	[ 'type: bug', 'Bug fixes' ],
 	[ 'type: docs', 'Documentation' ],
 	[ 'type: tooling', 'Tooling' ],
+	[ 'type: dependencies', 'Dependencies' ],
 	[ 'type: code quality', 'Code quality' ],
 ] );
 
@@ -18,6 +19,7 @@ const TYPE_ORDER = [
 	'Bug fixes',
 	'Documentation',
 	'Tooling',
+	'Dependencies',
 	'Code quality',
 ];
 
@@ -123,16 +125,58 @@ function sentence( text ) {
 	return /[.!?]$/.test( text ) ? text : `${ text }.`;
 }
 
-function getTypeLabels( pr ) {
-	return pr.labels
-		.map( ( label ) => label.name )
-		.filter( ( name ) => TYPE_LABELS.has( name.toLowerCase() ) );
+function getLabelNames( pr ) {
+	return pr.labels.map( ( label ) => label.name ).filter( Boolean );
+}
+
+function isBotPullRequest( pr ) {
+	const login = pr.user?.login || '';
+	const type = pr.user?.type || '';
+	return (
+		type.toLowerCase() === 'bot' ||
+		login.endsWith( '[bot]' ) ||
+		login.startsWith( 'app/' )
+	);
+}
+
+function getTypeClassification( pr ) {
+	const labelNames = getLabelNames( pr );
+	const explicitTypeLabels = labelNames.filter( ( name ) =>
+		name.toLowerCase().startsWith( 'type:' )
+	);
+	const supportedTypeLabels = explicitTypeLabels
+		.map( ( name ) => name.toLowerCase() )
+		.filter( ( name ) => TYPE_LABELS.has( name ) );
+	const typeLabels = [ ...new Set( supportedTypeLabels ) ];
+
+	return {
+		typeLabels,
+		foundTypeLabels: explicitTypeLabels,
+		hasUnsupportedTypeLabels:
+			explicitTypeLabels.length !== supportedTypeLabels.length,
+	};
+}
+
+function describeTypeLabels( foundTypeLabels ) {
+	return foundTypeLabels.length ? foundTypeLabels.join( ', ' ) : 'none';
+}
+
+function typeClassificationError( pr, foundTypeLabels ) {
+	const found = describeTypeLabels( foundTypeLabels );
+	return `#${ pr.number } needs exactly one type:* label; found ${ found }.`;
+}
+
+function hasValidTypeClassification( classification ) {
+	return (
+		classification.typeLabels.length === 1 &&
+		! classification.hasUnsupportedTypeLabels
+	);
 }
 
 function getArea( pr ) {
-	const areaLabels = pr.labels
-		.map( ( label ) => label.name )
-		.filter( ( name ) => name.toLowerCase().startsWith( 'area:' ) );
+	const areaLabels = getLabelNames( pr ).filter( ( name ) =>
+		name.toLowerCase().startsWith( 'area:' )
+	);
 	const supportedAreaLabels = areaLabels.filter( ( name ) =>
 		AREA_LABELS.has( name.toLowerCase() )
 	);
@@ -178,17 +222,15 @@ export function buildReleaseNotes( pullRequests, options ) {
 	const includedPullRequests = [];
 
 	for ( const pr of pullRequests ) {
-		const typeLabels = getTypeLabels( pr );
-		if ( typeLabels.length !== 1 ) {
+		const classification = getTypeClassification( pr );
+		if ( ! hasValidTypeClassification( classification ) ) {
 			errors.push(
-				`#${ pr.number } needs exactly one type:* label; found ${
-					typeLabels.length ? typeLabels.join( ', ' ) : 'none'
-				}.`
+				typeClassificationError( pr, classification.foundTypeLabels )
 			);
 			continue;
 		}
 
-		const typeLabel = typeLabels[ 0 ].toLowerCase();
+		const typeLabel = classification.typeLabels[ 0 ].toLowerCase();
 		if ( ! includedTypeLabels.has( typeLabel ) ) {
 			continue;
 		}
@@ -240,9 +282,9 @@ export function buildReleaseNotes( pullRequests, options ) {
 	const contributors = [
 		...new Set(
 			includedPullRequests
+				.filter( ( pr ) => ! isBotPullRequest( pr ) )
 				.map( ( pr ) => pr.user?.login )
 				.filter( Boolean )
-				.filter( ( login ) => ! login.endsWith( '[bot]' ) )
 		),
 	].sort( ( a, b ) => a.localeCompare( b ) );
 

--- a/tests/node/release-notes.test.mjs
+++ b/tests/node/release-notes.test.mjs
@@ -163,4 +163,90 @@ describe( 'release notes', () => {
 			}
 		);
 	} );
+
+	it( 'excludes dependency PRs from public release notes', () => {
+		const notes = buildReleaseNotes(
+			[
+				pullRequest(
+					50,
+					'build(deps): bump undici in /apps/desktop',
+					[ 'type: dependencies', 'javascript' ],
+					'app/dependabot'
+				),
+			],
+			{ ...baseOptions, strict: true }
+		);
+
+		assert.match(
+			notes,
+			/No public changelog entries were found for this milestone\./
+		);
+	} );
+
+	it( 'puts dependency PRs under Dependencies in full release notes', () => {
+		const notes = buildReleaseNotes(
+			[
+				pullRequest(
+					51,
+					'build(deps): bump nokogiri in /apps/desktop',
+					[ 'type: dependencies', 'ruby' ],
+					'app/dependabot'
+				),
+			],
+			{ ...baseOptions, full: true, strict: true }
+		);
+
+		assert.equal(
+			notes,
+			`# Cortext 0.2.0
+
+## Dependencies
+
+### Other
+
+- Bump nokogiri in /apps/desktop. ([#51](https://github.com/Automattic/cortext/pull/51))
+
+`
+		);
+	} );
+
+	it( 'rejects dependency PRs with a conflicting type label', () => {
+		assert.throws(
+			() =>
+				buildReleaseNotes(
+					[
+						pullRequest(
+							53,
+							'build(deps): bump a conflicted package',
+							[ 'type: dependencies', 'type: bug' ],
+							'amy'
+						),
+					],
+					{ ...baseOptions, strict: true }
+				),
+			/#53 needs exactly one type:\* label; found type: dependencies, type: bug\./
+		);
+	} );
+
+	it( 'rejects dependency PRs with multiple type labels', () => {
+		assert.throws(
+			() =>
+				buildReleaseNotes(
+					[
+						pullRequest( 55, 'build(deps): bump duplicate types', [
+							'type: dependencies',
+							'type: code quality',
+						] ),
+					],
+					{ ...baseOptions, strict: true }
+				),
+			( error ) => {
+				assert.match(
+					error.message,
+					/#55 needs exactly one type:\* label; found type: dependencies, type: code quality\./
+				);
+				return true;
+			}
+		);
+	} );
 } );


### PR DESCRIPTION
## What

Follow-up to #355.

Dependabot PRs now get `type: dependencies` across the dependency ecosystems we track, and release notes group that label under Dependencies.

## Why

#355 fixed the label failure from #354 for GitHub Actions updates, but other Dependabot ecosystems could still open PRs without the type label release notes expect.