### PR TITLE
Add inline document mentions

### DIFF
--- a/includes/Frontend/MentionRenderer.php
+++ b/includes/Frontend/MentionRenderer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Refreshes Cortext mention anchors on public renders.
+ * Updates Cortext mention links during public rendering.
  *
  * @package Cortext
  */
@@ -45,14 +45,12 @@ final class MentionRenderer {
 			_prime_post_caches( $ids, true, true );
 		}
 
-		// The rewritten title and icon depend on the current viewer's read
-		// access (see can_render_target). Output is therefore per-user; a
-		// full-page cache that stores a privileged render and serves it to
-		// anonymous visitors could expose private mention titles.
+		// Titles and icons depend on the current viewer's read access. Do not
+		// let a page cache reuse a signed-in render for someone who cannot read
+		// the target document; that would leak the mention title.
 		//
-		// Matches Cortext-generated mention anchors only. The inner `.*?` and
-		// `[^>]*` assume well-formed anchors with no `>` inside attribute
-		// values, which holds for markup this plugin emits.
+		// Only touch anchors emitted by Cortext. Mention markup does not put `>`
+		// inside attribute values, so the regex can stay narrow.
 		$pattern = '#<a\b(?=[^>]*\b' . Mention::ATTRIBUTE . '=(["\'])(?P<id>\d+)\1)[^>]*>(?P<inner>.*?)</a>#is';
 		$next    = preg_replace_callback(
 			$pattern,
@@ -83,7 +81,7 @@ final class MentionRenderer {
 	}
 
 	/**
-	 * Replaces one mention anchor with fresh target markup.
+	 * Builds current markup for one mention anchor.
 	 *
 	 * @param array<string,string> $matches Regex matches.
 	 */

--- a/includes/Frontend/MentionRenderer.php
+++ b/includes/Frontend/MentionRenderer.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Refreshes Cortext mention anchors on public renders.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Frontend;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\Mention\Mention;
+use Cortext\PostType\Document;
+use Cortext\PostType\DocumentIdentity;
+use Cortext\Taxonomy\TraitTaxonomy;
+use WP_Post;
+
+final class MentionRenderer {
+
+	private const ICON_COLORS = array(
+		'gray'   => '#9ca3af',
+		'brown'  => '#92400e',
+		'orange' => '#f97316',
+		'yellow' => '#eab308',
+		'green'  => '#22c55e',
+		'blue'   => '#3b82f6',
+		'purple' => '#a855f7',
+		'pink'   => '#ec4899',
+		'red'    => '#ef4444',
+	);
+
+	public function register(): void {
+		add_filter( 'the_content', array( $this, 'refresh_mentions' ), 12 );
+	}
+
+	public function refresh_mentions( string $content ): string {
+		if ( ! str_contains( $content, Mention::ATTRIBUTE ) ) {
+			return $content;
+		}
+
+		$ids = $this->extract_ids( $content );
+		if ( count( $ids ) > 0 && function_exists( '_prime_post_caches' ) ) {
+			_prime_post_caches( $ids, true, true );
+		}
+
+		// The rewritten title and icon depend on the current viewer's read
+		// access (see can_render_target). Output is therefore per-user; a
+		// full-page cache that stores a privileged render and serves it to
+		// anonymous visitors could expose private mention titles.
+		//
+		// Matches Cortext-generated mention anchors only. The inner `.*?` and
+		// `[^>]*` assume well-formed anchors with no `>` inside attribute
+		// values, which holds for markup this plugin emits.
+		$pattern = '#<a\b(?=[^>]*\b' . Mention::ATTRIBUTE . '=(["\'])(?P<id>\d+)\1)[^>]*>(?P<inner>.*?)</a>#is';
+		$next    = preg_replace_callback(
+			$pattern,
+			array( $this, 'replace_anchor' ),
+			$content
+		);
+
+		return is_string( $next ) ? $next : $content;
+	}
+
+	/**
+	 * Extracts distinct target ids from mention anchors.
+	 *
+	 * @param string $content Rendered HTML content.
+	 * @return int[]
+	 */
+	private function extract_ids( string $content ): array {
+		if ( ! preg_match_all( Mention::ID_PATTERN, $content, $matches ) ) {
+			return array();
+		}
+
+		$ids = array_map( 'intval', $matches[2] );
+		$ids = array_filter(
+			$ids,
+			static fn( int $id ): bool => $id > 0
+		);
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Replaces one mention anchor with fresh target markup.
+	 *
+	 * @param array<string,string> $matches Regex matches.
+	 */
+	private function replace_anchor( array $matches ): string {
+		$id       = (int) ( $matches['id'] ?? 0 );
+		$snapshot = wp_strip_all_tags( (string) ( $matches['inner'] ?? '' ) );
+		$post     = get_post( $id );
+
+		if ( ! $this->can_render_target( $post, $id ) ) {
+			return sprintf(
+				'<span class="cortext-mention cortext-mention--missing">%s</span>',
+				esc_html( $snapshot )
+			);
+		}
+
+		$title = get_the_title( $post );
+		if ( '' === trim( $title ) ) {
+			$title = __( '(untitled)', 'cortext' );
+		}
+
+		return sprintf(
+			'<a class="cortext-mention" data-crtxt-mention="%1$d"%2$s data-crtxt-path="%3$s" href="%4$s">%5$s</a>',
+			$id,
+			$this->icon_attributes( $post ),
+			esc_attr( $this->path_for( $post ) ),
+			esc_url( get_permalink( $post ) ),
+			esc_html( $title )
+		);
+	}
+
+	private function path_for( WP_Post $post ): string {
+		$slug = trim( (string) $post->post_name );
+		return '' === $slug ? (string) $post->ID : "{$slug}-{$post->ID}";
+	}
+
+	private function icon_attributes( WP_Post $post ): string {
+		$raw     = $this->icon_meta_for( $post );
+		$decoded = json_decode( $raw, true );
+
+		if ( is_array( $decoded ) ) {
+			if ( 'emoji' === ( $decoded['type'] ?? '' ) && is_string( $decoded['value'] ?? null ) && '' !== $decoded['value'] ) {
+				return sprintf(
+					' data-crtxt-icon-emoji="%s"',
+					esc_attr( (string) $decoded['value'] )
+				);
+			}
+
+			if ( 'image' === ( $decoded['type'] ?? '' ) ) {
+				$image_id = (int) ( $decoded['id'] ?? 0 );
+				$url      = '';
+				if ( $image_id > 0 ) {
+					$url = wp_get_attachment_image_url( $image_id, 'thumbnail' );
+					if ( ! $url ) {
+						$url = wp_get_attachment_url( $image_id );
+					}
+				}
+				if ( $url ) {
+					return sprintf(
+						' data-crtxt-icon-image="true" style="--cortext-mention-icon-image: url(\'%s\');"',
+						esc_url( $url )
+					);
+				}
+			}
+
+			if ( 'wp' === ( $decoded['type'] ?? '' ) && is_string( $decoded['name'] ?? null ) && '' !== $decoded['name'] ) {
+				$color = is_string( $decoded['color'] ?? null ) ? (string) $decoded['color'] : '';
+				$style = isset( self::ICON_COLORS[ $color ] )
+					? ' style="--cortext-mention-icon-color: ' . esc_attr( self::ICON_COLORS[ $color ] ) . ';"'
+					: '';
+				return sprintf(
+					' data-crtxt-icon-wp="%1$s"%2$s',
+					esc_attr( (string) $decoded['name'] ),
+					$style
+				);
+			}
+		}
+
+		return '';
+	}
+
+	private function icon_meta_for( WP_Post $post ): string {
+		$icon = (string) get_post_meta( $post->ID, DocumentIdentity::META_KEY, true );
+		if ( '' !== $icon ) {
+			return $icon;
+		}
+		if ( Document::is_collection_post( $post ) ) {
+			return (string) wp_json_encode(
+				array(
+					'type' => 'wp',
+					'name' => 'collection',
+				)
+			);
+		}
+
+		$terms = wp_get_object_terms( $post->ID, TraitTaxonomy::TAXONOMY, array( 'fields' => 'ids' ) );
+		if ( is_array( $terms ) && count( $terms ) > 0 ) {
+			return (string) wp_json_encode(
+				array(
+					'type' => 'wp',
+					'name' => 'listItem',
+				)
+			);
+		}
+
+		return '';
+	}
+
+	private function can_render_target( ?WP_Post $post, int $id ): bool {
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		}
+		if ( 'trash' === $post->post_status ) {
+			return false;
+		}
+		if ( ! post_type_supports( $post->post_type, 'cortext-document' ) ) {
+			return false;
+		}
+		return current_user_can( 'read_post', $id );
+	}
+}

--- a/includes/Mention/Mention.php
+++ b/includes/Mention/Mention.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Shared contract for Cortext inline mention markup.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Mention;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Inline mentions persist as an anchor carrying the target document id in a data
+ * attribute. The public renderer and the backlinks index both parse that markup,
+ * so the attribute name and id pattern live here as the single source of truth.
+ */
+final class Mention {
+
+	public const ATTRIBUTE = 'data-crtxt-mention';
+
+	// Matches a mention anchor's quoted target id; capture group 2 is the id.
+	public const ID_PATTERN = '/' . self::ATTRIBUTE . '=(["\'])(\d+)\1/';
+}

--- a/includes/Mention/Mention.php
+++ b/includes/Mention/Mention.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Shared contract for Cortext inline mention markup.
+ * Markup shared by Cortext inline mentions.
  *
  * @package Cortext
  */
@@ -12,9 +12,9 @@ namespace Cortext\Mention;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Inline mentions persist as an anchor carrying the target document id in a data
- * attribute. The public renderer and the backlinks index both parse that markup,
- * so the attribute name and id pattern live here as the single source of truth.
+ * Mentions are saved as anchors with the target document id in a data attribute.
+ * The public renderer and backlink index both parse that shape, so keep the
+ * attribute name and id regex together.
  */
 final class Mention {
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -20,6 +20,7 @@ use Cortext\Editor\RevisionThrottle;
 use Cortext\FieldValues\FieldValueIndex;
 use Cortext\Frontend\AdminBar;
 use Cortext\Frontend\Assets;
+use Cortext\Frontend\MentionRenderer;
 use Cortext\Frontend\Template;
 use Cortext\Media\CortextMedia;
 use Cortext\PostType\Document;
@@ -80,6 +81,7 @@ final class Plugin {
 		( new NotionController() )->register();
 		( new NotionImporter() )->register();
 		( new AdminBar() )->register();
+		( new MentionRenderer() )->register();
 		( new Template() )->register();
 		( new Assets() )->register();
 		( new DataView() )->register();

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"@wordpress/notices": "^5.44.0",
 		"@wordpress/preferences": "^4.44.0",
 		"@wordpress/private-apis": "^1.44.0",
+		"@wordpress/rich-text": "^7.45.0",
 		"@wordpress/route": "^0.10.0",
 		"@wordpress/url": "^4.44.0",
 		"cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@wordpress/private-apis':
         specifier: ^1.44.0
         version: 1.45.0
+      '@wordpress/rich-text':
+        specifier: ^7.45.0
+        version: 7.45.0(react@18.3.1)
       '@wordpress/route':
         specifier: ^0.10.0
         version: 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -33,6 +33,7 @@ import { definesTrait } from '../documents/capabilities';
 import { POST_TYPE } from './page-queries';
 import CortextInserterSidebar from './CortextInserterSidebar';
 import CortextLinkSuggestions from './CortextLinkSuggestions';
+import { CortextMentions } from './mention';
 import { DocumentPropertiesProvider } from './DocumentPropertiesContext';
 import DocumentPublishToggle from './DocumentPublishToggle';
 import EditorBody from './EditorBody';
@@ -338,6 +339,7 @@ function CanvasEditor( {
 			onRequestLayoutEdit={ requestPropertiesLayoutEdit }
 			onToggleVisible={ togglePropertiesVisible }
 		>
+			<CortextMentions />
 			<DocumentActions
 				disabled={ postLock.isReadOnly }
 				isActive={ isActive }

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -22,6 +22,7 @@ import { EditorSurfaceProvider } from './EditorSurfaceContext';
 import EditorBody from './EditorBody';
 import { PostLockFailureNotice, PostLockModal } from './PostLockControls';
 import CortextLinkSuggestions from './CortextLinkSuggestions';
+import { CortextMentions } from './mention';
 import { RowMutationContext } from './EditableCell';
 
 const ROW_DETAIL_EDITOR_CSS = `
@@ -246,6 +247,7 @@ export default function RowEditor( {
 			useSubRegistry
 		>
 			<CortextLinkSuggestions />
+			<CortextMentions />
 			{ /* tech-debt.md#td-row-detail-toolbar-isolation: row detail owns these SlotFills while
 			     peek/modal are open. */ }
 			<SlotFillProvider>

--- a/src/components/fetchCortextLinkSuggestions.js
+++ b/src/components/fetchCortextLinkSuggestions.js
@@ -3,6 +3,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
 import { DOCUMENT_POST_TYPE } from '../collections';
+import { computeDocumentUri } from '../router/useResolveEntity';
 
 // Cortext-scoped source for Gutenberg's link autocomplete.
 //
@@ -32,7 +33,8 @@ export async function fetchCortextLinkSuggestions(
 			per_page: perPage,
 			context: 'edit',
 			status: [ 'draft', 'private', 'publish' ],
-			_fields: 'id,link,title',
+			_fields:
+				'id,link,slug,title,meta,cortext_defines_trait,crtxt_trait',
 		} ),
 	} ).catch( () => [] ); // Fail by returning no suggestions, like core.
 
@@ -40,6 +42,10 @@ export async function fetchCortextLinkSuggestions(
 		.map( ( record ) => ( {
 			id: record.id,
 			url: record.link,
+			path: computeDocumentUri( record ),
+			icon: record.meta?.cortext_document_icon ?? '',
+			cortext_defines_trait: record.cortext_defines_trait,
+			crtxt_trait: record.crtxt_trait,
 			title: record.title?.raw || __( '(no title)', 'cortext' ),
 			type: DOCUMENT_POST_TYPE,
 			kind: 'post-type',

--- a/src/components/initEditor.js
+++ b/src/components/initEditor.js
@@ -25,7 +25,7 @@ import './initInserterMediaCategories';
 // Side-effect import: float Cortext blocks to the top of the slash inserter.
 import './prioritizeCortextInserterBlocks';
 
-// Side-effect import: register Cortext inline mention format and @ completer.
+// Register Cortext's inline mention format and @ completer.
 import './mention';
 
 // Core exposes `core/post-title` in the inserter and block actions by default.

--- a/src/components/initEditor.js
+++ b/src/components/initEditor.js
@@ -25,6 +25,9 @@ import './initInserterMediaCategories';
 // Side-effect import: float Cortext blocks to the top of the slash inserter.
 import './prioritizeCortextInserterBlocks';
 
+// Side-effect import: register Cortext inline mention format and @ completer.
+import './mention';
+
 // Core exposes `core/post-title` in the inserter and block actions by default.
 // Cortext owns title placement through EnsureHeaderBlocks, so users shouldn't
 // insert another title, duplicate it, or unlock its fixed position. Adjust the

--- a/src/components/mention/CortextMentions.js
+++ b/src/components/mention/CortextMentions.js
@@ -162,10 +162,9 @@ function setUpEditorDocumentBindings( rootDocument, navigate ) {
 	};
 }
 
-// Canvas and RowEditor both mount CortextMentions, so this can run more than
-// once on the same admin document. Ref-count the observer and navigation
-// handler per document so a single set is installed and teardown waits for the
-// last caller to release.
+// Canvas and RowEditor can mount CortextMentions at the same time. Share one
+// observer/navigation binding per document and release it after the last mount
+// unmounts.
 export function retainMentionIconHydratorsForEditorDocument(
 	rootDocument = document,
 	navigate = null
@@ -286,10 +285,9 @@ export default function CortextMentions() {
 		);
 	}, [ navigate ] );
 
-	// Value-stable signature of the mention set plus each target's current
-	// title and link. The selector runs on every store change but returns a
-	// string, so the rewrite below only fires when a mention is added or
-	// removed or a target is renamed, never on plain keystrokes.
+	// Track the mention ids plus each target's title/link. The selector still
+	// runs on store changes, but this string only changes when the mention set
+	// changes or a target is renamed.
 	const signature = useSelect( ( select ) => {
 		const mentionedIds = new Set();
 		collectBlocks( select( blockEditorStore ).getBlocks() ).forEach(

--- a/src/components/mention/CortextMentions.js
+++ b/src/components/mention/CortextMentions.js
@@ -1,0 +1,386 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { create, toHTMLString } from '@wordpress/rich-text';
+import { useNavigate } from '@tanstack/react-router';
+
+import { DOCUMENT_POST_TYPE } from '../../collections';
+import { documentTitle } from '../../documents/title';
+import { MENTION_ATTRIBUTE } from './constants';
+import { retainMentionIconHydrator } from './icon';
+import { handleMentionNavigationEvent } from './navigation';
+
+const MENTION_PATTERN = /data-crtxt-mention=(["'])(\d+)\1/g;
+const TARGET_QUERY = {
+	context: 'edit',
+	_fields: 'id,link,title',
+};
+const SNAPSHOT_ICON_ATTRIBUTES = [
+	'data-crtxt-icon-emoji',
+	'data-crtxt-icon-image',
+	'data-crtxt-icon-wp',
+	'data-crtxt-icon-color',
+	'data-crtxt-icon-hydrated-for',
+];
+const SNAPSHOT_ICON_STYLE_PROPERTIES = [
+	'--cortext-mention-icon-image',
+	'--cortext-mention-icon-color',
+	'--cortext-mention-icon-mask',
+];
+
+function targetForId( targets, id ) {
+	if ( targets instanceof Map ) {
+		return targets.get( id );
+	}
+	return targets?.[ id ];
+}
+
+export function collectMentionIdsFromHTML( html ) {
+	if ( typeof html !== 'string' || ! html.includes( MENTION_ATTRIBUTE ) ) {
+		return [];
+	}
+
+	const ids = new Set();
+	for ( const match of html.matchAll( MENTION_PATTERN ) ) {
+		ids.add( Number.parseInt( match[ 2 ], 10 ) );
+	}
+	return [ ...ids ].filter( ( id ) => id > 0 );
+}
+
+function collectBlocks( blocks, out = [] ) {
+	blocks.forEach( ( block ) => {
+		out.push( block );
+		if ( Array.isArray( block.innerBlocks ) ) {
+			collectBlocks( block.innerBlocks, out );
+		}
+	} );
+	return out;
+}
+
+function serializeHTML( html ) {
+	return toHTMLString( { value: create( { html } ) } );
+}
+
+function updateAttribute( element, name, value ) {
+	if ( value ) {
+		if ( element.getAttribute( name ) !== value ) {
+			element.setAttribute( name, value );
+			return true;
+		}
+		return false;
+	}
+	if ( element.hasAttribute( name ) ) {
+		element.removeAttribute( name );
+		return true;
+	}
+	return false;
+}
+
+function removeInlineStyleProperties( element, properties ) {
+	let changed = false;
+	properties.forEach( ( property ) => {
+		if ( element.style.getPropertyValue( property ) ) {
+			element.style.removeProperty( property );
+			changed = true;
+		}
+	} );
+	if ( changed && element.getAttribute( 'style' ) === '' ) {
+		element.removeAttribute( 'style' );
+	}
+	return changed;
+}
+
+function sameOriginIframeDocument( iframe ) {
+	try {
+		return iframe.contentDocument;
+	} catch {
+		return null;
+	}
+}
+
+const editorDocumentBindings = new WeakMap();
+
+function setUpEditorDocumentBindings( rootDocument, navigate ) {
+	const releases = new Map();
+	const iframeListeners = new Map();
+
+	function attachDocument( ownerDocument ) {
+		if ( ! ownerDocument?.body || releases.has( ownerDocument ) ) {
+			return;
+		}
+		const releaseIconHydrator = retainMentionIconHydrator( ownerDocument );
+		const releaseNavigation = navigate
+			? retainMentionNavigationHandler( ownerDocument, navigate )
+			: () => {};
+		releases.set( ownerDocument, () => {
+			releaseIconHydrator();
+			releaseNavigation();
+		} );
+	}
+
+	function attachIframe( iframe ) {
+		const iframeDocument = sameOriginIframeDocument( iframe );
+		if ( iframeDocument?.body ) {
+			attachDocument( iframeDocument );
+		}
+		if ( iframeListeners.has( iframe ) ) {
+			return;
+		}
+		const onLoad = () => {
+			const loadedDocument = sameOriginIframeDocument( iframe );
+			if ( loadedDocument?.body ) {
+				attachDocument( loadedDocument );
+			}
+		};
+		iframe.addEventListener( 'load', onLoad );
+		iframeListeners.set( iframe, onLoad );
+	}
+
+	function attachAll() {
+		attachDocument( rootDocument );
+		rootDocument.querySelectorAll( 'iframe' ).forEach( attachIframe );
+	}
+
+	attachAll();
+
+	const MutationObserver = rootDocument.defaultView?.MutationObserver;
+	const observer = MutationObserver
+		? new MutationObserver( attachAll )
+		: null;
+	observer?.observe( rootDocument.body, {
+		childList: true,
+		subtree: true,
+	} );
+
+	return () => {
+		observer?.disconnect();
+		iframeListeners.forEach( ( listener, iframe ) => {
+			iframe.removeEventListener( 'load', listener );
+		} );
+		releases.forEach( ( release ) => release() );
+	};
+}
+
+// Canvas and RowEditor both mount CortextMentions, so this can run more than
+// once on the same admin document. Ref-count the observer and navigation
+// handler per document so a single set is installed and teardown waits for the
+// last caller to release.
+export function retainMentionIconHydratorsForEditorDocument(
+	rootDocument = document,
+	navigate = null
+) {
+	if ( ! rootDocument?.body ) {
+		return () => {};
+	}
+
+	let binding = editorDocumentBindings.get( rootDocument );
+	if ( ! binding ) {
+		binding = {
+			count: 0,
+			release: setUpEditorDocumentBindings( rootDocument, navigate ),
+		};
+		editorDocumentBindings.set( rootDocument, binding );
+	}
+
+	binding.count += 1;
+	let released = false;
+	return () => {
+		if ( released ) {
+			return;
+		}
+		released = true;
+		binding.count -= 1;
+		if ( binding.count <= 0 ) {
+			binding.release();
+			editorDocumentBindings.delete( rootDocument );
+		}
+	};
+}
+
+function retainMentionNavigationHandler( ownerDocument, navigate ) {
+	function onClick( event ) {
+		handleMentionNavigationEvent( event, navigate );
+	}
+
+	ownerDocument.addEventListener( 'click', onClick, true );
+	return () => {
+		ownerDocument.removeEventListener( 'click', onClick, true );
+	};
+}
+
+export function rewriteMentionSnapshots( html, targets ) {
+	if ( typeof html !== 'string' || ! html.includes( MENTION_ATTRIBUTE ) ) {
+		return { html, changed: false };
+	}
+	if ( typeof document === 'undefined' ) {
+		return { html, changed: false };
+	}
+
+	const template = document.createElement( 'template' );
+	template.innerHTML = html;
+	let changed = false;
+
+	template.content
+		.querySelectorAll( `a[${ MENTION_ATTRIBUTE }]` )
+		.forEach( ( anchor ) => {
+			const id = Number.parseInt(
+				anchor.getAttribute( MENTION_ATTRIBUTE ) ?? '',
+				10
+			);
+			const target = targetForId( targets, id );
+			if ( ! target?.title ) {
+				return;
+			}
+
+			if ( anchor.textContent !== target.title ) {
+				anchor.textContent = target.title;
+				changed = true;
+			}
+			if (
+				target.href &&
+				anchor.getAttribute( 'href' ) !== target.href
+			) {
+				anchor.setAttribute( 'href', target.href );
+				changed = true;
+			}
+			if ( updateAttribute( anchor, 'data-crtxt-path', '' ) ) {
+				changed = true;
+			}
+			SNAPSHOT_ICON_ATTRIBUTES.forEach( ( name ) => {
+				if ( updateAttribute( anchor, name, '' ) ) {
+					changed = true;
+				}
+			} );
+			if (
+				removeInlineStyleProperties(
+					anchor,
+					SNAPSHOT_ICON_STYLE_PROPERTIES
+				)
+			) {
+				changed = true;
+			}
+		} );
+
+	if ( ! changed ) {
+		return { html, changed: false };
+	}
+
+	return {
+		html: serializeHTML( template.innerHTML ),
+		changed: true,
+	};
+}
+
+export default function CortextMentions() {
+	const navigate = useNavigate();
+	const registry = useRegistry();
+
+	useEffect( () => {
+		if ( typeof document === 'undefined' ) {
+			return undefined;
+		}
+		return retainMentionIconHydratorsForEditorDocument(
+			document,
+			navigate
+		);
+	}, [ navigate ] );
+
+	// Value-stable signature of the mention set plus each target's current
+	// title and link. The selector runs on every store change but returns a
+	// string, so the rewrite below only fires when a mention is added or
+	// removed or a target is renamed, never on plain keystrokes.
+	const signature = useSelect( ( select ) => {
+		const mentionedIds = new Set();
+		collectBlocks( select( blockEditorStore ).getBlocks() ).forEach(
+			( block ) => {
+				Object.values( block.attributes ?? {} ).forEach( ( value ) => {
+					collectMentionIdsFromHTML( value ).forEach( ( id ) =>
+						mentionedIds.add( id )
+					);
+				} );
+			}
+		);
+		const core = select( coreStore );
+		return [ ...mentionedIds ]
+			.sort( ( a, b ) => a - b )
+			.map( ( id ) => {
+				const record = core.getEntityRecord(
+					'postType',
+					DOCUMENT_POST_TYPE,
+					id,
+					TARGET_QUERY
+				);
+				if ( ! record ) {
+					return `${ id }:`;
+				}
+				const link = record.link ?? '';
+				return `${ id }:${ documentTitle( record ) }:${ link }`;
+			} )
+			.join( '|' );
+	}, [] );
+
+	const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( ! signature ) {
+			return;
+		}
+
+		const core = registry.select( coreStore );
+		const blocks = collectBlocks(
+			registry.select( blockEditorStore ).getBlocks()
+		);
+		const targets = new Map();
+		blocks.forEach( ( block ) => {
+			Object.values( block.attributes ?? {} ).forEach( ( value ) => {
+				collectMentionIdsFromHTML( value ).forEach( ( id ) => {
+					if ( targets.has( id ) ) {
+						return;
+					}
+					const record = core.getEntityRecord(
+						'postType',
+						DOCUMENT_POST_TYPE,
+						id,
+						TARGET_QUERY
+					);
+					if ( record ) {
+						targets.set( id, {
+							title: documentTitle( record ),
+							href: record.link,
+						} );
+					}
+				} );
+			} );
+		} );
+
+		if ( targets.size === 0 ) {
+			return;
+		}
+
+		blocks.forEach( ( block ) => {
+			const nextAttributes = {};
+			Object.entries( block.attributes ?? {} ).forEach(
+				( [ key, value ] ) => {
+					const result = rewriteMentionSnapshots( value, targets );
+					if ( result.changed ) {
+						nextAttributes[ key ] = result.html;
+					}
+				}
+			);
+
+			if ( Object.keys( nextAttributes ).length > 0 ) {
+				__unstableMarkNextChangeAsNotPersistent();
+				updateBlockAttributes( block.clientId, nextAttributes );
+			}
+		} );
+	}, [
+		signature,
+		registry,
+		updateBlockAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
+
+	return null;
+}

--- a/src/components/mention/completer.js
+++ b/src/components/mention/completer.js
@@ -60,9 +60,8 @@ export const mentionCompleter = {
 	getOptionCompletion: getMentionCompletion,
 };
 
-// Cortext claims the `@` trigger for document mentions, so any other
-// `@`-prefixed completer (notably core's user mentions) is dropped in favor of
-// ours. Filter by name too so re-applying the filter never duplicates ours.
+// Cortext uses `@` for document mentions. Remove the other `@` completers
+// (usually core user mentions), then add ours once.
 export function withCortextMentionCompleter( completers ) {
 	const withoutMentionPrefix = completers.filter(
 		( completer ) =>

--- a/src/components/mention/completer.js
+++ b/src/components/mention/completer.js
@@ -1,0 +1,79 @@
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+import { fetchCortextLinkSuggestions } from '../fetchCortextLinkSuggestions';
+
+export const MENTION_COMPLETER_NAME = 'cortext/mention';
+
+export async function fetchMentionOptions( search ) {
+	const documents = await fetchCortextLinkSuggestions( search, {
+		perPage: 10,
+	} );
+
+	return documents.map( ( document ) => {
+		const option = {
+			...document,
+			kind: 'document',
+		};
+		return {
+			...option,
+			key: `document-${ document.id }`,
+			value: option,
+			label: document.title || __( '(untitled)', 'cortext' ),
+		};
+	} );
+}
+
+export function getMentionCompletion( option ) {
+	if ( option?.kind !== 'document' ) {
+		return '';
+	}
+
+	const { id, title, url } = option;
+	const label = title || __( '(untitled)', 'cortext' );
+	return (
+		<a
+			className="cortext-mention"
+			data-crtxt-mention={ String( id ) }
+			href={ url }
+		>
+			{ label }
+		</a>
+	);
+}
+
+export function getMentionOptionLabel( option ) {
+	return option?.title || __( '(untitled)', 'cortext' );
+}
+
+export function getMentionOptionKeywords( option ) {
+	return getMentionOptionLabel( option ).split( /\s+/ );
+}
+
+export const mentionCompleter = {
+	name: MENTION_COMPLETER_NAME,
+	triggerPrefix: '@',
+	isDebounced: true,
+	options: fetchMentionOptions,
+	getOptionLabel: getMentionOptionLabel,
+	getOptionKeywords: getMentionOptionKeywords,
+	getOptionCompletion: getMentionCompletion,
+};
+
+// Cortext claims the `@` trigger for document mentions, so any other
+// `@`-prefixed completer (notably core's user mentions) is dropped in favor of
+// ours. Filter by name too so re-applying the filter never duplicates ours.
+export function withCortextMentionCompleter( completers ) {
+	const withoutMentionPrefix = completers.filter(
+		( completer ) =>
+			completer?.name !== MENTION_COMPLETER_NAME &&
+			completer?.triggerPrefix !== '@'
+	);
+	return [ mentionCompleter, ...withoutMentionPrefix ];
+}
+
+addFilter(
+	'editor.Autocomplete.completers',
+	'cortext/mention-completer',
+	withCortextMentionCompleter
+);

--- a/src/components/mention/completer.js
+++ b/src/components/mention/completer.js
@@ -31,14 +31,19 @@ export function getMentionCompletion( option ) {
 
 	const { id, title, url } = option;
 	const label = title || __( '(untitled)', 'cortext' );
+	// Trailing space so the caret lands on a text position after the atomic
+	// mention. Without it the caret cannot sit after a `contentEditable=false`
+	// anchor at the end of a block, and typing stops.
 	return (
-		<a
-			className="cortext-mention"
-			data-crtxt-mention={ String( id ) }
-			href={ url }
-		>
-			{ label }
-		</a>
+		<>
+			<a
+				className="cortext-mention"
+				data-crtxt-mention={ String( id ) }
+				href={ url }
+			>
+				{ label }
+			</a>{ ' ' }
+		</>
 	);
 }
 

--- a/src/components/mention/constants.js
+++ b/src/components/mention/constants.js
@@ -1,0 +1,3 @@
+export const MENTION_FORMAT = 'cortext/mention';
+export const MENTION_CLASS = 'cortext-mention';
+export const MENTION_ATTRIBUTE = 'data-crtxt-mention';

--- a/src/components/mention/format.js
+++ b/src/components/mention/format.js
@@ -1,0 +1,23 @@
+import { registerFormatType } from '@wordpress/rich-text';
+import { __ } from '@wordpress/i18n';
+
+import { MENTION_ATTRIBUTE, MENTION_CLASS, MENTION_FORMAT } from './constants';
+
+registerFormatType( MENTION_FORMAT, {
+	title: __( 'Mention', 'cortext' ),
+	tagName: 'a',
+	className: MENTION_CLASS,
+	attributes: {
+		id: MENTION_ATTRIBUTE,
+		href: 'href',
+		iconEmoji: 'data-crtxt-icon-emoji',
+		iconColor: 'data-crtxt-icon-color',
+		iconImage: 'data-crtxt-icon-image',
+		iconWp: 'data-crtxt-icon-wp',
+		path: 'data-crtxt-path',
+		style: 'style',
+	},
+	contentEditable: false,
+	interactive: true,
+	edit: () => null,
+} );

--- a/src/components/mention/icon.js
+++ b/src/components/mention/icon.js
@@ -203,9 +203,8 @@ function fetchMentionTargetIcon( id ) {
 		return mentionTargetIconCache.get( id );
 	}
 
-	// Resolved icons are cached for the session: a mention shows the target's
-	// icon as of first hydration and does not live-update if that icon later
-	// changes. Failed requests are evicted so a later mutation can retry.
+	// Cache icon lookups for this session. A mention keeps the icon found on
+	// first hydration; failed requests are dropped so a later mutation can retry.
 	const promise = apiFetch( {
 		path: `/wp/v2/crtxt_documents/${ id }?context=edit&_fields=id,meta,cortext_defines_trait,crtxt_trait`,
 	} )
@@ -292,7 +291,7 @@ export function retainMentionIconHydrator( ownerDocument ) {
 		};
 		const view = ownerDocument.defaultView;
 		let hydrateScheduled = false;
-		// Coalesce bursts of editor mutations into a single hydrate per frame.
+		// Batch editor mutation bursts into one hydrate per frame.
 		const scheduleHydrate = () => {
 			if ( hydrateScheduled ) {
 				return;

--- a/src/components/mention/icon.js
+++ b/src/components/mention/icon.js
@@ -1,0 +1,388 @@
+import apiFetch from '@wordpress/api-fetch';
+import { isValidElement, renderToString } from '@wordpress/element';
+import * as icons from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
+
+import { CORTEXT_GLYPHS } from '../cortextIcons';
+import { ICON_COLOR_BY_NAME } from '../iconColors';
+import { MENTION_ATTRIBUTE } from './constants';
+
+const COLLECTION_ICON = JSON.stringify( { type: 'wp', name: 'collection' } );
+const ROW_ICON = JSON.stringify( { type: 'wp', name: 'listItem' } );
+const HYDRATED_FOR_ATTRIBUTE = 'data-crtxt-icon-hydrated-for';
+const MENTION_SELECTED_CLASS = 'is-cortext-mention-selected';
+const ICON_ATTRIBUTES = [
+	'data-crtxt-icon-emoji',
+	'data-crtxt-icon-image',
+	'data-crtxt-icon-wp',
+	'data-crtxt-icon-color',
+];
+const ICON_STYLE_PROPERTIES = [
+	'--cortext-mention-icon-image',
+	'--cortext-mention-icon-color',
+	'--cortext-mention-icon-mask',
+];
+const wpIconMaskCache = new Map();
+const mentionTargetIconCache = new Map();
+const mentionIconHydrators = new WeakMap();
+
+function rangeIntersectsNode( range, node ) {
+	try {
+		return range.intersectsNode( node );
+	} catch {
+		return false;
+	}
+}
+
+export function updateMentionSelectionState( ownerDocument = document ) {
+	ownerDocument
+		.querySelectorAll?.( `.cortext-mention.${ MENTION_SELECTED_CLASS }` )
+		.forEach( ( anchor ) => {
+			anchor.classList.remove( MENTION_SELECTED_CLASS );
+		} );
+
+	const selection = ownerDocument.getSelection?.();
+	if ( ! selection || selection.isCollapsed || selection.rangeCount === 0 ) {
+		return;
+	}
+
+	const ranges = Array.from( { length: selection.rangeCount }, ( _, index ) =>
+		selection.getRangeAt( index )
+	);
+	ownerDocument
+		.querySelectorAll?.( '.cortext-mention' )
+		.forEach( ( anchor ) => {
+			if (
+				ranges.some( ( range ) => rangeIntersectsNode( range, anchor ) )
+			) {
+				anchor.classList.add( MENTION_SELECTED_CLASS );
+			}
+		} );
+}
+
+export function mentionIconForRecord( record ) {
+	const icon = record?.icon ?? record?.meta?.cortext_document_icon ?? '';
+	if ( icon ) {
+		return icon;
+	}
+	if ( record?.cortext_defines_trait === true ) {
+		return COLLECTION_ICON;
+	}
+	if ( Array.isArray( record?.crtxt_trait ) && record.crtxt_trait.length ) {
+		return ROW_ICON;
+	}
+	return '';
+}
+
+export function parseMentionIcon( icon ) {
+	if ( ! icon ) {
+		return null;
+	}
+
+	try {
+		const parsed = JSON.parse( icon );
+		if (
+			parsed?.type === 'emoji' &&
+			typeof parsed.value === 'string' &&
+			parsed.value !== ''
+		) {
+			return { type: 'emoji', value: parsed.value };
+		}
+		if (
+			parsed?.type === 'image' &&
+			Number.isInteger( parsed.id ) &&
+			parsed.id > 0
+		) {
+			return { type: 'image', id: parsed.id };
+		}
+		if (
+			parsed?.type === 'wp' &&
+			typeof parsed.name === 'string' &&
+			parsed.name !== ''
+		) {
+			const color =
+				typeof parsed.color === 'string' &&
+				ICON_COLOR_BY_NAME[ parsed.color ]
+					? parsed.color
+					: null;
+			return { type: 'wp', name: parsed.name, color };
+		}
+	} catch {
+		return null;
+	}
+
+	return null;
+}
+
+export function mentionEmojiFromIcon( icon ) {
+	const parsed = parseMentionIcon( icon );
+	return parsed?.type === 'emoji' ? parsed.value : '';
+}
+
+export function mentionIconImageId( icon ) {
+	const parsed = parseMentionIcon( icon );
+	return parsed?.type === 'image' ? parsed.id : 0;
+}
+
+export function mentionImageUrlFromMedia( media ) {
+	return (
+		media?.media_details?.sizes?.thumbnail?.source_url ??
+		media?.source_url ??
+		''
+	);
+}
+
+export async function fetchMentionIconImageUrl( icon ) {
+	const id = mentionIconImageId( icon );
+	if ( ! id ) {
+		return '';
+	}
+
+	try {
+		const media = await apiFetch( {
+			path: `/wp/v2/media/${ id }?context=edit&_fields=id,source_url,media_details`,
+		} );
+		return mentionImageUrlFromMedia( media );
+	} catch {
+		return '';
+	}
+}
+
+function cssUrl( value ) {
+	return `url("${ String( value ).replace( /["\\\n\r]/g, '\\$&' ) }")`;
+}
+
+export function mentionWpIconMask( name ) {
+	if ( wpIconMaskCache.has( name ) ) {
+		return wpIconMaskCache.get( name );
+	}
+
+	const glyph = CORTEXT_GLYPHS[ name ] ?? icons[ name ];
+	if ( ! isValidElement( glyph ) ) {
+		wpIconMaskCache.set( name, '' );
+		return '';
+	}
+	const svg = renderToString( <Icon icon={ glyph } /> ).replaceAll(
+		'currentColor',
+		'black'
+	);
+	const mask = `url("data:image/svg+xml,${ encodeURIComponent( svg ) }")`;
+	wpIconMaskCache.set( name, mask );
+	return mask;
+}
+
+export function hydrateMentionWpIconMasks( root = document ) {
+	root.querySelectorAll?.( '.cortext-mention[data-crtxt-icon-wp]' ).forEach(
+		( anchor ) => {
+			const name = anchor.getAttribute( 'data-crtxt-icon-wp' );
+			if ( ! name ) {
+				return;
+			}
+			const mask = mentionWpIconMask( name );
+			if ( mask ) {
+				anchor.style.setProperty( '--cortext-mention-icon-mask', mask );
+			}
+		}
+	);
+}
+
+function mentionIdFromAnchor( anchor ) {
+	const id = Number.parseInt(
+		anchor?.getAttribute?.( MENTION_ATTRIBUTE ) ?? '',
+		10
+	);
+	return id > 0 ? id : 0;
+}
+
+function fetchMentionTargetIcon( id ) {
+	if ( ! id ) {
+		return Promise.resolve( { icon: '', imageUrl: '' } );
+	}
+
+	if ( mentionTargetIconCache.has( id ) ) {
+		return mentionTargetIconCache.get( id );
+	}
+
+	// Resolved icons are cached for the session: a mention shows the target's
+	// icon as of first hydration and does not live-update if that icon later
+	// changes. Failed requests are evicted so a later mutation can retry.
+	const promise = apiFetch( {
+		path: `/wp/v2/crtxt_documents/${ id }?context=edit&_fields=id,meta,cortext_defines_trait,crtxt_trait`,
+	} )
+		.then( async ( record ) => {
+			const icon = mentionIconForRecord( record );
+			const imageUrl = await fetchMentionIconImageUrl( icon );
+			return { icon, imageUrl };
+		} )
+		.catch( () => {
+			mentionTargetIconCache.delete( id );
+			return { icon: '', imageUrl: '' };
+		} );
+
+	mentionTargetIconCache.set( id, promise );
+	return promise;
+}
+
+function applyMentionIcon( anchor, icon, imageUrl = '' ) {
+	const { attributes, style } = mentionIconSnapshotAttributes(
+		icon,
+		imageUrl
+	);
+
+	ICON_ATTRIBUTES.forEach( ( name ) => {
+		if ( attributes[ name ] ) {
+			anchor.setAttribute( name, attributes[ name ] );
+		} else {
+			anchor.removeAttribute( name );
+		}
+	} );
+	ICON_STYLE_PROPERTIES.forEach( ( property ) => {
+		anchor.style.removeProperty( property );
+	} );
+	Object.entries( style ).forEach( ( [ property, value ] ) => {
+		anchor.style.setProperty( property, value );
+	} );
+
+	const wpIconName = anchor.getAttribute( 'data-crtxt-icon-wp' );
+	if ( wpIconName ) {
+		const mask = mentionWpIconMask( wpIconName );
+		if ( mask ) {
+			anchor.style.setProperty( '--cortext-mention-icon-mask', mask );
+		}
+	}
+}
+
+export async function hydrateMentionIcons( root = document ) {
+	const anchors = [
+		...( root.querySelectorAll?.(
+			`.cortext-mention[${ MENTION_ATTRIBUTE }]`
+		) ?? [] ),
+	];
+
+	hydrateMentionWpIconMasks( root );
+
+	await Promise.all(
+		anchors.map( async ( anchor ) => {
+			const id = mentionIdFromAnchor( anchor );
+			if ( ! id ) {
+				return;
+			}
+			if (
+				anchor.getAttribute( HYDRATED_FOR_ATTRIBUTE ) === String( id )
+			) {
+				return;
+			}
+
+			const { icon, imageUrl } = await fetchMentionTargetIcon( id );
+			applyMentionIcon( anchor, icon, imageUrl );
+			anchor.setAttribute( HYDRATED_FOR_ATTRIBUTE, String( id ) );
+		} )
+	);
+}
+
+export function retainMentionIconHydrator( ownerDocument ) {
+	if ( ! ownerDocument ) {
+		return () => {};
+	}
+
+	let entry = mentionIconHydrators.get( ownerDocument );
+	if ( ! entry ) {
+		const hydrate = () => {
+			void hydrateMentionIcons( ownerDocument );
+		};
+		const view = ownerDocument.defaultView;
+		let hydrateScheduled = false;
+		// Coalesce bursts of editor mutations into a single hydrate per frame.
+		const scheduleHydrate = () => {
+			if ( hydrateScheduled ) {
+				return;
+			}
+			hydrateScheduled = true;
+			const run = () => {
+				hydrateScheduled = false;
+				hydrate();
+			};
+			if ( view?.requestAnimationFrame ) {
+				view.requestAnimationFrame( run );
+			} else {
+				run();
+			}
+		};
+		const updateSelection = () => {
+			updateMentionSelectionState( ownerDocument );
+		};
+		const MutationObserver = view?.MutationObserver;
+		const observer =
+			MutationObserver && ownerDocument.body
+				? new MutationObserver( scheduleHydrate )
+				: null;
+
+		hydrate();
+		updateSelection();
+		ownerDocument.addEventListener( 'selectionchange', updateSelection );
+		ownerDocument.addEventListener( 'mouseup', updateSelection, true );
+		ownerDocument.addEventListener( 'keyup', updateSelection, true );
+		observer?.observe( ownerDocument.body, {
+			attributes: true,
+			attributeFilter: [ MENTION_ATTRIBUTE, 'data-crtxt-icon-wp' ],
+			childList: true,
+			subtree: true,
+		} );
+		entry = { count: 0, observer, updateSelection };
+		mentionIconHydrators.set( ownerDocument, entry );
+	}
+
+	entry.count += 1;
+	return () => {
+		entry.count -= 1;
+		if ( entry.count <= 0 ) {
+			entry.observer?.disconnect();
+			ownerDocument.removeEventListener(
+				'selectionchange',
+				entry.updateSelection
+			);
+			ownerDocument.removeEventListener(
+				'mouseup',
+				entry.updateSelection,
+				true
+			);
+			ownerDocument.removeEventListener(
+				'keyup',
+				entry.updateSelection,
+				true
+			);
+			mentionIconHydrators.delete( ownerDocument );
+		}
+	};
+}
+
+export function mentionIconSnapshotAttributes( icon, imageUrl = '' ) {
+	const parsed = parseMentionIcon( icon );
+	const attributes = {};
+	const style = {};
+
+	if ( parsed?.type === 'emoji' ) {
+		attributes[ 'data-crtxt-icon-emoji' ] = parsed.value;
+		return { attributes, style };
+	}
+	if ( parsed?.type === 'image' && imageUrl ) {
+		attributes[ 'data-crtxt-icon-image' ] = 'true';
+		style[ '--cortext-mention-icon-image' ] = cssUrl( imageUrl );
+		return { attributes, style };
+	}
+	if ( parsed?.type === 'wp' ) {
+		const mask = mentionWpIconMask( parsed.name );
+		if ( ! mask ) {
+			return { attributes, style };
+		}
+		attributes[ 'data-crtxt-icon-wp' ] = parsed.name;
+		if ( parsed.color ) {
+			attributes[ 'data-crtxt-icon-color' ] = parsed.color;
+			style[ '--cortext-mention-icon-color' ] =
+				ICON_COLOR_BY_NAME[ parsed.color ];
+		}
+		return { attributes, style };
+	}
+
+	return { attributes, style };
+}

--- a/src/components/mention/index.js
+++ b/src/components/mention/index.js
@@ -1,0 +1,5 @@
+import './format';
+import './completer';
+import './mention.scss';
+
+export { default as CortextMentions } from './CortextMentions';

--- a/src/components/mention/mention.scss
+++ b/src/components/mention/mention.scss
@@ -1,0 +1,93 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+$mention-document-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z'/%3E%3Cpath d='M14 2v4a2 2 0 0 0 2 2h4'/%3E%3Cpath d='M10 9H8'/%3E%3Cpath d='M16 13H8'/%3E%3Cpath d='M16 17H8'/%3E%3C/svg%3E");
+
+.cortext-mention {
+	display: inline;
+	position: relative;
+	padding: 0 0.18em 0 1.35em;
+	border-radius: 3px;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	line-height: inherit;
+	text-decoration-line: underline;
+	text-decoration-thickness: 0.06em;
+	text-underline-offset: 0.12em;
+	vertical-align: baseline;
+	white-space: nowrap;
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+	user-select: text;
+	-webkit-user-select: text;
+
+	&::before {
+		content: "";
+		display: inline-block;
+		position: absolute;
+		top: 50%;
+		left: 0.18em;
+		width: 0.95em;
+		height: 0.95em;
+		background: var(--cortext-mention-icon-color, currentcolor);
+		line-height: 1;
+		opacity: 0.7;
+		transform: translateY(-50%);
+		-webkit-mask:
+			var(--cortext-mention-icon-mask, $mention-document-icon)
+			center / contain no-repeat;
+		mask:
+			var(--cortext-mention-icon-mask, $mention-document-icon) center /
+			contain no-repeat;
+	}
+
+	&[data-crtxt-icon-emoji]::before {
+		content: attr(data-crtxt-icon-emoji);
+		width: 0.95em;
+		height: auto;
+		background: none;
+		opacity: 1;
+		line-height: 1;
+		text-align: center;
+		-webkit-mask: none;
+		mask: none;
+	}
+
+	&[data-crtxt-icon-image]::before {
+		border-radius: 2px;
+		background:
+			var(--cortext-mention-icon-image) center / cover
+			no-repeat;
+		opacity: 1;
+		-webkit-mask: none;
+		mask: none;
+	}
+
+	&.is-cortext-mention-selected:not([data-crtxt-icon-emoji]):not([data-crtxt-icon-image])::before {
+		background: HighlightText;
+		opacity: 0.9;
+	}
+
+	&:hover {
+		background: $gray-100;
+		color: inherit;
+		text-decoration: none;
+	}
+
+	&::selection {
+		background: Highlight;
+		color: HighlightText;
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--wp-admin-theme-color);
+		outline-offset: 1px;
+	}
+
+	&--missing {
+		color: $gray-700;
+		background: transparent;
+		text-decoration: line-through;
+	}
+}

--- a/src/components/mention/navigation.js
+++ b/src/components/mention/navigation.js
@@ -15,9 +15,8 @@ export function mentionAnchorFromEvent( event ) {
 	return target?.closest?.( `a[${ MENTION_ATTRIBUTE }]` ) ?? null;
 }
 
-// The router resolves a document by the trailing id, so the stored path is only
-// cosmetic. Use it when present, otherwise navigate by bare id; the destination
-// view canonicalizes its own URL, so there is no per-click lookup.
+// The router only needs the trailing id. Use the stored path for nicer URLs
+// when it exists; otherwise the destination can canonicalize from the id.
 export function pathForMentionAnchor( anchor ) {
 	const stored = anchor.getAttribute( 'data-crtxt-path' );
 	if ( stored ) {

--- a/src/components/mention/navigation.js
+++ b/src/components/mention/navigation.js
@@ -1,0 +1,61 @@
+import { MENTION_ATTRIBUTE } from './constants';
+
+export function mentionAnchorFromEvent( event ) {
+	if ( event.button !== undefined && event.button !== 0 ) {
+		return null;
+	}
+	if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
+		return null;
+	}
+
+	const target =
+		event.target?.nodeType === 1
+			? event.target
+			: event.target?.parentElement;
+	return target?.closest?.( `a[${ MENTION_ATTRIBUTE }]` ) ?? null;
+}
+
+// The router resolves a document by the trailing id, so the stored path is only
+// cosmetic. Use it when present, otherwise navigate by bare id; the destination
+// view canonicalizes its own URL, so there is no per-click lookup.
+export function pathForMentionAnchor( anchor ) {
+	const stored = anchor.getAttribute( 'data-crtxt-path' );
+	if ( stored ) {
+		return stored;
+	}
+
+	const id = Number.parseInt(
+		anchor.getAttribute( MENTION_ATTRIBUTE ) ?? '',
+		10
+	);
+	return id > 0 ? String( id ) : '';
+}
+
+export function navigateToMentionAnchor( anchor, navigate ) {
+	const path = pathForMentionAnchor( anchor );
+	if ( ! path ) {
+		return;
+	}
+
+	navigate( {
+		to: '/$',
+		params: { _splat: path },
+	} );
+}
+
+function stopMentionEvent( event ) {
+	event.preventDefault();
+	event.stopPropagation();
+	event.stopImmediatePropagation?.();
+}
+
+export function handleMentionNavigationEvent( event, navigate ) {
+	const anchor = mentionAnchorFromEvent( event );
+	if ( ! anchor ) {
+		return false;
+	}
+
+	stopMentionEvent( event );
+	navigateToMentionAnchor( anchor, navigate );
+	return true;
+}

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -18,14 +18,14 @@ import PublicDataView, {
 // @wordpress/icons is JS-only. Render the glyph into each marker; the color
 // rides on the span's inline style (the glyph uses currentColor). The icon
 // namespace is heavy, so load it only when a page actually has a wp glyph.
-const wpIconMarkers = document.querySelectorAll(
+const wpDocumentIconMarkers = document.querySelectorAll(
 	'.cortext-document-icon--wp[data-icon]'
 );
-if ( wpIconMarkers.length ) {
+if ( wpDocumentIconMarkers.length ) {
 	import(
 		/* webpackChunkName: "document-icon-wp" */ './components/DocumentIconWp'
 	).then( ( { default: DocumentIconWp } ) => {
-		wpIconMarkers.forEach( ( el ) => {
+		wpDocumentIconMarkers.forEach( ( el ) => {
 			const name = el.getAttribute( 'data-icon' );
 			if ( ! name ) {
 				return;
@@ -34,6 +34,17 @@ if ( wpIconMarkers.length ) {
 				<DocumentIconWp name={ name } size={ 44 } />
 			);
 		} );
+	} );
+}
+
+const wpMentionAnchors = document.querySelectorAll(
+	'.cortext-mention[data-crtxt-icon-wp]'
+);
+if ( wpMentionAnchors.length ) {
+	import(
+		/* webpackChunkName: "mention-icon-wp" */ './components/mention/icon'
+	).then( ( { hydrateMentionWpIconMasks } ) => {
+		hydrateMentionWpIconMasks();
 	} );
 }
 

--- a/src/frontend.scss
+++ b/src/frontend.scss
@@ -14,6 +14,8 @@
 @use "./styles/tokens";
 @use "../node_modules/@wordpress/dataviews/build-style/style.css" as dataviews;
 
+$mention-document-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z'/%3E%3Cpath d='M14 2v4a2 2 0 0 0 2 2h4'/%3E%3Cpath d='M10 9H8'/%3E%3Cpath d='M16 13H8'/%3E%3Cpath d='M16 17H8'/%3E%3C/svg%3E");
+
 .cortext-public-page {
 	margin: 0;
 	// prettier-ignore
@@ -60,6 +62,95 @@
 
 	> .alignfull {
 		max-width: none;
+	}
+}
+
+.cortext-mention {
+	display: inline;
+	position: relative;
+	padding: 0 0.18em 0 1.35em;
+	border-radius: 3px;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	line-height: inherit;
+	text-decoration-line: underline;
+	text-decoration-thickness: 0.06em;
+	text-underline-offset: 0.12em;
+	vertical-align: baseline;
+	white-space: nowrap;
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+	user-select: text;
+	-webkit-user-select: text;
+
+	&::before {
+		content: "";
+		display: inline-block;
+		position: absolute;
+		top: 50%;
+		left: 0.18em;
+		width: 0.95em;
+		height: 0.95em;
+		background: var(--cortext-mention-icon-color, currentcolor);
+		line-height: 1;
+		opacity: 0.7;
+		transform: translateY(-50%);
+		-webkit-mask:
+			var(--cortext-mention-icon-mask, $mention-document-icon)
+			center / contain no-repeat;
+		mask:
+			var(--cortext-mention-icon-mask, $mention-document-icon) center /
+			contain no-repeat;
+	}
+
+	&[data-crtxt-icon-emoji]::before {
+		content: attr(data-crtxt-icon-emoji);
+		width: 0.95em;
+		height: auto;
+		background: none;
+		opacity: 1;
+		line-height: 1;
+		text-align: center;
+		-webkit-mask: none;
+		mask: none;
+	}
+
+	&[data-crtxt-icon-image]::before {
+		border-radius: 2px;
+		background:
+			var(--cortext-mention-icon-image) center / cover
+			no-repeat;
+		opacity: 1;
+		-webkit-mask: none;
+		mask: none;
+	}
+
+	&.is-cortext-mention-selected:not([data-crtxt-icon-emoji]):not([data-crtxt-icon-image])::before {
+		background: HighlightText;
+		opacity: 0.9;
+	}
+
+	&:hover {
+		background: $gray-100;
+		color: inherit;
+		text-decoration: none;
+	}
+
+	&::selection {
+		background: Highlight;
+		color: HighlightText;
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--wp-admin-theme-color);
+		outline-offset: 1px;
+	}
+
+	&--missing {
+		color: $gray-700;
+		background: transparent;
+		text-decoration: line-through;
 	}
 }
 

--- a/tests/js/components/MentionNavigation.test.js
+++ b/tests/js/components/MentionNavigation.test.js
@@ -64,7 +64,7 @@ describe( 'Cortext mention navigation', () => {
 		iframe.remove();
 	} );
 
-	it( 'uses the stored path snapshot and falls back to the bare id without a network round-trip', () => {
+	it( 'uses the stored path, or the bare id when no path is saved', () => {
 		const withPath = document.createElement( 'a' );
 		withPath.setAttribute( 'data-crtxt-mention', '7' );
 		withPath.setAttribute( 'data-crtxt-path', 'tasks-7' );
@@ -78,7 +78,7 @@ describe( 'Cortext mention navigation', () => {
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
 
-	it( 'prevents the public href from handling direct mention click events', async () => {
+	it( 'keeps direct mention clicks inside the Cortext router', async () => {
 		const anchor = document.createElement( 'a' );
 		anchor.setAttribute( 'data-crtxt-mention', '7' );
 		anchor.setAttribute( 'data-crtxt-path', 'target-7' );

--- a/tests/js/components/MentionNavigation.test.js
+++ b/tests/js/components/MentionNavigation.test.js
@@ -1,0 +1,103 @@
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockNavigate = jest.fn();
+
+import apiFetch from '@wordpress/api-fetch';
+
+import { retainMentionIconHydratorsForEditorDocument } from '../../../src/components/mention/CortextMentions';
+import {
+	handleMentionNavigationEvent,
+	pathForMentionAnchor,
+} from '../../../src/components/mention/navigation';
+
+describe( 'Cortext mention navigation', () => {
+	beforeEach( () => {
+		apiFetch.mockClear();
+		mockNavigate.mockClear();
+		// Only the icon hydrator fetches now; keep it resolving so it stays quiet.
+		apiFetch.mockResolvedValue( {} );
+	} );
+
+	it( 'intercepts the first click inside the editor iframe and navigates through the Cortext router', async () => {
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const editorDocument = iframe.contentDocument;
+		const anchor = editorDocument.createElement( 'a' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-mention', '7' );
+		anchor.setAttribute( 'data-crtxt-path', 'target-7' );
+		anchor.setAttribute( 'href', 'https://example.test/cortext/target/' );
+		anchor.textContent = 'Target';
+		editorDocument.body.appendChild( anchor );
+
+		const release = retainMentionIconHydratorsForEditorDocument(
+			document,
+			mockNavigate
+		);
+
+		const mouseDown = new MouseEvent( 'mousedown', {
+			bubbles: true,
+			cancelable: true,
+			button: 0,
+		} );
+		anchor.dispatchEvent( mouseDown );
+
+		expect( mouseDown.defaultPrevented ).toBe( false );
+		expect( mockNavigate ).not.toHaveBeenCalled();
+
+		const event = new MouseEvent( 'click', {
+			bubbles: true,
+			cancelable: true,
+			button: 0,
+		} );
+		anchor.dispatchEvent( event );
+
+		expect( event.defaultPrevented ).toBe( true );
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'target-7' },
+		} );
+		release();
+		iframe.remove();
+	} );
+
+	it( 'uses the stored path snapshot and falls back to the bare id without a network round-trip', () => {
+		const withPath = document.createElement( 'a' );
+		withPath.setAttribute( 'data-crtxt-mention', '7' );
+		withPath.setAttribute( 'data-crtxt-path', 'tasks-7' );
+
+		expect( pathForMentionAnchor( withPath ) ).toBe( 'tasks-7' );
+
+		const withoutPath = document.createElement( 'a' );
+		withoutPath.setAttribute( 'data-crtxt-mention', '7' );
+
+		expect( pathForMentionAnchor( withoutPath ) ).toBe( '7' );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'prevents the public href from handling direct mention click events', async () => {
+		const anchor = document.createElement( 'a' );
+		anchor.setAttribute( 'data-crtxt-mention', '7' );
+		anchor.setAttribute( 'data-crtxt-path', 'target-7' );
+		document.body.appendChild( anchor );
+		const event = new MouseEvent( 'click', {
+			bubbles: true,
+			cancelable: true,
+			button: 0,
+		} );
+		Object.defineProperty( event, 'target', { value: anchor } );
+
+		expect( handleMentionNavigationEvent( event, mockNavigate ) ).toBe(
+			true
+		);
+		expect( event.defaultPrevented ).toBe( true );
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'target-7' },
+		} );
+		anchor.remove();
+	} );
+} );

--- a/tests/js/components/RowEditor.test.js
+++ b/tests/js/components/RowEditor.test.js
@@ -33,6 +33,10 @@ jest.mock( '../../../src/components/CortextLinkSuggestions', () =>
 	jest.fn( () => null )
 );
 
+jest.mock( '../../../src/components/mention', () => ( {
+	CortextMentions: jest.fn( () => null ),
+} ) );
+
 jest.mock( '../../../src/components/initEditor', () => ( {
 	getEditorSettings: () => ( {} ),
 } ) );

--- a/tests/js/components/fetchCortextLinkSuggestions.test.js
+++ b/tests/js/components/fetchCortextLinkSuggestions.test.js
@@ -19,6 +19,8 @@ it( 'queries the Cortext document REST base, not wp/v2/search', async () => {
 	expect( path ).not.toContain( '/wp/v2/search' );
 	expect( path ).toContain( 'search=docs' );
 	expect( path ).toContain( 'context=edit' );
+	expect( path ).toContain( 'slug' );
+	expect( path ).toContain( 'meta' );
 } );
 
 it( 'includes draft, private and publish statuses (and so excludes trash)', async () => {
@@ -50,28 +52,41 @@ it( 'honours explicit page and perPage', async () => {
 it( 'maps documents to permalink suggestions using the raw title', async () => {
 	apiFetch.mockResolvedValueOnce( [
 		{
-			id: 12,
-			link: 'https://example.test/cortext/about/',
-			title: { raw: 'About & Co' },
-		},
+				id: 12,
+				link: 'https://example.test/cortext/about/',
+				slug: 'about',
+				title: { raw: 'About & Co' },
+				meta: {
+					cortext_document_icon: '{"type":"emoji","value":"A"}',
+				},
+			},
 	] );
 
 	const suggestions = await fetchCortextLinkSuggestions( 'about' );
 
 	expect( suggestions ).toEqual( [
 		{
-			id: 12,
-			url: 'https://example.test/cortext/about/',
-			title: 'About & Co',
-			type: 'crtxt_document',
-			kind: 'post-type',
+				id: 12,
+				url: 'https://example.test/cortext/about/',
+				path: 'about-12',
+				icon: '{"type":"emoji","value":"A"}',
+				cortext_defines_trait: undefined,
+				crtxt_trait: undefined,
+				title: 'About & Co',
+				type: 'crtxt_document',
+				kind: 'post-type',
 		},
 	] );
 } );
 
 it( 'falls back to a placeholder title and drops records without an id or url', async () => {
 	apiFetch.mockResolvedValueOnce( [
-		{ id: 1, link: 'https://example.test/?p=1', title: { raw: '' } },
+			{
+				id: 1,
+				link: 'https://example.test/?p=1',
+				slug: '',
+				title: { raw: '' },
+			},
 		{ id: 0, link: 'https://example.test/x', title: { raw: 'no id' } },
 		{ id: 2, link: '', title: { raw: 'no url' } },
 	] );
@@ -80,9 +95,13 @@ it( 'falls back to a placeholder title and drops records without an id or url', 
 
 	expect( suggestions ).toEqual( [
 		{
-			id: 1,
-			url: 'https://example.test/?p=1',
-			title: '(no title)',
+				id: 1,
+				url: 'https://example.test/?p=1',
+				path: '1',
+				icon: '',
+				cortext_defines_trait: undefined,
+				crtxt_trait: undefined,
+				title: '(no title)',
 			type: 'crtxt_document',
 			kind: 'post-type',
 		},

--- a/tests/js/components/fetchCortextLinkSuggestions.test.js
+++ b/tests/js/components/fetchCortextLinkSuggestions.test.js
@@ -52,41 +52,41 @@ it( 'honours explicit page and perPage', async () => {
 it( 'maps documents to permalink suggestions using the raw title', async () => {
 	apiFetch.mockResolvedValueOnce( [
 		{
-				id: 12,
-				link: 'https://example.test/cortext/about/',
-				slug: 'about',
-				title: { raw: 'About & Co' },
-				meta: {
-					cortext_document_icon: '{"type":"emoji","value":"A"}',
-				},
+			id: 12,
+			link: 'https://example.test/cortext/about/',
+			slug: 'about',
+			title: { raw: 'About & Co' },
+			meta: {
+				cortext_document_icon: '{"type":"emoji","value":"A"}',
 			},
+		},
 	] );
 
 	const suggestions = await fetchCortextLinkSuggestions( 'about' );
 
 	expect( suggestions ).toEqual( [
 		{
-				id: 12,
-				url: 'https://example.test/cortext/about/',
-				path: 'about-12',
-				icon: '{"type":"emoji","value":"A"}',
-				cortext_defines_trait: undefined,
-				crtxt_trait: undefined,
-				title: 'About & Co',
-				type: 'crtxt_document',
-				kind: 'post-type',
+			id: 12,
+			url: 'https://example.test/cortext/about/',
+			path: 'about-12',
+			icon: '{"type":"emoji","value":"A"}',
+			cortext_defines_trait: undefined,
+			crtxt_trait: undefined,
+			title: 'About & Co',
+			type: 'crtxt_document',
+			kind: 'post-type',
 		},
 	] );
 } );
 
 it( 'falls back to a placeholder title and drops records without an id or url', async () => {
 	apiFetch.mockResolvedValueOnce( [
-			{
-				id: 1,
-				link: 'https://example.test/?p=1',
-				slug: '',
-				title: { raw: '' },
-			},
+		{
+			id: 1,
+			link: 'https://example.test/?p=1',
+			slug: '',
+			title: { raw: '' },
+		},
 		{ id: 0, link: 'https://example.test/x', title: { raw: 'no id' } },
 		{ id: 2, link: '', title: { raw: 'no url' } },
 	] );
@@ -95,13 +95,13 @@ it( 'falls back to a placeholder title and drops records without an id or url', 
 
 	expect( suggestions ).toEqual( [
 		{
-				id: 1,
-				url: 'https://example.test/?p=1',
-				path: '1',
-				icon: '',
-				cortext_defines_trait: undefined,
-				crtxt_trait: undefined,
-				title: '(no title)',
+			id: 1,
+			url: 'https://example.test/?p=1',
+			path: '1',
+			icon: '',
+			cortext_defines_trait: undefined,
+			crtxt_trait: undefined,
+			title: '(no title)',
 			type: 'crtxt_document',
 			kind: 'post-type',
 		},

--- a/tests/js/components/mention.test.js
+++ b/tests/js/components/mention.test.js
@@ -135,9 +135,7 @@ describe( 'mention completer', () => {
 			'Project',
 			'Brief',
 		] );
-		expect( mentionCompleter.getOptionLabel ).toBe(
-			getMentionOptionLabel
-		);
+		expect( mentionCompleter.getOptionLabel ).toBe( getMentionOptionLabel );
 		expect( mentionCompleter.getOptionKeywords ).toBe(
 			getMentionOptionKeywords
 		);
@@ -165,12 +163,12 @@ describe( 'mention icons', () => {
 	} );
 
 	it( 'extracts emoji icons from document icon metadata', () => {
-		expect(
-			mentionEmojiFromIcon( '{"type":"emoji","value":"B"}' )
-		).toBe( 'B' );
-		expect(
-			mentionEmojiFromIcon( '{"type":"wp","name":"bell"}' )
-		).toBe( '' );
+		expect( mentionEmojiFromIcon( '{"type":"emoji","value":"B"}' ) ).toBe(
+			'B'
+		);
+		expect( mentionEmojiFromIcon( '{"type":"wp","name":"bell"}' ) ).toBe(
+			''
+		);
 		expect( mentionEmojiFromIcon( '{' ) ).toBe( '' );
 	} );
 
@@ -178,15 +176,14 @@ describe( 'mention icons', () => {
 		expect(
 			mentionIconForRecord( {
 				meta: {
-					cortext_document_icon:
-						'{"type":"emoji","value":"A"}',
+					cortext_document_icon: '{"type":"emoji","value":"A"}',
 				},
 				cortext_defines_trait: true,
 			} )
 		).toBe( '{"type":"emoji","value":"A"}' );
-		expect(
-			mentionIconForRecord( { cortext_defines_trait: true } )
-		).toBe( '{"type":"wp","name":"collection"}' );
+		expect( mentionIconForRecord( { cortext_defines_trait: true } ) ).toBe(
+			'{"type":"wp","name":"collection"}'
+		);
 		expect( mentionIconForRecord( { crtxt_trait: [ 5 ] } ) ).toBe(
 			'{"type":"wp","name":"listItem"}'
 		);
@@ -239,16 +236,14 @@ describe( 'mention icons', () => {
 			'purple'
 		);
 		expect(
-			anchor.style.getPropertyValue(
-				'--cortext-mention-icon-color'
-			)
+			anchor.style.getPropertyValue( '--cortext-mention-icon-color' )
 		).toBe( '#a855f7' );
 		expect(
 			anchor.style.getPropertyValue( '--cortext-mention-icon-mask' )
 		).toContain( 'data:image/svg+xml' );
-		expect(
-			anchor.getAttribute( 'data-crtxt-icon-hydrated-for' )
-		).toBe( '33' );
+		expect( anchor.getAttribute( 'data-crtxt-icon-hydrated-for' ) ).toBe(
+			'33'
+		);
 		anchor.remove();
 	} );
 
@@ -269,8 +264,7 @@ describe( 'mention icons', () => {
 		anchor.textContent = 'Rollup examples';
 		iframeDocument.body.appendChild( anchor );
 
-		const release =
-			retainMentionIconHydratorsForEditorDocument( document );
+		const release = retainMentionIconHydratorsForEditorDocument( document );
 
 		await waitFor( () => {
 			expect( anchor.getAttribute( 'data-crtxt-icon-wp' ) ).toBe(
@@ -313,9 +307,7 @@ describe( 'mention icons', () => {
 
 		selection.removeAllRanges();
 		updateMentionSelectionState( document );
-		expect( anchor ).not.toHaveClass(
-			'is-cortext-mention-selected'
-		);
+		expect( anchor ).not.toHaveClass( 'is-cortext-mention-selected' );
 		paragraph.remove();
 	} );
 } );
@@ -362,9 +354,7 @@ describe( 'mention snapshot rewrite helper', () => {
 		expect(
 			rewriteMentionSnapshots(
 				html,
-				new Map( [
-					[ 2, { title: 'Fresh', href: '/fresh-2' } ],
-				] )
+				new Map( [ [ 2, { title: 'Fresh', href: '/fresh-2' } ] ] )
 			)
 		).toEqual( { html, changed: false } );
 

--- a/tests/js/components/mention.test.js
+++ b/tests/js/components/mention.test.js
@@ -83,7 +83,7 @@ describe( 'mention completer', () => {
 		expect( options[ 0 ].iconImageUrl ).toBeUndefined();
 	} );
 
-	it( 'returns persisted mention anchor markup for document completions', () => {
+	it( 'saves a plain mention anchor for document completions', () => {
 		const html = renderToString(
 			getMentionCompletion( {
 				kind: 'document',
@@ -105,7 +105,7 @@ describe( 'mention completer', () => {
 		expect( html ).not.toContain( 'cortext-mention__label' );
 	} );
 
-	it( 'does not persist wp icon snapshots in completions', () => {
+	it( 'leaves icon snapshots out of saved completions', () => {
 		const html = renderToString(
 			getMentionCompletion( {
 				kind: 'document',
@@ -174,7 +174,7 @@ describe( 'mention icons', () => {
 		expect( mentionEmojiFromIcon( '{' ) ).toBe( '' );
 	} );
 
-	it( 'uses the destination record icon before derived fallbacks', () => {
+	it( "prefers the record's icon before fallback icons", () => {
 		expect(
 			mentionIconForRecord( {
 				meta: {
@@ -214,7 +214,7 @@ describe( 'mention icons', () => {
 		anchor.remove();
 	} );
 
-	it( 'hydrates mention icons from the current target record', async () => {
+	it( 'loads mention icons from the target record', async () => {
 		apiFetch.mockResolvedValue( {
 			id: 33,
 			meta: {
@@ -252,7 +252,7 @@ describe( 'mention icons', () => {
 		anchor.remove();
 	} );
 
-	it( 'hydrates mentions inside the editor iframe from the mounted controller', async () => {
+	it( 'updates mentions inside the editor iframe from the mounted controller', async () => {
 		apiFetch.mockResolvedValue( {
 			id: 289,
 			meta: {
@@ -329,7 +329,7 @@ describe( 'mention snapshot rewrite helper', () => {
 		expect( ids ).toEqual( [ 2, 3 ] );
 	} );
 
-	it( 'rewrites stale title and href snapshots', () => {
+	it( 'updates old title and href snapshots', () => {
 		const result = rewriteMentionSnapshots(
 			'<span>See <a class="cortext-mention" data-crtxt-mention="2" data-crtxt-path="old-2" data-crtxt-icon-emoji="O" style="--cortext-mention-icon-color: #111;" href="/old">Old</a></span>',
 			new Map( [
@@ -355,7 +355,7 @@ describe( 'mention snapshot rewrite helper', () => {
 		expect( result.html ).not.toContain( 'cortext-mention__label' );
 	} );
 
-	it( 'leaves current or unresolved snapshots alone', () => {
+	it( 'leaves up-to-date or unresolved snapshots alone', () => {
 		const html =
 			'<a class="cortext-mention" data-crtxt-mention="2" href="/fresh-2">Fresh</a>';
 

--- a/tests/js/components/mention.test.js
+++ b/tests/js/components/mention.test.js
@@ -1,0 +1,376 @@
+jest.mock( '@wordpress/hooks', () => ( {
+	addFilter: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/components/fetchCortextLinkSuggestions', () => ( {
+	fetchCortextLinkSuggestions: jest.fn(),
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import { fetchCortextLinkSuggestions } from '../../../src/components/fetchCortextLinkSuggestions';
+import { renderToString } from '@wordpress/element';
+import { waitFor } from '@testing-library/react';
+import {
+	fetchMentionOptions,
+	getMentionCompletion,
+	getMentionOptionKeywords,
+	getMentionOptionLabel,
+	mentionCompleter,
+	withCortextMentionCompleter,
+} from '../../../src/components/mention/completer';
+import {
+	collectMentionIdsFromHTML,
+	retainMentionIconHydratorsForEditorDocument,
+	rewriteMentionSnapshots,
+} from '../../../src/components/mention/CortextMentions';
+import {
+	hydrateMentionIcons,
+	hydrateMentionWpIconMasks,
+	mentionEmojiFromIcon,
+	mentionIconForRecord,
+	mentionWpIconMask,
+	updateMentionSelectionState,
+} from '../../../src/components/mention/icon';
+
+describe( 'mention completer', () => {
+	beforeEach( () => {
+		fetchCortextLinkSuggestions.mockReset();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {} );
+	} );
+
+	it( 'maps Cortext link suggestions to document mention options', async () => {
+		fetchCortextLinkSuggestions.mockResolvedValueOnce( [
+			{ id: 7, title: 'Roadmap', url: '/roadmap-7' },
+		] );
+
+		const options = await fetchMentionOptions( 'road' );
+
+		expect( fetchCortextLinkSuggestions ).toHaveBeenCalledWith( 'road', {
+			perPage: 10,
+		} );
+		expect( options[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				kind: 'document',
+				key: 'document-7',
+				label: 'Roadmap',
+				value: expect.objectContaining( {
+					id: 7,
+					kind: 'document',
+				} ),
+			} )
+		);
+	} );
+
+	it( 'does not fetch media while mapping mention options', async () => {
+		fetchCortextLinkSuggestions.mockResolvedValueOnce( [
+			{
+				icon: '{"type":"image","id":42}',
+				id: 7,
+				title: 'Roadmap',
+				url: '/roadmap-7',
+			},
+		] );
+
+		const options = await fetchMentionOptions( 'road' );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( options[ 0 ].iconImageUrl ).toBeUndefined();
+	} );
+
+	it( 'returns persisted mention anchor markup for document completions', () => {
+		const html = renderToString(
+			getMentionCompletion( {
+				kind: 'document',
+				icon: '{"type":"emoji","value":"B"}',
+				id: 9,
+				path: 'brief-9',
+				title: 'Brief',
+				url: '/brief-9',
+			} )
+		);
+
+		expect( html ).not.toContain( '&lt;a' );
+		expect( html ).toContain( 'class="cortext-mention"' );
+		expect( html ).toContain( 'data-crtxt-mention="9"' );
+		expect( html ).toContain( 'href="/brief-9"' );
+		expect( html ).not.toContain( 'data-crtxt-path' );
+		expect( html ).not.toContain( 'data-crtxt-icon' );
+		expect( html ).toContain( '>Brief</a>' );
+		expect( html ).not.toContain( 'cortext-mention__label' );
+	} );
+
+	it( 'does not persist wp icon snapshots in completions', () => {
+		const html = renderToString(
+			getMentionCompletion( {
+				kind: 'document',
+				icon: '{"type":"wp","name":"chartBar","color":"purple"}',
+				id: 9,
+				path: 'brief-9',
+				title: 'Brief',
+				url: '/brief-9',
+			} )
+		);
+
+		expect( html ).not.toContain( 'data-crtxt-icon-wp' );
+		expect( html ).not.toContain( 'data-crtxt-icon-color' );
+		expect( html ).not.toContain( '--cortext-mention-icon-color' );
+		expect( html ).not.toContain( '--cortext-mention-icon-mask' );
+		expect( html ).not.toContain( 'data:image/svg+xml' );
+	} );
+
+	it( 'provides labels and keywords for Gutenberg autocomplete items', () => {
+		const option = {
+			kind: 'document',
+			title: 'Project Brief',
+		};
+
+		expect( getMentionOptionLabel( option ) ).toBe( 'Project Brief' );
+		expect( getMentionOptionKeywords( option ) ).toEqual( [
+			'Project',
+			'Brief',
+		] );
+		expect( mentionCompleter.getOptionLabel ).toBe(
+			getMentionOptionLabel
+		);
+		expect( mentionCompleter.getOptionKeywords ).toBe(
+			getMentionOptionKeywords
+		);
+	} );
+
+	it( 'replaces the default user @ completer with Cortext mentions', () => {
+		const blockCompleter = { name: 'blocks', triggerPrefix: '/' };
+		const userCompleter = { name: 'users', triggerPrefix: '@' };
+		const linkCompleter = { name: 'links', triggerPrefix: '[[' };
+
+		expect(
+			withCortextMentionCompleter( [
+				linkCompleter,
+				userCompleter,
+				blockCompleter,
+			] )
+		).toEqual( [ mentionCompleter, linkCompleter, blockCompleter ] );
+	} );
+} );
+
+describe( 'mention icons', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {} );
+	} );
+
+	it( 'extracts emoji icons from document icon metadata', () => {
+		expect(
+			mentionEmojiFromIcon( '{"type":"emoji","value":"B"}' )
+		).toBe( 'B' );
+		expect(
+			mentionEmojiFromIcon( '{"type":"wp","name":"bell"}' )
+		).toBe( '' );
+		expect( mentionEmojiFromIcon( '{' ) ).toBe( '' );
+	} );
+
+	it( 'uses the destination record icon before derived fallbacks', () => {
+		expect(
+			mentionIconForRecord( {
+				meta: {
+					cortext_document_icon:
+						'{"type":"emoji","value":"A"}',
+				},
+				cortext_defines_trait: true,
+			} )
+		).toBe( '{"type":"emoji","value":"A"}' );
+		expect(
+			mentionIconForRecord( { cortext_defines_trait: true } )
+		).toBe( '{"type":"wp","name":"collection"}' );
+		expect( mentionIconForRecord( { crtxt_trait: [ 5 ] } ) ).toBe(
+			'{"type":"wp","name":"listItem"}'
+		);
+		expect( mentionIconForRecord( {} ) ).toBe( '' );
+	} );
+
+	it( 'builds wp icon masks without currentColor in the data URI', () => {
+		const mask = decodeURIComponent( mentionWpIconMask( 'collection' ) );
+
+		expect( mask ).toContain( 'black' );
+		expect( mask ).not.toContain( 'currentColor' );
+	} );
+
+	it( 'hydrates wp mention masks in the current document', () => {
+		const anchor = document.createElement( 'a' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-icon-wp', 'chartBar' );
+		document.body.appendChild( anchor );
+
+		hydrateMentionWpIconMasks( document );
+
+		expect(
+			anchor.style.getPropertyValue( '--cortext-mention-icon-mask' )
+		).toContain( 'data:image/svg+xml' );
+		anchor.remove();
+	} );
+
+	it( 'hydrates mention icons from the current target record', async () => {
+		apiFetch.mockResolvedValue( {
+			id: 33,
+			meta: {
+				cortext_document_icon:
+					'{"type":"wp","name":"chartBar","color":"purple"}',
+			},
+		} );
+		const anchor = document.createElement( 'a' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-mention', '33' );
+		document.body.appendChild( anchor );
+
+		await hydrateMentionIcons( document );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/crtxt_documents/33?context=edit&_fields=id,meta,cortext_defines_trait,crtxt_trait',
+		} );
+		expect( anchor.getAttribute( 'data-crtxt-icon-wp' ) ).toBe(
+			'chartBar'
+		);
+		expect( anchor.getAttribute( 'data-crtxt-icon-color' ) ).toBe(
+			'purple'
+		);
+		expect(
+			anchor.style.getPropertyValue(
+				'--cortext-mention-icon-color'
+			)
+		).toBe( '#a855f7' );
+		expect(
+			anchor.style.getPropertyValue( '--cortext-mention-icon-mask' )
+		).toContain( 'data:image/svg+xml' );
+		expect(
+			anchor.getAttribute( 'data-crtxt-icon-hydrated-for' )
+		).toBe( '33' );
+		anchor.remove();
+	} );
+
+	it( 'hydrates mentions inside the editor iframe from the mounted controller', async () => {
+		apiFetch.mockResolvedValue( {
+			id: 289,
+			meta: {
+				cortext_document_icon:
+					'{"type":"wp","name":"chartBar","color":"purple"}',
+			},
+		} );
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const iframeDocument = iframe.contentDocument;
+		const anchor = iframeDocument.createElement( 'a' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-mention', '289' );
+		anchor.textContent = 'Rollup examples';
+		iframeDocument.body.appendChild( anchor );
+
+		const release =
+			retainMentionIconHydratorsForEditorDocument( document );
+
+		await waitFor( () => {
+			expect( anchor.getAttribute( 'data-crtxt-icon-wp' ) ).toBe(
+				'chartBar'
+			);
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/crtxt_documents/289?context=edit&_fields=id,meta,cortext_defines_trait,crtxt_trait',
+		} );
+		expect( anchor.getAttribute( 'data-crtxt-icon-color' ) ).toBe(
+			'purple'
+		);
+
+		release();
+		iframe.remove();
+	} );
+
+	it( 'marks mentioned tokens that intersect the current text selection', () => {
+		const paragraph = document.createElement( 'p' );
+		const before = document.createTextNode( 'hola ' );
+		const anchor = document.createElement( 'a' );
+		const after = document.createTextNode( ' después' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-mention', '289' );
+		anchor.textContent = 'Rollup examples';
+		paragraph.append( before, anchor, after );
+		document.body.appendChild( paragraph );
+
+		const range = document.createRange();
+		range.setStart( before, 1 );
+		range.setEnd( after, 4 );
+		const selection = document.getSelection();
+		selection.removeAllRanges();
+		selection.addRange( range );
+
+		updateMentionSelectionState( document );
+
+		expect( anchor ).toHaveClass( 'is-cortext-mention-selected' );
+
+		selection.removeAllRanges();
+		updateMentionSelectionState( document );
+		expect( anchor ).not.toHaveClass(
+			'is-cortext-mention-selected'
+		);
+		paragraph.remove();
+	} );
+} );
+
+describe( 'mention snapshot rewrite helper', () => {
+	it( 'collects distinct mention target ids', () => {
+		const ids = collectMentionIdsFromHTML(
+			'<a data-crtxt-mention="2">A</a><a data-crtxt-mention="2">A</a><a data-crtxt-mention="3">B</a>'
+		);
+
+		expect( ids ).toEqual( [ 2, 3 ] );
+	} );
+
+	it( 'rewrites stale title and href snapshots', () => {
+		const result = rewriteMentionSnapshots(
+			'<span>See <a class="cortext-mention" data-crtxt-mention="2" data-crtxt-path="old-2" data-crtxt-icon-emoji="O" style="--cortext-mention-icon-color: #111;" href="/old">Old</a></span>',
+			new Map( [
+				[
+					2,
+					{
+						title: 'Fresh',
+						href: '/fresh-2',
+						path: 'fresh-2',
+						icon: '{"type":"emoji","value":"F"}',
+					},
+				],
+			] )
+		);
+
+		expect( result.changed ).toBe( true );
+		expect( result.html ).toContain( 'data-crtxt-mention="2"' );
+		expect( result.html ).not.toContain( 'data-crtxt-icon' );
+		expect( result.html ).not.toContain( 'data-crtxt-path' );
+		expect( result.html ).not.toContain( 'style=' );
+		expect( result.html ).toContain( 'href="/fresh-2"' );
+		expect( result.html ).toContain( '>Fresh</a>' );
+		expect( result.html ).not.toContain( 'cortext-mention__label' );
+	} );
+
+	it( 'leaves current or unresolved snapshots alone', () => {
+		const html =
+			'<a class="cortext-mention" data-crtxt-mention="2" href="/fresh-2">Fresh</a>';
+
+		expect(
+			rewriteMentionSnapshots(
+				html,
+				new Map( [
+					[ 2, { title: 'Fresh', href: '/fresh-2' } ],
+				] )
+			)
+		).toEqual( { html, changed: false } );
+
+		expect( rewriteMentionSnapshots( html, new Map() ) ).toEqual( {
+			html,
+			changed: false,
+		} );
+	} );
+} );

--- a/tests/js/components/mention.test.js
+++ b/tests/js/components/mention.test.js
@@ -102,6 +102,8 @@ describe( 'mention completer', () => {
 		expect( html ).not.toContain( 'data-crtxt-path' );
 		expect( html ).not.toContain( 'data-crtxt-icon' );
 		expect( html ).toContain( '>Brief</a>' );
+		// A trailing space keeps the caret typeable right after the mention.
+		expect( html ).toMatch( /<\/a>\s$/ );
 		expect( html ).not.toContain( 'cortext-mention__label' );
 	} );
 

--- a/tests/js/initEditor.test.js
+++ b/tests/js/initEditor.test.js
@@ -25,6 +25,10 @@ jest.mock( '../../src/blocks', () => ( {} ) );
 // import; stub it so the test doesn't pull the full data + editor chain.
 jest.mock( '../../src/components/initInserterMediaCategories', () => ( {} ) );
 
+// Mention registration is covered separately; avoid pulling rich-text stores
+// into this allowlist test.
+jest.mock( '../../src/components/mention', () => ( {} ) );
+
 import {
 	ALLOWED_BLOCK_TYPES,
 	COLLECTIONS_BLOCK_CATEGORY,

--- a/tests/php/test-frontend-mention-renderer.php
+++ b/tests/php/test-frontend-mention-renderer.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Tests for Cortext\Frontend\MentionRenderer.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Frontend\MentionRenderer;
+use Cortext\PostType\Document;
+use Cortext\PostType\DocumentIdentity;
+use WorDBless\BaseTestCase;
+
+final class Test_Frontend_Mention_Renderer extends BaseTestCase {
+
+	private MentionRenderer $renderer;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Document() )->register_post_type();
+		$this->renderer = new MentionRenderer();
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_refreshes_title_and_permalink_snapshot(): void {
+		$target = $this->create_document( 'Fresh title' );
+		update_post_meta(
+			$target,
+			DocumentIdentity::META_KEY,
+			wp_json_encode(
+				array(
+					'type'  => 'emoji',
+					'value' => 'F',
+				)
+			)
+		);
+		$html = sprintf(
+			'<p>See <a class="cortext-mention" data-crtxt-mention="%d" href="old">Old title</a>.</p>',
+			$target
+		);
+
+		$rendered = $this->renderer->refresh_mentions( $html );
+
+		$this->assertStringContainsString( 'data-crtxt-mention="' . $target . '"', $rendered );
+		$this->assertStringContainsString( 'data-crtxt-icon-emoji="F"', $rendered );
+		$this->assertStringContainsString( 'data-crtxt-path="fresh-title-' . $target . '"', $rendered );
+		$this->assertStringContainsString( 'href="' . esc_url( get_permalink( $target ) ) . '"', $rendered );
+		$this->assertStringContainsString( '>Fresh title</a>', $rendered );
+		$this->assertStringNotContainsString( 'cortext-mention__label', $rendered );
+		$this->assertStringNotContainsString( 'Old title', $rendered );
+	}
+
+	public function test_renders_wordpress_icon_marker(): void {
+		$target = $this->create_document( 'Icon target' );
+		update_post_meta(
+			$target,
+			DocumentIdentity::META_KEY,
+			wp_json_encode(
+				array(
+					'type'  => 'wp',
+					'name'  => 'starFilled',
+					'color' => 'yellow',
+				)
+			)
+		);
+		$html = sprintf(
+			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="old">Old title</a></p>',
+			$target
+		);
+
+		$rendered = $this->renderer->refresh_mentions( $html );
+
+		$this->assertStringContainsString( 'data-crtxt-icon-wp="starFilled"', $rendered );
+		$this->assertStringContainsString( 'style="--cortext-mention-icon-color: #eab308;"', $rendered );
+	}
+
+	public function test_deleted_target_degrades_to_missing_span(): void {
+		$target = $this->create_document( 'Gone' );
+		wp_delete_post( $target, true );
+		$html = sprintf(
+			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="old">Snapshot</a></p>',
+			$target
+		);
+
+		$rendered = $this->renderer->refresh_mentions( $html );
+
+		$this->assertStringContainsString(
+			'<span class="cortext-mention cortext-mention--missing">Snapshot</span>',
+			$rendered
+		);
+		$this->assertStringNotContainsString( '<a class="cortext-mention"', $rendered );
+	}
+
+	public function test_trashed_target_degrades_to_missing_span(): void {
+		$target = $this->create_document( 'Trashed' );
+		wp_trash_post( $target );
+		$html = sprintf(
+			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="old">Snapshot</a></p>',
+			$target
+		);
+
+		$rendered = $this->renderer->refresh_mentions( $html );
+
+		$this->assertStringContainsString(
+			'<span class="cortext-mention cortext-mention--missing">Snapshot</span>',
+			$rendered
+		);
+		$this->assertStringNotContainsString( '<a class="cortext-mention"', $rendered );
+	}
+
+	public function test_non_document_target_degrades_to_missing_span(): void {
+		$target = (int) wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular post',
+			)
+		);
+		$html   = sprintf(
+			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="old">Snapshot</a></p>',
+			$target
+		);
+
+		$rendered = $this->renderer->refresh_mentions( $html );
+
+		$this->assertStringContainsString(
+			'<span class="cortext-mention cortext-mention--missing">Snapshot</span>',
+			$rendered
+		);
+	}
+
+	public function test_unreadable_private_target_degrades_to_missing_span(): void {
+		$target = (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Secret title',
+				'post_name'   => 'secret-title',
+			)
+		);
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+		$html = sprintf(
+			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="old">Snapshot</a></p>',
+			$target
+		);
+
+		$rendered = $this->renderer->refresh_mentions( $html );
+
+		$this->assertStringContainsString(
+			'<span class="cortext-mention cortext-mention--missing">Snapshot</span>',
+			$rendered
+		);
+		$this->assertStringNotContainsString( 'Secret title', $rendered );
+	}
+
+	public function test_no_mention_content_passes_through_unchanged(): void {
+		$html = '<p>No mention here.</p>';
+
+		$this->assertSame( $html, $this->renderer->refresh_mentions( $html ) );
+	}
+
+	private function create_document( string $title ): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => $title,
+				'post_name'   => sanitize_title( $title ),
+			)
+		);
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+}

--- a/tests/php/test-frontend-mention-renderer.php
+++ b/tests/php/test-frontend-mention-renderer.php
@@ -31,7 +31,7 @@ final class Test_Frontend_Mention_Renderer extends BaseTestCase {
 		parent::tear_down();
 	}
 
-	public function test_refreshes_title_and_permalink_snapshot(): void {
+	public function test_updates_title_and_permalink_snapshot(): void {
 		$target = $this->create_document( 'Fresh title' );
 		update_post_meta(
 			$target,
@@ -83,7 +83,7 @@ final class Test_Frontend_Mention_Renderer extends BaseTestCase {
 		$this->assertStringContainsString( 'style="--cortext-mention-icon-color: #eab308;"', $rendered );
 	}
 
-	public function test_deleted_target_degrades_to_missing_span(): void {
+	public function test_deleted_target_renders_saved_label_as_missing_mention(): void {
 		$target = $this->create_document( 'Gone' );
 		wp_delete_post( $target, true );
 		$html = sprintf(
@@ -100,7 +100,7 @@ final class Test_Frontend_Mention_Renderer extends BaseTestCase {
 		$this->assertStringNotContainsString( '<a class="cortext-mention"', $rendered );
 	}
 
-	public function test_trashed_target_degrades_to_missing_span(): void {
+	public function test_trashed_target_renders_saved_label_as_missing_mention(): void {
 		$target = $this->create_document( 'Trashed' );
 		wp_trash_post( $target );
 		$html = sprintf(
@@ -117,7 +117,7 @@ final class Test_Frontend_Mention_Renderer extends BaseTestCase {
 		$this->assertStringNotContainsString( '<a class="cortext-mention"', $rendered );
 	}
 
-	public function test_non_document_target_degrades_to_missing_span(): void {
+	public function test_non_document_target_renders_saved_label_as_missing_mention(): void {
 		$target = (int) wp_insert_post(
 			array(
 				'post_type'   => 'post',
@@ -138,7 +138,7 @@ final class Test_Frontend_Mention_Renderer extends BaseTestCase {
 		);
 	}
 
-	public function test_unreadable_private_target_degrades_to_missing_span(): void {
+	public function test_unreadable_private_target_renders_saved_label_as_missing_mention(): void {
 		$target = (int) wp_insert_post(
 			array(
 				'post_type'   => Document::POST_TYPE,
@@ -162,7 +162,7 @@ final class Test_Frontend_Mention_Renderer extends BaseTestCase {
 		$this->assertStringNotContainsString( 'Secret title', $rendered );
 	}
 
-	public function test_no_mention_content_passes_through_unchanged(): void {
+	public function test_content_without_mentions_is_unchanged(): void {
 		$html = '<p>No mention here.</p>';
 
 		$this->assertSame( $html, $this->renderer->refresh_mentions( $html ) );


### PR DESCRIPTION
## What

Part of #160

Lets users mention Cortext documents with `@` while editing, in both the page editor and the row detail editor. The autocomplete searches Cortext documents, inserts a compact inline mention, and keeps clicks inside the Cortext router. On public pages, readable mentions render as links with the current title and icon; private, deleted, or unreadable targets fall back to the saved label.

## How

- Saving mentions as anchors with the target document id.
- Refreshing saved title/link snapshots when the target changes.
- Rendering public mentions through normal read permissions so private titles do not leak.

## Testing Instructions

1. Open a Cortext document and type `@` in a text block.
2. Pick another Cortext document from the autocomplete menu.
3. Save and reload the document, then confirm the mention still shows the right title and icon.
4. Rename the target document and confirm the mention updates in the source document.
5. Click the mention in the editor and confirm Cortext opens the target document.
6. Open the source document publicly and confirm the mention renders correctly.

## Screen recording


https://github.com/user-attachments/assets/fa7d48c8-5d45-495a-bbca-ae6d48cf22b5


