### PR TITLE
Performance: Calculate table footer totals on the server

### DIFF
--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -32,7 +32,40 @@ use WP_REST_Response;
 
 final class RowsController {
 
-	private const NAMESPACE = 'cortext/v1';
+	private const NAMESPACE                   = 'cortext/v1';
+	private const COUNT_CALCULATIONS          = array(
+		'count',
+		'countValues',
+		'countUnique',
+		'empty',
+		'notEmpty',
+	);
+	private const PRESENCE_COUNT_CALCULATIONS = array( 'count', 'empty', 'notEmpty' );
+	private const BOOLEAN_COUNT_CALCULATIONS  = array( 'count' );
+	private const PERCENT_CALCULATIONS        = array( 'percentEmpty', 'percentNotEmpty' );
+	private const NUMBER_CALCULATIONS         = array(
+		'sum',
+		'average',
+		'median',
+		'min',
+		'max',
+		'range',
+	);
+	private const NUMBER_TYPES                = array( 'number', 'integer' );
+	private const DATE_TYPES                  = array( 'date', 'datetime' );
+	private const BOOLEAN_TYPES               = array( 'boolean', 'checkbox' );
+	private const MULTI_VALUE_TYPES           = array( 'array', 'multiselect' );
+	private const SCALAR_COUNT_TYPES          = array(
+		'title',
+		'text',
+		'email',
+		'url',
+		'select',
+		'number',
+		'integer',
+		'date',
+		'datetime',
+	);
 
 	public function register(): void {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
@@ -60,25 +93,25 @@ final class RowsController {
 					'callback'            => array( $this, 'get_rows' ),
 					'permission_callback' => array( $this, 'can_read' ),
 					'args'                => array(
-						'trait'    => array(
+						'trait'        => array(
 							'type'     => 'integer',
 							'required' => true,
 						),
-						'page'     => array(
+						'page'         => array(
 							'type'    => 'integer',
 							'default' => 1,
 							'minimum' => 1,
 						),
-						'per_page' => array(
+						'per_page'     => array(
 							'type'              => 'integer',
 							'default'           => 25,
 							'validate_callback' => static fn( $value ) => (int) $value >= 1 && (int) $value <= 100,
 						),
-						'search'   => array(
+						'search'       => array(
 							'type'    => 'string',
 							'default' => '',
 						),
-						'sort'     => array(
+						'sort'         => array(
 							'type'       => 'object',
 							'default'    => null,
 							'properties' => array(
@@ -89,23 +122,28 @@ final class RowsController {
 								),
 							),
 						),
-						'filters'  => array(
+						'filters'      => array(
 							'type'    => 'array',
 							'default' => array(),
 						),
-						'include'  => array(
+						'include'      => array(
 							'type'              => 'array',
 							'default'           => array(),
 							'items'             => array( 'type' => 'integer' ),
 							'sanitize_callback' => array( $this, 'sanitize_include_param' ),
 							'validate_callback' => array( $this, 'validate_include_param' ),
 						),
-						'fields'   => array(
+						'fields'       => array(
 							'type'    => 'array',
 							'default' => null,
 							'items'   => array( 'type' => 'string' ),
 						),
-						'context'  => array(
+						'calculations' => array(
+							'type'       => 'object',
+							'default'    => array(),
+							'properties' => array(),
+						),
+						'context'      => array(
 							'type'    => 'string',
 							'default' => 'edit',
 							'enum'    => array( 'view', 'edit' ),
@@ -181,6 +219,18 @@ final class RowsController {
 		$formatted_field_ids = is_array( $requested_fields )
 			? $this->filter_requested_field_ids( $requested_fields, $field_ids )
 			: $field_ids;
+		$row_query           = new RowsFilterQuery();
+		$field_schema        = $row_query->field_schema_for( $collection_id );
+		$fields              = $this->field_definitions( $field_ids );
+
+		$calculation_requests = $this->validated_calculations(
+			$request->get_param( 'calculations' ),
+			$field_schema,
+			$collection_id
+		);
+		if ( is_wp_error( $calculation_requests ) ) {
+			return $calculation_requests;
+		}
 
 		// If `include` was sent but sanitizes to an empty list, return no rows.
 		// Falling through would return page 1 of the collection, which is not
@@ -188,20 +238,25 @@ final class RowsController {
 		// but future callers might.
 		$query_params = $request->get_query_params();
 		if ( array_key_exists( 'include', $query_params ) && count( (array) $request->get_param( 'include' ) ) === 0 ) {
+			$response = array(
+				'rows'       => array(),
+				'total'      => 0,
+				'totalPages' => 0,
+				'collection' => $this->collection_definition( $collection ),
+				'fields'     => $fields,
+			);
+			if ( count( $calculation_requests ) > 0 ) {
+				$response['calculations'] = $this->calculate_rows(
+					array(),
+					$calculation_requests,
+					$field_schema
+				);
+			}
 			return new WP_REST_Response(
-				array(
-					'rows'       => array(),
-					'total'      => 0,
-					'totalPages' => 0,
-					'collection' => $this->collection_definition( $collection ),
-					'fields'     => $this->field_definitions( $field_ids ),
-				),
+				$response,
 				200
 			);
 		}
-
-		$row_query    = new RowsFilterQuery();
-		$field_schema = $row_query->field_schema_for( $collection_id );
 
 		$sort_validation = $row_query->validate_sort(
 			$request->get_param( 'sort' ),
@@ -286,18 +341,32 @@ final class RowsController {
 			$posts
 		);
 
-		$fields = $this->field_definitions( $field_ids );
-
-		return new WP_REST_Response(
-			array(
-				'rows'       => $rows,
-				'total'      => $total,
-				'totalPages' => $total_pages,
-				'collection' => $this->collection_definition( $collection ),
-				'fields'     => $fields,
-			),
-			200
+		$response = array(
+			'rows'       => $rows,
+			'total'      => $total,
+			'totalPages' => $total_pages,
+			'collection' => $this->collection_definition( $collection ),
+			'fields'     => $fields,
 		);
+
+		if ( count( $calculation_requests ) > 0 ) {
+			$calculation_posts        = $this->query_posts_for_calculations(
+				$request,
+				$collection_id,
+				$row_statuses,
+				$row_query,
+				$field_schema,
+				$where_sql,
+				$filter_sql['join']
+			);
+			$response['calculations'] = $this->calculate_rows(
+				$calculation_posts,
+				$calculation_requests,
+				$field_schema
+			);
+		}
+
+		return new WP_REST_Response( $response, 200 );
 	}
 
 	/**
@@ -421,6 +490,457 @@ final class RowsController {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Builds the unpaged query for table calculation totals.
+	 *
+	 * @param WP_REST_Request $request       Full request object.
+	 * @param int             $collection_id Collection (trait) post ID.
+	 * @param string[]        $row_statuses  Post statuses visible to this request.
+	 * @return array
+	 */
+	private function build_calculation_query_args( WP_REST_Request $request, int $collection_id, array $row_statuses ): array {
+		$args = array(
+			'post_type'      => Document::POST_TYPE,
+			'post_status'    => $row_statuses,
+			'posts_per_page' => -1,
+			'paged'          => 1,
+			'no_found_rows'  => true,
+			'orderby'        => array( 'ID' => 'ASC' ),
+		);
+
+		$trait_term_id = Relations::trait_term_id_for_collection( $collection_id );
+		if ( $trait_term_id > 0 ) {
+			$args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				array(
+					'taxonomy' => TraitTaxonomy::TAXONOMY,
+					'field'    => 'term_id',
+					'terms'    => array( $trait_term_id ),
+				),
+			);
+		}
+
+		$include = (array) $request->get_param( 'include' );
+		if ( count( $include ) > 0 ) {
+			$args['post__in'] = $include;
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Queries every row in the current filter and search scope for calculations.
+	 *
+	 * @param WP_REST_Request $request       Full request object.
+	 * @param int             $collection_id Collection (trait) post ID.
+	 * @param string[]        $row_statuses  Post statuses visible to this request.
+	 * @param RowsFilterQuery $row_query     Row filter/search compiler.
+	 * @param array           $field_schema  Field schema from RowsFilterQuery.
+	 * @param string          $where_sql     Compiled filter/search WHERE SQL.
+	 * @param string          $join_sql      Compiled filter JOIN SQL.
+	 * @return WP_Post[]
+	 */
+	private function query_posts_for_calculations(
+		WP_REST_Request $request,
+		int $collection_id,
+		array $row_statuses,
+		RowsFilterQuery $row_query,
+		array $field_schema,
+		string $where_sql,
+		string $join_sql
+	): array {
+		$scope = new RowsQueryScope(
+			$row_query,
+			$field_schema,
+			$where_sql,
+			$join_sql,
+			null,
+			'',
+			TraitTaxonomy::term_taxonomy_id_for_trait( $collection_id )
+		);
+		$query = $scope->run(
+			$this->build_calculation_query_args( $request, $collection_id, $row_statuses )
+		);
+
+		return array_values(
+			array_filter(
+				$query->posts,
+				static fn( $post ): bool => $post instanceof WP_Post
+			)
+		);
+	}
+
+	/**
+	 * Adds system fields that can be visible in DataViews, but are not sortable
+	 * or filterable row-query fields.
+	 *
+	 * @param array $field_schema Base query field schema.
+	 * @return array
+	 */
+	private function calculation_field_schema( array $field_schema ): array {
+		unset( $field_schema['manual'] );
+
+		$field_schema['cover']       = array(
+			'id'     => 0,
+			'key'    => 'cover',
+			'type'   => 'media',
+			'system' => true,
+		);
+		$field_schema['created_by']  = array(
+			'id'     => 0,
+			'key'    => 'created_by',
+			'type'   => 'text',
+			'system' => true,
+		);
+		$field_schema['modified_by'] = array(
+			'id'     => 0,
+			'key'    => 'modified_by',
+			'type'   => 'text',
+			'system' => true,
+		);
+
+		return $field_schema;
+	}
+
+	/**
+	 * Validates the requested `calculations[field-id]=operation` map.
+	 *
+	 * @param mixed $raw           Raw request value.
+	 * @param array $field_schema  Field schema from RowsFilterQuery.
+	 * @param int   $collection_id Collection post ID for errors.
+	 * @return array<string,string>|WP_Error
+	 */
+	private function validated_calculations( mixed $raw, array $field_schema, int $collection_id ): array|WP_Error {
+		if ( null === $raw || array() === $raw || '' === $raw ) {
+			return array();
+		}
+		if ( ! is_array( $raw ) ) {
+			return new WP_Error(
+				'cortext_invalid_calculations',
+				__( 'Calculations must be an object keyed by field ID.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$schema   = $this->calculation_field_schema( $field_schema );
+		$requests = array();
+		foreach ( $raw as $field_key => $calculation ) {
+			$field_key   = (string) $field_key;
+			$calculation = (string) $calculation;
+
+			if ( ! isset( $schema[ $field_key ] ) ) {
+				return new WP_Error(
+					'cortext_invalid_calculation_field',
+					sprintf(
+						/* translators: 1: field key, 2: collection ID */
+						__( 'Field "%1$s" cannot be calculated for collection %2$d.', 'cortext' ),
+						$field_key,
+						$collection_id
+					),
+					array( 'status' => 400 )
+				);
+			}
+
+			if ( ! $this->is_calculation_available( $schema[ $field_key ], $calculation ) ) {
+				return new WP_Error(
+					'cortext_invalid_calculation',
+					sprintf(
+						/* translators: 1: calculation key, 2: field key */
+						__( 'Calculation "%1$s" is not available for field "%2$s".', 'cortext' ),
+						$calculation,
+						$field_key
+					),
+					array( 'status' => 400 )
+				);
+			}
+
+			$requests[ $field_key ] = $calculation;
+		}
+
+		return $requests;
+	}
+
+	/**
+	 * Returns all calculations available for a schema field.
+	 *
+	 * @param array $field Schema field entry.
+	 * @return string[]
+	 */
+	private function calculation_options_for_field( array $field ): array {
+		$type          = (string) ( $field['type'] ?? 'text' );
+		$count_options = self::PRESENCE_COUNT_CALCULATIONS;
+		if ( in_array( $type, self::BOOLEAN_TYPES, true ) ) {
+			$count_options = self::BOOLEAN_COUNT_CALCULATIONS;
+		} elseif ( in_array( $type, self::SCALAR_COUNT_TYPES, true ) ) {
+			$count_options = self::COUNT_CALCULATIONS;
+		} elseif ( in_array( $type, self::MULTI_VALUE_TYPES, true ) ) {
+			$count_options = self::PRESENCE_COUNT_CALCULATIONS;
+		}
+
+		$options = $count_options;
+		if ( in_array( 'empty', $count_options, true ) && in_array( 'notEmpty', $count_options, true ) ) {
+			$options = array_merge( $options, self::PERCENT_CALCULATIONS );
+		}
+		if ( in_array( $type, self::NUMBER_TYPES, true ) ) {
+			$options = array_merge( $options, self::NUMBER_CALCULATIONS );
+		} elseif ( in_array( $type, self::DATE_TYPES, true ) ) {
+			$options = array_merge( $options, array( 'min', 'max' ) );
+		}
+
+		return array_values( array_unique( $options ) );
+	}
+
+	private function is_calculation_available( array $field, string $calculation ): bool {
+		return in_array( $calculation, $this->calculation_options_for_field( $field ), true );
+	}
+
+	/**
+	 * Computes raw calculation values for a list of matching rows.
+	 *
+	 * @param WP_Post[]            $posts        Matching rows.
+	 * @param array<string,string> $requests     Field key => calculation key.
+	 * @param array                $field_schema Field schema from RowsFilterQuery.
+	 * @return array<string,array{calculation:string,value:mixed}>
+	 */
+	private function calculate_rows( array $posts, array $requests, array $field_schema ): array {
+		$schema           = $this->calculation_field_schema( $field_schema );
+		$custom_field_ids = array();
+		foreach ( $requests as $field_key => $calculation ) {
+			if ( 'count' === $calculation ) {
+				continue;
+			}
+			if ( preg_match( '/^field-(\d+)$/', $field_key, $matches ) ) {
+				$custom_field_ids[] = (int) $matches[1];
+			}
+		}
+		$custom_field_ids = array_values( array_unique( $custom_field_ids ) );
+
+		$ctx              = new RowFormatContext();
+		$ctx->field_types = $this->field_types_map( $custom_field_ids );
+		$multi_field_ids  = $this->multi_value_field_ids_from( $ctx->field_types );
+
+		$this->prime_user_cache( $posts );
+		$related_ids = $this->collect_related_row_ids( $posts, $custom_field_ids, $ctx );
+		if ( count( $related_ids ) > 0 ) {
+			_prime_post_caches( $related_ids, false, true );
+		}
+
+		$results = array();
+		foreach ( $requests as $field_key => $calculation ) {
+			if ( ! isset( $schema[ $field_key ] ) ) {
+				continue;
+			}
+
+			if ( 'count' === $calculation ) {
+				$results[ $field_key ] = array(
+					'calculation' => $calculation,
+					'value'       => count( $posts ),
+				);
+				continue;
+			}
+
+			$field  = $schema[ $field_key ];
+			$values = array_map(
+				function ( WP_Post $post ) use ( $field_key, $field, $ctx, $multi_field_ids ) {
+					return $this->calculation_value_for_post( $post, $field_key, $field, $ctx, $multi_field_ids );
+				},
+				$posts
+			);
+
+			$results[ $field_key ] = array(
+				'calculation' => $calculation,
+				'value'       => $this->calculate_values( $values, $field, $calculation, count( $posts ) ),
+			);
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Reads the normalized row value used by table calculations.
+	 *
+	 * @param WP_Post          $post            Row post.
+	 * @param string           $field_key       DataView field key.
+	 * @param array            $field           Schema field entry.
+	 * @param RowFormatContext $ctx            Formatting context.
+	 * @param array<int,true>  $multi_field_ids Multi-value custom fields.
+	 * @return mixed
+	 */
+	private function calculation_value_for_post( WP_Post $post, string $field_key, array $field, RowFormatContext $ctx, array $multi_field_ids ): mixed {
+		if ( 'title' === $field_key ) {
+			return $post->post_title;
+		}
+		if ( 'created_at' === $field_key ) {
+			return $this->format_gmt_date( $post->post_date_gmt );
+		}
+		if ( 'modified_at' === $field_key ) {
+			return $this->format_gmt_date( $post->post_modified_gmt );
+		}
+		if ( 'created_by' === $field_key ) {
+			return $this->display_name_for( (int) $post->post_author );
+		}
+		if ( 'modified_by' === $field_key ) {
+			$modified_by_id = (int) get_post_meta( $post->ID, '_modified_by', true );
+			return $this->display_name_for( $modified_by_id > 0 ? $modified_by_id : (int) $post->post_author );
+		}
+		if ( 'cover' === $field_key ) {
+			$cover = $this->cover_data_for_post( $post );
+			return $cover['url'] ?? '';
+		}
+
+		if ( ! preg_match( '/^field-(\d+)$/', $field_key, $matches ) ) {
+			return null;
+		}
+
+		$field_id   = (int) $matches[1];
+		$field_type = (string) ( $field['type'] ?? '' );
+		if ( 'relation' === $field_type ) {
+			return $this->format_relation_value( $post->ID, $field_id, $ctx );
+		}
+		if ( 'rollup' === $field_type ) {
+			return $this->compute_rollup_value( $post->ID, $field_id, $ctx );
+		}
+		return $this->format_typed_value(
+			$post->ID,
+			$field_id,
+			$field_type,
+			isset( $multi_field_ids[ $field_id ] )
+		);
+	}
+
+	/**
+	 * Computes one raw calculation value.
+	 *
+	 * @param array  $values      Normalized row values.
+	 * @param array  $field       Schema field entry.
+	 * @param string $calculation Calculation key.
+	 * @param int    $row_count   Matching row count.
+	 * @return mixed
+	 */
+	private function calculate_values( array $values, array $field, string $calculation, int $row_count ): mixed {
+		if ( 'count' === $calculation ) {
+			return $row_count;
+		}
+
+		$populated = array_values(
+			array_filter(
+				$values,
+				fn( $value ): bool => ! $this->is_empty_calculation_value( $value )
+			)
+		);
+
+		return match ( $calculation ) {
+			'countValues' => count( $populated ),
+			'countUnique' => count( array_unique( array_map( array( $this, 'unique_calculation_key' ), $populated ) ) ),
+			'empty' => $row_count - count( $populated ),
+			'notEmpty' => count( $populated ),
+			'percentEmpty' => $row_count > 0 ? ( $row_count - count( $populated ) ) / $row_count : null,
+			'percentNotEmpty' => $row_count > 0 ? count( $populated ) / $row_count : null,
+			'sum' => $this->sum_calculation_value( $values ),
+			'average' => $this->average_calculation_value( $values ),
+			'median' => $this->median_calculation_value( $values ),
+			'range' => $this->range_calculation_value( $values ),
+			'min', 'max' => $this->extrema_calculation_value( $values, $field, $calculation ),
+			default => null,
+		};
+	}
+
+	private function is_empty_calculation_value( mixed $value ): bool {
+		return null === $value || '' === $value || ( is_array( $value ) && count( $value ) === 0 );
+	}
+
+	private function unique_calculation_key( mixed $value ): string {
+		if ( is_array( $value ) ) {
+			$items = array_map( 'strval', $value );
+			sort( $items, SORT_STRING );
+			return (string) wp_json_encode( $items );
+		}
+		return (string) $value;
+	}
+
+	/**
+	 * Returns finite numeric values used by math calculations.
+	 *
+	 * @param array $values Normalized row values.
+	 * @return float[]
+	 */
+	private function numeric_calculation_values( array $values ): array {
+		$numbers = array();
+		foreach ( $values as $value ) {
+			if ( $this->is_empty_calculation_value( $value ) || ! is_numeric( $value ) ) {
+				continue;
+			}
+			$numbers[] = (float) $value;
+		}
+		return $numbers;
+	}
+
+	private function sum_calculation_value( array $values ): ?float {
+		$numbers = $this->numeric_calculation_values( $values );
+		return count( $numbers ) > 0 ? array_sum( $numbers ) : null;
+	}
+
+	private function average_calculation_value( array $values ): ?float {
+		$numbers = $this->numeric_calculation_values( $values );
+		return count( $numbers ) > 0 ? array_sum( $numbers ) / count( $numbers ) : null;
+	}
+
+	private function median_calculation_value( array $values ): ?float {
+		$numbers = $this->numeric_calculation_values( $values );
+		if ( count( $numbers ) === 0 ) {
+			return null;
+		}
+		sort( $numbers, SORT_NUMERIC );
+		$count  = count( $numbers );
+		$middle = intdiv( $count, 2 );
+		if ( 1 === $count % 2 ) {
+			return $numbers[ $middle ];
+		}
+		return ( $numbers[ $middle - 1 ] + $numbers[ $middle ] ) / 2;
+	}
+
+	private function range_calculation_value( array $values ): ?float {
+		$numbers = $this->numeric_calculation_values( $values );
+		return count( $numbers ) > 0 ? max( $numbers ) - min( $numbers ) : null;
+	}
+
+	private function extrema_calculation_value( array $values, array $field, string $direction ): mixed {
+		$type = (string) ( $field['type'] ?? 'text' );
+		$best = null;
+		foreach ( $values as $value ) {
+			$comparable = $this->comparable_calculation_value( $value, $type );
+			if ( null === $comparable ) {
+				continue;
+			}
+
+			if (
+				null === $best ||
+				( 'min' === $direction && $comparable < $best['comparable'] ) ||
+				( 'max' === $direction && $comparable > $best['comparable'] )
+			) {
+				$best = array(
+					'comparable' => $comparable,
+					'value'      => $value,
+				);
+			}
+		}
+
+		return $best['value'] ?? null;
+	}
+
+	private function comparable_calculation_value( mixed $value, string $type ): int|float|null {
+		if ( $this->is_empty_calculation_value( $value ) ) {
+			return null;
+		}
+		if ( in_array( $type, self::NUMBER_TYPES, true ) ) {
+			return is_numeric( $value ) ? (float) $value : null;
+		}
+		if ( in_array( $type, self::DATE_TYPES, true ) ) {
+			$timestamp = strtotime( (string) $value );
+			return false === $timestamp ? null : $timestamp;
+		}
+		return null;
 	}
 
 	private function row_statuses_for_request(): array {
@@ -1048,20 +1568,7 @@ final class RowsController {
 		$created_by_id  = (int) $post->post_author;
 		$modified_by_id = (int) get_post_meta( $post->ID, '_modified_by', true );
 		$cover_id       = (int) get_post_thumbnail_id( $post );
-		$cover          = null;
-		if ( $cover_id > 0 ) {
-			$cover_src = wp_get_attachment_image_src( $cover_id, 'large' );
-			if ( ! is_array( $cover_src ) ) {
-				$cover_src = wp_get_attachment_image_src( $cover_id, 'full' );
-			}
-			if ( is_array( $cover_src ) && ! empty( $cover_src[0] ) ) {
-				$cover = array(
-					'id'  => $cover_id,
-					'url' => $cover_src[0],
-					'alt' => (string) get_post_meta( $cover_id, '_wp_attachment_image_alt', true ),
-				);
-			}
-		}
+		$cover          = $this->cover_data_for_post( $post );
 
 		return array(
 			'id'             => $post->ID,
@@ -1077,6 +1584,33 @@ final class RowsController {
 			'featured_media' => $cover_id,
 			'cover'          => $cover,
 			'meta'           => $meta,
+		);
+	}
+
+	/**
+	 * Returns the row cover payload used in row responses.
+	 *
+	 * @param WP_Post $post Row post object.
+	 * @return array{id:int,url:string,alt:string}|null
+	 */
+	private function cover_data_for_post( WP_Post $post ): ?array {
+		$cover_id = (int) get_post_thumbnail_id( $post );
+		if ( $cover_id < 1 ) {
+			return null;
+		}
+
+		$cover_src = wp_get_attachment_image_src( $cover_id, 'large' );
+		if ( ! is_array( $cover_src ) ) {
+			$cover_src = wp_get_attachment_image_src( $cover_id, 'full' );
+		}
+		if ( ! is_array( $cover_src ) || empty( $cover_src[0] ) ) {
+			return null;
+		}
+
+		return array(
+			'id'  => $cover_id,
+			'url' => $cover_src[0],
+			'alt' => (string) get_post_meta( $cover_id, '_wp_attachment_image_alt', true ),
 		);
 	}
 

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -88,10 +88,6 @@ import { elementsFromOptions } from '../hooks/optionElements';
 import { notifyDocumentTrashChanged } from '../hooks/documentTrashInvalidation';
 import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
 
-function hasActiveCalculations( view ) {
-	return Object.values( view?.calculations ?? {} ).some( Boolean );
-}
-
 const BULK_DELETE_CONCURRENCY = 4;
 // tech-debt.md#td-dataviews-list-row-hooks: DataViews ties list focus to its own selection. Cortext
 // uses blank-row clicks and keyboard activation to open the row instead.
@@ -174,6 +170,7 @@ export default function CollectionDataViews( {
 
 	const {
 		data,
+		calculations: serverCalculations,
 		paginationInfo: serverPaginationInfo,
 		isLoading,
 		hasResolved: rowsResolved,
@@ -184,8 +181,7 @@ export default function CollectionDataViews( {
 	} = useCollectionRows(
 		isResolving ? null : collectionId,
 		reconciledView,
-		availableFields,
-		{ forceClient: hasActiveCalculations( reconciledView ) }
+		availableFields
 	);
 
 	const isTableLayout = view?.type === 'table';
@@ -1619,6 +1615,10 @@ export default function CollectionDataViews( {
 											view={ view }
 											fields={ availableFields }
 											data={ dataFilteredForCalculations }
+											calculations={ serverCalculations }
+											isServerPaginated={
+												isServerPaginated
+											}
 											onChangeView={ onChangeView }
 											hasSelectionColumn={
 												hasSelectionColumn

--- a/src/components/TableCalculationsFooter.js
+++ b/src/components/TableCalculationsFooter.js
@@ -7,6 +7,7 @@ import TableCalculationMenu from './TableCalculationMenu';
 import {
 	CALCULATION_LABELS,
 	calculateField,
+	formatCalculationValue,
 	isCalculationAvailable,
 	withColumnCalculation,
 } from './tableCalculations';
@@ -35,7 +36,14 @@ function useDataViewsTable( wrapperRef ) {
 	return table;
 }
 
-function CalculationCell( { field, rows, view, onChangeView } ) {
+function CalculationCell( {
+	field,
+	rows,
+	view,
+	serverCalculations,
+	isServerPaginated,
+	onChangeView,
+} ) {
 	const emptyLabel = __( 'Calculate', 'cortext' );
 	const selected = isCalculationAvailable(
 		field,
@@ -43,7 +51,26 @@ function CalculationCell( { field, rows, view, onChangeView } ) {
 	)
 		? view.calculations[ field.id ]
 		: null;
-	const result = selected ? calculateField( rows, field, selected ) : '';
+	const serverCalculation = selected
+		? serverCalculations?.[ field.id ]
+		: null;
+	const hasServerResult =
+		Boolean( serverCalculation ) &&
+		serverCalculation.calculation === selected;
+	let result = '';
+	if ( selected && hasServerResult ) {
+		result = formatCalculationValue(
+			serverCalculation.value,
+			field,
+			selected
+		);
+	} else if ( selected && ! isServerPaginated ) {
+		// In client mode `rows` is the full filtered set, so a local
+		// calculation is correct. In server mode `rows` is only the current
+		// page, so wait for the server total instead of showing a page-only
+		// number.
+		result = calculateField( rows, field, selected );
+	}
 	const label = selected ? CALCULATION_LABELS[ selected ] : emptyLabel;
 
 	const pick = ( calculation ) => {
@@ -95,6 +122,8 @@ export default function TableCalculationsFooter( {
 	view,
 	fields,
 	data,
+	calculations,
+	isServerPaginated = false,
 	onChangeView,
 	hasSelectionColumn = false,
 	bulkActions = null,
@@ -144,6 +173,8 @@ export default function TableCalculationsFooter( {
 									field={ field }
 									rows={ data }
 									view={ view }
+									serverCalculations={ calculations }
+									isServerPaginated={ isServerPaginated }
 									onChangeView={ onChangeView }
 								/>
 							) : null }

--- a/src/components/tableCalculations.js
+++ b/src/components/tableCalculations.js
@@ -219,10 +219,21 @@ function formatPercent( part, total ) {
 	if ( total === 0 ) {
 		return '';
 	}
+	return formatPercentRatio( part / total );
+}
+
+function formatPercentRatio( ratio ) {
+	if ( ratio === null || ratio === undefined ) {
+		return '';
+	}
+	const number = Number( ratio );
+	if ( ! Number.isFinite( number ) ) {
+		return '';
+	}
 	return new Intl.NumberFormat( undefined, {
 		style: 'percent',
 		maximumFractionDigits: 0,
-	} ).format( part / total );
+	} ).format( number );
 }
 
 function comparableValue( value, field ) {
@@ -295,6 +306,33 @@ function formatResultValue( value, field ) {
 	}
 
 	return String( value );
+}
+
+export function formatCalculationValue( value, field, calculation ) {
+	if ( ! isCalculationAvailable( field, calculation ) ) {
+		return '';
+	}
+
+	switch ( calculation ) {
+		case 'count':
+		case 'countValues':
+		case 'countUnique':
+		case 'empty':
+		case 'notEmpty':
+			return value === null || value === undefined ? '' : String( value );
+		case 'percentEmpty':
+		case 'percentNotEmpty':
+			return formatPercentRatio( value );
+		case 'sum':
+		case 'average':
+		case 'median':
+		case 'range':
+		case 'min':
+		case 'max':
+			return formatResultValue( value, field );
+		default:
+			return '';
+	}
 }
 
 export function calculateField( rows, field, calculation ) {

--- a/src/hooks/useCollectionRows.js
+++ b/src/hooks/useCollectionRows.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 
+import { sanitizeCalculations } from '../components/tableCalculations';
 import { useCollectionRowsInvalidation } from './rowInvalidation';
 
 // tech-debt.md#td-rows-not-in-core-data: rows live outside core-data, so this hook manages
@@ -24,10 +25,6 @@ function serverFieldInfo( field ) {
 
 function fieldInfoMap( fields = [] ) {
 	return new Map( fields.map( ( f ) => [ f.id, serverFieldInfo( f ) ] ) );
-}
-
-function hasCalculations( view ) {
-	return Object.values( view?.calculations ?? {} ).some( Boolean );
 }
 
 function pageNumber( value, fallback = 1 ) {
@@ -341,6 +338,13 @@ function buildServerQueryArgs( collectionId, view, filters = [], fields = [] ) {
 		} );
 	}
 
+	const calculations = sanitizeCalculations( view?.calculations, fields );
+	Object.entries( calculations )
+		.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+		.forEach( ( [ fieldId, calculation ] ) => {
+			args[ `calculations[${ fieldId }]` ] = calculation;
+		} );
+
 	return args;
 }
 
@@ -421,7 +425,6 @@ export function buildQueryPlan(
 	const filterResult = serverFilterResult( view?.filters, fieldInfo );
 	const canUseServer =
 		! options.forceClient &&
-		! hasCalculations( view ) &&
 		isServerSupportedSort( view?.sort, fieldInfo ) &&
 		! filterResult.hasUnsupported;
 
@@ -463,6 +466,7 @@ export default function useCollectionRows(
 	const [ state, setState ] = useState( {
 		data: [],
 		collection: null,
+		calculations: {},
 		paginationInfo: { totalItems: 0, totalPages: 0 },
 		isLoading: false,
 		hasResolved: false,
@@ -513,6 +517,7 @@ export default function useCollectionRows(
 			setState( {
 				data: [],
 				collection: null,
+				calculations: {},
 				paginationInfo: { totalItems: 0, totalPages: 0 },
 				isLoading: false,
 				hasResolved: false,
@@ -618,6 +623,12 @@ export default function useCollectionRows(
 				setState( {
 					data: Array.isArray( body.rows ) ? body.rows : [],
 					collection: body.collection ?? null,
+					calculations:
+						body.calculations &&
+						typeof body.calculations === 'object' &&
+						! Array.isArray( body.calculations )
+							? body.calculations
+							: {},
 					paginationInfo: {
 						totalItems: body.total ?? 0,
 						totalPages: body.totalPages ?? 1,
@@ -633,6 +644,7 @@ export default function useCollectionRows(
 				setState( {
 					data: [],
 					collection: null,
+					calculations: {},
 					paginationInfo: { totalItems: 0, totalPages: 0 },
 					isLoading: false,
 					hasResolved: true,

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -3184,7 +3184,6 @@ test.describe( 'Collection view block', () => {
 				await createCalculationFixture( requestUtils )
 			);
 			const pageKey = `field-${ fixture.fields.pages.id }`;
-			const statusKey = `field-${ fixture.fields.status.id }`;
 
 			fixture.page = await requestUtils.rest( {
 				method: 'POST',
@@ -3196,9 +3195,9 @@ test.describe( 'Collection view block', () => {
 						fields: [ 'title', pageKey ],
 						filters: [
 							{
-								field: statusKey,
-								operator: 'isAny',
-								value: [ 'Alpha', 'Beta' ],
+								field: pageKey,
+								operator: 'lessThan',
+								value: 30,
 							},
 						],
 						calculations: { [ pageKey ]: 'sum' },
@@ -3218,6 +3217,10 @@ test.describe( 'Collection view block', () => {
 					rowRequestUrls.push( url );
 				}
 			} );
+			const calculationRowRequestUrls = () =>
+				rowRequestUrls.filter( ( url ) =>
+					url.includes( `calculations[${ pageKey }]=sum` )
+				);
 
 			await admin.visitAdminPage(
 				'admin.php',
@@ -3243,17 +3246,16 @@ test.describe( 'Collection view block', () => {
 				).nth( 1 )
 			).toContainText( '30' );
 			await expect
-				.poll( () => rowRequestUrls.length )
+				.poll( () => calculationRowRequestUrls().length )
 				.toBeGreaterThan( 0 );
 			expect(
-				rowRequestUrls.some( ( url ) => url.includes( 'per_page=100' ) )
+				calculationRowRequestUrls().some( ( url ) =>
+					url.includes( 'per_page=100' )
+				)
 			).toBe( false );
 			expect(
-				rowRequestUrls.some( ( url ) => url.includes( 'per_page=1' ) )
-			).toBe( true );
-			expect(
-				rowRequestUrls.some( ( url ) =>
-					url.includes( `calculations[${ pageKey }]=sum` )
+				calculationRowRequestUrls().some( ( url ) =>
+					url.includes( 'per_page=1' )
 				)
 			).toBe( true );
 
@@ -3265,14 +3267,16 @@ test.describe( 'Collection view block', () => {
 					canvas.locator( 'tfoot.cortext-table-calculations' )
 				).nth( 1 )
 			).toContainText( '30' );
+			await expect
+				.poll( () =>
+					calculationRowRequestUrls().some( ( url ) =>
+						url.includes( 'page=2' )
+					)
+				)
+				.toBe( true );
 			expect(
-				rowRequestUrls.some( ( url ) => url.includes( 'page=2' ) )
-			).toBe( true );
-			expect(
-				rowRequestUrls.every(
-					( url ) =>
-						url.includes( 'per_page=1' ) &&
-						url.includes( `calculations[${ pageKey }]=sum` )
+				calculationRowRequestUrls().every( ( url ) =>
+					url.includes( 'per_page=1' )
 				)
 			).toBe( true );
 		} finally {

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -3208,6 +3208,17 @@ test.describe( 'Collection view block', () => {
 				},
 			} );
 
+			const rowRequestUrls = [];
+			page.on( 'request', ( request ) => {
+				const url = decodeURIComponent( request.url() );
+				if (
+					url.includes( '/cortext/v1/rows' ) &&
+					url.includes( `trait=${ fixture.collection.id }` )
+				) {
+					rowRequestUrls.push( url );
+				}
+			} );
+
 			await admin.visitAdminPage(
 				'admin.php',
 				`page=cortext&p=/${ fixture.page.id }`
@@ -3231,6 +3242,39 @@ test.describe( 'Collection view block', () => {
 					canvas.locator( 'tfoot.cortext-table-calculations' )
 				).nth( 1 )
 			).toContainText( '30' );
+			await expect
+				.poll( () => rowRequestUrls.length )
+				.toBeGreaterThan( 0 );
+			expect(
+				rowRequestUrls.some( ( url ) => url.includes( 'per_page=100' ) )
+			).toBe( false );
+			expect(
+				rowRequestUrls.some( ( url ) => url.includes( 'per_page=1' ) )
+			).toBe( true );
+			expect(
+				rowRequestUrls.some( ( url ) =>
+					url.includes( `calculations[${ pageKey }]=sum` )
+				)
+			).toBe( true );
+
+			await canvas.getByRole( 'button', { name: 'Next page' } ).click();
+			await expect( canvas.getByText( 'Beta Book' ) ).toBeVisible();
+			await expect( canvas.getByText( 'Alpha Book' ) ).toBeHidden();
+			await expect(
+				tableFooterDataCells(
+					canvas.locator( 'tfoot.cortext-table-calculations' )
+				).nth( 1 )
+			).toContainText( '30' );
+			expect(
+				rowRequestUrls.some( ( url ) => url.includes( 'page=2' ) )
+			).toBe( true );
+			expect(
+				rowRequestUrls.every(
+					( url ) =>
+						url.includes( 'per_page=1' ) &&
+						url.includes( `calculations[${ pageKey }]=sum` )
+				)
+			).toBe( true );
 		} finally {
 			for ( const row of fixture.rows ?? [] ) {
 				await deleteIfCreated(

--- a/tests/js/components/TableCalculationsFooter.test.js
+++ b/tests/js/components/TableCalculationsFooter.test.js
@@ -1,0 +1,87 @@
+import { render, waitFor, within } from '@testing-library/react';
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, ...props } ) => (
+		<button type="button" { ...props }>
+			{ children }
+		</button>
+	),
+	Dropdown: ( { renderToggle } ) => (
+		<div>{ renderToggle( { isOpen: false, onToggle: jest.fn() } ) }</div>
+	),
+} ) );
+
+import TableCalculationsFooter from '../../../src/components/TableCalculationsFooter';
+
+const field = {
+	id: 'field-1',
+	label: 'Pages',
+	type: 'integer',
+	cortextType: 'number',
+	getValue: ( { item } ) => item.pages,
+};
+
+function tableWrapper() {
+	const wrapper = document.createElement( 'div' );
+	wrapper.innerHTML =
+		'<table class="dataviews-view-table"><tbody></tbody></table>';
+	document.body.appendChild( wrapper );
+	return wrapper;
+}
+
+function renderFooter( props = {} ) {
+	const wrapper = tableWrapper();
+	render(
+		<TableCalculationsFooter
+			wrapperRef={ { current: wrapper } }
+			view={ {
+				fields: [ 'field-1' ],
+				calculations: { 'field-1': 'sum' },
+			} }
+			fields={ [ field ] }
+			data={ [ { pages: 1 }, { pages: 2 } ] }
+			onChangeView={ jest.fn() }
+			{ ...props }
+		/>
+	);
+	return wrapper;
+}
+
+describe( 'TableCalculationsFooter', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'prefers matching server calculation results', async () => {
+		const wrapper = renderFooter( {
+			calculations: {
+				'field-1': { calculation: 'sum', value: 30 },
+			},
+		} );
+
+		await waitFor( () =>
+			expect( within( wrapper ).getByText( '30' ) ).toBeInTheDocument()
+		);
+		expect( within( wrapper ).getByText( 'Sum' ) ).toBeInTheDocument();
+	} );
+
+	it( 'falls back to local row calculation when the server result is absent', async () => {
+		const wrapper = renderFooter();
+
+		await waitFor( () =>
+			expect( within( wrapper ).getByText( '3' ) ).toBeInTheDocument()
+		);
+		expect( within( wrapper ).getByText( 'Sum' ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves the footer blank in server pagination until a matching total arrives', async () => {
+		// These rows are only the current page. A local total would be wrong,
+		// so the cell stays blank until the server result arrives.
+		const wrapper = renderFooter( { isServerPaginated: true } );
+
+		await waitFor( () =>
+			expect( within( wrapper ).getByText( 'Sum' ) ).toBeInTheDocument()
+		);
+		expect( within( wrapper ).queryByText( '3' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/tests/js/components/tableCalculations.test.js
+++ b/tests/js/components/tableCalculations.test.js
@@ -1,6 +1,7 @@
 import {
 	calculateField,
 	calculationOptionsForField,
+	formatCalculationValue,
 	isEmptyValue,
 	sanitizeCalculations,
 	withColumnCalculation,
@@ -192,6 +193,36 @@ describe( 'calculateField', () => {
 		).toBe( '' );
 		expect(
 			calculateField( rows, field( { cortextType: 'number' } ), 'range' )
+		).toBe( '' );
+	} );
+} );
+
+describe( 'formatCalculationValue', () => {
+	it( 'formats server values the same way as local totals', () => {
+		const numberField = field( { cortextType: 'number' } );
+
+		expect( formatCalculationValue( 30, numberField, 'sum' ) ).toBe( '30' );
+		expect(
+			formatCalculationValue( 0.25, numberField, 'percentEmpty' )
+		).toBe( '25%' );
+		expect( formatCalculationValue( null, numberField, 'average' ) ).toBe(
+			''
+		);
+		expect( formatCalculationValue( 0, numberField, 'countValues' ) ).toBe(
+			'0'
+		);
+	} );
+
+	it( 'leaves percent totals blank when the server has no rows', () => {
+		// The server sends null for percent calculations with no matching
+		// rows. Show that as blank, not "0%".
+		const numberField = field( { cortextType: 'number' } );
+
+		expect(
+			formatCalculationValue( null, numberField, 'percentEmpty' )
+		).toBe( '' );
+		expect(
+			formatCalculationValue( null, numberField, 'percentNotEmpty' )
 		).toBe( '' );
 	} );
 } );

--- a/tests/js/hooks/useCollectionRows.test.js
+++ b/tests/js/hooks/useCollectionRows.test.js
@@ -194,26 +194,22 @@ describe( 'useCollectionRows', () => {
 		expect( lastRequestPath() ).toContain( 'sort[direction]=desc' );
 	} );
 
-	it( 'accumulates every server page in client mode', async () => {
-		apiFetch.mockImplementation( ( { path } ) => {
-			const page = Number(
-				new URL( path, 'https://example.test' ).searchParams.get(
-					'page'
-				)
-			);
-			return Promise.resolve( {
-				rows: [ { id: page } ],
-				collection: null,
-				total: 3,
-				totalPages: 3,
-			} );
+	it( 'requests calculations in server mode and stores the response totals', async () => {
+		apiFetch.mockResolvedValue( {
+			rows: [ { id: 1 } ],
+			collection: null,
+			total: 3,
+			totalPages: 3,
+			calculations: {
+				'field-20': { calculation: 'sum', value: 30 },
+			},
 		} );
 
 		const view = {
 			type: 'table',
 			filters: [],
 			calculations: {
-				'field-10': 'count',
+				'field-20': 'sum',
 			},
 			page: 1,
 			perPage: 25,
@@ -223,12 +219,15 @@ describe( 'useCollectionRows', () => {
 			useCollectionRows( 7, view, baseFields )
 		);
 
-		await waitFor( () => expect( result.current.data ).toHaveLength( 3 ) );
-		expect( apiFetch ).toHaveBeenCalledTimes( 3 );
-		expect( result.current.data.map( ( row ) => row.id ) ).toEqual( [
-			1, 2, 3,
-		] );
-		expect( result.current.queryMode ).toBe( 'client' );
+		await waitFor( () =>
+			expect( result.current.data ).toEqual( [ { id: 1 } ] )
+		);
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.queryMode ).toBe( 'server' );
+		expect( result.current.calculations ).toEqual( {
+			'field-20': { calculation: 'sum', value: 30 },
+		} );
+		expect( lastRequestPath() ).toContain( 'calculations[field-20]=sum' );
 	} );
 
 	it( 'fetches remaining client-mode pages in parallel', async () => {
@@ -262,15 +261,12 @@ describe( 'useCollectionRows', () => {
 		const view = {
 			type: 'table',
 			filters: [],
-			calculations: {
-				'field-10': 'count',
-			},
 			page: 1,
 			perPage: 25,
 		};
 
 		const { result } = renderHook( () =>
-			useCollectionRows( 7, view, baseFields )
+			useCollectionRows( 7, view, baseFields, { forceClient: true } )
 		);
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 4 ) );

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -212,6 +212,87 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$this->assertArrayHasKey( 'totalPages', $data );
 		$this->assertArrayHasKey( 'collection', $data );
 		$this->assertArrayHasKey( 'fields', $data );
+		$this->assertArrayNotHasKey( 'calculations', $data );
+	}
+
+	public function test_query_rows_returns_calculations_for_full_result_set_with_paged_rows(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+		$fixture   = $this->create_collection_fixture( 'calculations', 'number' );
+		$score_id  = $fixture['field_id'];
+		$status_id = $this->create_collection_field( $fixture['collection_id'], 'Status', 'text' );
+		$notes_id  = $this->create_collection_field( $fixture['collection_id'], 'Notes', 'text' );
+		$due_id    = $this->create_collection_field( $fixture['collection_id'], 'Due', 'date' );
+
+		$this->create_row_fixture(
+			$fixture['collection_id'],
+			'Alpha row',
+			'private',
+			array(
+				"field-{$score_id}"  => 10,
+				"field-{$status_id}" => 'Alpha',
+				"field-{$due_id}"    => '2026-02-01',
+			)
+		);
+		$this->create_row_fixture(
+			$fixture['collection_id'],
+			'Beta row',
+			'private',
+			array(
+				"field-{$score_id}"  => 20,
+				"field-{$status_id}" => 'Beta',
+				"field-{$notes_id}"  => 'Filled',
+				"field-{$due_id}"    => '2026-01-01',
+			)
+		);
+		$this->create_row_fixture(
+			$fixture['collection_id'],
+			'Gamma row',
+			'private',
+			array(
+				"field-{$score_id}"  => 30,
+				"field-{$status_id}" => 'Alpha',
+				"field-{$due_id}"    => '2026-03-01',
+			)
+		);
+
+		$response = $this->query_rows(
+			array(
+				'trait'        => $fixture['collection_id'],
+				'per_page'     => 1,
+				'calculations' => array(
+					"field-{$score_id}"  => 'sum',
+					"field-{$status_id}" => 'countUnique',
+					"field-{$notes_id}"  => 'percentEmpty',
+					"field-{$due_id}"    => 'min',
+				),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertCount( 1, $data['rows'] );
+		$this->assertSame( 3, $data['total'] );
+		$this->assertSame( 60.0, $data['calculations'][ "field-{$score_id}" ]['value'] );
+		$this->assertSame( 2, $data['calculations'][ "field-{$status_id}" ]['value'] );
+		$this->assertEqualsWithDelta( 2 / 3, $data['calculations'][ "field-{$notes_id}" ]['value'], 0.00001 );
+		$this->assertSame( '2026-01-01', $data['calculations'][ "field-{$due_id}" ]['value'] );
+	}
+
+	public function test_query_rows_rejects_invalid_calculation_for_field_type(): void {
+		wp_set_current_user( $this->create_user( 'author' ) );
+		$fixture = $this->create_collection_fixture( 'badcalc', 'text' );
+
+		$response = $this->query_rows(
+			array(
+				'trait'        => $fixture['collection_id'],
+				'calculations' => array(
+					"field-{$fixture['field_id']}" => 'sum',
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_invalid_calculation', $response->as_error()->get_error_code() );
 	}
 
 	public function test_field_definitions_in_response(): void {
@@ -307,16 +388,7 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 			)
 		);
 
-		$field_id = (int) wp_insert_post(
-			array(
-				'post_type'   => Field::POST_TYPE,
-				'post_status' => 'private',
-				'post_title'  => 'Score',
-				'meta_input'  => array( 'type' => $field_type ),
-			)
-		);
-
-		add_post_meta( $collection_id, 'cortext_fields', (string) $field_id );
+		$field_id = $this->create_collection_field( $collection_id, 'Score', $field_type );
 
 		return array(
 			'collection_id' => $collection_id,
@@ -324,7 +396,22 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		);
 	}
 
-	private function create_row_fixture( int $collection_id, string $title, string $post_status ): int {
+	private function create_collection_field( int $collection_id, string $title, string $field_type ): int {
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => array( 'type' => $field_type ),
+			)
+		);
+
+		add_post_meta( $collection_id, 'cortext_fields', (string) $field_id );
+
+		return $field_id;
+	}
+
+	private function create_row_fixture( int $collection_id, string $title, string $post_status, array $meta = array() ): int {
 		$row_id = (int) wp_insert_post(
 			array(
 				'post_type'   => Document::POST_TYPE,
@@ -336,6 +423,10 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 		$term_id = TraitTaxonomy::term_id_for_trait( $collection_id );
 		if ( $term_id > 0 ) {
 			wp_set_object_terms( $row_id, array( $term_id ), TraitTaxonomy::TAXONOMY, false );
+		}
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $row_id, $key, $value );
 		}
 
 		return $row_id;


### PR DESCRIPTION
## What

Closes #132.

Table calculation footers now request the rows endpoint for totals when the table uses server pagination. The footer shows totals for the full filtered and searched result set, not just the current page, and still falls back to the existing local calculation path when server-side totals are unavailable.

## Why

This avoids fetching every page just to calculate footer values locally, which made the default table calculation path heavier than necessary.

## How

- Returning raw calculation values from the rows endpoint when callers request them.
- Reusing the existing footer formatting so server and local totals display the same way.
- Skipping row value hydration for plain `count` totals.

## Testing Instructions

1. Open a collection table with enough rows to paginate.
2. Add a numeric table calculation, such as Sum, in the footer.
3. Apply a filter that still leaves more rows than the current page.
4. Move between pages and confirm the footer total stays the same.
5. Check that the total reflects all matching rows, not only the visible page.

## Screen recording

https://github.com/user-attachments/assets/9d1d0c9d-afff-47d7-ba89-0af019c7a465

