### PR TITLE
Add backlinks for document mentions

### DIFF
--- a/cortext.php
+++ b/cortext.php
@@ -61,4 +61,5 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command( 'cortext perf-seed', array( \Cortext\CLI\PerfBench::class, 'seed' ) );
 	\WP_CLI::add_command( 'cortext perf-bench', array( \Cortext\CLI\PerfBench::class, 'bench' ) );
 	\WP_CLI::add_command( 'cortext backfill-media', \Cortext\CLI\BackfillMedia::class );
+	\WP_CLI::add_command( 'cortext backfill-mentions', \Cortext\CLI\BackfillMentions::class );
 }

--- a/includes/CLI/BackfillMentions.php
+++ b/includes/CLI/BackfillMentions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WP-CLI command that backfills the Cortext mention index.
+ * WP-CLI helper for rebuilding the Cortext mention index.
  *
  * @package Cortext
  */
@@ -18,7 +18,7 @@ use WP_CLI_Command;
 final class BackfillMentions extends WP_CLI_Command {
 
 	/**
-	 * Re-indexes inline document mentions in existing Cortext documents.
+	 * Rebuilds inline document mentions for existing Cortext documents.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -31,7 +31,7 @@ final class BackfillMentions extends WP_CLI_Command {
 
 		WP_CLI::success(
 			sprintf(
-				'Indexed %d mention(s) across %d document(s).',
+				'Indexed %d mention(s) in %d document(s).',
 				$result['mentions'],
 				$result['documents']
 			)

--- a/includes/CLI/BackfillMentions.php
+++ b/includes/CLI/BackfillMentions.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * WP-CLI command that backfills the Cortext mention index.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\Taxonomy\MentionTaxonomy;
+use WP_CLI;
+use WP_CLI_Command;
+
+final class BackfillMentions extends WP_CLI_Command {
+
+	/**
+	 * Re-indexes inline document mentions in existing Cortext documents.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp cortext backfill-mentions
+	 *
+	 * @when after_wp_load
+	 */
+	public function __invoke(): void {
+		$result = ( new MentionTaxonomy() )->backfill();
+
+		WP_CLI::success(
+			sprintf(
+				'Indexed %d mention(s) across %d document(s).',
+				$result['mentions'],
+				$result['documents']
+			)
+		);
+	}
+}

--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -447,18 +447,21 @@ final class Documents {
 			);
 		}
 
-		if ( ! empty( $opts['include_trash_meta'] ) ) {
-			$document['modified_at'] = $this->format_gmt_date( $post->post_modified_gmt );
-			// The Trash panel reads `cortext_defines_trait` (collection) and
-			// `crtxt_trait` (row) to pick the label, icon, and cascade-count copy,
-			// and to keep the type-to-confirm guard on collection deletes. Mirror
-			// the `cortext_defines_trait` field that `/wp/v2/crtxt_documents`
-			// exposes; without it a trashed collection reads as a page.
+		if ( ! empty( $opts['include_trait_flags'] ) || ! empty( $opts['include_trash_meta'] ) ) {
+			// Mirror the `cortext_defines_trait` (collection) and `crtxt_trait`
+			// (row) fields that `/wp/v2/crtxt_documents` exposes, so list icons
+			// and the Trash panel can tell collections and rows apart from pages.
+			// The Trash panel also uses them for the cascade-count copy and the
+			// type-to-confirm guard on collection deletes.
 			$document['cortext_defines_trait'] = Document::is_collection_post( $post );
 			$document['crtxt_trait']           = array_values(
 				array_map( 'intval', wp_get_object_terms( $post->ID, TraitTaxonomy::TAXONOMY, array( 'fields' => 'ids' ) ) )
 			);
-			$document['meta']                  = array(
+		}
+
+		if ( ! empty( $opts['include_trash_meta'] ) ) {
+			$document['modified_at'] = $this->format_gmt_date( $post->post_modified_gmt );
+			$document['meta']        = array(
 				'cortext_document_icon'              => $icon,
 				'cortext_fields'                     => Document::collection_field_ids( (int) $post->ID ),
 				TrashCascade::PARENT_MARKER_META     => (int) get_post_meta( $post->ID, TrashCascade::PARENT_MARKER_META, true ),

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -27,6 +27,7 @@ use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
 use Cortext\PostType\TrashCascade;
+use Cortext\Rest\BacklinksController;
 use Cortext\Rest\DocumentLocatorController;
 use Cortext\Rest\DocumentsController;
 use Cortext\Rest\FavoritesController;
@@ -38,6 +39,7 @@ use Cortext\Rest\RecentsController;
 use Cortext\Rest\RowsController;
 use Cortext\Rest\SampleContentController;
 use Cortext\Rest\WorkspaceHomeController;
+use Cortext\Taxonomy\MentionTaxonomy;
 use Cortext\Taxonomy\TraitTaxonomy;
 use Cortext\Theming\Preferences;
 
@@ -57,6 +59,7 @@ final class Plugin {
 		( new Document() )->register();
 		( new DocumentIdentity() )->register();
 		( new TraitTaxonomy() )->register();
+		( new MentionTaxonomy() )->register();
 		( new Field() )->register();
 		( new FieldValueIndex() )->register();
 
@@ -71,6 +74,7 @@ final class Plugin {
 		( new DocumentPropertiesBlock() )->register();
 		( new FavoritesController() )->register();
 		( new FieldsController() )->register();
+		( new BacklinksController() )->register();
 		( new DocumentLocatorController() )->register();
 		( new DocumentsController( null, $trash_cascade ) )->register();
 		( new PostLocksController() )->register();

--- a/includes/Rest/BacklinksController.php
+++ b/includes/Rest/BacklinksController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST endpoint for backlinks to a Cortext document.
+ * REST endpoint that lists documents mentioning a target.
  *
  * @package Cortext
  */
@@ -24,8 +24,8 @@ final class BacklinksController {
 
 	private const NAMESPACE = 'cortext/v1';
 
-	// Backlinks fill one sidebar panel; cap the result and report truncation
-	// rather than page through thousands of sources.
+	// The sidebar only needs a bounded list; return a truncation flag instead of
+	// paging through very large backlink sets.
 	private const MAX_SOURCES = 200;
 
 	public function register(): void {
@@ -87,7 +87,7 @@ final class BacklinksController {
 				array(
 					'post_type'           => Document::POST_TYPE,
 					'post_status'         => array( 'publish', 'draft', 'private' ),
-					// Fetch one past the cap so a fuller index reports as truncated.
+					// Fetch one extra row so the response can say when the list was capped.
 					// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Backlinks are capped intentionally for one sidebar payload.
 					'posts_per_page'      => self::MAX_SOURCES + 1,
 					'ignore_sticky_posts' => true,

--- a/includes/Rest/BacklinksController.php
+++ b/includes/Rest/BacklinksController.php
@@ -115,7 +115,7 @@ final class BacklinksController {
 				if ( ! $source_post instanceof WP_Post ) {
 					$source_post = get_post( (int) $source_post );
 				}
-				if ( ! $source_post instanceof WP_Post || (int) $source_post->ID === $target_id ) {
+				if ( ! $source_post instanceof WP_Post ) {
 					continue;
 				}
 				if ( ! current_user_can( 'read_post', (int) $source_post->ID ) ) {
@@ -123,7 +123,14 @@ final class BacklinksController {
 				}
 				$document = $documents->format_document( $source_post, array( 'include_trait_flags' => true ) );
 				if ( null !== $document ) {
-					$sources[] = $document;
+					$document['mentions'] = max(
+						1,
+						MentionTaxonomy::count_target_mentions(
+							(string) $source_post->post_content,
+							$target_id
+						)
+					);
+					$sources[]            = $document;
 				}
 			}
 		}
@@ -131,7 +138,7 @@ final class BacklinksController {
 		return new WP_REST_Response(
 			array(
 				'target'    => $target,
-				'total'     => count( $sources ),
+				'total'     => array_sum( array_column( $sources, 'mentions' ) ),
 				'truncated' => $truncated,
 				'sources'   => $sources,
 			),

--- a/includes/Rest/BacklinksController.php
+++ b/includes/Rest/BacklinksController.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * REST endpoint for backlinks to a Cortext document.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\Documents;
+use Cortext\PostType\Document;
+use Cortext\Taxonomy\MentionTaxonomy;
+use WP_Error;
+use WP_Post;
+use WP_Query;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class BacklinksController {
+
+	private const NAMESPACE = 'cortext/v1';
+
+	// Backlinks fill one sidebar panel; cap the result and report truncation
+	// rather than page through thousands of sources.
+	private const MAX_SOURCES = 200;
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/documents/(?P<id>\d+)/backlinks',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_backlinks' ),
+					'permission_callback' => array( $this, 'check_document_post' ),
+					'args'                => array(
+						'id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function check_document_post( WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$post = get_post( $id );
+
+		if ( ! $post instanceof WP_Post || ! post_type_supports( $post->post_type, 'cortext-document' ) ) {
+			return new WP_Error(
+				'cortext_document_not_found',
+				__( 'Document not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! current_user_can( 'read_post', $id ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public function get_backlinks( WP_REST_Request $request ): WP_REST_Response {
+		$target_id   = (int) $request->get_param( 'id' );
+		$documents   = new Documents();
+		$target_post = get_post( $target_id );
+		$target      = $target_post instanceof WP_Post
+			? $documents->format_document( $target_post )
+			: null;
+		$term_id     = MentionTaxonomy::term_id_for_target( $target_id );
+		$sources     = array();
+		$truncated   = false;
+
+		if ( $term_id > 0 ) {
+			$query = new WP_Query(
+				array(
+					'post_type'           => Document::POST_TYPE,
+					'post_status'         => array( 'publish', 'draft', 'private' ),
+					// Fetch one past the cap so a fuller index reports as truncated.
+					// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Backlinks are capped intentionally for one sidebar payload.
+					'posts_per_page'      => self::MAX_SOURCES + 1,
+					'ignore_sticky_posts' => true,
+					'no_found_rows'       => true,
+					'orderby'             => 'modified',
+					'order'               => 'DESC',
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Backlinks are served from the mention mirror taxonomy.
+					'tax_query'           => array(
+						array(
+							'taxonomy' => MentionTaxonomy::TAXONOMY,
+							'field'    => 'term_id',
+							'terms'    => array( $term_id ),
+						),
+					),
+				)
+			);
+
+			$found_posts = $query->posts;
+			$truncated   = count( $found_posts ) > self::MAX_SOURCES;
+			if ( $truncated ) {
+				$found_posts = array_slice( $found_posts, 0, self::MAX_SOURCES );
+			}
+
+			foreach ( $found_posts as $source_post ) {
+				if ( ! $source_post instanceof WP_Post ) {
+					$source_post = get_post( (int) $source_post );
+				}
+				if ( ! $source_post instanceof WP_Post || (int) $source_post->ID === $target_id ) {
+					continue;
+				}
+				if ( ! current_user_can( 'read_post', (int) $source_post->ID ) ) {
+					continue;
+				}
+				$document = $documents->format_document( $source_post, array( 'include_trait_flags' => true ) );
+				if ( null !== $document ) {
+					$sources[] = $document;
+				}
+			}
+		}
+
+		return new WP_REST_Response(
+			array(
+				'target'    => $target,
+				'total'     => count( $sources ),
+				'truncated' => $truncated,
+				'sources'   => $sources,
+			),
+			200
+		);
+	}
+}

--- a/includes/Taxonomy/MentionTaxonomy.php
+++ b/includes/Taxonomy/MentionTaxonomy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Indexes Cortext inline mentions with private mirror terms.
+ * Keeps a private taxonomy mirror of inline document mentions.
  *
  * @package Cortext
  */
@@ -78,9 +78,9 @@ final class MentionTaxonomy {
 			array( 'slug' => self::term_slug_for_target( $target_id ) )
 		);
 		if ( is_wp_error( $result ) ) {
-			// A concurrent save may have inserted the mirror term between the
-			// lookup above and this insert. WP returns the existing term id in
-			// the `term_exists` error data; fall back to a slug lookup.
+			// Another save may have created the mirror term after the lookup
+			// above. WP puts the existing id in `term_exists`; otherwise, look
+			// it up by slug.
 			$existing_id = (int) $result->get_error_data();
 			return $existing_id > 0 ? $existing_id : self::term_id_for_target( $target_id );
 		}
@@ -88,7 +88,7 @@ final class MentionTaxonomy {
 	}
 
 	/**
-	 * Extracts distinct mentioned target ids from post content.
+	 * Finds the target document ids mentioned in post content.
 	 *
 	 * @param string $content   Post content.
 	 * @param int    $source_id Source document id to exclude from results.
@@ -124,7 +124,7 @@ final class MentionTaxonomy {
 	}
 
 	/**
-	 * Syncs mention terms when a document is saved.
+	 * Updates mention terms when a document is saved.
 	 *
 	 * @param int     $post_id Document id.
 	 * @param WP_Post $post    Saved document.
@@ -158,7 +158,7 @@ final class MentionTaxonomy {
 	}
 
 	/**
-	 * Re-indexes every existing Cortext document.
+	 * Rebuilds the mention index for existing Cortext documents.
 	 *
 	 * @return array{documents:int,mentions:int}
 	 */

--- a/includes/Taxonomy/MentionTaxonomy.php
+++ b/includes/Taxonomy/MentionTaxonomy.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Indexes Cortext inline mentions with private mirror terms.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Taxonomy;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\Mention\Mention;
+use Cortext\PostType\Document;
+use WP_HTML_Tag_Processor;
+use WP_Post;
+
+final class MentionTaxonomy {
+
+	public const TAXONOMY = 'crtxt_mention';
+
+	public function register(): void {
+		add_action( 'init', array( $this, 'register_taxonomy' ) );
+		add_action( 'save_post_' . Document::POST_TYPE, array( $this, 'sync_mentions_on_save' ), 10, 3 );
+		add_action( 'before_delete_post', array( $this, 'sync_term_on_delete' ), 10, 2 );
+	}
+
+	public function register_taxonomy(): void {
+		register_taxonomy(
+			self::TAXONOMY,
+			array( Document::POST_TYPE ),
+			array(
+				'labels'             => array(
+					'name'          => __( 'Mentions', 'cortext' ),
+					'singular_name' => __( 'Mention', 'cortext' ),
+				),
+				'public'             => false,
+				'publicly_queryable' => false,
+				'hierarchical'       => false,
+				'show_ui'            => false,
+				'show_in_menu'       => false,
+				'show_in_nav_menus'  => false,
+				'show_in_rest'       => false,
+				'show_admin_column'  => false,
+				'show_tagcloud'      => false,
+				'rewrite'            => false,
+			)
+		);
+	}
+
+	public static function term_slug_for_target( int $target_id ): string {
+		return (string) $target_id;
+	}
+
+	public static function term_name_for_target( int $target_id ): string {
+		return "Mention {$target_id}";
+	}
+
+	public static function term_id_for_target( int $target_id ): int {
+		$term = get_term_by( 'slug', self::term_slug_for_target( $target_id ), self::TAXONOMY );
+		return ( $term && ! is_wp_error( $term ) ) ? (int) $term->term_id : 0;
+	}
+
+	public static function target_id_from_slug( string $slug ): int {
+		return ctype_digit( $slug ) ? (int) $slug : 0;
+	}
+
+	public function ensure_mirror_term( int $target_id ): int {
+		$existing = self::term_id_for_target( $target_id );
+		if ( $existing > 0 ) {
+			return $existing;
+		}
+
+		$result = wp_insert_term(
+			self::term_name_for_target( $target_id ),
+			self::TAXONOMY,
+			array( 'slug' => self::term_slug_for_target( $target_id ) )
+		);
+		if ( is_wp_error( $result ) ) {
+			// A concurrent save may have inserted the mirror term between the
+			// lookup above and this insert. WP returns the existing term id in
+			// the `term_exists` error data; fall back to a slug lookup.
+			$existing_id = (int) $result->get_error_data();
+			return $existing_id > 0 ? $existing_id : self::term_id_for_target( $target_id );
+		}
+		return self::term_id_for_target( $target_id );
+	}
+
+	/**
+	 * Extracts distinct mentioned target ids from post content.
+	 *
+	 * @param string $content   Post content.
+	 * @param int    $source_id Source document id to exclude from results.
+	 * @return int[]
+	 */
+	public static function extract_target_ids( string $content, int $source_id = 0 ): array {
+		if ( ! str_contains( $content, Mention::ATTRIBUTE ) ) {
+			return array();
+		}
+
+		$ids = array();
+		if ( class_exists( WP_HTML_Tag_Processor::class ) ) {
+			$processor = new WP_HTML_Tag_Processor( $content );
+			while ( $processor->next_tag( array( 'tag_name' => 'a' ) ) ) {
+				$value = $processor->get_attribute( Mention::ATTRIBUTE );
+				if ( is_string( $value ) && ctype_digit( $value ) ) {
+					$id = (int) $value;
+					if ( $id > 0 && $id !== $source_id ) {
+						$ids[ $id ] = true;
+					}
+				}
+			}
+		} elseif ( preg_match_all( Mention::ID_PATTERN, $content, $matches ) ) {
+			foreach ( $matches[2] as $raw_id ) {
+				$id = (int) $raw_id;
+				if ( $id > 0 && $id !== $source_id ) {
+					$ids[ $id ] = true;
+				}
+			}
+		}
+
+		return array_keys( $ids );
+	}
+
+	/**
+	 * Syncs mention terms when a document is saved.
+	 *
+	 * @param int     $post_id Document id.
+	 * @param WP_Post $post    Saved document.
+	 * @param bool    $update  Whether this is an existing post being updated.
+	 */
+	public function sync_mentions_on_save( int $post_id, WP_Post $post, bool $update ): void {
+		unset( $update );
+
+		if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+		if ( Document::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+
+		$this->sync_post( $post );
+	}
+
+	public function sync_term_on_delete( int $post_id, ?WP_Post $post = null ): void {
+		if ( ! $post instanceof WP_Post ) {
+			$post = get_post( $post_id );
+		}
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+
+		$term = get_term_by( 'slug', self::term_slug_for_target( $post_id ), self::TAXONOMY );
+		if ( $term && ! is_wp_error( $term ) ) {
+			wp_delete_term( (int) $term->term_id, self::TAXONOMY );
+		}
+	}
+
+	/**
+	 * Re-indexes every existing Cortext document.
+	 *
+	 * @return array{documents:int,mentions:int}
+	 */
+	public function backfill(): array {
+		$ids      = get_posts(
+			array(
+				'post_type'           => Document::POST_TYPE,
+				'post_status'         => get_post_stati( array(), 'names' ),
+				'posts_per_page'      => -1,
+				'fields'              => 'ids',
+				'ignore_sticky_posts' => true,
+				'no_found_rows'       => true,
+			)
+		);
+		$mentions = 0;
+		foreach ( array_map( 'intval', $ids ) as $post_id ) {
+			$post = get_post( $post_id );
+			if ( $post instanceof WP_Post ) {
+				$mentions += $this->sync_post( $post );
+			}
+		}
+
+		return array(
+			'documents' => count( $ids ),
+			'mentions'  => $mentions,
+		);
+	}
+
+	private function sync_post( WP_Post $post ): int {
+		$target_ids = self::extract_target_ids( wp_unslash( (string) $post->post_content ), (int) $post->ID );
+		$term_ids   = array();
+		foreach ( $target_ids as $target_id ) {
+			$target = get_post( $target_id );
+			if ( ! $target instanceof WP_Post || Document::POST_TYPE !== $target->post_type ) {
+				continue;
+			}
+			$term_id = $this->ensure_mirror_term( $target_id );
+			if ( $term_id > 0 ) {
+				$term_ids[] = $term_id;
+			}
+		}
+
+		wp_set_object_terms(
+			(int) $post->ID,
+			array_values( array_unique( $term_ids ) ),
+			self::TAXONOMY,
+			false
+		);
+
+		return count( $term_ids );
+	}
+}

--- a/includes/Taxonomy/MentionTaxonomy.php
+++ b/includes/Taxonomy/MentionTaxonomy.php
@@ -90,11 +90,10 @@ final class MentionTaxonomy {
 	/**
 	 * Finds the target document ids mentioned in post content.
 	 *
-	 * @param string $content   Post content.
-	 * @param int    $source_id Source document id to exclude from results.
+	 * @param string $content Post content.
 	 * @return int[]
 	 */
-	public static function extract_target_ids( string $content, int $source_id = 0 ): array {
+	public static function extract_target_ids( string $content ): array {
 		if ( ! str_contains( $content, Mention::ATTRIBUTE ) ) {
 			return array();
 		}
@@ -106,7 +105,7 @@ final class MentionTaxonomy {
 				$value = $processor->get_attribute( Mention::ATTRIBUTE );
 				if ( is_string( $value ) && ctype_digit( $value ) ) {
 					$id = (int) $value;
-					if ( $id > 0 && $id !== $source_id ) {
+					if ( $id > 0 ) {
 						$ids[ $id ] = true;
 					}
 				}
@@ -114,13 +113,28 @@ final class MentionTaxonomy {
 		} elseif ( preg_match_all( Mention::ID_PATTERN, $content, $matches ) ) {
 			foreach ( $matches[2] as $raw_id ) {
 				$id = (int) $raw_id;
-				if ( $id > 0 && $id !== $source_id ) {
+				if ( $id > 0 ) {
 					$ids[ $id ] = true;
 				}
 			}
 		}
 
 		return array_keys( $ids );
+	}
+
+	/**
+	 * Counts how many times a target is mentioned in content.
+	 *
+	 * @param string $content   Post content.
+	 * @param int    $target_id Target document id.
+	 * @return int
+	 */
+	public static function count_target_mentions( string $content, int $target_id ): int {
+		if ( $target_id <= 0 || ! str_contains( $content, Mention::ATTRIBUTE ) ) {
+			return 0;
+		}
+		$pattern = '/' . preg_quote( Mention::ATTRIBUTE, '/' ) . '=(["\'])' . $target_id . '\1/';
+		return (int) preg_match_all( $pattern, $content );
 	}
 
 	/**
@@ -188,7 +202,7 @@ final class MentionTaxonomy {
 	}
 
 	private function sync_post( WP_Post $post ): int {
-		$target_ids = self::extract_target_ids( wp_unslash( (string) $post->post_content ), (int) $post->ID );
+		$target_ids = self::extract_target_ids( wp_unslash( (string) $post->post_content ) );
 		$term_ids   = array();
 		foreach ( $target_ids as $target_id ) {
 			$target = get_post( $target_id );

--- a/src/components/BacklinksList.js
+++ b/src/components/BacklinksList.js
@@ -1,0 +1,60 @@
+import { Button } from '@wordpress/components';
+
+import { useCurrentViewMode } from './CurrentViewModeContext';
+import { useDocumentPeekActions } from './DocumentPeekProvider';
+import { documentTitle, listIconForRecord } from '../documents';
+import './BacklinksPanel.scss';
+
+// Shared list of backlink sources. Each row shows the source's icon and title,
+// with a muted breadcrumb of the collection it lives in when there is one.
+// Opening a source reuses the peek (replacing its content) rather than routing
+// underneath an open modal.
+export default function BacklinksList( { sources, onNavigate } ) {
+	const { openDocument } = useDocumentPeekActions();
+	const currentViewMode = useCurrentViewMode();
+	return (
+		<ul className="cortext-backlinks__list">
+			{ sources.map( ( source ) => (
+				<li className="cortext-backlinks__item" key={ source.id }>
+					<Button
+						className="cortext-backlinks__button"
+						variant="tertiary"
+						onClick={ () => {
+							openDocument( {
+								id: source.id,
+								postType: 'crtxt_document',
+								collectionId: source.collection?.id ?? null,
+								preferredMode: currentViewMode,
+							} );
+							onNavigate?.();
+						} }
+					>
+						<span
+							className="cortext-backlinks__icon"
+							aria-hidden="true"
+						>
+							{ listIconForRecord( source, 16 ) }
+						</span>
+						<span className="cortext-backlinks__label">
+							<span className="cortext-backlinks__heading">
+								<span className="cortext-backlinks__title">
+									{ documentTitle( source ) }
+								</span>
+								{ source.mentions > 1 ? (
+									<span className="cortext-backlinks__count">
+										{ `(${ source.mentions })` }
+									</span>
+								) : null }
+							</span>
+							{ source.collection?.title ? (
+								<span className="cortext-backlinks__crumb">
+									{ source.collection.title }
+								</span>
+							) : null }
+						</span>
+					</Button>
+				</li>
+			) ) }
+		</ul>
+	);
+}

--- a/src/components/BacklinksPanel.js
+++ b/src/components/BacklinksPanel.js
@@ -1,135 +1,28 @@
-import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { PanelBody } from '@wordpress/components';
 import { _n, sprintf } from '@wordpress/i18n';
-import { chevronDown, chevronRight } from '@wordpress/icons';
-import { useNavigate } from '@tanstack/react-router';
 
-import { documentTitle, listIconForRecord } from '../documents';
+import BacklinksList from './BacklinksList';
+import { useBacklinks } from './useBacklinks';
 import './BacklinksPanel.scss';
 
-function uniqueSources( sources ) {
-	const seen = new Set();
-	return sources.filter( ( source ) => {
-		if ( ! source?.id || seen.has( source.id ) ) {
-			return false;
-		}
-		seen.add( source.id );
-		return true;
-	} );
-}
+// Inspector treatment: a native collapsible panel that sits with the rest of
+// the document settings. The peek uses BacklinksToolbarButton instead.
+export default function BacklinksPanel( { documentId, initialOpen = false } ) {
+	const { sources, total } = useBacklinks( documentId );
 
-function sourcesFromResponse( data ) {
-	if ( Array.isArray( data?.sources ) ) {
-		return uniqueSources( data.sources );
-	}
-	if ( ! Array.isArray( data?.groups ) ) {
-		return [];
-	}
-	return uniqueSources(
-		data.groups.flatMap( ( group ) =>
-			Array.isArray( group?.sources ) ? group.sources : []
-		)
-	);
-}
-
-function BacklinksList( { sources } ) {
-	const navigate = useNavigate();
-	return (
-		<div className="cortext-backlinks">
-			<ul className="cortext-backlinks__list">
-				{ sources.map( ( source ) => (
-					<li className="cortext-backlinks__item" key={ source.id }>
-						<Button
-							className="cortext-backlinks__button"
-							variant="tertiary"
-							onClick={ () => {
-								if ( source.path ) {
-									navigate( {
-										to: '/$',
-										params: {
-											_splat: source.path,
-										},
-									} );
-								}
-							} }
-						>
-							<span
-								className="cortext-backlinks__icon"
-								aria-hidden="true"
-							>
-								{ listIconForRecord( source, 16 ) }
-							</span>
-							<span className="cortext-backlinks__title">
-								{ documentTitle( source ) }
-							</span>
-						</Button>
-					</li>
-				) ) }
-			</ul>
-		</div>
-	);
-}
-
-// Backlinks stay collapsed by default to a single quiet line, in the spirit of
-// Notion's linked-references; expanding reveals the source list inline.
-export default function BacklinksPanel( {
-	className = '',
-	documentId,
-	initialOpen = false,
-} ) {
-	const [ data, setData ] = useState( null );
-	const [ isOpen, setIsOpen ] = useState( initialOpen );
-
-	useEffect( () => {
-		if ( ! documentId ) {
-			setData( null );
-			return undefined;
-		}
-
-		let cancelled = false;
-		apiFetch( {
-			path: `/cortext/v1/documents/${ documentId }/backlinks`,
-		} )
-			.then( ( response ) => {
-				if ( ! cancelled ) {
-					setData( response );
-				}
-			} )
-			.catch( () => {
-				if ( ! cancelled ) {
-					setData( null );
-				}
-			} );
-
-		return () => {
-			cancelled = true;
-		};
-	}, [ documentId ] );
-
-	const sources = sourcesFromResponse( data );
-	const total = sources.length;
 	if ( total < 1 ) {
 		return null;
 	}
 
-	const label = sprintf(
+	const title = sprintf(
 		/* translators: %d: backlink count. */
-		_n( 'Backlink (%d)', 'Backlinks (%d)', total, 'cortext' ),
+		_n( '%d backlink', '%d backlinks', total, 'cortext' ),
 		total
 	);
 
 	return (
-		<div className={ `cortext-backlinks-panel ${ className }`.trim() }>
-			<Button
-				className="cortext-backlinks-panel__toggle"
-				icon={ isOpen ? chevronDown : chevronRight }
-				onClick={ () => setIsOpen( ( value ) => ! value ) }
-				aria-expanded={ isOpen }
-			>
-				{ label }
-			</Button>
-			{ isOpen ? <BacklinksList sources={ sources } /> : null }
-		</div>
+		<PanelBody title={ title } initialOpen={ initialOpen }>
+			<BacklinksList sources={ sources } />
+		</PanelBody>
 	);
 }

--- a/src/components/BacklinksPanel.js
+++ b/src/components/BacklinksPanel.js
@@ -1,0 +1,140 @@
+import apiFetch from '@wordpress/api-fetch';
+import { Button, PanelBody } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { _n, sprintf } from '@wordpress/i18n';
+import { useNavigate } from '@tanstack/react-router';
+
+import { documentTitle, listIconForRecord } from '../documents';
+import './BacklinksPanel.scss';
+
+function uniqueSources( sources ) {
+	const seen = new Set();
+	return sources.filter( ( source ) => {
+		if ( ! source?.id || seen.has( source.id ) ) {
+			return false;
+		}
+		seen.add( source.id );
+		return true;
+	} );
+}
+
+function sourcesFromResponse( data ) {
+	if ( Array.isArray( data?.sources ) ) {
+		return uniqueSources( data.sources );
+	}
+	if ( ! Array.isArray( data?.groups ) ) {
+		return [];
+	}
+	return uniqueSources(
+		data.groups.flatMap( ( group ) =>
+			Array.isArray( group?.sources ) ? group.sources : []
+		)
+	);
+}
+
+function BacklinksList( { sources } ) {
+	const navigate = useNavigate();
+	return (
+		<div className="cortext-backlinks">
+			<ul className="cortext-backlinks__list">
+				{ sources.map( ( source ) => (
+					<li className="cortext-backlinks__item" key={ source.id }>
+						<Button
+							className="cortext-backlinks__button"
+							variant="tertiary"
+							onClick={ () => {
+								if ( source.path ) {
+									navigate( {
+										to: '/$',
+										params: {
+											_splat: source.path,
+										},
+									} );
+								}
+							} }
+						>
+							<span
+								className="cortext-backlinks__icon"
+								aria-hidden="true"
+							>
+								{ listIconForRecord( source, 16 ) }
+							</span>
+							<span className="cortext-backlinks__title">
+								{ documentTitle( source ) }
+							</span>
+						</Button>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+}
+
+export default function BacklinksPanel( {
+	asPanel = true,
+	className = '',
+	documentId,
+	initialOpen = false,
+} ) {
+	const [ data, setData ] = useState( null );
+
+	useEffect( () => {
+		if ( ! documentId ) {
+			setData( null );
+			return undefined;
+		}
+
+		let cancelled = false;
+		apiFetch( {
+			path: `/cortext/v1/documents/${ documentId }/backlinks`,
+		} )
+			.then( ( response ) => {
+				if ( ! cancelled ) {
+					setData( response );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setData( null );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ documentId ] );
+
+	const sources = sourcesFromResponse( data );
+	const total = sources.length;
+	if ( total < 1 ) {
+		return null;
+	}
+
+	const title = sprintf(
+		/* translators: %d: backlink count. */
+		_n( 'Backlink (%d)', 'Backlinks (%d)', total, 'cortext' ),
+		total
+	);
+	const content = <BacklinksList sources={ sources } />;
+
+	if ( ! asPanel ) {
+		return (
+			<section
+				className={ `cortext-backlinks-panel ${ className }`.trim() }
+			>
+				<h2 className="cortext-backlinks-panel__title">{ title }</h2>
+				{ content }
+			</section>
+		);
+	}
+
+	return (
+		<PanelBody
+			className={ className }
+			title={ title }
+			initialOpen={ initialOpen }
+		>
+			{ content }
+		</PanelBody>
+	);
+}

--- a/src/components/BacklinksPanel.js
+++ b/src/components/BacklinksPanel.js
@@ -1,7 +1,8 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Button, PanelBody } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { _n, sprintf } from '@wordpress/i18n';
+import { chevronDown, chevronRight } from '@wordpress/icons';
 import { useNavigate } from '@tanstack/react-router';
 
 import { documentTitle, listIconForRecord } from '../documents';
@@ -70,13 +71,15 @@ function BacklinksList( { sources } ) {
 	);
 }
 
+// Backlinks stay collapsed by default to a single quiet line, in the spirit of
+// Notion's linked-references; expanding reveals the source list inline.
 export default function BacklinksPanel( {
-	asPanel = true,
 	className = '',
 	documentId,
 	initialOpen = false,
 } ) {
 	const [ data, setData ] = useState( null );
+	const [ isOpen, setIsOpen ] = useState( initialOpen );
 
 	useEffect( () => {
 		if ( ! documentId ) {
@@ -110,31 +113,23 @@ export default function BacklinksPanel( {
 		return null;
 	}
 
-	const title = sprintf(
+	const label = sprintf(
 		/* translators: %d: backlink count. */
 		_n( 'Backlink (%d)', 'Backlinks (%d)', total, 'cortext' ),
 		total
 	);
-	const content = <BacklinksList sources={ sources } />;
-
-	if ( ! asPanel ) {
-		return (
-			<section
-				className={ `cortext-backlinks-panel ${ className }`.trim() }
-			>
-				<h2 className="cortext-backlinks-panel__title">{ title }</h2>
-				{ content }
-			</section>
-		);
-	}
 
 	return (
-		<PanelBody
-			className={ className }
-			title={ title }
-			initialOpen={ initialOpen }
-		>
-			{ content }
-		</PanelBody>
+		<div className={ `cortext-backlinks-panel ${ className }`.trim() }>
+			<Button
+				className="cortext-backlinks-panel__toggle"
+				icon={ isOpen ? chevronDown : chevronRight }
+				onClick={ () => setIsOpen( ( value ) => ! value ) }
+				aria-expanded={ isOpen }
+			>
+				{ label }
+			</Button>
+			{ isOpen ? <BacklinksList sources={ sources } /> : null }
+		</div>
 	);
 }

--- a/src/components/BacklinksPanel.scss
+++ b/src/components/BacklinksPanel.scss
@@ -1,17 +1,37 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
-.cortext-backlinks {
-	display: flex;
-	flex-direction: column;
-	gap: $grid-unit-10;
+.cortext-backlinks-panel {
+	padding: $grid-unit-05 $grid-unit-20;
+	border-top: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
 }
 
-.cortext-backlinks-panel__title {
+.cortext-backlinks-panel__toggle.components-button {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-05;
+	width: 100%;
+	height: auto;
+	padding: $grid-unit-05 0;
 	color: var(--cortext-text-muted);
-	font-size: 11px;
-	font-weight: 600;
-	text-transform: uppercase;
+	font-size: 12px;
+	font-weight: 500;
+	text-align: start;
+
+	&:hover:not(:disabled) {
+		color: inherit;
+	}
+
+	svg {
+		flex: 0 0 auto;
+		width: 18px;
+		height: 18px;
+		fill: currentcolor;
+	}
+}
+
+.cortext-backlinks {
+	padding-bottom: $grid-unit-05;
 }
 
 .cortext-backlinks__list {
@@ -35,7 +55,7 @@
 	gap: $grid-unit-10;
 	width: 100%;
 	min-width: 0;
-	height: 32px;
+	height: 28px;
 	padding: 0 $grid-unit-10;
 	color: inherit;
 	text-align: start;
@@ -46,8 +66,8 @@
 	align-items: center;
 	justify-content: center;
 	flex: 0 0 auto;
-	width: 18px;
-	height: 18px;
+	width: 16px;
+	height: 16px;
 	color: var(--cortext-text-muted);
 }
 
@@ -56,12 +76,4 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-}
-
-.cortext-backlinks-panel {
-	display: flex;
-	flex-direction: column;
-	gap: $grid-unit-10;
-	padding: $grid-unit-20 $grid-unit-30 $grid-unit-30;
-	border-top: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
 }

--- a/src/components/BacklinksPanel.scss
+++ b/src/components/BacklinksPanel.scss
@@ -1,39 +1,6 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
-.cortext-backlinks-panel {
-	padding: $grid-unit-05 $grid-unit-20;
-	border-top: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
-}
-
-.cortext-backlinks-panel__toggle.components-button {
-	display: flex;
-	align-items: center;
-	gap: $grid-unit-05;
-	width: 100%;
-	height: auto;
-	padding: $grid-unit-05 0;
-	color: var(--cortext-text-muted);
-	font-size: 12px;
-	font-weight: 500;
-	text-align: start;
-
-	&:hover:not(:disabled) {
-		color: inherit;
-	}
-
-	svg {
-		flex: 0 0 auto;
-		width: 18px;
-		height: 18px;
-		fill: currentcolor;
-	}
-}
-
-.cortext-backlinks {
-	padding-bottom: $grid-unit-05;
-}
-
 .cortext-backlinks__list {
 	display: flex;
 	flex-direction: column;
@@ -55,8 +22,9 @@
 	gap: $grid-unit-10;
 	width: 100%;
 	min-width: 0;
-	height: 28px;
-	padding: 0 $grid-unit-10;
+	height: auto;
+	min-height: 32px;
+	padding: $grid-unit-05 $grid-unit-10;
 	color: inherit;
 	text-align: start;
 }
@@ -71,9 +39,64 @@
 	color: var(--cortext-text-muted);
 }
 
+.cortext-backlinks__label {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	line-height: 1.3;
+}
+
+.cortext-backlinks__heading {
+	display: flex;
+	min-width: 0;
+	align-items: baseline;
+	gap: $grid-unit-05;
+}
+
 .cortext-backlinks__title {
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.cortext-backlinks__count {
+	flex: 0 0 auto;
+	color: var(--cortext-text-muted);
+	font-size: 11px;
+	font-variant-numeric: tabular-nums;
+}
+
+.cortext-backlinks__crumb {
+	min-width: 0;
+	overflow: hidden;
+	color: var(--cortext-text-muted);
+	font-size: 11px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+// Peek toolbar trigger + popover.
+.cortext-backlinks-toolbar {
+	display: inline-flex;
+}
+
+.cortext-backlinks-toolbar__count {
+	margin-inline-start: $grid-unit-05;
+	font-size: 11px;
+	font-variant-numeric: tabular-nums;
+}
+
+.cortext-backlinks-popover__inner {
+	min-width: 240px;
+	max-width: 320px;
+	padding: $grid-unit-10;
+}
+
+.cortext-backlinks-popover__title {
+	padding: 0 $grid-unit-10 $grid-unit-05;
+	color: var(--cortext-text-muted);
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
 }

--- a/src/components/BacklinksPanel.scss
+++ b/src/components/BacklinksPanel.scss
@@ -1,0 +1,67 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.cortext-backlinks {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+}
+
+.cortext-backlinks-panel__title {
+	color: var(--cortext-text-muted);
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.cortext-backlinks__list {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.cortext-backlinks__item {
+	margin: 0;
+	padding: 0;
+}
+
+.cortext-backlinks__button.components-button {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	gap: $grid-unit-10;
+	width: 100%;
+	min-width: 0;
+	height: 32px;
+	padding: 0 $grid-unit-10;
+	color: inherit;
+	text-align: start;
+}
+
+.cortext-backlinks__icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	width: 18px;
+	height: 18px;
+	color: var(--cortext-text-muted);
+}
+
+.cortext-backlinks__title {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.cortext-backlinks-panel {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+	padding: $grid-unit-20 $grid-unit-30 $grid-unit-30;
+	border-top: $border-width solid var(--cortext-row-detail-border, #e9e9e7);
+}

--- a/src/components/BacklinksToolbarButton.js
+++ b/src/components/BacklinksToolbarButton.js
@@ -11,7 +11,7 @@ import './BacklinksPanel.scss';
 // detail toolbar that opens the source list in a popover, so backlinks never
 // take room in the content itself.
 export default function BacklinksToolbarButton( { documentId } ) {
-	const { sources, total } = useBacklinks( documentId );
+	const { sources, total, refresh } = useBacklinks( documentId );
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	if ( total < 1 ) {
@@ -32,7 +32,15 @@ export default function BacklinksToolbarButton( { documentId } ) {
 				label={ label }
 				showTooltip
 				aria-expanded={ isOpen }
-				onClick={ () => setIsOpen( ( value ) => ! value ) }
+				onClick={ () =>
+					setIsOpen( ( value ) => {
+						const nextValue = ! value;
+						if ( nextValue ) {
+							void refresh();
+						}
+						return nextValue;
+					} )
+				}
 			>
 				<span className="cortext-backlinks-toolbar__count">
 					{ total }

--- a/src/components/BacklinksToolbarButton.js
+++ b/src/components/BacklinksToolbarButton.js
@@ -1,0 +1,61 @@
+import { Button, Popover } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { _n, sprintf } from '@wordpress/i18n';
+import { link } from '@wordpress/icons';
+
+import BacklinksList from './BacklinksList';
+import { useBacklinks } from './useBacklinks';
+import './BacklinksPanel.scss';
+
+// Discreet backlinks affordance for the row peek: an icon with the count in the
+// detail toolbar that opens the source list in a popover, so backlinks never
+// take room in the content itself.
+export default function BacklinksToolbarButton( { documentId } ) {
+	const { sources, total } = useBacklinks( documentId );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	if ( total < 1 ) {
+		return null;
+	}
+
+	const label = sprintf(
+		/* translators: %d: backlink count. */
+		_n( '%d backlink', '%d backlinks', total, 'cortext' ),
+		total
+	);
+
+	return (
+		<div className="cortext-backlinks-toolbar">
+			<Button
+				className="cortext-row-detail__toolbar-button cortext-backlinks-toolbar__button"
+				icon={ link }
+				label={ label }
+				showTooltip
+				aria-expanded={ isOpen }
+				onClick={ () => setIsOpen( ( value ) => ! value ) }
+			>
+				<span className="cortext-backlinks-toolbar__count">
+					{ total }
+				</span>
+			</Button>
+			{ isOpen ? (
+				<Popover
+					className="cortext-backlinks-popover"
+					placement="bottom-end"
+					onClose={ () => setIsOpen( false ) }
+					onFocusOutside={ () => setIsOpen( false ) }
+				>
+					<div className="cortext-backlinks-popover__inner">
+						<div className="cortext-backlinks-popover__title">
+							{ label }
+						</div>
+						<BacklinksList
+							sources={ sources }
+							onNavigate={ () => setIsOpen( false ) }
+						/>
+					</div>
+				</Popover>
+			) : null }
+		</div>
+	);
+}

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -29,6 +29,7 @@ import useAutosave from '../hooks/useAutosave';
 import useDelayedFlag from '../hooks/useDelayedFlag';
 import usePostLock from '../hooks/usePostLock';
 import { withViewTransition } from '../hooks/viewTransition';
+import { notifyBacklinksChanged } from '../hooks/backlinksInvalidation';
 import { definesTrait } from '../documents/capabilities';
 import { POST_TYPE } from './page-queries';
 import CortextInserterSidebar from './CortextInserterSidebar';
@@ -232,7 +233,7 @@ function CanvasEditor( {
 	const autosaveRecentTarget =
 		recentTarget ??
 		( post?.id && ! isCollection && ! hasTrait ? { id: post.id } : null );
-	const { status, flushNow, isDirty, isSaving } = useAutosave( {
+	const { status, lastSavedAt, flushNow, isDirty, isSaving } = useAutosave( {
 		recentTarget: autosaveRecentTarget,
 	} );
 	const postLock = usePostLock( {
@@ -242,6 +243,7 @@ function CanvasEditor( {
 	} );
 	const { resetPost } = useDispatch( editorStore );
 	const discard = useCallback( () => resetPost(), [ resetPost ] );
+	const lastNotifiedBacklinkSaveRef = useRef( null );
 
 	useEffect( () => {
 		onApi?.( { flushNow, discard } );
@@ -249,10 +251,17 @@ function CanvasEditor( {
 	}, [ discard, flushNow, onApi ] );
 
 	useEffect( () => {
-		if ( status === 'saved' ) {
-			onSaved?.();
+		if (
+			status !== 'saved' ||
+			! lastSavedAt ||
+			lastNotifiedBacklinkSaveRef.current === lastSavedAt
+		) {
+			return;
 		}
-	}, [ onSaved, status ] );
+		lastNotifiedBacklinkSaveRef.current = lastSavedAt;
+		notifyBacklinksChanged();
+		onSaved?.();
+	}, [ lastSavedAt, onSaved, status ] );
 
 	useEffect( () => {
 		if (

--- a/src/components/DocumentInspectorSidebar.js
+++ b/src/components/DocumentInspectorSidebar.js
@@ -43,6 +43,7 @@ import CanvasOwnerInspector, {
 import './DocumentInspectorSidebar.scss';
 
 import DocumentPropertiesActions from './DocumentPropertiesActions';
+import BacklinksPanel from './BacklinksPanel';
 import MediaPicker, { MediaUploadCheck } from './MediaPicker';
 import DocumentIcon from './DocumentIcon';
 import DocumentIdentityControls from './DocumentIdentityControls';
@@ -630,6 +631,7 @@ function DocumentInspectorContent( { postId } ) {
 				title={ __( 'Identity', 'cortext' ) }
 			/>
 			<PageActionsPanel postId={ postId } />
+			<BacklinksPanel documentId={ postId } />
 		</div>
 	);
 }
@@ -644,16 +646,18 @@ function CollectionInspectorContent( { postId, postType } ) {
 				title={ __( 'Identity', 'cortext' ) }
 			/>
 			<CanvasOwnerInspector.Slot />
+			<BacklinksPanel documentId={ postId } />
 		</div>
 	);
 }
 
 // Row inspector for property actions. Values stay in the document block; the
 // sidebar handles visibility and field creation.
-function RowInspectorContent() {
+function RowInspectorContent( { postId } ) {
 	return (
 		<div className="cortext-row-inspector">
 			<DocumentPropertiesActions />
+			<BacklinksPanel documentId={ postId } />
 		</div>
 	);
 }
@@ -761,7 +765,9 @@ export default function DocumentInspectorSidebar( {
 							postType={ postType }
 						/>
 					) }
-					{ ! isCollection && hasTrait && <RowInspectorContent /> }
+					{ ! isCollection && hasTrait && (
+						<RowInspectorContent postId={ postId } />
+					) }
 					{ ! isCollection && ! hasTrait && (
 						<DocumentInspectorContent postId={ postId } />
 					) }

--- a/src/components/DocumentPeekHost.js
+++ b/src/components/DocumentPeekHost.js
@@ -19,6 +19,7 @@ import {
 import { elementsFromOptions } from '../hooks/optionElements';
 import useCollectionFields from '../hooks/useCollectionFields';
 import { adjacentRowId } from './rowDetailUtils';
+import { parseIdFromUri } from '../router/useResolveEntity';
 
 // EntityRoute adds this title field for full-page rows. Do the same here so
 // RowProperties and RowDetailView get the same field shape.
@@ -56,6 +57,7 @@ export default function DocumentPeekHost() {
 	// the route, so it doesn't need the same gate.
 	const params = useParams( { strict: false } );
 	const splat = params?._splat ?? '';
+	const routeDocId = parseIdFromUri( splat );
 	const prevSplatRef = useRef( splat );
 	const peekStateRef = useRef( { peek, isPinned } );
 	peekStateRef.current = { peek, isPinned };
@@ -154,7 +156,20 @@ export default function DocumentPeekHost() {
 		} );
 	}, [ peek?.source ] );
 
-	if ( ! peek || ! peekFields || ! renderedMode ) {
+	// Opening the doc that is already the background route would mount a second
+	// editor for the same post and loop. Treat it as "go back": close the
+	// redundant peek instead of rendering it.
+	const isCircular =
+		!! peek &&
+		routeDocId !== null &&
+		String( peek.docId ) === String( routeDocId );
+	useEffect( () => {
+		if ( isCircular ) {
+			closeDocument();
+		}
+	}, [ isCircular, closeDocument ] );
+
+	if ( ! peek || ! peekFields || ! renderedMode || isCircular ) {
 		return null;
 	}
 

--- a/src/components/RowDetailView.js
+++ b/src/components/RowDetailView.js
@@ -23,6 +23,8 @@ import {
 	unseen,
 } from '@wordpress/icons';
 
+import BacklinksToolbarButton from './BacklinksToolbarButton';
+
 import './RowDetailView.scss';
 
 // The editor surface (EditorProvider + EditorBody + autosave + block
@@ -136,6 +138,7 @@ export function ModeControl( { mode, onChangeMode } ) {
 function DetailShell( {
 	arePropertiesVisible,
 	children,
+	documentId,
 	fields,
 	isPinned,
 	isPropertiesLayoutEditing,
@@ -235,6 +238,7 @@ function DetailShell( {
 							/>
 						</div>
 					) : null }
+					<BacklinksToolbarButton documentId={ documentId } />
 					<div className="cortext-row-detail__toolbar-group cortext-row-detail__toolbar-group--end">
 						<Button
 							className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--close"
@@ -540,6 +544,7 @@ export default function RowDetailView( {
 				arePropertiesVisible={ arePropertiesVisible }
 				canGoNext={ canUseRowControls && canGoNext }
 				canGoPrevious={ canUseRowControls && canGoPrevious }
+				documentId={ row?.id ?? rowId }
 				fields={ propertyFields }
 				isPinned={ isPinned }
 				isPropertiesLayoutEditing={ isPropertiesLayoutEditing }

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -23,6 +23,7 @@ import EditorBody from './EditorBody';
 import { PostLockFailureNotice, PostLockModal } from './PostLockControls';
 import CortextLinkSuggestions from './CortextLinkSuggestions';
 import { CortextMentions } from './mention';
+import BacklinksPanel from './BacklinksPanel';
 import { RowMutationContext } from './EditableCell';
 
 const ROW_DETAIL_EDITOR_CSS = `
@@ -179,6 +180,11 @@ function DetailPaneContent( {
 				extraStyles={ ROW_DETAIL_EXTRA_STYLES }
 				onReady={ handleReady }
 				onRestored={ onRestored }
+			/>
+			<BacklinksPanel
+				asPanel={ false }
+				documentId={ row?.id ?? rowId }
+				className="cortext-row-detail__backlinks"
 			/>
 			<PostLockModal
 				isOpen={ postLock.isLocked }

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -11,6 +11,7 @@ import { SlotFillProvider } from '@wordpress/components';
 
 import useAutosave from '../hooks/useAutosave';
 import usePostLock from '../hooks/usePostLock';
+import { notifyBacklinksChanged } from '../hooks/backlinksInvalidation';
 // Registers core + Cortext blocks before any editor renders. Living here
 // (rather than at a static import in RowDetailView) keeps the Cortext
 // block sources and the registerCoreBlocks call site off the initial
@@ -93,6 +94,7 @@ function RowAutosaveBridge( {
 			return;
 		}
 		lastNotifiedSaveRef.current = lastSavedAt;
+		notifyBacklinksChanged();
 		onSaved?.();
 	}, [ isActive, lastSavedAt, onSaved, status ] );
 

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -23,7 +23,6 @@ import EditorBody from './EditorBody';
 import { PostLockFailureNotice, PostLockModal } from './PostLockControls';
 import CortextLinkSuggestions from './CortextLinkSuggestions';
 import { CortextMentions } from './mention';
-import BacklinksPanel from './BacklinksPanel';
 import { RowMutationContext } from './EditableCell';
 
 const ROW_DETAIL_EDITOR_CSS = `
@@ -180,10 +179,6 @@ function DetailPaneContent( {
 				extraStyles={ ROW_DETAIL_EXTRA_STYLES }
 				onReady={ handleReady }
 				onRestored={ onRestored }
-			/>
-			<BacklinksPanel
-				documentId={ row?.id ?? rowId }
-				className="cortext-row-detail__backlinks"
 			/>
 			<PostLockModal
 				isOpen={ postLock.isLocked }

--- a/src/components/RowEditor.js
+++ b/src/components/RowEditor.js
@@ -182,7 +182,6 @@ function DetailPaneContent( {
 				onRestored={ onRestored }
 			/>
 			<BacklinksPanel
-				asPanel={ false }
 				documentId={ row?.id ?? rowId }
 				className="cortext-row-detail__backlinks"
 			/>

--- a/src/components/useBacklinks.js
+++ b/src/components/useBacklinks.js
@@ -1,5 +1,7 @@
 import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+
+import { useBacklinksInvalidation } from '../hooks/backlinksInvalidation';
 
 function uniqueSources( sources ) {
 	const seen = new Set();
@@ -30,32 +32,42 @@ function sourcesFromResponse( data ) {
 // and their count; callers decide how to surface them (panel, popover, etc.).
 export function useBacklinks( documentId ) {
 	const [ data, setData ] = useState( null );
+	const requestRef = useRef( 0 );
 
-	useEffect( () => {
+	const refresh = useCallback( () => {
 		if ( ! documentId ) {
 			setData( null );
-			return undefined;
+			return Promise.resolve( null );
 		}
 
-		let cancelled = false;
-		apiFetch( {
+		const request = requestRef.current + 1;
+		requestRef.current = request;
+
+		return apiFetch( {
 			path: `/cortext/v1/documents/${ documentId }/backlinks`,
 		} )
 			.then( ( response ) => {
-				if ( ! cancelled ) {
+				if ( requestRef.current === request ) {
 					setData( response );
 				}
+				return response;
 			} )
 			.catch( () => {
-				if ( ! cancelled ) {
+				if ( requestRef.current === request ) {
 					setData( null );
 				}
+				return null;
 			} );
-
-		return () => {
-			cancelled = true;
-		};
 	}, [ documentId ] );
+
+	useEffect( () => {
+		refresh();
+		return () => {
+			requestRef.current += 1;
+		};
+	}, [ refresh ] );
+
+	useBacklinksInvalidation( refresh );
 
 	const sources = sourcesFromResponse( data );
 	// A single source can mention the target more than once; the total counts
@@ -64,5 +76,5 @@ export function useBacklinks( documentId ) {
 		( sum, source ) => sum + ( Number( source.mentions ) || 1 ),
 		0
 	);
-	return { sources, total };
+	return { sources, total, refresh };
 }

--- a/src/components/useBacklinks.js
+++ b/src/components/useBacklinks.js
@@ -1,0 +1,68 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+
+function uniqueSources( sources ) {
+	const seen = new Set();
+	return sources.filter( ( source ) => {
+		if ( ! source?.id || seen.has( source.id ) ) {
+			return false;
+		}
+		seen.add( source.id );
+		return true;
+	} );
+}
+
+function sourcesFromResponse( data ) {
+	if ( Array.isArray( data?.sources ) ) {
+		return uniqueSources( data.sources );
+	}
+	if ( ! Array.isArray( data?.groups ) ) {
+		return [];
+	}
+	return uniqueSources(
+		data.groups.flatMap( ( group ) =>
+			Array.isArray( group?.sources ) ? group.sources : []
+		)
+	);
+}
+
+// Fetches the documents that mention `documentId`. Returns the deduped sources
+// and their count; callers decide how to surface them (panel, popover, etc.).
+export function useBacklinks( documentId ) {
+	const [ data, setData ] = useState( null );
+
+	useEffect( () => {
+		if ( ! documentId ) {
+			setData( null );
+			return undefined;
+		}
+
+		let cancelled = false;
+		apiFetch( {
+			path: `/cortext/v1/documents/${ documentId }/backlinks`,
+		} )
+			.then( ( response ) => {
+				if ( ! cancelled ) {
+					setData( response );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setData( null );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ documentId ] );
+
+	const sources = sourcesFromResponse( data );
+	// A single source can mention the target more than once; the total counts
+	// every mention, while the list shows each source once with its own count.
+	const total = sources.reduce(
+		( sum, source ) => sum + ( Number( source.mentions ) || 1 ),
+		0
+	);
+	return { sources, total };
+}

--- a/src/hooks/backlinksInvalidation.js
+++ b/src/hooks/backlinksInvalidation.js
@@ -1,0 +1,25 @@
+import { useEffect } from '@wordpress/element';
+
+export const BACKLINKS_CHANGED_EVENT = 'cortext:backlinks-changed';
+
+export function notifyBacklinksChanged() {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	window.dispatchEvent( new CustomEvent( BACKLINKS_CHANGED_EVENT ) );
+}
+
+export function useBacklinksInvalidation( onInvalidate ) {
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return undefined;
+		}
+		const listener = () => {
+			onInvalidate?.();
+		};
+		window.addEventListener( BACKLINKS_CHANGED_EVENT, listener );
+		return () => {
+			window.removeEventListener( BACKLINKS_CHANGED_EVENT, listener );
+		};
+	}, [ onInvalidate ] );
+}

--- a/tests/js/components/BacklinksPanel.test.js
+++ b/tests/js/components/BacklinksPanel.test.js
@@ -1,0 +1,133 @@
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockNavigate = jest.fn();
+jest.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
+
+jest.mock( '../../../src/documents', () => ( {
+	documentTitle: ( record ) => record?.title || '(untitled)',
+	listIconForRecord: () => <span data-testid="backlink-icon" />,
+} ) );
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+import BacklinksPanel from '../../../src/components/BacklinksPanel';
+
+describe( 'BacklinksPanel', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders flat backlinks and navigates to a source', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			total: 2,
+			sources: [
+				{
+					collection: {
+						id: 5,
+						title: 'Tasks',
+						path: 'tasks-5',
+					},
+					id: 11,
+					title: 'Launch',
+					path: 'launch-11',
+				},
+				{
+					collection: null,
+					id: 12,
+					title: 'Notes',
+					path: 'notes-12',
+				},
+			],
+		} );
+
+		render( <BacklinksPanel documentId={ 9 } initialOpen /> );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/documents/9/backlinks',
+		} );
+		expect(
+			await screen.findByText( 'Backlinks (2)' )
+		).toBeInTheDocument();
+		expect( screen.queryByText( 'Tasks (1)' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Pages (1)' ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByText( 'Launch' ) );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'launch-11' },
+		} );
+	} );
+
+	it( 'stays hidden when there are no backlinks', async () => {
+		apiFetch.mockResolvedValueOnce( { total: 0, sources: [] } );
+
+		const { container } = render( <BacklinksPanel documentId={ 9 } /> );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalled() );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'does not repeat the collection header for a single backlink', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			total: 1,
+			sources: [
+				{
+					collection: null,
+					id: 12,
+					title: 'Welcome to Cortext',
+					path: 'welcome-to-cortext-12',
+				},
+			],
+		} );
+
+		render( <BacklinksPanel documentId={ 9 } initialOpen /> );
+
+		expect( await screen.findByText( 'Backlink (1)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Welcome to Cortext' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Pages (1)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'deduplicates legacy grouped responses by source id', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			total: 2,
+			groups: [
+				{
+					collection: { id: 5, title: 'Tasks' },
+					sources: [
+						{
+							id: 12,
+							title: 'Shared source',
+							path: 'shared-source-12',
+						},
+					],
+				},
+				{
+					collection: { id: 6, title: 'Musicians' },
+					sources: [
+						{
+							id: 12,
+							title: 'Shared source',
+							path: 'shared-source-12',
+						},
+					],
+				},
+			],
+		} );
+
+		render( <BacklinksPanel documentId={ 9 } initialOpen /> );
+
+		expect(
+			await screen.findByText( 'Shared source' )
+		).toBeInTheDocument();
+		expect( screen.getAllByText( 'Shared source' ) ).toHaveLength( 1 );
+		expect( screen.queryByText( 'Tasks (1)' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Musicians (1)' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/tests/js/components/BacklinksPanel.test.js
+++ b/tests/js/components/BacklinksPanel.test.js
@@ -23,7 +23,7 @@ describe( 'BacklinksPanel', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'renders flat backlinks and navigates to a source', async () => {
+	it( 'shows backlinks and opens the source document', async () => {
 		apiFetch.mockResolvedValueOnce( {
 			total: 2,
 			sources: [
@@ -65,7 +65,7 @@ describe( 'BacklinksPanel', () => {
 		} );
 	} );
 
-	it( 'stays hidden when there are no backlinks', async () => {
+	it( 'hides itself when there are no backlinks', async () => {
 		apiFetch.mockResolvedValueOnce( { total: 0, sources: [] } );
 
 		const { container } = render( <BacklinksPanel documentId={ 9 } /> );
@@ -74,7 +74,7 @@ describe( 'BacklinksPanel', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'does not repeat the collection header for a single backlink', async () => {
+	it( 'shows a single backlink without a group header', async () => {
 		apiFetch.mockResolvedValueOnce( {
 			total: 1,
 			sources: [
@@ -94,7 +94,7 @@ describe( 'BacklinksPanel', () => {
 		expect( screen.queryByText( 'Pages (1)' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'deduplicates legacy grouped responses by source id', async () => {
+	it( 'keeps legacy grouped responses from showing the same source twice', async () => {
 		apiFetch.mockResolvedValueOnce( {
 			total: 2,
 			groups: [

--- a/tests/js/components/BacklinksPanel.test.js
+++ b/tests/js/components/BacklinksPanel.test.js
@@ -16,10 +16,18 @@ jest.mock( '../../../src/documents', () => ( {
 	listIconForRecord: () => <span data-testid="backlink-icon" />,
 } ) );
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 
 import BacklinksPanel from '../../../src/components/BacklinksPanel';
+import BacklinksToolbarButton from '../../../src/components/BacklinksToolbarButton';
+import { notifyBacklinksChanged } from '../../../src/hooks/backlinksInvalidation';
 
 describe( 'BacklinksPanel', () => {
 	beforeEach( () => {
@@ -72,6 +80,74 @@ describe( 'BacklinksPanel', () => {
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalled() );
 		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'refreshes when backlink data changes', async () => {
+		apiFetch
+			.mockResolvedValueOnce( { total: 0, sources: [] } )
+			.mockResolvedValueOnce( {
+				total: 1,
+				sources: [
+					{
+						collection: null,
+						id: 12,
+						title: 'Updated source',
+						path: 'updated-source-12',
+					},
+				],
+			} );
+
+		const { container } = render(
+			<BacklinksPanel documentId={ 9 } initialOpen />
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( container ).toBeEmptyDOMElement();
+
+		act( () => {
+			notifyBacklinksChanged();
+		} );
+
+		expect( await screen.findByText( '1 backlink' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Updated source' ) ).toBeInTheDocument();
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'refreshes the popover when it opens', async () => {
+		apiFetch
+			.mockResolvedValueOnce( {
+				total: 1,
+				sources: [
+					{
+						collection: null,
+						id: 12,
+						title: 'Draft source',
+						path: 'draft-source-12',
+					},
+				],
+			} )
+			.mockResolvedValueOnce( {
+				total: 2,
+				sources: [
+					{
+						collection: null,
+						id: 12,
+						title: 'Draft source',
+						mentions: 2,
+						path: 'draft-source-12',
+					},
+				],
+			} );
+
+		render( <BacklinksToolbarButton documentId={ 9 } /> );
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: '1 backlink' } )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		expect( await screen.findByText( '2 backlinks' ) ).toBeInTheDocument();
+		expect( screen.getByText( '(2)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows a single backlink without a group header', async () => {

--- a/tests/js/components/BacklinksPanel.test.js
+++ b/tests/js/components/BacklinksPanel.test.js
@@ -3,9 +3,12 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 	default: jest.fn(),
 } ) );
 
-const mockNavigate = jest.fn();
-jest.mock( '@tanstack/react-router', () => ( {
-	useNavigate: () => mockNavigate,
+const mockOpenDocument = jest.fn();
+jest.mock( '../../../src/components/DocumentPeekProvider', () => ( {
+	useDocumentPeekActions: () => ( { openDocument: mockOpenDocument } ),
+} ) );
+jest.mock( '../../../src/components/CurrentViewModeContext', () => ( {
+	useCurrentViewMode: () => 'side',
 } ) );
 
 jest.mock( '../../../src/documents', () => ( {
@@ -51,18 +54,15 @@ describe( 'BacklinksPanel', () => {
 		expect( apiFetch ).toHaveBeenCalledWith( {
 			path: '/cortext/v1/documents/9/backlinks',
 		} );
-		expect(
-			await screen.findByText( 'Backlinks (2)' )
-		).toBeInTheDocument();
+		expect( await screen.findByText( '2 backlinks' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Tasks (1)' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Pages (1)' ) ).not.toBeInTheDocument();
 
 		fireEvent.click( screen.getByText( 'Launch' ) );
 
-		expect( mockNavigate ).toHaveBeenCalledWith( {
-			to: '/$',
-			params: { _splat: 'launch-11' },
-		} );
+		expect( mockOpenDocument ).toHaveBeenCalledWith(
+			expect.objectContaining( { id: 11, collectionId: 5 } )
+		);
 	} );
 
 	it( 'hides itself when there are no backlinks', async () => {
@@ -89,7 +89,7 @@ describe( 'BacklinksPanel', () => {
 
 		render( <BacklinksPanel documentId={ 9 } initialOpen /> );
 
-		expect( await screen.findByText( 'Backlink (1)' ) ).toBeInTheDocument();
+		expect( await screen.findByText( '1 backlink' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Welcome to Cortext' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Pages (1)' ) ).not.toBeInTheDocument();
 	} );

--- a/tests/js/components/RowEditor.test.js
+++ b/tests/js/components/RowEditor.test.js
@@ -37,6 +37,10 @@ jest.mock( '../../../src/components/mention', () => ( {
 	CortextMentions: jest.fn( () => null ),
 } ) );
 
+jest.mock( '../../../src/components/BacklinksPanel', () =>
+	jest.fn( () => null )
+);
+
 jest.mock( '../../../src/components/initEditor', () => ( {
 	getEditorSettings: () => ( {} ),
 } ) );

--- a/tests/php/InMemoryPostsQuery.php
+++ b/tests/php/InMemoryPostsQuery.php
@@ -22,7 +22,6 @@ namespace Cortext\Tests;
 
 use Cortext\Fields\FieldTypeRegistry;
 use Cortext\PostType\Document;
-use Cortext\Taxonomy\TraitTaxonomy;
 use WorDBless\Posts as WorDBlessPosts;
 use WP_Post;
 use WP_Query;
@@ -321,11 +320,9 @@ trait InMemoryPostsQuery {
 	}
 
 	/**
-	 * Evaluates a subset of `tax_query` clauses for the `crtxt_trait`
-	 * taxonomy. Supports `EXISTS`, `NOT EXISTS`, and a `term_id` membership
-	 * test. The trait term slug is the collection document id, so a
-	 * candidate document is a row when at least one trait term is attached
-	 * to it. Term relationships are derived from `wp_get_object_terms`,
+	 * Evaluates a subset of `tax_query` clauses against the in-memory term
+	 * store. Supports `EXISTS`, `NOT EXISTS`, and membership tests by term id
+	 * or slug. Term relationships are derived from `wp_get_object_terms`,
 	 * which `wp_set_object_terms` writes through WP's standard taxonomy
 	 * machinery and WorDBless backs in memory.
 	 *
@@ -338,14 +335,16 @@ trait InMemoryPostsQuery {
 				continue;
 			}
 			$taxonomy = (string) ( $clause['taxonomy'] ?? '' );
-			if ( TraitTaxonomy::TAXONOMY !== $taxonomy ) {
+			if ( '' === $taxonomy ) {
 				continue;
 			}
 			$compare = strtoupper( (string) ( $clause['operator'] ?? 'IN' ) );
+			$field   = (string) ( $clause['field'] ?? 'term_id' );
+			$fields  = in_array( $field, array( 'slug', 'name' ), true ) ? 'slugs' : 'ids';
 			$terms   = wp_get_object_terms(
 				(int) $post->ID,
-				TraitTaxonomy::TAXONOMY,
-				array( 'fields' => 'ids' )
+				$taxonomy,
+				array( 'fields' => $fields )
 			);
 			$has_any = is_array( $terms ) && count( $terms ) > 0;
 
@@ -361,10 +360,15 @@ trait InMemoryPostsQuery {
 				}
 				continue;
 			}
-			$expected = array_map( 'intval', (array) ( $clause['terms'] ?? array() ) );
+			$expected = in_array( $field, array( 'slug', 'name' ), true )
+				? array_map( 'strval', (array) ( $clause['terms'] ?? array() ) )
+				: array_map( 'intval', (array) ( $clause['terms'] ?? array() ) );
 			$matched  = false;
-			foreach ( (array) $terms as $term_id ) {
-				if ( in_array( (int) $term_id, $expected, true ) ) {
+			foreach ( (array) $terms as $term ) {
+				$value = in_array( $field, array( 'slug', 'name' ), true )
+					? (string) $term
+					: (int) $term;
+				if ( in_array( $value, $expected, true ) ) {
 					$matched = true;
 					break;
 				}

--- a/tests/php/InMemoryTermStore.php
+++ b/tests/php/InMemoryTermStore.php
@@ -331,7 +331,18 @@ trait InMemoryTermStore {
 				$resolved[] = (int) $row['term_id'];
 			}
 		}
-		$current = $append ? ( self::$object_terms[ $object_id ] ?? array() ) : array();
+		$current = self::$object_terms[ $object_id ] ?? array();
+		if ( ! $append ) {
+			$current = array_values(
+				array_filter(
+					$current,
+					static function ( int $term_id ) use ( $taxonomy ): bool {
+						$row = self::$term_store[ $term_id ] ?? null;
+						return $row && $row['taxonomy'] !== $taxonomy;
+					}
+				)
+			);
+		}
 		self::$object_terms[ $object_id ] = array_values( array_unique( array_merge( $current, $resolved ) ) );
 	}
 

--- a/tests/php/test-rest-backlinks-controller.php
+++ b/tests/php/test-rest-backlinks-controller.php
@@ -55,7 +55,7 @@ final class Test_Rest_Backlinks_Controller extends BaseTestCase {
 		parent::tear_down();
 	}
 
-	public function test_returns_page_and_row_backlinks_as_a_flat_list(): void {
+	public function test_returns_page_and_row_backlinks_together(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
 
 		$target     = $this->create_document( 'Target' );
@@ -95,7 +95,7 @@ final class Test_Rest_Backlinks_Controller extends BaseTestCase {
 		$this->assertSame( 0, $response->get_data()['total'] );
 	}
 
-	public function test_unreadable_source_is_filtered_out(): void {
+	public function test_hides_sources_the_viewer_cannot_read(): void {
 		$admin = $this->create_user( 'administrator' );
 		wp_set_current_user( $admin );
 
@@ -129,7 +129,7 @@ final class Test_Rest_Backlinks_Controller extends BaseTestCase {
 		$this->assertSame( 404, $response->get_status() );
 	}
 
-	public function test_empty_result_when_never_mentioned(): void {
+	public function test_returns_empty_sources_when_target_has_no_backlinks(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
 		$target = $this->create_document( 'Target' );
 

--- a/tests/php/test-rest-backlinks-controller.php
+++ b/tests/php/test-rest-backlinks-controller.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Tests for Cortext\Rest\BacklinksController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Document;
+use Cortext\PostType\Field;
+use Cortext\Rest\BacklinksController;
+use Cortext\Taxonomy\MentionTaxonomy;
+use Cortext\Taxonomy\TraitTaxonomy;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Backlinks_Controller extends BaseTestCase {
+
+	use InMemoryPostsQuery;
+	use InMemoryTermStore;
+
+	private MentionTaxonomy $mentions;
+	private TraitTaxonomy $traits;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Document() )->register_post_type();
+		( new Field() )->register_post_type();
+		$this->traits   = new TraitTaxonomy();
+		$this->mentions = new MentionTaxonomy();
+		$this->traits->register_taxonomy();
+		$this->mentions->register_taxonomy();
+		$this->install_in_memory_term_store();
+		$this->install_in_memory_posts_query();
+
+		add_action( 'save_post_' . Document::POST_TYPE, array( $this->mentions, 'sync_mentions_on_save' ), 10, 3 );
+		add_action( 'before_delete_post', array( $this->mentions, 'sync_term_on_delete' ), 10, 2 );
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new BacklinksController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		remove_action( 'save_post_' . Document::POST_TYPE, array( $this->mentions, 'sync_mentions_on_save' ), 10 );
+		remove_action( 'before_delete_post', array( $this->mentions, 'sync_term_on_delete' ), 10 );
+		$this->uninstall_in_memory_posts_query();
+		$this->uninstall_in_memory_term_store();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_returns_page_and_row_backlinks_as_a_flat_list(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$target     = $this->create_document( 'Target' );
+		$page       = $this->create_document( 'Source page', $this->mention_markup( $target ) );
+		$collection = $this->create_collection( 'Tasks' );
+		$row        = $this->create_row( $collection, 'Source row', $this->mention_markup( $target ) );
+
+		$response = $this->get_backlinks( $target );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 2, $data['total'] );
+		$this->assertFalse( $data['truncated'] );
+		$this->assertArrayNotHasKey( 'groups', $data );
+		$this->assertEqualsCanonicalizing( array( $page, $row ), array_column( $data['sources'], 'id' ) );
+
+		$row_source = null;
+		foreach ( $data['sources'] as $source ) {
+			if ( $row === $source['id'] ) {
+				$row_source = $source;
+			}
+		}
+		$this->assertNotNull( $row_source );
+		$this->assertSame( $collection, $row_source['collection']['id'] );
+	}
+
+	public function test_trashed_source_is_excluded(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$target = $this->create_document( 'Target' );
+		$source = $this->create_document( 'Source', $this->mention_markup( $target ) );
+		wp_trash_post( $source );
+
+		$response = $this->get_backlinks( $target );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 0, $response->get_data()['total'] );
+	}
+
+	public function test_unreadable_source_is_filtered_out(): void {
+		$admin = $this->create_user( 'administrator' );
+		wp_set_current_user( $admin );
+
+		$target  = $this->create_document( 'Target' );
+		$public  = $this->create_document( 'Public source', $this->mention_markup( $target ) );
+		$private = (int) wp_insert_post(
+			array(
+				'post_type'    => Document::POST_TYPE,
+				'post_status'  => 'private',
+				'post_title'   => 'Private source',
+				'post_content' => $this->mention_markup( $target ),
+				'post_author'  => $admin,
+			)
+		);
+		$this->assertGreaterThan( 0, $private );
+
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+		$response = $this->get_backlinks( $target );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 1, $data['total'] );
+		$this->assertSame( array( $public ), array_column( $data['sources'], 'id' ) );
+	}
+
+	public function test_unknown_target_returns_404(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$response = $this->get_backlinks( 99999 );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	public function test_empty_result_when_never_mentioned(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$target = $this->create_document( 'Target' );
+
+		$response = $this->get_backlinks( $target );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 0, $response->get_data()['total'] );
+		$this->assertSame( array(), $response->get_data()['sources'] );
+	}
+
+	private function get_backlinks( int $id ) {
+		$request = new WP_REST_Request( 'GET', '/cortext/v1/documents/' . $id . '/backlinks' );
+		return rest_do_request( $request );
+	}
+
+	private function create_document( string $title, string $content = '' ): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'    => Document::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => $title,
+				'post_content' => $content,
+			)
+		);
+	}
+
+	private function create_collection( string $title ): int {
+		$collection = $this->create_document( $title );
+		$this->traits->ensure_mirror_term( $collection );
+		return $collection;
+	}
+
+	private function create_row( int $collection, string $title, string $content = '' ): int {
+		$row     = $this->create_document( $title, $content );
+		$term_id = TraitTaxonomy::term_id_for_trait( $collection );
+		wp_set_object_terms( $row, array( $term_id ), TraitTaxonomy::TAXONOMY, false );
+		return $row;
+	}
+
+	private function mention_markup( int $target ): string {
+		return sprintf(
+			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="#">Target</a></p>',
+			$target
+		);
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+}

--- a/tests/php/test-taxonomy-mention-taxonomy.php
+++ b/tests/php/test-taxonomy-mention-taxonomy.php
@@ -73,7 +73,7 @@ final class Test_Taxonomy_Mention_Taxonomy extends BaseTestCase {
 		$this->assertSame( array(), $slugs );
 	}
 
-	public function test_self_mention_is_skipped(): void {
+	public function test_self_mention_is_indexed(): void {
 		$source = $this->create_document( 'Self' );
 		wp_update_post(
 			array(
@@ -82,7 +82,16 @@ final class Test_Taxonomy_Mention_Taxonomy extends BaseTestCase {
 			)
 		);
 
-		$this->assertSame( 0, MentionTaxonomy::term_id_for_target( $source ) );
+		$this->assertGreaterThan(
+			0,
+			MentionTaxonomy::term_id_for_target( $source )
+		);
+		$slugs = wp_get_object_terms(
+			$source,
+			MentionTaxonomy::TAXONOMY,
+			array( 'fields' => 'slugs' )
+		);
+		$this->assertContains( (string) $source, $slugs );
 	}
 
 	public function test_target_delete_removes_the_target_term(): void {

--- a/tests/php/test-taxonomy-mention-taxonomy.php
+++ b/tests/php/test-taxonomy-mention-taxonomy.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for Cortext\Taxonomy\MentionTaxonomy.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Document;
+use Cortext\Taxonomy\MentionTaxonomy;
+use WorDBless\BaseTestCase;
+
+final class Test_Taxonomy_Mention_Taxonomy extends BaseTestCase {
+
+	use InMemoryTermStore;
+
+	private MentionTaxonomy $mentions;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Document() )->register_post_type();
+		$this->mentions = new MentionTaxonomy();
+		$this->mentions->register_taxonomy();
+		$this->install_in_memory_term_store();
+		add_action( 'save_post_' . Document::POST_TYPE, array( $this->mentions, 'sync_mentions_on_save' ), 10, 3 );
+		add_action( 'before_delete_post', array( $this->mentions, 'sync_term_on_delete' ), 10, 2 );
+	}
+
+	public function tear_down(): void {
+		remove_action( 'save_post_' . Document::POST_TYPE, array( $this->mentions, 'sync_mentions_on_save' ), 10 );
+		remove_action( 'before_delete_post', array( $this->mentions, 'sync_term_on_delete' ), 10 );
+		$this->uninstall_in_memory_term_store();
+		parent::tear_down();
+	}
+
+	public function test_extract_target_ids_parses_and_dedupes_mentions(): void {
+		$html = '<p><a data-crtxt-mention="8">A</a><a data-crtxt-mention="8">A again</a><a data-crtxt-mention="9">B</a></p>';
+
+		$this->assertSame( array( 8, 9 ), MentionTaxonomy::extract_target_ids( $html ) );
+	}
+
+	public function test_save_tags_source_with_target_mirror_term(): void {
+		$target = $this->create_document( 'Target' );
+		$source = $this->create_document(
+			'Source',
+			$this->mention_markup( $target )
+		);
+
+		$slugs = wp_get_object_terms( $source, MentionTaxonomy::TAXONOMY, array( 'fields' => 'slugs' ) );
+
+		$this->assertSame( array( (string) $target ), $slugs );
+	}
+
+	public function test_resave_without_mention_removes_relationship(): void {
+		$target = $this->create_document( 'Target' );
+		$source = $this->create_document(
+			'Source',
+			$this->mention_markup( $target )
+		);
+
+		wp_update_post(
+			array(
+				'ID'           => $source,
+				'post_content' => '<p>No mentions.</p>',
+			)
+		);
+
+		$slugs = wp_get_object_terms( $source, MentionTaxonomy::TAXONOMY, array( 'fields' => 'slugs' ) );
+		$this->assertSame( array(), $slugs );
+	}
+
+	public function test_self_mention_is_skipped(): void {
+		$source = $this->create_document( 'Self' );
+		wp_update_post(
+			array(
+				'ID'           => $source,
+				'post_content' => $this->mention_markup( $source ),
+			)
+		);
+
+		$this->assertSame( 0, MentionTaxonomy::term_id_for_target( $source ) );
+	}
+
+	public function test_target_delete_removes_mirror_term(): void {
+		$target = $this->create_document( 'Target' );
+		$this->create_document( 'Source', $this->mention_markup( $target ) );
+		$this->assertGreaterThan( 0, MentionTaxonomy::term_id_for_target( $target ) );
+
+		wp_delete_post( $target, true );
+
+		$this->assertSame( 0, MentionTaxonomy::term_id_for_target( $target ) );
+	}
+
+	private function create_document( string $title, string $content = '' ): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'    => Document::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => $title,
+				'post_content' => $content,
+			)
+		);
+	}
+
+	private function mention_markup( int $target ): string {
+		return sprintf(
+			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="#">Target</a></p>',
+			$target
+		);
+	}
+}

--- a/tests/php/test-taxonomy-mention-taxonomy.php
+++ b/tests/php/test-taxonomy-mention-taxonomy.php
@@ -37,13 +37,13 @@ final class Test_Taxonomy_Mention_Taxonomy extends BaseTestCase {
 		parent::tear_down();
 	}
 
-	public function test_extract_target_ids_parses_and_dedupes_mentions(): void {
+	public function test_extract_target_ids_finds_each_mentioned_target_once(): void {
 		$html = '<p><a data-crtxt-mention="8">A</a><a data-crtxt-mention="8">A again</a><a data-crtxt-mention="9">B</a></p>';
 
 		$this->assertSame( array( 8, 9 ), MentionTaxonomy::extract_target_ids( $html ) );
 	}
 
-	public function test_save_tags_source_with_target_mirror_term(): void {
+	public function test_save_tags_source_with_the_target_term(): void {
 		$target = $this->create_document( 'Target' );
 		$source = $this->create_document(
 			'Source',
@@ -55,7 +55,7 @@ final class Test_Taxonomy_Mention_Taxonomy extends BaseTestCase {
 		$this->assertSame( array( (string) $target ), $slugs );
 	}
 
-	public function test_resave_without_mention_removes_relationship(): void {
+	public function test_resave_without_mentions_removes_the_target_term(): void {
 		$target = $this->create_document( 'Target' );
 		$source = $this->create_document(
 			'Source',
@@ -85,7 +85,7 @@ final class Test_Taxonomy_Mention_Taxonomy extends BaseTestCase {
 		$this->assertSame( 0, MentionTaxonomy::term_id_for_target( $source ) );
 	}
 
-	public function test_target_delete_removes_mirror_term(): void {
+	public function test_target_delete_removes_the_target_term(): void {
 		$target = $this->create_document( 'Target' );
 		$this->create_document( 'Source', $this->mention_markup( $target ) );
 		$this->assertGreaterThan( 0, MentionTaxonomy::term_id_for_target( $target ) );


### PR DESCRIPTION
## What

Follow-up to #376, closes #160.

Adds backlinks for document mentions. When a document mentions the document you are viewing, Cortext shows that source and lets you jump back to it.

In the document inspector, backlinks appear as a collapsible panel. In the side detail view, they sit behind a small toolbar button so they do not take over the editor body. Open backlink views also refresh after content is saved, and the side popover checks again when opened.

## How

- Keeping a private mention index updated when documents are saved or deleted.
- Counting repeated mentions from the same source, while still showing that source only once.
- Adding a backfill command for existing content.
- Hiding backlink sources that the current viewer cannot read.

## Testing Instructions

1. Open a document that is mentioned by another document.
2. Confirm backlinks appear on the mentioned document.
3. Click a backlink and confirm that Cortext opens the source document.
4. Mention the same target twice from one source, save, and confirm the count updates without duplicating the source.
5. Remove the mention, save, and confirm the backlink disappears.
6. Open the side detail backlink popover and confirm it shows the current count.
7. Run the backfill command on existing content and confirm backlinks still appear.

## Screenshots
<img width="277" height="531" alt="image" src="https://github.com/user-attachments/assets/cf974829-60d3-45f5-9f98-30e84f881dbe" />
<img width="1151" height="837" alt="image" src="https://github.com/user-attachments/assets/1f88fd3b-2a9c-4896-92e9-34691ef20641" />
