### PR TITLE
Perf: Lazy-load and paginate the sidebar tree

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -36,6 +36,7 @@ use Cortext\Rest\PostLocksController;
 use Cortext\Rest\RecentsController;
 use Cortext\Rest\RowsController;
 use Cortext\Rest\SampleContentController;
+use Cortext\Rest\SidebarTreePreferencesController;
 use Cortext\Rest\WorkspaceHomeController;
 use Cortext\Taxonomy\TraitTaxonomy;
 use Cortext\Theming\Preferences;
@@ -76,6 +77,7 @@ final class Plugin {
 		( new RecentsController() )->register();
 		( new RowsController() )->register();
 		( new SampleContentController() )->register();
+		( new SidebarTreePreferencesController() )->register();
 		( new WorkspaceHomeController() )->register();
 		( new NotionController() )->register();
 		( new NotionImporter() )->register();

--- a/includes/PostType/Document.php
+++ b/includes/PostType/Document.php
@@ -95,6 +95,66 @@ final class Document {
 				),
 			)
 		);
+		register_rest_field(
+			self::POST_TYPE,
+			'cortext_has_tree_children',
+			array(
+				'get_callback' => array( $this, 'has_tree_children_rest_field' ),
+				'schema'       => array(
+					'type'     => 'boolean',
+					'context'  => array( 'edit' ),
+					'readonly' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Returns true when a document has at least one editable child in the sidebar tree.
+	 *
+	 * @param array<string,mixed> $record REST record data.
+	 */
+	public function has_tree_children_rest_field( array $record ): bool {
+		$parent_id = isset( $record['id'] ) ? (int) $record['id'] : 0;
+		if ( $parent_id < 1 ) {
+			return false;
+		}
+
+		$per_page      = 20;
+		$page          = 1;
+		$matched_count = 0;
+		do {
+			$query         = new \WP_Query(
+				array(
+					'post_type'              => self::POST_TYPE,
+					'post_status'            => array( 'draft', 'private', 'publish' ),
+					'post_parent'            => $parent_id,
+					'posts_per_page'         => $per_page,
+					'paged'                  => $page,
+					'fields'                 => 'ids',
+					'no_found_rows'          => true,
+					'perm'                   => 'editable',
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+					'tax_query'              => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+						array(
+							'taxonomy' => TraitTaxonomy::TAXONOMY,
+							'operator' => 'NOT EXISTS',
+						),
+					),
+				)
+			);
+			$matched_count = count( $query->posts );
+
+			foreach ( $query->posts as $child_id ) {
+				if ( current_user_can( 'edit_post', (int) $child_id ) ) {
+					return true;
+				}
+			}
+			++$page;
+		} while ( $matched_count === $per_page );
+
+		return false;
 	}
 
 	/**
@@ -748,6 +808,7 @@ final class Document {
 		$with_trait     = $request->get_param( 'cortext_trait' );
 		$collections    = $request->get_param( 'cortext_collections' );
 		$no_collections = $request->get_param( 'cortext_no_collections' );
+		$tree_order     = $request->get_param( 'cortext_tree_order' );
 
 		$tax_query = $args['tax_query'] ?? array();
 
@@ -793,6 +854,13 @@ final class Document {
 		if ( count( $tax_query ) > 0 ) {
 			$args['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		}
+		if ( null !== $tree_order && '' !== (string) $tree_order && '0' !== (string) $tree_order ) {
+			$args['orderby'] = array(
+				'menu_order' => 'ASC',
+				'ID'         => 'ASC',
+			);
+			unset( $args['order'] );
+		}
 		return $args;
 	}
 
@@ -817,6 +885,10 @@ final class Document {
 		);
 		$params['cortext_collections']    = array(
 			'description' => __( 'Limit to documents that define a schema (collections).', 'cortext' ),
+			'type'        => 'boolean',
+		);
+		$params['cortext_tree_order']     = array(
+			'description' => __( 'Sort tree branches by menu order, then document ID.', 'cortext' ),
 			'type'        => 'boolean',
 		);
 		return $params;

--- a/includes/Rest/SidebarTreePreferencesController.php
+++ b/includes/Rest/SidebarTreePreferencesController.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * REST endpoint for the current user's sidebar tree expansion state.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\PostType\Document;
+use Cortext\Taxonomy\TraitTaxonomy;
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class SidebarTreePreferencesController {
+
+	private const NAMESPACE = 'cortext/v1';
+	private const META_KEY  = 'cortext_sidebar_expanded_documents';
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/sidebar-tree-preferences',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_preferences' ),
+					'permission_callback' => array( $this, 'can_read' ),
+				),
+				array(
+					'methods'             => 'PUT',
+					'callback'            => array( $this, 'update_preferences' ),
+					'permission_callback' => array( $this, 'can_read' ),
+					'args'                => array(
+						'expanded' => array(
+							'type'     => 'array',
+							'required' => true,
+							'items'    => array(
+								'type'    => 'integer',
+								'minimum' => 1,
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function can_read(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	public function get_preferences(): WP_REST_Response {
+		return new WP_REST_Response(
+			array(
+				'expanded' => $this->resolve_stored_expanded( get_current_user_id() ),
+			),
+			200
+		);
+	}
+
+	public function update_preferences( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$expanded = $request->get_param( 'expanded' );
+		if ( ! is_array( $expanded ) ) {
+			return new WP_Error(
+				'cortext_sidebar_tree_preferences_invalid_payload',
+				__( 'Expanded documents must be sent as a list.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$valid = $this->valid_tree_document_ids( $this->normalize_ids( $expanded ) );
+		update_user_meta( get_current_user_id(), self::META_KEY, $valid );
+
+		return new WP_REST_Response(
+			array(
+				'expanded' => $valid,
+			),
+			200
+		);
+	}
+
+	private function resolve_stored_expanded( int $user_id ): array {
+		$raw = get_user_meta( $user_id, self::META_KEY, true );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$valid = $this->valid_tree_document_ids( $this->normalize_ids( $raw ) );
+		if ( array_values( $raw ) !== $valid ) {
+			update_user_meta( $user_id, self::META_KEY, $valid );
+		}
+
+		return $valid;
+	}
+
+	/**
+	 * Normalizes expanded document ids.
+	 *
+	 * @param array<int,mixed> $raw Stored or requested ids.
+	 * @return int[]
+	 */
+	private function normalize_ids( array $raw ): array {
+		$ids  = array();
+		$seen = array();
+		foreach ( $raw as $entry ) {
+			$id = is_numeric( $entry ) ? (int) $entry : 0;
+			if ( $id < 1 || isset( $seen[ $id ] ) ) {
+				continue;
+			}
+			$seen[ $id ] = true;
+			$ids[]       = $id;
+		}
+		return $ids;
+	}
+
+	/**
+	 * Keeps only editable documents that belong in the tree.
+	 *
+	 * @param int[] $ids Candidate document ids.
+	 * @return int[]
+	 */
+	private function valid_tree_document_ids( array $ids ): array {
+		$out = array();
+		foreach ( $ids as $id ) {
+			if ( $this->is_tree_document( $id ) ) {
+				$out[] = $id;
+			}
+		}
+		return $out;
+	}
+
+	private function is_tree_document( int $id ): bool {
+		$post = get_post( $id );
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+			return false;
+		}
+		if ( ! in_array( $post->post_status, array( 'draft', 'private', 'publish' ), true ) ) {
+			return false;
+		}
+		if ( ! current_user_can( 'edit_post', $id ) ) {
+			return false;
+		}
+		return ! $this->has_trait_without_defining_one( $post );
+	}
+
+	private function has_trait_without_defining_one( WP_Post $post ): bool {
+		if ( Document::is_collection_post( $post ) ) {
+			return false;
+		}
+
+		$terms = wp_get_object_terms(
+			$post->ID,
+			TraitTaxonomy::TAXONOMY,
+			array( 'fields' => 'ids' )
+		);
+		return is_array( $terms ) && count( $terms ) > 0;
+	}
+}

--- a/src/components/DocumentInspectorSidebar.js
+++ b/src/components/DocumentInspectorSidebar.js
@@ -60,6 +60,7 @@ import { DOCUMENT_POST_TYPE, FULL_PAGE_COLLECTION_QUERY } from '../collections';
 import { definesTrait } from '../documents/capabilities';
 import { unlock } from '../lock-unlock';
 import { notifyDocumentTrashChanged } from '../hooks/documentTrashInvalidation';
+import { notifySidebarTreeChanged } from '../hooks/sidebarTreeInvalidation';
 import { useFavorites } from '../hooks/useFavorites';
 import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 
@@ -529,6 +530,7 @@ function PageActionsPanel( { postId } ) {
 				DOCUMENT_POST_TYPE,
 				FULL_PAGE_COLLECTION_QUERY,
 			] );
+			notifySidebarTreeChanged();
 			notifyDocumentTrashChanged();
 			try {
 				await setFavorites( ( current ) =>

--- a/src/components/ImportPane.js
+++ b/src/components/ImportPane.js
@@ -25,6 +25,7 @@ import { extractCollections, runImport } from './notionImport';
 import { DOCUMENT_POST_TYPE, FULL_PAGE_COLLECTION_QUERY } from '../collections';
 import { ACTIVE_PAGES_QUERY } from './page-queries';
 import { computeDocumentUri } from '../router/useResolveEntity';
+import { notifySidebarTreeChanged } from '../hooks/sidebarTreeInvalidation';
 
 const NOTION_KEY_STORAGE = 'cortext.notionKey';
 
@@ -106,6 +107,7 @@ export default function ImportPane() {
 					DOCUMENT_POST_TYPE,
 					FULL_PAGE_COLLECTION_QUERY,
 				] );
+				notifySidebarTreeChanged();
 			};
 
 			runImport( notionApiKey, collection.id, ( progress ) => {

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -2,6 +2,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import { useParams } from '@tanstack/react-router';
 import {
 	Button,
 	Dropdown,
@@ -72,6 +73,8 @@ import ThemeToggle from './ThemeToggle';
 import {
 	computeDocumentUri,
 	IMPORT_URI,
+	parseIdFromUri,
+	parseSplatUri,
 	PUBLISHED_DOCUMENTS_URI,
 } from '../router/useResolveEntity';
 import { DOCUMENT_POST_TYPE, FULL_PAGE_COLLECTION_QUERY } from '../collections';
@@ -81,7 +84,7 @@ import useDelayedFlag, {
 import { useFavorites } from '../hooks/useFavorites';
 import useSidebarSections from '../hooks/useSidebarSections';
 import useTrashedDocuments from '../hooks/useTrashedDocuments';
-import { useWorkspaceHomePath } from '../hooks/useWorkspaceHomePath';
+import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 import {
 	DocumentsProvider,
 	favoriteIdentForRecord,
@@ -94,7 +97,7 @@ import {
 } from '../documents';
 import useSidebarDnd from './sidebar/useSidebarDnd';
 import useSidebarNavigation from './sidebar/useSidebarNavigation';
-import useSidebarTree from './sidebar/useSidebarTree';
+import useSidebarTree, { ROOT_PARENT_ID } from './sidebar/useSidebarTree';
 import DocumentRow from './sidebar/DocumentRow';
 import {
 	isPublicWebAffordancesEnabled,
@@ -107,8 +110,8 @@ export default function Sidebar( {
 	onToggleCollapsed,
 	onWidthChange,
 } ) {
-	// tech-debt.md#td-workspace-tree-no-unified-model: this tree still comes from flat REST lists capped at
-	// `per_page: 100`. The follow-up is lazy loading or a paged tree endpoint.
+	// Favorites still needs collection labels. The Documents tree below loads
+	// lazily through useSidebarTree.
 	const { records: collections, isResolving: isResolvingCollections } =
 		useEntityRecords(
 			'postType',
@@ -116,26 +119,63 @@ export default function Sidebar( {
 			FULL_PAGE_COLLECTION_QUERY
 		);
 	const trashedDocumentsState = useTrashedDocuments();
+	const params = useParams( { strict: false } );
+	const routeUri = params._splat ?? '';
+	const { prefix: routePrefix, tail: routeTail } = useMemo(
+		() => parseSplatUri( routeUri ),
+		[ routeUri ]
+	);
+	const routeSelectedId = useMemo(
+		() =>
+			routePrefix === 'page' || routePrefix === null
+				? parseIdFromUri( routeTail )
+				: null,
+		[ routePrefix, routeTail ]
+	);
+	const routeSelectedCollectionId = useMemo(
+		() =>
+			routePrefix === 'collection' ? parseIdFromUri( routeTail ) : null,
+		[ routePrefix, routeTail ]
+	);
 	const {
-		pages,
-		homePath,
 		home,
 		setHome,
-		isResolvingHomePath,
-		isResolvingPages,
+		isResolving: isResolvingHome,
 		isUpdating: isHomeUpdating,
-	} = useWorkspaceHomePath();
-	const showPagesSkeleton = useDelayedFlag(
-		isResolvingPages && pages.length === 0,
-		120,
-		SKELETON_MIN_VISIBLE_MS
-	);
+	} = useWorkspaceHome();
 	const {
 		favorites,
 		setFavorites,
 		isResolving: isResolvingFavorites,
 	} = useFavorites();
 	const { saveEntityRecord } = useDispatch( 'core' );
+	const {
+		tree,
+		pages,
+		rootBranch,
+		isResolvingPages,
+		expandedIds,
+		toggleExpand,
+		expand,
+		loadBranch,
+		loadMore,
+		refreshBranch,
+		getBranch,
+	} = useSidebarTree( {
+		selectedId: routeSelectedId,
+		selectedCollectionId: routeSelectedCollectionId,
+	} );
+	const fallbackHomePage = tree[ 0 ]?.page ?? null;
+	const homePath =
+		home?.path ??
+		( fallbackHomePage ? computeDocumentUri( fallbackHomePage ) : null );
+	const isResolvingHomePath =
+		isResolvingHome || ( ! home?.path && isResolvingPages );
+	const showPagesSkeleton = useDelayedFlag(
+		isResolvingPages && pages.length === 0,
+		120,
+		SKELETON_MIN_VISIBLE_MS
+	);
 	const {
 		navigate,
 		activeUri,
@@ -218,14 +258,6 @@ export default function Sidebar( {
 		[ isRowSelected, navigate ]
 	);
 
-	// The tree is built from one non-row document list (pages and collections).
-	// The `collections` query feeds only the Favorites label lookup.
-	const { tree, expandedIds, toggleExpand, expand } = useSidebarTree( {
-		documents: pages,
-		selectedId,
-		selectedCollectionId,
-	} );
-
 	// `draggedId` and `activeDrop` flow into the per-row callbacks below, so
 	// the DnD hook has to resolve before any `useCallback` that lists them as
 	// deps. Otherwise their `const` bindings sit in the temporal dead zone
@@ -235,6 +267,9 @@ export default function Sidebar( {
 			pages,
 			expandedIds,
 			expand,
+			loadBranch,
+			refreshBranch,
+			getBranch,
 			saveEntityRecord,
 		} );
 
@@ -328,12 +363,20 @@ export default function Sidebar( {
 		[ navigate ]
 	);
 	const createAndOpen = useCallback(
-		async ( input ) => openAfterCreate( await create( input ) ),
-		[ create, openAfterCreate ]
+		async ( input ) => {
+			const created = await create( input );
+			refreshBranch( created?.parent ?? input?.parent ?? ROOT_PARENT_ID );
+			return openAfterCreate( created );
+		},
+		[ create, openAfterCreate, refreshBranch ]
 	);
 	const createCollectionAndOpen = useCallback(
-		async ( input ) => openAfterCreate( await createCollection( input ) ),
-		[ createCollection, openAfterCreate ]
+		async ( input ) => {
+			const created = await createCollection( input );
+			refreshBranch( created?.parent ?? input?.parent ?? ROOT_PARENT_ID );
+			return openAfterCreate( created );
+		},
+		[ createCollection, openAfterCreate, refreshBranch ]
 	);
 	const createRootPage = useCallback(
 		() => createAndOpen( {} ),
@@ -360,6 +403,7 @@ export default function Sidebar( {
 		isSelected: isRowSelected,
 		onSelect: onRowSelect,
 		onToggleExpand: toggleExpand,
+		onLoadMore: loadMore,
 		isFavorite,
 		isFavoriteDisabled: areFavoriteActionsDisabled,
 		onToggleFavorite: toggleFavorite,
@@ -602,11 +646,22 @@ export default function Sidebar( {
 								{ isResolvingPages &&
 									pages.length === 0 &&
 									showPagesSkeleton && (
-										<SidebarListSkeleton itemCount={ 5 } />
+										<SidebarListSkeleton itemCount={ 1 } />
 									) }
 								{ ! isResolvingPages && pages.length === 0 && (
 									<p className="cortext-sidebar__empty">
 										{ __( 'Nothing here yet.', 'cortext' ) }
+									</p>
+								) }
+								{ rootBranch.error && (
+									<p
+										className="cortext-sidebar__row-error"
+										role="alert"
+									>
+										{ __(
+											"We couldn't load these documents.",
+											'cortext'
+										) }
 									</p>
 								) }
 
@@ -616,10 +671,42 @@ export default function Sidebar( {
 											key={ node.page.id }
 											record={ node.page }
 											childNodes={ node.children }
+											childBranch={ node.branch }
 											depth={ 0 }
 											{ ...rowChrome }
 										/>
 									) ) }
+									{ rootBranch.hasResolved &&
+										rootBranch.page <
+											rootBranch.totalPages && (
+											<li
+												className="cortext-sidebar__node cortext-sidebar__load-more-node"
+												style={ {
+													'--cortext-depth': 0,
+												} }
+											>
+												<Button
+													className="cortext-sidebar__load-more"
+													size="compact"
+													isBusy={
+														rootBranch.isLoading
+													}
+													disabled={
+														rootBranch.isLoading
+													}
+													onClick={ () =>
+														loadMore(
+															ROOT_PARENT_ID
+														)
+													}
+												>
+													{ __(
+														'Show more',
+														'cortext'
+													) }
+												</Button>
+											</li>
+										) }
 								</ul>
 							</SidebarSection>
 

--- a/src/components/Sidebar.scss
+++ b/src/components/Sidebar.scss
@@ -378,6 +378,18 @@
 		margin: 0;
 	}
 
+	&__load-more-node {
+		padding-inline-start: calc((var(--cortext-depth, 0) + 1) * #{$grid-unit-20});
+	}
+
+	&__load-more.components-button {
+		width: 100%;
+		height: $grid-unit-30;
+		justify-content: flex-start;
+		color: var(--cortext-text-muted);
+		font-size: 12px;
+	}
+
 	&__row-wrapper {
 		position: relative;
 	}

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -35,6 +35,7 @@ import { useDocumentActions, useDocumentRecord } from '../../documents';
  * @param {Object}                            props
  * @param {Object}                            props.record                    Raw document record.
  * @param {Array}                             [props.childNodes]              Child tree nodes (hierarchy only).
+ * @param {Object}                            [props.childBranch]             Lazy-loaded child branch state.
  * @param {number}                            [props.depth]                   Nesting depth, 0 at the root.
  * @param {Set<number>}                       props.expandedIds               Currently expanded row ids.
  * @param {?number}                           [props.draggedId]               Id of the row being dragged.
@@ -43,6 +44,7 @@ import { useDocumentActions, useDocumentRecord } from '../../documents';
  * @param {Function|boolean}                  props.isSelected                Selection predicate or flag.
  * @param {Function}                          props.onSelect                  Called with the record on title click.
  * @param {Function}                          props.onToggleExpand            Called with the record id on chevron click.
+ * @param {Function}                          props.onLoadMore                Called with the parent id from a branch Show more button.
  * @param {Function}                          props.onCreateChild             Called with the parent id from the add-child button.
  * @param {Function}                          [props.onCreateChildCollection] Called with the parent id to create a child collection.
  * @param {Function|boolean}                  props.isFavorite                Favorite predicate or flag.
@@ -57,6 +59,7 @@ import { useDocumentActions, useDocumentRecord } from '../../documents';
 export default function DocumentRow( {
 	record,
 	childNodes = [],
+	childBranch = null,
 	depth = 0,
 	expandedIds,
 	draggedId = null,
@@ -65,6 +68,7 @@ export default function DocumentRow( {
 	isSelected,
 	onSelect,
 	onToggleExpand,
+	onLoadMore,
 	onCreateChild,
 	onCreateChildCollection,
 	isFavorite,
@@ -80,7 +84,25 @@ export default function DocumentRow( {
 	const { rename, duplicate, trash } = useDocumentActions();
 
 	const recordId = record.id;
-	const hasChildren = features.hierarchy && childNodes.length > 0;
+	const hasLoadedChildren = features.hierarchy && childNodes.length > 0;
+	const hasServerChildren = record.cortext_has_tree_children === true;
+	const hasMoreChildren =
+		childBranch?.hasResolved &&
+		childBranch.totalPages > 0 &&
+		childBranch.page < childBranch.totalPages;
+	const branchKnownEmpty =
+		childBranch?.hasResolved &&
+		! childBranch?.isLoading &&
+		! childBranch?.error &&
+		! hasLoadedChildren &&
+		! hasMoreChildren;
+	const canExpand =
+		features.hierarchy &&
+		! branchKnownEmpty &&
+		( hasLoadedChildren ||
+			hasServerChildren ||
+			childBranch?.isLoading ||
+			childBranch?.error );
 	const isExpanded = expandedIds?.has( recordId ) ?? false;
 	const rowIsSelected =
 		typeof isSelected === 'function' ? isSelected( record ) : !! isSelected;
@@ -191,7 +213,7 @@ export default function DocumentRow( {
 					{ ...attributes }
 					{ ...listeners }
 				>
-					{ hasChildren ? (
+					{ canExpand ? (
 						<Button
 							className={
 								'cortext-sidebar__chevron' +
@@ -413,7 +435,7 @@ export default function DocumentRow( {
 				</div>
 			</div>
 
-			{ hasChildren && (
+			{ canExpand && (
 				<div
 					className={
 						'cortext-sidebar__children-wrapper' +
@@ -427,6 +449,7 @@ export default function DocumentRow( {
 								key={ childNode.page.id }
 								record={ childNode.page }
 								childNodes={ childNode.children }
+								childBranch={ childNode.branch }
 								depth={ depth + 1 }
 								expandedIds={ expandedIds }
 								draggedId={ draggedId }
@@ -435,6 +458,7 @@ export default function DocumentRow( {
 								isSelected={ isSelected }
 								onSelect={ onSelect }
 								onToggleExpand={ onToggleExpand }
+								onLoadMore={ onLoadMore }
 								onCreateChild={ onCreateChild }
 								onCreateChildCollection={
 									onCreateChildCollection
@@ -449,6 +473,41 @@ export default function DocumentRow( {
 								onAutoRenameConsumed={ onAutoRenameConsumed }
 							/>
 						) ) }
+						{ childBranch?.error && (
+							<li className="cortext-sidebar__node">
+								<p
+									className="cortext-sidebar__row-error"
+									role="alert"
+								>
+									{ __(
+										"We couldn't load these documents.",
+										'cortext'
+									) }
+								</p>
+							</li>
+						) }
+						{ hasMoreChildren && (
+							<li
+								className="cortext-sidebar__node cortext-sidebar__load-more-node"
+								style={ { '--cortext-depth': depth + 1 } }
+							>
+								<Button
+									className="cortext-sidebar__load-more"
+									size="compact"
+									isBusy={ childBranch.isLoading }
+									disabled={ childBranch.isLoading }
+									onClick={ ( e ) => {
+										e.stopPropagation();
+										onLoadMore?.( recordId );
+									} }
+									onPointerDown={ ( e ) =>
+										e.stopPropagation()
+									}
+								>
+									{ __( 'Show more', 'cortext' ) }
+								</Button>
+							</li>
+						) }
 					</ul>
 				</div>
 			) }

--- a/src/components/sidebar/useSidebarDnd.js
+++ b/src/components/sidebar/useSidebarDnd.js
@@ -1,4 +1,10 @@
-import { useState, useMemo, useRef, useCallback } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	useRef,
+	useCallback,
+	useEffect,
+} from '@wordpress/element';
 import {
 	PointerSensor,
 	KeyboardSensor,
@@ -36,12 +42,18 @@ function parseDropId( id ) {
  * @param {Array}    args.pages            Loaded `crtxt_document` records (every non-row document: pages and collections).
  * @param {Set}      args.expandedIds      Currently expanded node ids (from `useSidebarTree`).
  * @param {Function} args.expand           Expand callback from `useSidebarTree`.
+ * @param {Function} args.loadBranch       Loads a lazy tree branch.
+ * @param {Function} args.refreshBranch    Refreshes a loaded lazy tree branch.
+ * @param {Function} args.getBranch        Reads a lazy tree branch state.
  * @param {Function} args.saveEntityRecord core-data dispatcher used to persist moves.
  */
 export default function useSidebarDnd( {
 	pages,
 	expandedIds,
 	expand,
+	loadBranch,
+	refreshBranch,
+	getBranch,
 	saveEntityRecord,
 } ) {
 	const sensors = useSensors(
@@ -52,6 +64,7 @@ export default function useSidebarDnd( {
 	const [ draggedId, setDraggedId ] = useState( null );
 	const [ activeDrop, setActiveDrop ] = useState( null );
 	const autoExpandTimerRef = useRef( null );
+	const recordsRef = useRef( [] );
 
 	const clearAutoExpandTimer = useCallback( () => {
 		if ( autoExpandTimerRef.current ) {
@@ -66,6 +79,10 @@ export default function useSidebarDnd( {
 	// list every collection twice and corrupt the sibling order math in
 	// `computeDropTarget`.
 	const treeRecords = useMemo( () => pages, [ pages ] );
+
+	useEffect( () => {
+		recordsRef.current = treeRecords;
+	}, [ treeRecords ] );
 
 	const handleDragStart = useCallback( ( { active } ) => {
 		const id = active?.data?.current?.pageId ?? null;
@@ -104,14 +121,7 @@ export default function useSidebarDnd( {
 			clearAutoExpandTimer();
 			if ( parsed?.zone === 'inside' ) {
 				const target = pages.find( ( p ) => p.id === parsed.targetId );
-				const hasKids = treeRecords.some(
-					( r ) => ( r.parent || 0 ) === parsed.targetId
-				);
-				if (
-					target &&
-					hasKids &&
-					! expandedIds.has( parsed.targetId )
-				) {
+				if ( target && ! expandedIds.has( parsed.targetId ) ) {
 					autoExpandTimerRef.current = setTimeout( () => {
 						expand( parsed.targetId );
 					}, AUTO_EXPAND_DELAY );
@@ -140,11 +150,45 @@ export default function useSidebarDnd( {
 				return;
 			}
 
+			let records = recordsRef.current;
+			const target = records.find( ( r ) => r.id === parsed.targetId );
+			const active = records.find( ( r ) => r.id === activeId );
+			if ( ! target || ! active ) {
+				return;
+			}
+			const destinationParent =
+				parsed.zone === 'inside'
+					? parsed.targetId
+					: Number( target.parent || 0 );
+			let destinationBranch = getBranch?.( destinationParent );
+			if (
+				parsed.zone === 'inside' &&
+				! destinationBranch?.hasResolved
+			) {
+				destinationBranch = await loadBranch?.( destinationParent );
+				// `recordsRef` only catches up to the loaded children on the
+				// next render, so merge them in from the returned branch.
+				// Without them `computeDropTarget` treats the parent as empty
+				// and drops the row at `menu_order` 0 instead of appending it.
+				const byId = new Map();
+				[
+					...recordsRef.current,
+					...( destinationBranch?.records ?? [] ),
+				].forEach( ( record ) => byId.set( record.id, record ) );
+				records = [ ...byId.values() ];
+			}
+			if (
+				! destinationBranch?.hasResolved ||
+				destinationBranch.page < destinationBranch.totalPages
+			) {
+				return;
+			}
+
 			const updates = computeDropTarget(
 				activeId,
 				parsed.targetId,
 				parsed.zone,
-				treeRecords
+				records
 			);
 			if ( ! updates ) {
 				return;
@@ -154,7 +198,7 @@ export default function useSidebarDnd( {
 			// the endpoint that owns it.
 			await Promise.all(
 				updates.map( ( u ) => {
-					const record = treeRecords.find( ( r ) => r.id === u.id );
+					const record = records.find( ( r ) => r.id === u.id );
 					return saveEntityRecord(
 						'postType',
 						record?.type ?? POST_TYPE,
@@ -166,12 +210,16 @@ export default function useSidebarDnd( {
 			if ( parsed.zone === 'inside' ) {
 				expand( parsed.targetId );
 			}
+			refreshBranch?.( Number( active.parent || 0 ) );
+			refreshBranch?.( destinationParent );
 		},
 		[
 			draggedId,
-			treeRecords,
 			saveEntityRecord,
 			expand,
+			loadBranch,
+			refreshBranch,
+			getBranch,
 			clearAutoExpandTimer,
 		]
 	);

--- a/src/components/sidebar/useSidebarTree.js
+++ b/src/components/sidebar/useSidebarTree.js
@@ -1,89 +1,619 @@
-import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import {
+	useState,
+	useMemo,
+	useCallback,
+	useEffect,
+	useRef,
+} from '@wordpress/element';
 
-import { buildTree, collectAncestorIds } from '../document-tree';
+import { SIDEBAR_TREE_CHANGED_EVENT } from '../../hooks/sidebarTreeInvalidation';
+
+export const ROOT_PARENT_ID = 0;
+export const SIDEBAR_TREE_PER_PAGE = 20;
+export const SIDEBAR_TREE_PREFERENCES_PATH =
+	'/cortext/v1/sidebar-tree-preferences';
+
+const DOCUMENTS_PATH = '/wp/v2/crtxt_documents';
+const ACTIVE_STATUSES = [ 'draft', 'private', 'publish' ];
+const TREE_FIELDS = [
+	'id',
+	'type',
+	'parent',
+	'menu_order',
+	'status',
+	'slug',
+	'title',
+	'meta',
+	'cortext_defines_trait',
+	'cortext_has_tree_children',
+	'crtxt_trait',
+];
+
+const EMPTY_BRANCH = {
+	records: [],
+	page: 0,
+	total: 0,
+	totalPages: 0,
+	isLoading: false,
+	hasResolved: false,
+	error: null,
+};
+
+function parentKey( parentId ) {
+	const parsed = Number( parentId );
+	return Number.isFinite( parsed ) && parsed > 0 ? Math.floor( parsed ) : 0;
+}
+
+function normalizeId( value ) {
+	const parsed = Number( value );
+	return Number.isFinite( parsed ) && parsed > 0 ? Math.floor( parsed ) : 0;
+}
+
+function normalizeIds( ids ) {
+	if ( ! Array.isArray( ids ) ) {
+		return [];
+	}
+	const seen = new Set();
+	const out = [];
+	ids.forEach( ( value ) => {
+		const id = normalizeId( value );
+		if ( id > 0 && ! seen.has( id ) ) {
+			seen.add( id );
+			out.push( id );
+		}
+	} );
+	return out;
+}
+
+function headerNumber( response, name, fallback ) {
+	const value = response?.headers?.get?.( name );
+	const parsed = Number( value );
+	return Number.isFinite( parsed ) && parsed >= 0 ? parsed : fallback;
+}
+
+function mergeRecords( current, incoming ) {
+	const byId = new Map();
+	const out = [];
+	[ ...( current ?? [] ), ...( incoming ?? [] ) ].forEach( ( record ) => {
+		const id = normalizeId( record?.id );
+		if ( id < 1 ) {
+			return;
+		}
+		if ( byId.has( id ) ) {
+			const index = byId.get( id );
+			out[ index ] = record;
+			return;
+		}
+		byId.set( id, out.length );
+		out.push( record );
+	} );
+	return out;
+}
+
+function branchHasMore( branch ) {
+	return Boolean(
+		branch?.hasResolved &&
+			branch.totalPages > 0 &&
+			branch.page < branch.totalPages
+	);
+}
+
+function buildNodesForParent( parentId, branches, seen = new Set() ) {
+	const branch = branches.get( parentKey( parentId ) );
+	if ( ! branch?.records?.length ) {
+		return [];
+	}
+	return branch.records.map( ( page ) => {
+		const id = normalizeId( page.id );
+		if ( id < 1 || seen.has( id ) ) {
+			return { page, children: [], branch: branches.get( id ) };
+		}
+		const nextSeen = new Set( seen );
+		nextSeen.add( id );
+		return {
+			page,
+			children: buildNodesForParent( id, branches, nextSeen ),
+			branch: branches.get( id ),
+		};
+	} );
+}
+
+function findRecordInBranches( branches, id ) {
+	const targetId = normalizeId( id );
+	if ( targetId < 1 ) {
+		return null;
+	}
+	for ( const branch of branches.values() ) {
+		const record = branch.records.find( ( item ) => item.id === targetId );
+		if ( record ) {
+			return record;
+		}
+	}
+	return null;
+}
+
+function collectDescendantIds( parentId, branches ) {
+	const normalizedParent = normalizeId( parentId );
+	if ( normalizedParent < 1 ) {
+		return new Set();
+	}
+
+	const childrenByParent = new Map();
+	branches.forEach( ( branch ) => {
+		branch.records.forEach( ( record ) => {
+			const id = normalizeId( record?.id );
+			if ( id < 1 ) {
+				return;
+			}
+			const recordParent = parentKey( record?.parent );
+			if ( ! childrenByParent.has( recordParent ) ) {
+				childrenByParent.set( recordParent, [] );
+			}
+			childrenByParent.get( recordParent ).push( id );
+		} );
+	} );
+
+	const descendants = new Set();
+	const stack = [ ...( childrenByParent.get( normalizedParent ) ?? [] ) ];
+	while ( stack.length > 0 ) {
+		const id = stack.pop();
+		if ( descendants.has( id ) ) {
+			continue;
+		}
+		descendants.add( id );
+		stack.push( ...( childrenByParent.get( id ) ?? [] ) );
+	}
+	return descendants;
+}
+
+export function buildSidebarTreeBranchPath( parentId, page = 1 ) {
+	return addQueryArgs( DOCUMENTS_PATH, {
+		context: 'edit',
+		parent: parentKey( parentId ),
+		page: Math.max( 1, Math.floor( Number( page ) || 1 ) ),
+		per_page: SIDEBAR_TREE_PER_PAGE,
+		status: ACTIVE_STATUSES,
+		cortext_no_trait: 1,
+		cortext_tree_order: 1,
+		orderby: 'menu_order',
+		order: 'asc',
+		_fields: TREE_FIELDS.join( ',' ),
+	} );
+}
+
+export function buildSidebarTreeRecordPath( id ) {
+	return addQueryArgs( `${ DOCUMENTS_PATH }/${ normalizeId( id ) }`, {
+		context: 'edit',
+		_fields: TREE_FIELDS.join( ',' ),
+	} );
+}
+
+async function fetchBranchPage( parentId, page ) {
+	const response = await apiFetch( {
+		path: buildSidebarTreeBranchPath( parentId, page ),
+		parse: false,
+	} );
+	const records = await response.json();
+	const safeRecords = Array.isArray( records ) ? records : [];
+	return {
+		records: safeRecords,
+		total: headerNumber( response, 'X-WP-Total', safeRecords.length ),
+		totalPages: headerNumber(
+			response,
+			'X-WP-TotalPages',
+			safeRecords.length > 0 ? page : 0
+		),
+	};
+}
 
 /**
- * Sidebar tree state. `documents` is the single non-row list (pages plus
- * collections) that feeds the whole tree, so each document renders once. Page
- * vs collection is a per-record concern derived elsewhere from whether the
- * document defines a trait (`cortext_defines_trait`). The hook also expands
- * ancestors of the active selection so direct links from Home, Favorites, or
- * Recents reveal nested documents instead of hiding them under a collapsed
- * parent.
+ * State for the sidebar's lazy-loaded document tree.
  *
  * @param {Object}  args
- * @param {Array}   args.documents            Loaded non-row `crtxt_document` records (pages and collections).
  * @param {?number} args.selectedId           Currently selected page id, or null.
  * @param {?number} args.selectedCollectionId Currently selected collection id, or null.
  */
-export default function useSidebarTree( {
-	documents,
-	selectedId,
-	selectedCollectionId,
-} ) {
-	const tree = useMemo( () => buildTree( documents ?? [] ), [ documents ] );
-
+export default function useSidebarTree( { selectedId, selectedCollectionId } ) {
+	const [ branches, setBranches ] = useState( () => new Map() );
 	const [ expandedIds, setExpandedIds ] = useState( () => new Set() );
+	const [ isResolvingPreferences, setIsResolvingPreferences ] =
+		useState( true );
+	const branchesRef = useRef( branches );
+	const expandedIdsRef = useRef( expandedIds );
+	const loadingRef = useRef( new Map() );
+	const preferenceWriteRef = useRef( Promise.resolve() );
 
 	useEffect( () => {
-		const list = documents ?? [];
-		let ancestorIds = [];
-		if ( selectedId !== null ) {
-			ancestorIds = collectAncestorIds( selectedId, list );
-		} else if ( selectedCollectionId !== null ) {
-			// Direct links from Home, Favorites, and Recents should reveal
-			// nested documents instead of leaving them under a collapsed parent.
-			const collection = list.find(
-				( c ) => c.id === selectedCollectionId
-			);
-			const parent = Number( collection?.parent ?? 0 );
-			if ( parent > 0 ) {
-				ancestorIds = [ parent, ...collectAncestorIds( parent, list ) ];
+		branchesRef.current = branches;
+	}, [ branches ] );
+
+	useEffect( () => {
+		expandedIdsRef.current = expandedIds;
+	}, [ expandedIds ] );
+
+	const loadedRecords = useMemo( () => {
+		const byId = new Map();
+		branches.forEach( ( branch ) => {
+			branch.records.forEach( ( record ) => {
+				byId.set( record.id, record );
+			} );
+		} );
+		return [ ...byId.values() ];
+	}, [ branches ] );
+
+	const getBranch = useCallback(
+		( parentId ) => branchesRef.current.get( parentKey( parentId ) ),
+		[]
+	);
+
+	const loadBranch = useCallback( async ( parentId, options = {} ) => {
+		const key = parentKey( parentId );
+		const current = branchesRef.current.get( key ) ?? EMPTY_BRANCH;
+		const append = options.append === true;
+		const force = options.force === true;
+		const page = append
+			? Math.max( 1, current.page + 1 )
+			: Math.max( 1, Math.floor( Number( options.page ) || 1 ) );
+
+		if (
+			! force &&
+			! append &&
+			current.hasResolved &&
+			current.page >= page
+		) {
+			return current;
+		}
+		if ( append && current.hasResolved && ! branchHasMore( current ) ) {
+			return current;
+		}
+
+		const loadKey = `${ key }:${ page }`;
+		if ( loadingRef.current.has( loadKey ) ) {
+			return loadingRef.current.get( loadKey );
+		}
+		setBranches( ( previous ) => {
+			const next = new Map( previous );
+			next.set( key, {
+				...( previous.get( key ) ?? EMPTY_BRANCH ),
+				isLoading: true,
+				error: null,
+			} );
+			return next;
+		} );
+
+		const promise = fetchBranchPage( key, page )
+			.then( ( result ) => {
+				let nextBranch;
+				setBranches( ( previous ) => {
+					const previousBranch = previous.get( key ) ?? EMPTY_BRANCH;
+					nextBranch = {
+						records: append
+							? mergeRecords(
+									previousBranch.records,
+									result.records
+							  )
+							: result.records,
+						page,
+						total: result.total,
+						totalPages: result.totalPages,
+						isLoading: false,
+						hasResolved: true,
+						error: null,
+					};
+					const next = new Map( previous );
+					next.set( key, nextBranch );
+					branchesRef.current = next;
+					return next;
+				} );
+				return nextBranch;
+			} )
+			.catch( ( error ) => {
+				let nextBranch;
+				setBranches( ( previous ) => {
+					const previousBranch = previous.get( key ) ?? EMPTY_BRANCH;
+					nextBranch = {
+						...previousBranch,
+						isLoading: false,
+						hasResolved: previousBranch.hasResolved,
+						error,
+					};
+					const next = new Map( previous );
+					next.set( key, nextBranch );
+					branchesRef.current = next;
+					return next;
+				} );
+				return nextBranch;
+			} )
+			.finally( () => {
+				loadingRef.current.delete( loadKey );
+			} );
+		loadingRef.current.set( loadKey, promise );
+		return promise;
+	}, [] );
+
+	const loadMore = useCallback(
+		( parentId ) => loadBranch( parentId, { append: true } ),
+		[ loadBranch ]
+	);
+
+	const refreshBranch = useCallback(
+		async ( parentId ) => {
+			const key = parentKey( parentId );
+			const current = branchesRef.current.get( key );
+			if ( ! current?.hasResolved ) {
+				return loadBranch( key, { force: true } );
 			}
+			const pagesToLoad = Math.max( 1, current.page );
+			let refreshed = null;
+			for ( let page = 1; page <= pagesToLoad; page++ ) {
+				refreshed = await loadBranch( key, {
+					page,
+					append: page > 1,
+					force: true,
+				} );
+			}
+			return refreshed;
+		},
+		[ loadBranch ]
+	);
+
+	const refreshLoadedBranches = useCallback( () => {
+		const parentIds = [ ...branchesRef.current.keys() ];
+		parentIds.forEach( ( parentId ) => {
+			refreshBranch( parentId );
+		} );
+	}, [ refreshBranch ] );
+
+	const persistExpanded = useCallback( ( ids ) => {
+		const expanded = normalizeIds( ids );
+		const write = () =>
+			apiFetch( {
+				path: SIDEBAR_TREE_PREFERENCES_PATH,
+				method: 'PUT',
+				data: { expanded },
+			} );
+		const promise = preferenceWriteRef.current.then( write, write );
+		preferenceWriteRef.current = promise.catch( () => {} );
+		return promise.catch( () => {} );
+	}, [] );
+
+	const setExpanded = useCallback(
+		( updater, { persist = true } = {} ) => {
+			const previous = expandedIdsRef.current;
+			const next =
+				typeof updater === 'function'
+					? updater( previous )
+					: new Set( normalizeIds( updater ) );
+			expandedIdsRef.current = next;
+			setExpandedIds( next );
+			if ( persist ) {
+				persistExpanded( [ ...next ] );
+			}
+		},
+		[ persistExpanded ]
+	);
+
+	const expand = useCallback(
+		( id, options = {} ) => {
+			const normalized = normalizeId( id );
+			if ( normalized < 1 ) {
+				return;
+			}
+			setExpanded( ( previous ) => {
+				if ( previous.has( normalized ) ) {
+					return previous;
+				}
+				const next = new Set( previous );
+				next.add( normalized );
+				return next;
+			}, options );
+			loadBranch( normalized );
+		},
+		[ loadBranch, setExpanded ]
+	);
+
+	const toggleExpand = useCallback(
+		( id ) => {
+			const normalized = normalizeId( id );
+			if ( normalized < 1 ) {
+				return;
+			}
+			let shouldLoad = false;
+			setExpanded( ( previous ) => {
+				const next = new Set( previous );
+				if ( next.has( normalized ) ) {
+					next.delete( normalized );
+					const descendants = collectDescendantIds(
+						normalized,
+						branchesRef.current
+					);
+					descendants.forEach( ( descendantId ) => {
+						next.delete( descendantId );
+					} );
+				} else {
+					next.add( normalized );
+					shouldLoad = true;
+				}
+				return next;
+			} );
+			if ( shouldLoad ) {
+				loadBranch( normalized );
+			}
+		},
+		[ loadBranch, setExpanded ]
+	);
+
+	const fetchRecord = useCallback( async ( id ) => {
+		const normalized = normalizeId( id );
+		if ( normalized < 1 ) {
+			return null;
 		}
-		if ( ancestorIds.length === 0 ) {
-			return;
+		const loaded = findRecordInBranches( branchesRef.current, normalized );
+		if ( loaded ) {
+			return loaded;
 		}
-		setExpandedIds( ( prev ) => {
-			let changed = false;
-			const next = new Set( prev );
-			ancestorIds.forEach( ( id ) => {
-				if ( ! next.has( id ) ) {
-					next.add( id );
-					changed = true;
+		try {
+			return await apiFetch( {
+				path: buildSidebarTreeRecordPath( normalized ),
+			} );
+		} catch {
+			return null;
+		}
+	}, [] );
+
+	const loadBranchUntilContains = useCallback(
+		async ( parentId, childId ) => {
+			const key = parentKey( parentId );
+			const targetId = normalizeId( childId );
+			let branch = branchesRef.current.get( key );
+			if (
+				branch?.records.some( ( record ) => record.id === targetId )
+			) {
+				return branch;
+			}
+			branch = await loadBranch( key );
+			while (
+				branch?.hasResolved &&
+				! branch.records.some( ( record ) => record.id === targetId ) &&
+				branchHasMore( branch )
+			) {
+				branch = await loadBranch( key, { append: true } );
+			}
+			return branch;
+		},
+		[ loadBranch ]
+	);
+
+	const revealRecordPath = useCallback(
+		async ( id, { persist = true } = {} ) => {
+			let cursor = await fetchRecord( id );
+			if ( ! cursor ) {
+				return;
+			}
+			const chain = [];
+			const seen = new Set();
+			while ( cursor && ! seen.has( cursor.id ) ) {
+				seen.add( cursor.id );
+				chain.unshift( cursor );
+				const parentId = normalizeId( cursor.parent );
+				if ( parentId < 1 ) {
+					break;
+				}
+				cursor = await fetchRecord( parentId );
+			}
+
+			let parentId = ROOT_PARENT_ID;
+			for ( const record of chain ) {
+				await loadBranchUntilContains( parentId, record.id );
+				parentId = record.id;
+			}
+
+			const ancestorIds = chain
+				.slice( 0, -1 )
+				.map( ( record ) => record.id );
+			if ( ancestorIds.length > 0 ) {
+				setExpanded(
+					( previous ) => {
+						let changed = false;
+						const next = new Set( previous );
+						ancestorIds.forEach( ( ancestorId ) => {
+							if ( ! next.has( ancestorId ) ) {
+								next.add( ancestorId );
+								changed = true;
+							}
+						} );
+						return changed ? next : previous;
+					},
+					{ persist }
+				);
+				ancestorIds.forEach( ( ancestorId ) =>
+					loadBranch( ancestorId )
+				);
+			}
+		},
+		[ fetchRecord, loadBranch, loadBranchUntilContains, setExpanded ]
+	);
+
+	useEffect( () => {
+		loadBranch( ROOT_PARENT_ID );
+	}, [ loadBranch ] );
+
+	useEffect( () => {
+		let cancelled = false;
+		setIsResolvingPreferences( true );
+		apiFetch( { path: SIDEBAR_TREE_PREFERENCES_PATH } )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				const ids = normalizeIds( response?.expanded );
+				const restored = new Set( ids );
+				expandedIdsRef.current = restored;
+				setExpandedIds( restored );
+				ids.forEach( ( id ) => {
+					revealRecordPath( id, { persist: false } ).then( () =>
+						loadBranch( id )
+					);
+				} );
+			} )
+			.catch( () => {} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsResolvingPreferences( false );
 				}
 			} );
-			return changed ? next : prev;
-		} );
-	}, [ selectedId, selectedCollectionId, documents ] );
+		return () => {
+			cancelled = true;
+		};
+	}, [ loadBranch, revealRecordPath ] );
 
-	const toggleExpand = useCallback( ( id ) => {
-		setExpandedIds( ( prev ) => {
-			const next = new Set( prev );
-			if ( next.has( id ) ) {
-				next.delete( id );
+	useEffect( () => {
+		const targetId = selectedId ?? selectedCollectionId ?? null;
+		if ( targetId === null ) {
+			return;
+		}
+		revealRecordPath( targetId, { persist: true } );
+	}, [ selectedId, selectedCollectionId, revealRecordPath ] );
+
+	useEffect( () => {
+		const handleTreeChange = ( event ) => {
+			const parentId = event?.detail?.parentId;
+			if ( normalizeId( parentId ) > 0 || parentId === ROOT_PARENT_ID ) {
+				refreshBranch( parentId );
 			} else {
-				next.add( id );
+				refreshLoadedBranches();
 			}
-			return next;
-		} );
-	}, [] );
+		};
+		window.addEventListener( SIDEBAR_TREE_CHANGED_EVENT, handleTreeChange );
+		return () =>
+			window.removeEventListener(
+				SIDEBAR_TREE_CHANGED_EVENT,
+				handleTreeChange
+			);
+	}, [ refreshBranch, refreshLoadedBranches ] );
 
-	const expand = useCallback( ( id ) => {
-		setExpandedIds( ( prev ) => {
-			if ( prev.has( id ) ) {
-				return prev;
-			}
-			const next = new Set( prev );
-			next.add( id );
-			return next;
-		} );
-	}, [] );
+	const tree = useMemo(
+		() => buildNodesForParent( ROOT_PARENT_ID, branches ),
+		[ branches ]
+	);
+	const rootBranch = branches.get( ROOT_PARENT_ID ) ?? EMPTY_BRANCH;
 
 	return {
 		tree,
+		pages: loadedRecords,
+		rootBranch,
+		isResolvingPages:
+			( rootBranch.isLoading && ! rootBranch.hasResolved ) ||
+			isResolvingPreferences,
 		expandedIds,
 		toggleExpand,
 		expand,
+		loadBranch,
+		loadMore,
+		refreshBranch,
+		refreshLoadedBranches,
+		getBranch,
 	};
 }

--- a/src/components/sidebar/useSidebarTree.js
+++ b/src/components/sidebar/useSidebarTree.js
@@ -361,9 +361,9 @@ export default function useSidebarTree( { selectedId, selectedCollectionId } ) {
 
 	const refreshLoadedBranches = useCallback( () => {
 		const parentIds = [ ...branchesRef.current.keys() ];
-		parentIds.forEach( ( parentId ) => {
-			refreshBranch( parentId );
-		} );
+		return Promise.allSettled(
+			parentIds.map( ( parentId ) => refreshBranch( parentId ) )
+		);
 	}, [ refreshBranch ] );
 
 	const persistExpanded = useCallback( ( ids ) => {
@@ -580,10 +580,17 @@ export default function useSidebarTree( { selectedId, selectedCollectionId } ) {
 	useEffect( () => {
 		const handleTreeChange = ( event ) => {
 			const parentId = event?.detail?.parentId;
+			const revealId = normalizeId( event?.detail?.revealId );
+			let refreshPromise;
 			if ( normalizeId( parentId ) > 0 || parentId === ROOT_PARENT_ID ) {
-				refreshBranch( parentId );
+				refreshPromise = refreshBranch( parentId );
 			} else {
-				refreshLoadedBranches();
+				refreshPromise = refreshLoadedBranches();
+			}
+			if ( revealId > 0 ) {
+				Promise.resolve( refreshPromise ).finally( () => {
+					revealRecordPath( revealId );
+				} );
 			}
 		};
 		window.addEventListener( SIDEBAR_TREE_CHANGED_EVENT, handleTreeChange );
@@ -592,7 +599,7 @@ export default function useSidebarTree( { selectedId, selectedCollectionId } ) {
 				SIDEBAR_TREE_CHANGED_EVENT,
 				handleTreeChange
 			);
-	}, [ refreshBranch, refreshLoadedBranches ] );
+	}, [ refreshBranch, refreshLoadedBranches, revealRecordPath ] );
 
 	const tree = useMemo(
 		() => buildNodesForParent( ROOT_PARENT_ID, branches ),

--- a/src/documents/actions.js
+++ b/src/documents/actions.js
@@ -7,6 +7,7 @@ import { DOCUMENT_POST_TYPE } from '../collections';
 import { computeDocumentUri } from '../router/useResolveEntity';
 import { notifyDocumentTrashChanged } from '../hooks/documentTrashInvalidation';
 import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
+import { notifySidebarTreeChanged } from '../hooks/sidebarTreeInvalidation';
 import { cascadeFavorites } from './favorites';
 import { afterDocumentTrash, applyInvalidationPack } from './invalidation';
 
@@ -33,6 +34,9 @@ export async function createDocument( input, ctx ) {
 	);
 	if ( created?.id ) {
 		applyInvalidationPack( ctx.invalidateResolution, afterDocumentTrash );
+		notifySidebarTreeChanged( {
+			parentId: Number( created.parent ?? payload.parent ?? 0 ),
+		} );
 	}
 	return created;
 }
@@ -67,7 +71,14 @@ export async function renameDocument( record, title, ctx ) {
 	if ( record.status === 'draft' ) {
 		payload.status = 'private';
 	}
-	await ctx.saveEntityRecord( 'postType', DOCUMENT_POST_TYPE, payload );
+	const updated = await ctx.saveEntityRecord(
+		'postType',
+		DOCUMENT_POST_TYPE,
+		payload
+	);
+	notifySidebarTreeChanged( {
+		parentId: Number( updated?.parent ?? record.parent ?? 0 ),
+	} );
 	await ctx.touchRecent( { id: record.id } );
 }
 
@@ -77,6 +88,9 @@ export async function duplicateDocument( record, ctx ) {
 		method: 'POST',
 	} );
 	applyInvalidationPack( ctx.invalidateResolution, afterDocumentTrash );
+	notifySidebarTreeChanged( {
+		parentId: Number( created?.parent ?? record.parent ?? 0 ),
+	} );
 	const skipped = Array.isArray( created?.skipped_fields )
 		? created.skipped_fields
 		: [];
@@ -119,6 +133,7 @@ export async function trashDocument( record, ctx ) {
 		ctx.receiveEntityRecords( 'postType', DOCUMENT_POST_TYPE, [ trashed ] );
 	}
 	applyInvalidationPack( ctx.invalidateResolution, afterDocumentTrash );
+	notifySidebarTreeChanged();
 	notifyDocumentTrashChanged();
 	const cascadeIds = collectCascadeIds( record, deleted?.cascade_deleted );
 	await cascadeFavorites(
@@ -138,6 +153,7 @@ export async function restoreDocument( record, ctx ) {
 		method: 'POST',
 	} );
 	applyInvalidationPack( ctx.invalidateResolution, afterDocumentTrash );
+	notifySidebarTreeChanged();
 	notifyDocumentTrashChanged();
 	notifyCollectionRowsChanged();
 }
@@ -148,6 +164,7 @@ export async function permanentlyDeleteDocument( record, ctx ) {
 		method: 'POST',
 	} );
 	applyInvalidationPack( ctx.invalidateResolution, afterDocumentTrash );
+	notifySidebarTreeChanged();
 	notifyDocumentTrashChanged();
 	notifyCollectionRowsChanged();
 	return response;

--- a/src/hooks/sidebarTreeInvalidation.js
+++ b/src/hooks/sidebarTreeInvalidation.js
@@ -1,0 +1,10 @@
+export const SIDEBAR_TREE_CHANGED_EVENT = 'cortext:sidebar-tree-changed';
+
+export function notifySidebarTreeChanged( detail = {} ) {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	window.dispatchEvent(
+		new CustomEvent( SIDEBAR_TREE_CHANGED_EVENT, { detail } )
+	);
+}

--- a/src/hooks/useWorkspaceHomePath.js
+++ b/src/hooks/useWorkspaceHomePath.js
@@ -1,10 +1,25 @@
 import { useEntityRecords } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 
-import { ACTIVE_PAGES_QUERY, POST_TYPE } from '../components/page-queries';
+import { POST_TYPE } from '../components/page-queries';
 import { firstDocumentInTree } from '../components/document-tree';
 import { computeDocumentUri } from '../router/useResolveEntity';
 import { useWorkspaceHome } from './useWorkspaceHome';
+
+// Only the first root document is needed as a home fallback when no explicit
+// home is set, so this stays a single-record request rather than loading the
+// whole tree. It mirrors the sidebar tree's root query so the fallback matches
+// the first row the sidebar shows.
+const HOME_FALLBACK_QUERY = {
+	parent: 0,
+	per_page: 1,
+	status: [ 'draft', 'private', 'publish' ],
+	context: 'edit',
+	cortext_no_trait: 1,
+	cortext_tree_order: 1,
+	orderby: 'menu_order',
+	order: 'asc',
+};
 
 export function useWorkspaceHomePath() {
 	const {
@@ -17,7 +32,7 @@ export function useWorkspaceHomePath() {
 	const { records, isResolving: isResolvingPages } = useEntityRecords(
 		'postType',
 		POST_TYPE,
-		ACTIVE_PAGES_QUERY
+		HOME_FALLBACK_QUERY
 	);
 	const pages = useMemo( () => records ?? [], [ records ] );
 	const fallbackHomePage = useMemo(

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -48,6 +48,7 @@ import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 import useCollectionFields from '../hooks/useCollectionFields';
 import { notifyDocumentTrashChanged } from '../hooks/documentTrashInvalidation';
 import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
+import { notifySidebarTreeChanged } from '../hooks/sidebarTreeInvalidation';
 import EmptyState from './EmptyState';
 import { computeDocumentUri, useResolveDocument } from './useResolveEntity';
 import { init, parseTarget, reducer } from './entityRouteReducer';
@@ -398,6 +399,10 @@ export default function EntityRoute( { history } ) {
 				POST_TYPE,
 				TRASHED_PAGES_QUERY,
 			] );
+			notifySidebarTreeChanged( {
+				parentId: Number( response?.post?.parent ?? 0 ),
+				revealId: Number( postId ),
+			} );
 			notifyDocumentTrashChanged();
 			// A restored row lives inside a collection's data view rather than
 			// the tree, and can change rollups and relations elsewhere, so

--- a/tests/e2e/specs/sidebar-lazy-tree.spec.js
+++ b/tests/e2e/specs/sidebar-lazy-tree.spec.js
@@ -60,7 +60,7 @@ async function loadMoreUntilVisible( target, loadMoreButton, maxClicks = 10 ) {
 			return;
 		}
 		await expect( loadMoreButton ).toBeVisible();
-		await loadMoreButton.click( { force: true } );
+		await loadMoreButton.evaluate( ( button ) => button.click() );
 	}
 	await expect( target ).toBeVisible();
 }

--- a/tests/e2e/specs/sidebar-lazy-tree.spec.js
+++ b/tests/e2e/specs/sidebar-lazy-tree.spec.js
@@ -60,7 +60,7 @@ async function loadMoreUntilVisible( target, loadMoreButton, maxClicks = 10 ) {
 			return;
 		}
 		await expect( loadMoreButton ).toBeVisible();
-		await loadMoreButton.click();
+		await loadMoreButton.click( { force: true } );
 	}
 	await expect( target ).toBeVisible();
 }

--- a/tests/e2e/specs/sidebar-lazy-tree.spec.js
+++ b/tests/e2e/specs/sidebar-lazy-tree.spec.js
@@ -1,0 +1,170 @@
+/**
+ * E2E tests for the lazy-loaded sidebar tree.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const SHELL_PATH = 'admin.php';
+const SHELL_QUERY = 'page=cortext';
+const SUFFIX = Date.now().toString( 36 ).slice( -5 );
+const ROOT_PREFIX = `E2E Lazy Root ${ SUFFIX }`;
+const CHILD_PREFIX = `E2E Lazy Child ${ SUFFIX }`;
+const PARENT_TITLE = `E2E Lazy Parent ${ SUFFIX }`;
+const LAST_ROOT_TITLE = `${ ROOT_PREFIX } 100`;
+const FIRST_CHILD_TITLE = `${ CHILD_PREFIX } 001`;
+const LAST_CHILD_TITLE = `${ CHILD_PREFIX } 101`;
+
+async function createDocument( requestUtils, title, args = {} ) {
+	return requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_documents',
+		data: {
+			status: 'private',
+			title,
+			...args,
+		},
+	} );
+}
+
+async function deleteIfCreated( requestUtils, id ) {
+	if ( ! id ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path: `/wp/v2/crtxt_documents/${ id }`,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+function sidebarNodeByTitle( page, title ) {
+	return page
+		.locator( '.cortext-sidebar__node', {
+			has: page.getByRole( 'button', { name: title } ),
+		} )
+		.first();
+}
+
+async function expandSidebarNode( page, title ) {
+	const node = sidebarNodeByTitle( page, title );
+	await node.locator( '.cortext-sidebar__chevron' ).first().click();
+}
+
+async function loadMoreUntilVisible( target, loadMoreButton, maxClicks = 10 ) {
+	for ( let clicks = 0; clicks < maxClicks; clicks++ ) {
+		if ( await target.isVisible().catch( () => false ) ) {
+			return;
+		}
+		await expect( loadMoreButton ).toBeVisible();
+		await loadMoreButton.click();
+	}
+	await expect( target ).toBeVisible();
+}
+
+test.describe( 'Sidebar lazy tree', () => {
+	test.setTimeout( 120_000 );
+
+	let createdIds = [];
+	let parent;
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		createdIds = [];
+		parent = await createDocument( requestUtils, PARENT_TITLE, {
+			menu_order: -1000,
+		} );
+		createdIds.push( parent.id );
+
+		for ( let i = 1; i <= 100; i++ ) {
+			const root = await createDocument(
+				requestUtils,
+				`${ ROOT_PREFIX } ${ String( i ).padStart( 3, '0' ) }`,
+				{ menu_order: -1000 + i }
+			);
+			createdIds.push( root.id );
+		}
+
+		for ( let i = 1; i <= 101; i++ ) {
+			const child = await createDocument(
+				requestUtils,
+				`${ CHILD_PREFIX } ${ String( i ).padStart( 3, '0' ) }`,
+				{
+					parent: parent.id,
+					menu_order: -1000 + i,
+				}
+			);
+			createdIds.push( child.id );
+		}
+
+		await requestUtils.rest( {
+			method: 'PUT',
+			path: '/cortext/v1/sidebar-tree-preferences',
+			data: { expanded: [] },
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.rest( {
+			method: 'PUT',
+			path: '/cortext/v1/sidebar-tree-preferences',
+			data: { expanded: [] },
+		} );
+		for ( const id of [ ...createdIds ].reverse() ) {
+			await deleteIfCreated( requestUtils, id );
+		}
+	} );
+
+	test( 'paginates root and child branches, then restores the open branch', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( SHELL_PATH, SHELL_QUERY );
+		await expect( page.locator( '#cortext-sidebar' ) ).toBeVisible();
+
+		await expect(
+			page.getByRole( 'button', { name: PARENT_TITLE } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: LAST_ROOT_TITLE } )
+		).toHaveCount( 0 );
+
+		await loadMoreUntilVisible(
+			page.getByRole( 'button', { name: LAST_ROOT_TITLE } ),
+			page
+				.locator(
+					'#cortext-sidebar .cortext-sidebar__list > .cortext-sidebar__load-more-node'
+				)
+				.getByRole( 'button', { name: 'Show more' } )
+		);
+
+		const childRequest = page.waitForResponse(
+			( response ) =>
+				response.url().includes( '/wp-json/wp/v2/crtxt_documents' ) &&
+				response.url().includes( `parent=${ parent.id }` )
+		);
+		await expandSidebarNode( page, PARENT_TITLE );
+		await childRequest;
+
+		await expect(
+			page.getByRole( 'button', { name: FIRST_CHILD_TITLE } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'button', { name: LAST_CHILD_TITLE } )
+		).toHaveCount( 0 );
+
+		await loadMoreUntilVisible(
+			page.getByRole( 'button', { name: LAST_CHILD_TITLE } ),
+			sidebarNodeByTitle( page, PARENT_TITLE ).getByRole( 'button', {
+				name: 'Show more',
+			} )
+		);
+
+		await page.reload();
+		await expect(
+			page.getByRole( 'button', { name: FIRST_CHILD_TITLE } )
+		).toBeVisible();
+	} );
+} );

--- a/tests/e2e/specs/sidebar-lazy-tree.spec.js
+++ b/tests/e2e/specs/sidebar-lazy-tree.spec.js
@@ -140,13 +140,7 @@ test.describe( 'Sidebar lazy tree', () => {
 				.getByRole( 'button', { name: 'Show more' } )
 		);
 
-		const childRequest = page.waitForResponse(
-			( response ) =>
-				response.url().includes( '/wp-json/wp/v2/crtxt_documents' ) &&
-				response.url().includes( `parent=${ parent.id }` )
-		);
 		await expandSidebarNode( page, PARENT_TITLE );
-		await childRequest;
 
 		await expect(
 			page.getByRole( 'button', { name: FIRST_CHILD_TITLE, exact: true } )

--- a/tests/e2e/specs/sidebar-lazy-tree.spec.js
+++ b/tests/e2e/specs/sidebar-lazy-tree.spec.js
@@ -44,7 +44,7 @@ async function deleteIfCreated( requestUtils, id ) {
 function sidebarNodeByTitle( page, title ) {
 	return page
 		.locator( '.cortext-sidebar__node', {
-			has: page.getByRole( 'button', { name: title } ),
+			has: page.getByRole( 'button', { name: title, exact: true } ),
 		} )
 		.first();
 }
@@ -125,14 +125,14 @@ test.describe( 'Sidebar lazy tree', () => {
 		await expect( page.locator( '#cortext-sidebar' ) ).toBeVisible();
 
 		await expect(
-			page.getByRole( 'button', { name: PARENT_TITLE } )
+			page.getByRole( 'button', { name: PARENT_TITLE, exact: true } )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'button', { name: LAST_ROOT_TITLE } )
+			page.getByRole( 'button', { name: LAST_ROOT_TITLE, exact: true } )
 		).toHaveCount( 0 );
 
 		await loadMoreUntilVisible(
-			page.getByRole( 'button', { name: LAST_ROOT_TITLE } ),
+			page.getByRole( 'button', { name: LAST_ROOT_TITLE, exact: true } ),
 			page
 				.locator(
 					'#cortext-sidebar .cortext-sidebar__list > .cortext-sidebar__load-more-node'
@@ -149,14 +149,14 @@ test.describe( 'Sidebar lazy tree', () => {
 		await childRequest;
 
 		await expect(
-			page.getByRole( 'button', { name: FIRST_CHILD_TITLE } )
+			page.getByRole( 'button', { name: FIRST_CHILD_TITLE, exact: true } )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'button', { name: LAST_CHILD_TITLE } )
+			page.getByRole( 'button', { name: LAST_CHILD_TITLE, exact: true } )
 		).toHaveCount( 0 );
 
 		await loadMoreUntilVisible(
-			page.getByRole( 'button', { name: LAST_CHILD_TITLE } ),
+			page.getByRole( 'button', { name: LAST_CHILD_TITLE, exact: true } ),
 			sidebarNodeByTitle( page, PARENT_TITLE ).getByRole( 'button', {
 				name: 'Show more',
 			} )
@@ -164,7 +164,7 @@ test.describe( 'Sidebar lazy tree', () => {
 
 		await page.reload();
 		await expect(
-			page.getByRole( 'button', { name: FIRST_CHILD_TITLE } )
+			page.getByRole( 'button', { name: FIRST_CHILD_TITLE, exact: true } )
 		).toBeVisible();
 	} );
 } );

--- a/tests/js/components/sidebar/DocumentRow.test.js
+++ b/tests/js/components/sidebar/DocumentRow.test.js
@@ -57,6 +57,7 @@ function makePage( overrides = {} ) {
 		id: 1,
 		type: 'crtxt_document',
 		title: { rendered: 'Hello', raw: 'Hello' },
+		cortext_has_tree_children: false,
 		...overrides,
 	};
 }
@@ -92,6 +93,7 @@ function baseProps( overrides = {} ) {
 		isSelected: false,
 		onSelect: jest.fn(),
 		onToggleExpand: jest.fn(),
+		onLoadMore: jest.fn(),
 		onCreateChild: jest.fn(),
 		onCreateChildCollection: jest.fn(),
 		isFavorite: false,
@@ -180,11 +182,52 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 		).toBeTruthy();
 	} );
 
-	it( 'renders a chevron placeholder when the node has no children', () => {
+	it( 'shows a chevron when the API says the branch has children', () => {
+		const { container } = renderRow( {
+			record: makePage( { cortext_has_tree_children: true } ),
+		} );
+		expect(
+			container.querySelector(
+				'.cortext-sidebar__chevron:not(.cortext-sidebar__chevron--placeholder)'
+			)
+		).toBeTruthy();
+	} );
+
+	it( 'shows a chevron placeholder when the API says there are no children', () => {
 		const { container } = renderRow();
 		expect(
 			container.querySelector( '.cortext-sidebar__chevron--placeholder' )
 		).toBeTruthy();
+	} );
+
+	it( 'keeps the placeholder after an empty branch loads', () => {
+		const { container } = renderRow( {
+			record: makePage( { cortext_has_tree_children: true } ),
+			childBranch: {
+				records: [],
+				page: 1,
+				total: 0,
+				totalPages: 0,
+				isLoading: false,
+				hasResolved: true,
+				error: null,
+			},
+		} );
+		expect(
+			container.querySelector( '.cortext-sidebar__chevron--placeholder' )
+		).toBeTruthy();
+	} );
+
+	it( 'toggles an unloaded branch when its chevron is clicked', () => {
+		const { props } = renderRow( {
+			record: makePage( { cortext_has_tree_children: true } ),
+		} );
+		fireEvent.click(
+			screen.getByRole( 'button', {
+				name: 'Expand',
+			} )
+		);
+		expect( props.onToggleExpand ).toHaveBeenCalledWith( 1 );
 	} );
 
 	it( 'exposes three drop zones (before / inside / after)', () => {
@@ -349,6 +392,30 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 			container.querySelectorAll( '.cortext-sidebar__row' )
 		).toHaveLength( 2 );
 		expect( screen.getByText( 'Child' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the next-page button when a child branch has more rows', () => {
+		const child = makePage( {
+			id: 2,
+			title: { rendered: 'Child', raw: 'Child' },
+		} );
+		const { props } = renderRow( {
+			childNodes: [ { page: child, children: [] } ],
+			childBranch: {
+				records: [ child ],
+				page: 1,
+				total: 150,
+				totalPages: 2,
+				isLoading: false,
+				hasResolved: true,
+				error: null,
+			},
+			expandedIds: new Set( [ 1 ] ),
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Show more' } ) );
+
+		expect( props.onLoadMore ).toHaveBeenCalledWith( 1 );
 	} );
 } );
 

--- a/tests/js/components/sidebar/useSidebarTree.test.js
+++ b/tests/js/components/sidebar/useSidebarTree.test.js
@@ -1,0 +1,285 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+import useSidebarTree, {
+	buildSidebarTreeBranchPath,
+	ROOT_PARENT_ID,
+	SIDEBAR_TREE_PREFERENCES_PATH,
+} from '../../../../src/components/sidebar/useSidebarTree';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+function makeRecord( id, parent = 0, title = `Page ${ id }` ) {
+	return {
+		id,
+		type: 'crtxt_document',
+		parent,
+		menu_order: id,
+		status: 'private',
+		slug: `page-${ id }`,
+		title: { rendered: title, raw: title },
+		meta: { cortext_document_icon: '' },
+		cortext_defines_trait: false,
+		cortext_has_tree_children: false,
+		crtxt_trait: [],
+	};
+}
+
+function responsePage( records, total = records.length, totalPages = 1 ) {
+	return {
+		headers: {
+			get: ( name ) => {
+				if ( name === 'X-WP-Total' ) {
+					return String( total );
+				}
+				if ( name === 'X-WP-TotalPages' ) {
+					return String( totalPages );
+				}
+				return null;
+			},
+		},
+		json: jest.fn().mockResolvedValue( records ),
+	};
+}
+
+function parsedPath( path ) {
+	return new URL( path, 'https://example.test' );
+}
+
+describe( 'buildSidebarTreeBranchPath', () => {
+	it( 'builds a request for one parent branch', () => {
+		const url = parsedPath( buildSidebarTreeBranchPath( 12, 3 ) );
+
+		expect( url.pathname ).toBe( '/wp/v2/crtxt_documents' );
+		expect( url.searchParams.get( 'context' ) ).toBe( 'edit' );
+		expect( url.searchParams.get( 'parent' ) ).toBe( '12' );
+		expect( url.searchParams.get( 'page' ) ).toBe( '3' );
+		expect( url.searchParams.get( 'per_page' ) ).toBe( '20' );
+		expect( url.searchParams.get( 'cortext_no_trait' ) ).toBe( '1' );
+		expect( url.searchParams.get( 'cortext_tree_order' ) ).toBe( '1' );
+		expect( url.searchParams.get( 'orderby' ) ).toBe( 'menu_order' );
+		expect( url.searchParams.get( '_fields' ) ).toContain(
+			'cortext_defines_trait'
+		);
+		expect( url.searchParams.get( '_fields' ) ).toContain(
+			'cortext_has_tree_children'
+		);
+	} );
+} );
+
+describe( 'useSidebarTree', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	function mockTreeRequests( {
+		preferences = [],
+		branches = {},
+		records = {},
+	} = {} ) {
+		apiFetch.mockImplementation( ( request ) => {
+			const { path, method } = request;
+			if ( path === SIDEBAR_TREE_PREFERENCES_PATH ) {
+				if ( method === 'PUT' ) {
+					return Promise.resolve( {
+						expanded: request.data?.expanded ?? [],
+					} );
+				}
+				return Promise.resolve( { expanded: preferences } );
+			}
+
+			const url = parsedPath( path );
+			const recordMatch = url.pathname.match(
+				/^\/wp\/v2\/crtxt_documents\/(\d+)$/
+			);
+			if ( recordMatch ) {
+				return Promise.resolve( records[ Number( recordMatch[ 1 ] ) ] );
+			}
+
+			const parent = Number( url.searchParams.get( 'parent' ) ?? 0 );
+			const page = Number( url.searchParams.get( 'page' ) ?? 1 );
+			const branch = branches[ `${ parent }:${ page }` ] ?? {
+				records: [],
+				total: 0,
+				totalPages: 0,
+			};
+			return Promise.resolve(
+				responsePage( branch.records, branch.total, branch.totalPages )
+			);
+		} );
+	}
+
+	it( 'loads the root branch, then appends the next page', async () => {
+		mockTreeRequests( {
+			branches: {
+				'0:1': {
+					records: [ makeRecord( 1 ) ],
+					total: 2,
+					totalPages: 2,
+				},
+				'0:2': {
+					records: [ makeRecord( 2 ) ],
+					total: 2,
+					totalPages: 2,
+				},
+			},
+		} );
+
+		const { result } = renderHook( () =>
+			useSidebarTree( {
+				selectedId: null,
+				selectedCollectionId: null,
+			} )
+		);
+
+		await waitFor( () => expect( result.current.tree ).toHaveLength( 1 ) );
+
+		expect( result.current.rootBranch.totalPages ).toBe( 2 );
+
+		await act( async () => {
+			await result.current.loadMore( ROOT_PARENT_ID );
+		} );
+
+		await waitFor( () =>
+			expect(
+				result.current.tree.map( ( node ) => node.page.id )
+			).toEqual( [ 1, 2 ] )
+		);
+	} );
+
+	it( 'loads children and saves the branch as expanded', async () => {
+		mockTreeRequests( {
+			branches: {
+				'0:1': {
+					records: [ makeRecord( 1 ) ],
+					total: 1,
+					totalPages: 1,
+				},
+				'1:1': {
+					records: [ makeRecord( 2, 1, 'Child' ) ],
+					total: 1,
+					totalPages: 1,
+				},
+			},
+		} );
+
+		const { result } = renderHook( () =>
+			useSidebarTree( {
+				selectedId: null,
+				selectedCollectionId: null,
+			} )
+		);
+
+		await waitFor( () => expect( result.current.tree ).toHaveLength( 1 ) );
+
+		await act( async () => {
+			result.current.toggleExpand( 1 );
+		} );
+
+		await waitFor( () =>
+			expect( result.current.tree[ 0 ].children[ 0 ].page.id ).toBe( 2 )
+		);
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: SIDEBAR_TREE_PREFERENCES_PATH,
+				method: 'PUT',
+				data: { expanded: [ 1 ] },
+			} )
+		);
+	} );
+
+	it( 'reopens branches saved in user preferences', async () => {
+		mockTreeRequests( {
+			preferences: [ 1 ],
+			records: {
+				1: makeRecord( 1 ),
+			},
+			branches: {
+				'0:1': {
+					records: [ makeRecord( 1 ) ],
+					total: 1,
+					totalPages: 1,
+				},
+				'1:1': {
+					records: [ makeRecord( 2, 1, 'Child' ) ],
+					total: 1,
+					totalPages: 1,
+				},
+			},
+		} );
+
+		const { result } = renderHook( () =>
+			useSidebarTree( {
+				selectedId: null,
+				selectedCollectionId: null,
+			} )
+		);
+
+		await waitFor( () =>
+			expect( result.current.tree[ 0 ].children[ 0 ].page.id ).toBe( 2 )
+		);
+
+		expect( result.current.expandedIds.has( 1 ) ).toBe( true );
+	} );
+
+	it( 'removes saved descendants when a parent branch is collapsed', async () => {
+		mockTreeRequests( {
+			preferences: [ 1, 2 ],
+			records: {
+				1: makeRecord( 1 ),
+				2: makeRecord( 2, 1, 'Child' ),
+			},
+			branches: {
+				'0:1': {
+					records: [ makeRecord( 1 ) ],
+					total: 1,
+					totalPages: 1,
+				},
+				'1:1': {
+					records: [ makeRecord( 2, 1, 'Child' ) ],
+					total: 1,
+					totalPages: 1,
+				},
+				'2:1': {
+					records: [ makeRecord( 3, 2, 'Grandchild' ) ],
+					total: 1,
+					totalPages: 1,
+				},
+			},
+		} );
+
+		const { result } = renderHook( () =>
+			useSidebarTree( {
+				selectedId: null,
+				selectedCollectionId: null,
+			} )
+		);
+
+		await waitFor( () => {
+			expect( result.current.expandedIds.has( 1 ) ).toBe( true );
+			expect( result.current.expandedIds.has( 2 ) ).toBe( true );
+		} );
+
+		await waitFor( () =>
+			expect( result.current.tree[ 0 ].children[ 0 ].page.id ).toBe( 2 )
+		);
+
+		await act( async () => {
+			result.current.toggleExpand( 1 );
+		} );
+
+		expect( result.current.expandedIds.has( 1 ) ).toBe( false );
+		expect( result.current.expandedIds.has( 2 ) ).toBe( false );
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: SIDEBAR_TREE_PREFERENCES_PATH,
+				method: 'PUT',
+				data: { expanded: [] },
+			} )
+		);
+	} );
+} );

--- a/tests/js/components/sidebar/useSidebarTree.test.js
+++ b/tests/js/components/sidebar/useSidebarTree.test.js
@@ -6,6 +6,7 @@ import useSidebarTree, {
 	ROOT_PARENT_ID,
 	SIDEBAR_TREE_PREFERENCES_PATH,
 } from '../../../../src/components/sidebar/useSidebarTree';
+import { SIDEBAR_TREE_CHANGED_EVENT } from '../../../../src/hooks/sidebarTreeInvalidation';
 
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,
@@ -280,6 +281,53 @@ describe( 'useSidebarTree', () => {
 				method: 'PUT',
 				data: { expanded: [] },
 			} )
+		);
+	} );
+
+	it( 'reveals a restored active document after refreshing its branch', async () => {
+		mockTreeRequests( {
+			records: {
+				2: makeRecord( 2 ),
+			},
+			branches: {
+				'0:1': {
+					records: [ makeRecord( 1 ) ],
+					total: 2,
+					totalPages: 2,
+				},
+				'0:2': {
+					records: [ makeRecord( 2 ) ],
+					total: 2,
+					totalPages: 2,
+				},
+			},
+		} );
+
+		const { result } = renderHook( () =>
+			useSidebarTree( {
+				selectedId: null,
+				selectedCollectionId: null,
+			} )
+		);
+
+		await waitFor( () =>
+			expect(
+				result.current.tree.map( ( node ) => node.page.id )
+			).toEqual( [ 1 ] )
+		);
+
+		await act( async () => {
+			window.dispatchEvent(
+				new CustomEvent( SIDEBAR_TREE_CHANGED_EVENT, {
+					detail: { parentId: ROOT_PARENT_ID, revealId: 2 },
+				} )
+			);
+		} );
+
+		await waitFor( () =>
+			expect(
+				result.current.tree.map( ( node ) => node.page.id )
+			).toEqual( [ 1, 2 ] )
 		);
 	} );
 } );

--- a/tests/php/test-post-type-document.php
+++ b/tests/php/test-post-type-document.php
@@ -178,6 +178,40 @@ final class Test_Post_Type_Document extends BaseTestCase {
 		$this->assertFalse( $callback( array( 'id' => $page_id ) ) );
 	}
 
+	public function test_tree_children_rest_field_marks_parents_with_visible_children(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		( new Document() )->register_rest_fields();
+
+		$fields = $GLOBALS['wp_rest_additional_fields'][ Document::POST_TYPE ] ?? array();
+		$this->assertArrayHasKey( 'cortext_has_tree_children', $fields );
+		$this->assertTrue( $fields['cortext_has_tree_children']['schema']['readonly'] );
+		$this->assertSame( 'boolean', $fields['cortext_has_tree_children']['schema']['type'] );
+
+		$callback = $fields['cortext_has_tree_children']['get_callback'];
+		$parent   = $this->create_document();
+		$child    = $this->create_document( array( 'post_parent' => $parent ) );
+		$leaf     = $this->create_document();
+
+		$this->assertTrue( $callback( array( 'id' => $parent ) ) );
+		$this->assertFalse( $callback( array( 'id' => $child ) ) );
+		$this->assertFalse( $callback( array( 'id' => $leaf ) ) );
+	}
+
+	public function test_tree_children_rest_field_does_not_count_rows(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		( new Document() )->register_rest_fields();
+
+		$fields     = $GLOBALS['wp_rest_additional_fields'][ Document::POST_TYPE ] ?? array();
+		$callback   = $fields['cortext_has_tree_children']['get_callback'];
+		$parent     = $this->create_document();
+		$collection = $this->create_collection();
+		$row        = $this->create_document( array( 'post_parent' => $parent ) );
+		$term       = TraitTaxonomy::term_id_for_trait( $collection );
+		wp_set_object_terms( $row, array( $term ), TraitTaxonomy::TAXONOMY );
+
+		$this->assertFalse( $callback( array( 'id' => $parent ) ) );
+	}
+
 	public function test_sanitize_detail_layout_accepts_array_with_visible_entries(): void {
 		$sanitized = Document::sanitize_detail_layout(
 			array(
@@ -953,7 +987,29 @@ final class Test_Post_Type_Document extends BaseTestCase {
 		$this->assertSame( array(), $args );
 	}
 
-	public function test_expose_trait_filter_params_lists_the_four_filter_params(): void {
+	public function test_apply_trait_filters_sorts_tree_branches_stably(): void {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/crtxt_documents' );
+		$request->set_param( 'cortext_tree_order', '1' );
+
+		$args = ( new Document() )->apply_trait_filters(
+			array(
+				'orderby' => 'menu_order',
+				'order'   => 'asc',
+			),
+			$request
+		);
+
+		$this->assertSame(
+			array(
+				'menu_order' => 'ASC',
+				'ID'         => 'ASC',
+			),
+			$args['orderby']
+		);
+		$this->assertArrayNotHasKey( 'order', $args );
+	}
+
+	public function test_expose_trait_filter_params_lists_the_filter_params(): void {
 		$params = ( new Document() )->expose_trait_filter_params( array() );
 
 		$this->assertArrayHasKey( 'cortext_no_trait', $params );
@@ -967,6 +1023,9 @@ final class Test_Post_Type_Document extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'cortext_collections', $params );
 		$this->assertSame( 'boolean', $params['cortext_collections']['type'] );
+
+		$this->assertArrayHasKey( 'cortext_tree_order', $params );
+		$this->assertSame( 'boolean', $params['cortext_tree_order']['type'] );
 	}
 
 	private function create_document( array $args = array() ): int {
@@ -988,6 +1047,16 @@ final class Test_Post_Type_Document extends BaseTestCase {
 		add_post_meta( $id, 'cortext_fields', (string) $field_id );
 
 		return $id;
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
 	}
 
 	private function create_field( string $type ): int {

--- a/tests/php/test-rest-sidebar-tree-preferences-controller.php
+++ b/tests/php/test-rest-sidebar-tree-preferences-controller.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Tests for Cortext\Rest\SidebarTreePreferencesController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Document;
+use Cortext\Rest\SidebarTreePreferencesController;
+use Cortext\Taxonomy\TraitTaxonomy;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Sidebar_Tree_Preferences_Controller extends BaseTestCase {
+
+	use InMemoryTermStore;
+
+	private const META_KEY = 'cortext_sidebar_expanded_documents';
+
+	private int $admin_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Document() )->register_post_type();
+		$trait_taxonomy = new TraitTaxonomy();
+		$trait_taxonomy->register_taxonomy();
+		add_action( 'added_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'updated_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'deleted_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'before_delete_post', array( $trait_taxonomy, 'sync_term_on_delete' ), 10, 2 );
+		$this->install_in_memory_term_store();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new SidebarTreePreferencesController() )->register();
+		do_action( 'rest_api_init' );
+
+		$this->admin_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $this->admin_id );
+	}
+
+	public function tear_down(): void {
+		delete_user_meta( $this->admin_id, self::META_KEY );
+		$this->uninstall_in_memory_term_store();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_registers_route(): void {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/cortext/v1/sidebar-tree-preferences', $routes );
+	}
+
+	public function test_get_returns_empty_list_when_no_expanded_documents_are_set(): void {
+		$response = $this->get_preferences();
+
+		$this->assertSame( array(), $response->get_data()['expanded'] );
+	}
+
+	public function test_saves_expanded_documents_per_user(): void {
+		$page_id       = $this->create_document( 'Tree page' );
+		$collection_id = $this->create_document( 'Tree collection' );
+		add_post_meta( $collection_id, 'cortext_fields', '1' );
+
+		$set_response = $this->set_preferences(
+			array( $page_id, $collection_id, $page_id )
+		);
+
+		$this->assertSame( array( $page_id, $collection_id ), $set_response->get_data()['expanded'] );
+		$this->assertSame(
+			array( $page_id, $collection_id ),
+			$this->get_preferences()->get_data()['expanded']
+		);
+
+		$other_user = $this->create_user( 'administrator' );
+		wp_set_current_user( $other_user );
+		$this->assertSame( array(), $this->get_preferences()->get_data()['expanded'] );
+		wp_set_current_user( $this->admin_id );
+	}
+
+	public function test_rejects_rows_and_documents_outside_the_tree(): void {
+		$valid_page = $this->create_document( 'Valid page' );
+		$row_id     = $this->create_document( 'Row' );
+		wp_set_object_terms( $row_id, array( 'collection-slug' ), TraitTaxonomy::TAXONOMY );
+
+		$trashed_id = $this->create_document( 'Trashed page', array( 'post_status' => 'trash' ) );
+
+		$response = $this->set_preferences( array( $valid_page, $row_id, $trashed_id ) );
+
+		$this->assertSame( array( $valid_page ), $response->get_data()['expanded'] );
+	}
+
+	public function test_get_removes_invalid_stored_ids(): void {
+		$valid_page = $this->create_document( 'Valid page' );
+		update_user_meta( $this->admin_id, self::META_KEY, array( $valid_page, 999999 ) );
+
+		$response = $this->get_preferences();
+
+		$this->assertSame( array( $valid_page ), $response->get_data()['expanded'] );
+		$this->assertSame(
+			array( $valid_page ),
+			get_user_meta( $this->admin_id, self::META_KEY, true )
+		);
+	}
+
+	public function test_rejects_missing_expanded_payload(): void {
+		$request = new WP_REST_Request( 'PUT', '/cortext/v1/sidebar-tree-preferences' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	private function get_preferences() {
+		return rest_do_request( new WP_REST_Request( 'GET', '/cortext/v1/sidebar-tree-preferences' ) );
+	}
+
+	private function set_preferences( array $expanded ) {
+		$request = new WP_REST_Request( 'PUT', '/cortext/v1/sidebar-tree-preferences' );
+		$request->set_param( 'expanded', $expanded );
+		return rest_do_request( $request );
+	}
+
+	private function create_document( string $title, array $args = array() ): int {
+		return (int) wp_insert_post(
+			array_merge(
+				array(
+					'post_type'   => Document::POST_TYPE,
+					'post_status' => 'publish',
+					'post_title'  => $title,
+				),
+				$args
+			)
+		);
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'sidebar_tree_user_', true ),
+				'user_pass'  => 'password',
+				'user_email' => uniqid( 'sidebar-tree-user-', true ) . '@example.test',
+				'role'       => $role,
+			)
+		);
+	}
+}


### PR DESCRIPTION
## What

The Documents sidebar no longer loads the whole workspace up front. It starts with the first page of root documents, loads child branches when you open them, and keeps `Show more` scoped to the branch you’re looking at.

## Why

Big workspaces were making the sidebar do too much work on first load. This keeps the tree responsive without changing how people browse it.

## How

- Loading root and child branches in pages.
- Keeping tree order stable across pages.
- Saving open branches per user, but clearing nested saved branches when their parent is closed.
- Refreshing loaded branches after document changes.

## Testing Instructions

1. Open a workspace with more than 20 root documents.
2. Confirm the Documents section shows one initial skeleton row, then the first batch.
3. Click `Show more` at the root and confirm more root documents append.
4. Expand a document with many children and confirm its children load there.
5. Close a parent branch, reload, and confirm it stays closed unless it contains the active document.
6. Confirm a document with no children does not show an expand chevron.

## Screen recording

https://github.com/user-attachments/assets/6b433ab3-0029-4fde-8cf1-142bca16786f

