### PR TITLE
Desktop: Add desktop auto-updates

### DIFF
--- a/.buildkite/commands/release-desktop.sh
+++ b/.buildkite/commands/release-desktop.sh
@@ -56,7 +56,9 @@ export APPLE_API_KEY="$apple_api_key_path"
 export APPLE_API_KEY_ID="$APP_STORE_CONNECT_API_KEY_KEY_ID"
 export APPLE_API_ISSUER="$APP_STORE_CONNECT_API_KEY_ISSUER_ID"
 
-npm --prefix apps/desktop run dist -- -c.extraMetadata.version="$version"
+# Buildkite uploads release assets only after signature and notarization checks
+# pass. Keep electron-builder from trying to publish during the build step.
+npm --prefix apps/desktop run dist -- -c.extraMetadata.version="$version" --publish never
 
 echo "--- :white_check_mark: verify signature + notarization"
 dmg=(apps/desktop/dist/*.dmg)

--- a/.buildkite/commands/release-desktop.sh
+++ b/.buildkite/commands/release-desktop.sh
@@ -74,7 +74,7 @@ if ! "$publish"; then
   exit 0
 fi
 
-echo "--- :rocket: attach DMG to draft GitHub Release"
+echo "--- :rocket: attach DMG and auto-update feed to draft GitHub Release"
 if ! gh release view "$version" --repo Automattic/cortext >/dev/null 2>&1; then
   gh release create "$version" \
     --repo Automattic/cortext \
@@ -82,4 +82,21 @@ if ! gh release view "$version" --repo Automattic/cortext >/dev/null 2>&1; then
     --title "Cortext $version" \
     --notes "Cortext $version"
 fi
-gh release upload "$version" "$dmg" --repo Automattic/cortext --clobber
+
+# electron-updater reads latest-mac.yml from the Release, then downloads the
+# signed zip. Squirrel.Mac installs the zip; the DMG stays for first installs.
+# Keep the Release as a draft until a human publishes it, so shipped apps do not
+# see these assets early.
+[[ -f apps/desktop/dist/latest-mac.yml ]] || {
+  echo "latest-mac.yml missing; did the mac zip target run?"; exit 1;
+}
+shopt -s nullglob
+update_assets=(
+  apps/desktop/dist/*-mac.zip
+  apps/desktop/dist/*-mac.zip.blockmap
+  apps/desktop/dist/latest-mac.yml
+)
+shopt -u nullglob
+
+gh release upload "$version" "$dmg" "${update_assets[@]}" \
+  --repo Automattic/cortext --clobber

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,10 @@ build/
 dist/
 wordpress/
 
+# Local env and test artifacts
+.wp-env.override.json
+test-results/
+
 # Lockfiles
 package-lock.json
 pnpm-lock.yaml

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -119,13 +119,21 @@ The DMG is not signed, so macOS blocks it on first launch. Open it once from
 System Settings > Privacy & Security > "Open Anyway", or run
 `xattr -dr com.apple.quarantine /Applications/Cortext.app`.
 
-On launch the installed app checks GitHub for the latest release and links to
-the download if you are behind. It does not update itself.
+On launch, and every few hours after that, the installed app checks the latest
+published GitHub Release with electron-updater. If a newer version exists, it
+downloads it in the background and asks the user to restart. Draft Releases are
+ignored, so users only get an update after someone publishes the Release. The
+Cortext app menu includes "Check for Updates..." and a toggle for automatic
+installs. In-place updates require the signed, notarized app running from
+Applications.
 
 In desktop, WordPress is bundled runtime code, not a site the user maintains
-through wp-admin. The snapshot disables core, plugin, and theme updates, and
-each launch refreshes the update-lock mu-plugin in the extracted site. WordPress
-changes come through new Cortext desktop releases.
+through wp-admin. The snapshot disables core, plugin, and theme updates. Each
+launch refreshes the update-lock mu-plugin in the extracted site. New WordPress
+and Cortext code ships with Cortext desktop releases: after an app update,
+Cortext refreshes the bundled files in the extracted site, keeps the user's
+database and uploads, and lets WordPress run any database upgrade on the next
+load.
 
 Release builds are arm64-only, signed, and notarized on Buildkite. Local builds
 remain unsigned unless you provide a signing environment.

--- a/apps/desktop/lib/auto-update.js
+++ b/apps/desktop/lib/auto-update.js
@@ -62,8 +62,8 @@ function notInApplicationsFolder() {
 async function promptMoveToApplications() {
 	const { response } = await showMessage( {
 		type: 'info',
-			message: 'Move Cortext to Applications to use updates',
-			detail: 'Cortext needs to run from Applications for automatic updates. Move it now?',
+		message: 'Move Cortext to Applications to use updates',
+		detail: 'Cortext needs to run from Applications for automatic updates. Move it now?',
 		buttons: [ 'Move to Applications', 'Not Now' ],
 		defaultId: 0,
 		cancelId: 1,
@@ -119,12 +119,12 @@ function wireEvents() {
 			setState( 'downloading' );
 			return;
 		}
-			// Manual mode: ask before downloading when automatic installs are off.
+		// Manual mode: ask before downloading when automatic installs are off.
 		showManualDialogs = false;
 		const { response } = await showMessage( {
 			type: 'info',
 			message: 'A new version of Cortext is available',
-				detail: 'Download it now? You can install it later.',
+			detail: 'Download it now? You can install it later.',
 			buttons: [ 'Download', 'Later' ],
 			defaultId: 0,
 			cancelId: 1,
@@ -158,7 +158,7 @@ function wireEvents() {
 		const { response } = await showMessage( {
 			type: 'info',
 			message: 'Update ready to install',
-				detail: 'Restart Cortext now to install the update, or install it later.',
+			detail: 'Restart Cortext now to install the update, or install it later.',
 			buttons: [ 'Restart Now', 'Later' ],
 			defaultId: 0,
 			cancelId: 1,
@@ -197,8 +197,8 @@ function initAutoUpdates( {
 	onStateChange = onState;
 	prepareQuit = prepare;
 	autoUpdater.autoDownload = autoDownload;
-		// Keep install-on-quit tied to the same preference. With the setting off,
-		// a manually downloaded update should not install during the next quit.
+	// Keep install-on-quit tied to the same preference. With the setting off,
+	// a manually downloaded update should not install during the next quit.
 	autoUpdater.autoInstallOnAppQuit = autoDownload;
 	autoUpdater.allowPrerelease = true;
 	autoUpdater.logger = null;
@@ -211,22 +211,22 @@ function runCheck( { manual } ) {
 		return;
 	}
 	if ( notInApplicationsFolder() ) {
-			// Silent checks from a read-only or quarantined path only fail, so skip
-			// them. Manual checks can ask the user to move the app.
+		// Silent checks from a read-only or quarantined path only fail, so skip
+		// them. Manual checks can ask the user to move the app.
 		if ( manual ) {
 			promptMoveToApplications();
 		}
 		return;
 	}
-		// Set this for every check. A later silent retry should not inherit a
-		// previous manual dialog.
+	// Set this for every check. A later silent retry should not inherit a
+	// previous manual dialog.
 	showManualDialogs = manual;
 	autoUpdater.checkForUpdates().catch( reportError );
 }
 
-	// Run a silent launch check and schedule later checks. If electron-updater
-	// cannot load in a packaged build, use the old notify-only checker so users
-	// still hear about updates.
+// Run a silent launch check and schedule later checks. If electron-updater
+// cannot load in a packaged build, use the old notify-only checker so users
+// still hear about updates.
 function scheduleUpdateCheck( options = {} ) {
 	const ready = initAutoUpdates( options );
 	if ( ! ready ) {
@@ -260,8 +260,8 @@ function quitAndInstall() {
 		return;
 	}
 	setState( 'restart' );
-		// Let main.js enter its normal quit path, which stops PHP before the
-		// updater restarts the app.
+	// Let main.js enter its normal quit path, which stops PHP before the
+	// updater restarts the app.
 	prepareQuit?.();
 	autoUpdater.quitAndInstall();
 }

--- a/apps/desktop/lib/auto-update.js
+++ b/apps/desktop/lib/auto-update.js
@@ -1,0 +1,283 @@
+const { app, dialog } = require( 'electron' );
+const {
+	scheduleUpdateCheck: scheduleLegacyNotify,
+} = require( './update-check' );
+
+// electron-updater handles Squirrel.Mac updates, but only in a packaged, signed
+// app. It reads app-update.yml from Resources, a file electron-builder writes
+// during packaging. Dev runs do not have it, so load the updater only after the
+// packaged-app guard.
+
+// Keep checking after launch so an app left open all day can still notice a new
+// published Release.
+const RECHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+let autoUpdater = null;
+let state = 'idle'; // idle | checking | available | downloading | downloaded | error | restart
+let showManualDialogs = false;
+let recheckTimer = null;
+let mainWindow = null;
+let onStateChange = null;
+let prepareQuit = null;
+
+function setState( next ) {
+	if ( state === next ) {
+		return;
+	}
+	state = next;
+	onStateChange?.( state );
+}
+
+function getUpdaterState() {
+	return state;
+}
+
+function isUpdateReadyToInstall() {
+	return state === 'downloaded';
+}
+
+function showMessage( options ) {
+	return mainWindow
+		? dialog.showMessageBox( mainWindow, options )
+		: dialog.showMessageBox( options );
+}
+
+function isTransientNetworkError( err ) {
+	const message = String( err?.message || err || '' );
+	return /net::|ENOTFOUND|EAI_AGAIN|getaddrinfo|ETIMEDOUT|ECONNRESET|ECONNREFUSED|timed out|offline/i.test(
+		message
+	);
+}
+
+// Downloads from a mounted DMG or ~/Downloads cannot replace the running app.
+// Ask the user to move Cortext before starting the update flow.
+function notInApplicationsFolder() {
+	return (
+		process.platform === 'darwin' &&
+		typeof app.isInApplicationsFolder === 'function' &&
+		! app.isInApplicationsFolder()
+	);
+}
+
+async function promptMoveToApplications() {
+	const { response } = await showMessage( {
+		type: 'info',
+			message: 'Move Cortext to Applications to use updates',
+			detail: 'Cortext needs to run from Applications for automatic updates. Move it now?',
+		buttons: [ 'Move to Applications', 'Not Now' ],
+		defaultId: 0,
+		cancelId: 1,
+	} );
+	if ( response === 0 ) {
+		try {
+			app.moveToApplicationsFolder();
+		} catch ( err ) {
+			console.log(
+				'[cortext-desktop] move to Applications failed:',
+				err.message
+			);
+		}
+	}
+}
+
+function reportError( err ) {
+	console.log( '[cortext-desktop] update error:', err?.message || err );
+	if ( isTransientNetworkError( err ) ) {
+		setState( 'idle' );
+		scheduleRecheck();
+		return;
+	}
+	setState( 'error' );
+	if ( showManualDialogs ) {
+		showManualDialogs = false;
+		showMessage( {
+			type: 'error',
+			message: 'Could not check for updates',
+			detail: String( err?.message || err ),
+			buttons: [ 'OK' ],
+		} );
+	}
+}
+
+function scheduleRecheck() {
+	if ( recheckTimer ) {
+		return;
+	}
+	recheckTimer = setTimeout( () => {
+		recheckTimer = null;
+		runCheck( { manual: false } );
+	}, RECHECK_INTERVAL_MS );
+	recheckTimer.unref?.();
+}
+
+function wireEvents() {
+	autoUpdater.on( 'checking-for-update', () => setState( 'checking' ) );
+
+	autoUpdater.on( 'update-available', async () => {
+		setState( 'available' );
+		if ( autoUpdater.autoDownload ) {
+			setState( 'downloading' );
+			return;
+		}
+			// Manual mode: ask before downloading when automatic installs are off.
+		showManualDialogs = false;
+		const { response } = await showMessage( {
+			type: 'info',
+			message: 'A new version of Cortext is available',
+				detail: 'Download it now? You can install it later.',
+			buttons: [ 'Download', 'Later' ],
+			defaultId: 0,
+			cancelId: 1,
+		} );
+		if ( response === 0 ) {
+			setState( 'downloading' );
+			autoUpdater.downloadUpdate().catch( reportError );
+		} else {
+			setState( 'idle' );
+		}
+	} );
+
+	autoUpdater.on( 'update-not-available', () => {
+		setState( 'idle' );
+		if ( showManualDialogs ) {
+			showManualDialogs = false;
+			showMessage( {
+				type: 'info',
+				message: 'Cortext is up to date',
+				detail: `You are on version ${ app.getVersion() }.`,
+				buttons: [ 'OK' ],
+			} );
+		}
+		scheduleRecheck();
+	} );
+
+	autoUpdater.on( 'download-progress', () => setState( 'downloading' ) );
+
+	autoUpdater.on( 'update-downloaded', async () => {
+		setState( 'downloaded' );
+		const { response } = await showMessage( {
+			type: 'info',
+			message: 'Update ready to install',
+				detail: 'Restart Cortext now to install the update, or install it later.',
+			buttons: [ 'Restart Now', 'Later' ],
+			defaultId: 0,
+			cancelId: 1,
+		} );
+		if ( response === 0 ) {
+			quitAndInstall();
+		}
+	} );
+
+	autoUpdater.on( 'error', reportError );
+}
+
+function initAutoUpdates( {
+	autoDownload = true,
+	window = null,
+	onState = null,
+	prepareQuit: prepare = null,
+} = {} ) {
+	if ( autoUpdater ) {
+		mainWindow = window ?? mainWindow;
+		return true;
+	}
+	if ( ! app.isPackaged || process.env.CORTEXT_E2E === '1' ) {
+		return false;
+	}
+	try {
+		( { autoUpdater } = require( 'electron-updater' ) );
+	} catch ( err ) {
+		console.log(
+			'[cortext-desktop] electron-updater unavailable:',
+			err.message
+		);
+		return false;
+	}
+	mainWindow = window;
+	onStateChange = onState;
+	prepareQuit = prepare;
+	autoUpdater.autoDownload = autoDownload;
+		// Keep install-on-quit tied to the same preference. With the setting off,
+		// a manually downloaded update should not install during the next quit.
+	autoUpdater.autoInstallOnAppQuit = autoDownload;
+	autoUpdater.allowPrerelease = true;
+	autoUpdater.logger = null;
+	wireEvents();
+	return true;
+}
+
+function runCheck( { manual } ) {
+	if ( ! autoUpdater ) {
+		return;
+	}
+	if ( notInApplicationsFolder() ) {
+			// Silent checks from a read-only or quarantined path only fail, so skip
+			// them. Manual checks can ask the user to move the app.
+		if ( manual ) {
+			promptMoveToApplications();
+		}
+		return;
+	}
+		// Set this for every check. A later silent retry should not inherit a
+		// previous manual dialog.
+	showManualDialogs = manual;
+	autoUpdater.checkForUpdates().catch( reportError );
+}
+
+	// Run a silent launch check and schedule later checks. If electron-updater
+	// cannot load in a packaged build, use the old notify-only checker so users
+	// still hear about updates.
+function scheduleUpdateCheck( options = {} ) {
+	const ready = initAutoUpdates( options );
+	if ( ! ready ) {
+		if ( app.isPackaged ) {
+			scheduleLegacyNotify();
+		}
+		return;
+	}
+	runCheck( { manual: false } );
+}
+
+function checkForUpdatesInteractive() {
+	if ( ! autoUpdater ) {
+		showMessage( {
+			type: 'info',
+			message: 'Use the installed app for updates',
+			detail: 'Run the installed Cortext app to check for updates.',
+			buttons: [ 'OK' ],
+		} );
+		return;
+	}
+	if ( state === 'downloaded' ) {
+		quitAndInstall();
+		return;
+	}
+	runCheck( { manual: true } );
+}
+
+function quitAndInstall() {
+	if ( ! autoUpdater ) {
+		return;
+	}
+	setState( 'restart' );
+		// Let main.js enter its normal quit path, which stops PHP before the
+		// updater restarts the app.
+	prepareQuit?.();
+	autoUpdater.quitAndInstall();
+}
+
+function setAutoDownload( enabled ) {
+	if ( autoUpdater ) {
+		autoUpdater.autoDownload = enabled;
+		autoUpdater.autoInstallOnAppQuit = enabled;
+	}
+}
+
+module.exports = {
+	scheduleUpdateCheck,
+	checkForUpdatesInteractive,
+	getUpdaterState,
+	isUpdateReadyToInstall,
+	quitAndInstall,
+	setAutoDownload,
+};

--- a/apps/desktop/lib/menu.js
+++ b/apps/desktop/lib/menu.js
@@ -1,0 +1,49 @@
+const { app, Menu } = require( 'electron' );
+
+const isMac = process.platform === 'darwin';
+
+// Once we replace the default menu, add the standard roles back by hand. The
+// whole-submenu roles keep copy/paste/select-all/window shortcuts working, and
+// the app menu gets the update controls.
+function buildAppMenu( {
+	updateLabel,
+	onUpdateItem,
+	autoInstallUpdates,
+	onToggleAutoInstall,
+} ) {
+	const template = [
+		...( isMac
+			? [
+					{
+						label: app.name,
+						submenu: [
+							{ role: 'about' },
+							{ type: 'separator' },
+							{ label: updateLabel, click: onUpdateItem },
+							{
+								label: 'Automatically install updates',
+								type: 'checkbox',
+								checked: autoInstallUpdates,
+								click: ( item ) =>
+									onToggleAutoInstall( item.checked ),
+							},
+							{ type: 'separator' },
+							{ role: 'services' },
+							{ type: 'separator' },
+							{ role: 'hide' },
+							{ role: 'hideOthers' },
+							{ role: 'unhide' },
+							{ type: 'separator' },
+							{ role: 'quit' },
+						],
+					},
+			  ]
+			: [] ),
+		{ role: 'editMenu' },
+		{ role: 'viewMenu' },
+		{ role: 'windowMenu' },
+	];
+	return Menu.buildFromTemplate( template );
+}
+
+module.exports = { buildAppMenu };

--- a/apps/desktop/lib/settings.js
+++ b/apps/desktop/lib/settings.js
@@ -1,0 +1,49 @@
+const { app } = require( 'electron' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const DEFAULTS = {
+		// Download updates in the background and install them after the user
+		// restarts. When off, ask before downloading and do not install on quit.
+	autoInstallUpdates: true,
+};
+
+let cache = null;
+
+function settingsPath() {
+	return path.join( app.getPath( 'userData' ), 'settings.json' );
+}
+
+function readAll() {
+	if ( cache ) {
+		return cache;
+	}
+	try {
+		cache = {
+			...DEFAULTS,
+			...JSON.parse( fs.readFileSync( settingsPath(), 'utf8' ) ),
+		};
+	} catch {
+		cache = { ...DEFAULTS };
+	}
+	return cache;
+}
+
+function get( key ) {
+	return readAll()[ key ];
+}
+
+	// Write through a sibling temp file, then rename it over settings.json. A
+	// crash mid-write leaves the old file intact.
+function set( key, value ) {
+	const next = { ...readAll(), [ key ]: value };
+	const file = settingsPath();
+	const tmp = `${ file }.${ process.pid }.tmp`;
+	fs.mkdirSync( path.dirname( file ), { recursive: true } );
+	fs.writeFileSync( tmp, JSON.stringify( next, null, 2 ) );
+	fs.renameSync( tmp, file );
+	cache = next;
+	return value;
+}
+
+module.exports = { get, set, DEFAULTS };

--- a/apps/desktop/lib/settings.js
+++ b/apps/desktop/lib/settings.js
@@ -3,8 +3,8 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 
 const DEFAULTS = {
-		// Download updates in the background and install them after the user
-		// restarts. When off, ask before downloading and do not install on quit.
+	// Download updates in the background and install them after the user
+	// restarts. When off, ask before downloading and do not install on quit.
 	autoInstallUpdates: true,
 };
 
@@ -33,8 +33,8 @@ function get( key ) {
 	return readAll()[ key ];
 }
 
-	// Write through a sibling temp file, then rename it over settings.json. A
-	// crash mid-write leaves the old file intact.
+// Write through a sibling temp file, then rename it over settings.json. A
+// crash mid-write leaves the old file intact.
 function set( key, value ) {
 	const next = { ...readAll(), [ key ]: value };
 	const file = settingsPath();

--- a/apps/desktop/lib/site-refresh.js
+++ b/apps/desktop/lib/site-refresh.js
@@ -1,0 +1,167 @@
+const { spawnSync } = require( 'child_process' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+const { parseVersion, isNewer } = require( './version' );
+
+// The extracted site stores the app version that created it. When a newer app
+// ships a newer snapshot, refresh the code and keep user data.
+const MARKER_FILE = '.cortext-snapshot-version';
+const BAK_PREFIX = '.cortext-wordpress-bak-';
+const NEXT_PREFIX = '.next-';
+
+// Desktop disables wp-admin file edits and plugin/theme installs
+// (DISALLOW_FILE_MODS). For this app, the SQLite database, uploads, and
+// generated wp-config are the user state we carry across a code refresh. Paths
+// are relative to the WordPress root.
+const PRESERVE = [
+	'wp-content/database',
+	'wp-content/uploads',
+	'wp-config.php',
+];
+
+function markerPath( siteRoot ) {
+	return path.join( siteRoot, MARKER_FILE );
+}
+
+function readMarker( siteRoot ) {
+	try {
+		return fs.readFileSync( markerPath( siteRoot ), 'utf8' ).trim();
+	} catch {
+		return null;
+	}
+}
+
+function writeMarker( siteRoot, version ) {
+	fs.mkdirSync( siteRoot, { recursive: true } );
+	fs.writeFileSync( markerPath( siteRoot ), String( version ) );
+}
+
+function extractSnapshot( snapshotZip, dest ) {
+	fs.mkdirSync( dest, { recursive: true } );
+		// macOS `unzip` can exit 1 for warnings, such as stripped absolute paths.
+		// Check the extracted files instead.
+	spawnSync( 'unzip', [ '-q', '-o', snapshotZip, '-d', dest ], {
+		stdio: [ 'ignore', 'ignore', 'ignore' ],
+	} );
+	if ( ! fs.existsSync( path.join( dest, 'wordpress/index.php' ) ) ) {
+		throw new Error( `Snapshot extraction failed under ${ dest }` );
+	}
+}
+
+function carryOver( fromWordpress, toWordpress ) {
+	for ( const rel of PRESERVE ) {
+		const src = path.join( fromWordpress, rel );
+		if ( ! fs.existsSync( src ) ) {
+			continue;
+		}
+		const dest = path.join( toWordpress, rel );
+		fs.rmSync( dest, { recursive: true, force: true } );
+		fs.mkdirSync( path.dirname( dest ), { recursive: true } );
+		fs.cpSync( src, dest, { recursive: true } );
+	}
+}
+
+// If the app was killed after the old tree was stashed but before the new tree
+// landed, restore the user's site before first-run extraction can seed a fresh
+// one.
+function recoverInterruptedSwap( siteRoot ) {
+	if ( ! fs.existsSync( siteRoot ) ) {
+		return;
+	}
+		// Remove scratch extraction dirs left by a killed refresh so they do not
+		// pile up.
+	for ( const name of fs.readdirSync( siteRoot ) ) {
+		if ( name.startsWith( NEXT_PREFIX ) ) {
+			fs.rmSync( path.join( siteRoot, name ), {
+				recursive: true,
+				force: true,
+			} );
+		}
+	}
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	if ( fs.existsSync( wordpressDir ) ) {
+		return;
+	}
+	const baks = fs
+		.readdirSync( siteRoot )
+		.filter( ( name ) => name.startsWith( BAK_PREFIX ) )
+		.sort();
+	if ( baks.length ) {
+		fs.renameSync(
+			path.join( siteRoot, baks[ baks.length - 1 ] ),
+			wordpressDir
+		);
+	}
+}
+
+// Refresh the extracted site's code from the bundled snapshot when this app is
+// newer than the marker. Keep the user's database, uploads, and wp-config.
+// Returns true when it swapped files.
+function refreshSiteIfOutdated( { snapshotZip, siteRoot, version } ) {
+	recoverInterruptedSwap( siteRoot );
+
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	if ( ! fs.existsSync( wordpressDir ) ) {
+			// No site has been extracted yet; first-run extraction writes the marker.
+		return false;
+	}
+
+	const markerString = readMarker( siteRoot );
+	const current = parseVersion( version );
+	const marker = parseVersion( markerString );
+		// Exact same build, including prerelease suffix: no refresh needed.
+	if ( markerString && markerString === String( version ) ) {
+		return false;
+	}
+		// Never downgrade. If the marker is numerically newer, the user already ran
+		// a build ahead of this bundle; replacing code under that database could
+		// break it. parseVersion compares only the numeric core, so same-core
+		// prereleases (0.2.0-rc.1 -> 0.2.0-rc.2) still refresh, matching the app
+		// binary swap.
+	if ( current && marker && isNewer( marker, current ) ) {
+		return false;
+	}
+	if ( ! fs.existsSync( snapshotZip ) ) {
+		return false;
+	}
+
+	const stamp = `${ Date.now() }-${ process.pid }`;
+	const nextSite = path.join( siteRoot, `.next-${ stamp }` );
+	const bakDir = path.join( siteRoot, `${ BAK_PREFIX }${ stamp }` );
+
+	fs.rmSync( nextSite, { recursive: true, force: true } );
+	try {
+		extractSnapshot( snapshotZip, nextSite );
+		carryOver( wordpressDir, path.join( nextSite, 'wordpress' ) );
+
+			// Keep the swap on one volume. Each rename is atomic: stash the live
+			// tree, promote the new tree, restore the stash if promotion fails.
+		fs.renameSync( wordpressDir, bakDir );
+		try {
+			fs.renameSync( path.join( nextSite, 'wordpress' ), wordpressDir );
+		} catch ( swapErr ) {
+			fs.renameSync( bakDir, wordpressDir );
+			throw swapErr;
+		}
+
+		writeMarker( siteRoot, version );
+		fs.rmSync( bakDir, { recursive: true, force: true } );
+		fs.rmSync( nextSite, { recursive: true, force: true } );
+		console.log( `[cortext-desktop] site refreshed to ${ version }` );
+		return true;
+	} catch ( err ) {
+		fs.rmSync( nextSite, { recursive: true, force: true } );
+		console.log( '[cortext-desktop] site refresh skipped:', err.message );
+		return false;
+	}
+}
+
+module.exports = {
+	refreshSiteIfOutdated,
+	recoverInterruptedSwap,
+	readMarker,
+	writeMarker,
+	MARKER_FILE,
+	BAK_PREFIX,
+	PRESERVE,
+};

--- a/apps/desktop/lib/site-refresh.js
+++ b/apps/desktop/lib/site-refresh.js
@@ -38,8 +38,8 @@ function writeMarker( siteRoot, version ) {
 
 function extractSnapshot( snapshotZip, dest ) {
 	fs.mkdirSync( dest, { recursive: true } );
-		// macOS `unzip` can exit 1 for warnings, such as stripped absolute paths.
-		// Check the extracted files instead.
+	// macOS `unzip` can exit 1 for warnings, such as stripped absolute paths.
+	// Check the extracted files instead.
 	spawnSync( 'unzip', [ '-q', '-o', snapshotZip, '-d', dest ], {
 		stdio: [ 'ignore', 'ignore', 'ignore' ],
 	} );
@@ -68,8 +68,8 @@ function recoverInterruptedSwap( siteRoot ) {
 	if ( ! fs.existsSync( siteRoot ) ) {
 		return;
 	}
-		// Remove scratch extraction dirs left by a killed refresh so they do not
-		// pile up.
+	// Remove scratch extraction dirs left by a killed refresh so they do not
+	// pile up.
 	for ( const name of fs.readdirSync( siteRoot ) ) {
 		if ( name.startsWith( NEXT_PREFIX ) ) {
 			fs.rmSync( path.join( siteRoot, name ), {
@@ -102,22 +102,22 @@ function refreshSiteIfOutdated( { snapshotZip, siteRoot, version } ) {
 
 	const wordpressDir = path.join( siteRoot, 'wordpress' );
 	if ( ! fs.existsSync( wordpressDir ) ) {
-			// No site has been extracted yet; first-run extraction writes the marker.
+		// No site has been extracted yet; first-run extraction writes the marker.
 		return false;
 	}
 
 	const markerString = readMarker( siteRoot );
 	const current = parseVersion( version );
 	const marker = parseVersion( markerString );
-		// Exact same build, including prerelease suffix: no refresh needed.
+	// Exact same build, including prerelease suffix: no refresh needed.
 	if ( markerString && markerString === String( version ) ) {
 		return false;
 	}
-		// Never downgrade. If the marker is numerically newer, the user already ran
-		// a build ahead of this bundle; replacing code under that database could
-		// break it. parseVersion compares only the numeric core, so same-core
-		// prereleases (0.2.0-rc.1 -> 0.2.0-rc.2) still refresh, matching the app
-		// binary swap.
+	// Never downgrade. If the marker is numerically newer, the user already ran
+	// a build ahead of this bundle; replacing code under that database could
+	// break it. parseVersion compares only the numeric core, so same-core
+	// prereleases (0.2.0-rc.1 -> 0.2.0-rc.2) still refresh, matching the app
+	// binary swap.
 	if ( current && marker && isNewer( marker, current ) ) {
 		return false;
 	}
@@ -134,8 +134,8 @@ function refreshSiteIfOutdated( { snapshotZip, siteRoot, version } ) {
 		extractSnapshot( snapshotZip, nextSite );
 		carryOver( wordpressDir, path.join( nextSite, 'wordpress' ) );
 
-			// Keep the swap on one volume. Each rename is atomic: stash the live
-			// tree, promote the new tree, restore the stash if promotion fails.
+		// Keep the swap on one volume. Each rename is atomic: stash the live
+		// tree, promote the new tree, restore the stash if promotion fails.
 		fs.renameSync( wordpressDir, bakDir );
 		try {
 			fs.renameSync( path.join( nextSite, 'wordpress' ), wordpressDir );

--- a/apps/desktop/lib/update-check.js
+++ b/apps/desktop/lib/update-check.js
@@ -1,30 +1,10 @@
 const https = require( 'https' );
 const { app, dialog, shell } = require( 'electron' );
+const { parseVersion, isNewer } = require( './version' );
 
 const RELEASES_API =
 	'https://api.github.com/repos/Automattic/cortext/releases?per_page=10';
 const RELEASES_URL = 'https://github.com/Automattic/cortext/releases';
-
-// WordPress-style versions: "0.1.0", no leading "v". Pre-release suffixes are
-// ignored for the comparison; only the numeric core decides what is newer.
-function parseVersion( tag ) {
-	const match = String( tag || '' )
-		.trim()
-		.replace( /^v/, '' )
-		.match( /^(\d+)\.(\d+)\.(\d+)/ );
-	return match
-		? [ Number( match[ 1 ] ), Number( match[ 2 ] ), Number( match[ 3 ] ) ]
-		: null;
-}
-
-function isNewer( candidate, current ) {
-	for ( let i = 0; i < 3; i++ ) {
-		if ( candidate[ i ] !== current[ i ] ) {
-			return candidate[ i ] > current[ i ];
-		}
-	}
-	return false;
-}
 
 function fetchReleases() {
 	return new Promise( ( resolve, reject ) => {

--- a/apps/desktop/lib/version.js
+++ b/apps/desktop/lib/version.js
@@ -1,0 +1,22 @@
+// WordPress-style versions: "0.1.0", with no leading "v". Ignore prerelease
+// suffixes for ordering; the numeric core decides what is newer.
+function parseVersion( tag ) {
+	const match = String( tag || '' )
+		.trim()
+		.replace( /^v/, '' )
+		.match( /^(\d+)\.(\d+)\.(\d+)/ );
+	return match
+		? [ Number( match[ 1 ] ), Number( match[ 2 ] ), Number( match[ 3 ] ) ]
+		: null;
+}
+
+function isNewer( candidate, current ) {
+	for ( let i = 0; i < 3; i++ ) {
+		if ( candidate[ i ] !== current[ i ] ) {
+			return candidate[ i ] > current[ i ];
+		}
+	}
+	return false;
+}
+
+module.exports = { parseVersion, isNewer };

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require( 'electron' );
+const { app, BrowserWindow, Menu } = require( 'electron' );
 const { spawnSync } = require( 'child_process' );
 const path = require( 'path' );
 const fs = require( 'fs' );
@@ -7,7 +7,19 @@ const {
 	startRuntime,
 	stopRuntime,
 } = require( './lib/runtime' );
-const { scheduleUpdateCheck } = require( './lib/update-check' );
+const {
+	scheduleUpdateCheck,
+	checkForUpdatesInteractive,
+	isUpdateReadyToInstall,
+	setAutoDownload,
+} = require( './lib/auto-update' );
+const {
+	refreshSiteIfOutdated,
+	recoverInterruptedSwap,
+	writeMarker,
+} = require( './lib/site-refresh' );
+const { buildAppMenu } = require( './lib/menu' );
+const settings = require( './lib/settings' );
 
 // Bundled resources (the snapshot and the PHP runtime) sit next to the app in
 // dev and under `process.resourcesPath` once packaged into the .app.
@@ -45,10 +57,27 @@ function ensureSiteFromSnapshot() {
 			`Snapshot extraction failed: ${ wordpressDir } is empty.`
 		);
 	}
+	writeMarker( siteRoot, app.getVersion() );
 	return wordpressDir;
 }
 
-async function createWindow() {
+function refreshMenu() {
+	Menu.setApplicationMenu(
+		buildAppMenu( {
+			updateLabel: isUpdateReadyToInstall()
+				? 'Restart to Apply Update'
+				: 'Check for Updates…',
+			onUpdateItem: () => checkForUpdatesInteractive(),
+			autoInstallUpdates: settings.get( 'autoInstallUpdates' ),
+			onToggleAutoInstall: ( enabled ) => {
+				settings.set( 'autoInstallUpdates', enabled );
+				setAutoDownload( enabled );
+			},
+		} )
+	);
+}
+
+function createWindow() {
 	const win = new BrowserWindow( {
 		width: 1280,
 		height: 800,
@@ -65,8 +94,10 @@ async function createWindow() {
 		win.setTitle( 'Cortext' );
 	} );
 
-	await win.loadFile( path.resolve( __dirname, 'loading.html' ) );
+	return win;
+}
 
+async function loadSite( win ) {
 	try {
 		await runtimeHandle.ready;
 		await win.loadURL(
@@ -75,14 +106,22 @@ async function createWindow() {
 		if ( ! app.isPackaged && process.env.CORTEXT_DEVTOOLS !== '0' ) {
 			win.webContents.openDevTools( { mode: 'detach' } );
 		}
-		scheduleUpdateCheck();
+		scheduleUpdateCheck( {
+			window: win,
+			onState: refreshMenu,
+			prepareQuit: () => {
+				quitting = true;
+			},
+			autoDownload: settings.get( 'autoInstallUpdates' ),
+		} );
 	} catch ( err ) {
 		console.error( '[cortext-desktop] failed to reach PHP server:', err );
 		await win.loadFile( path.resolve( __dirname, 'error.html' ) );
 	}
 }
 
-app.whenReady().then( () => {
+app.whenReady().then( async () => {
+	let win = null;
 	try {
 		if (
 			process.platform === 'darwin' &&
@@ -92,7 +131,24 @@ app.whenReady().then( () => {
 			app.dock.setIcon( APP_ICON );
 		}
 
-		const wordpressDir = ensureSiteFromSnapshot();
+		refreshMenu();
+		win = createWindow();
+		// Load the loading screen before any site refresh so users never stare at
+		// a blank window.
+		await win.loadFile( path.resolve( __dirname, 'loading.html' ) );
+
+		const siteRoot = getSiteRoot();
+		recoverInterruptedSwap( siteRoot );
+		ensureSiteFromSnapshot();
+		// Update bundled WordPress/Cortext files before PHP starts. User data
+		// stays in place.
+		refreshSiteIfOutdated( {
+			snapshotZip: SNAPSHOT_ZIP,
+			siteRoot,
+			version: app.getVersion(),
+		} );
+		const wordpressDir = path.join( siteRoot, 'wordpress' );
+
 		runtimeHandle = startRuntime( {
 			appDir: RESOURCES_DIR,
 			wordpressDir,
@@ -106,10 +162,15 @@ app.whenReady().then( () => {
 				}
 			},
 		} );
-		createWindow();
+
+		await loadSite( win );
 	} catch ( err ) {
 		console.error( '[cortext-desktop]', err );
-		app.quit();
+		if ( win ) {
+			win.loadFile( path.resolve( __dirname, 'error.html' ) );
+		} else {
+			app.quit();
+		}
 	}
 } );
 

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -8,9 +8,12 @@
 			"name": "cortext-desktop",
 			"version": "0.1.1",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"electron-updater": "^6.8.9"
+			},
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",
-				"electron": "^42.3.1",
+				"electron": "^42.3.3",
 				"electron-builder": "^26.8.1"
 			}
 		},
@@ -170,9 +173,9 @@
 			}
 		},
 		"node_modules/@electron/get/node_modules/undici": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
-			"integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -256,21 +259,6 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/@electron/osx-sign/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
@@ -282,29 +270,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/gjtorikian/"
-			}
-		},
-		"node_modules/@electron/osx-sign/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@electron/osx-sign/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/@electron/rebuild": {
@@ -937,44 +902,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/app-builder-lib/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/fs-extra/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/fs-extra/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/app-builder-lib/node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -992,7 +919,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
 			"license": "Python-2.0"
 		},
 		"node_modules/assert-plus": {
@@ -1184,44 +1110,6 @@
 			},
 			"engines": {
 				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/builder-util/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/builder-util/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/builder-util/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/cacheable-lookup": {
@@ -1493,7 +1381,6 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -1661,44 +1548,6 @@
 				"dmg-license": "^1.0.11"
 			}
 		},
-		"node_modules/dmg-builder/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/dmg-license": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
@@ -1787,9 +1636,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "42.3.1",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-42.3.1.tgz",
-			"integrity": "sha512-srUkulADc2QNJKlhxYU+wSaGEQ/Wbz/F3ko3DzUhNyvtWkP0XCTdGwKAOX1q4z1bVlWYZT7LV7APFmUAGTFykg==",
+			"version": "42.3.3",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-42.3.3.tgz",
+			"integrity": "sha512-0MwYp9wTb7TrtTalOYqeW+suqd9T/Znstr/nDLKqFGIjHdBZX339guo3mQqTPURRZ/UQmYM4uMpzKpI5wLptfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1844,44 +1693,6 @@
 				"electron-winstaller": "5.4.0"
 			}
 		},
-		"node_modules/electron-builder/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/electron-builder/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/electron-builder/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/electron-publish": {
 			"version": "26.8.1",
 			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
@@ -1899,42 +1710,45 @@
 				"mime": "^2.5.2"
 			}
 		},
-		"node_modules/electron-publish/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
+		"node_modules/electron-updater": {
+			"version": "6.8.9",
+			"resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+			"integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
 			"license": "MIT",
 			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
+				"builder-util-runtime": "9.7.0",
+				"fs-extra": "^10.1.0",
+				"js-yaml": "^4.1.0",
+				"lazy-val": "^1.0.5",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isequal": "^4.5.0",
+				"semver": "~7.7.3",
+				"tiny-typed-emitter": "^2.1.0"
 			}
 		},
-		"node_modules/electron-publish/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
+		"node_modules/electron-updater/node_modules/builder-util-runtime": {
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+			"integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
 			"license": "MIT",
 			"dependencies": {
-				"universalify": "^2.0.0"
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
 			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/electron-publish/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
+		"node_modules/electron-updater/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
 			"engines": {
-				"node": ">= 10.0.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/electron-winstaller": {
@@ -2212,20 +2026,55 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/fs-extra/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -2458,7 +2307,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/has-flag": {
@@ -2726,7 +2574,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
 			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2804,7 +2651,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
 			"integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash": {
@@ -2812,6 +2658,19 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
 			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
 			"license": "MIT"
 		},
 		"node_modules/lowercase-keys": {
@@ -2974,7 +2833,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/node-abi": {
@@ -3480,7 +3338,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
 			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -3741,44 +3598,6 @@
 				"fs-extra": "^10.0.0"
 			}
 		},
-		"node_modules/temp-file/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/temp-file/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/temp-file/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/tiny-async-pool": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
@@ -3798,6 +3617,12 @@
 			"bin": {
 				"semver": "bin/semver"
 			}
+		},
+		"node_modules/tiny-typed-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+			"integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.17",
@@ -3861,9 +3686,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-			"integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,7 +19,7 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",
-		"electron": "^42.3.1",
+		"electron": "^42.3.3",
 		"electron-builder": "^26.8.1"
 	},
 	"build": {
@@ -52,6 +52,10 @@
 				{
 					"target": "dmg",
 					"arch": "arm64"
+				},
+				{
+					"target": "zip",
+					"arch": "arm64"
 				}
 			],
 			"identity": "Automattic, Inc. (PZYM8XX95Q)",
@@ -64,6 +68,16 @@
 				"Contents/Resources/runtime/bin/php"
 			],
 			"notarize": true
-		}
+		},
+		"publish": [
+			{
+				"provider": "github",
+				"owner": "Automattic",
+				"repo": "cortext"
+			}
+		]
+	},
+	"dependencies": {
+		"electron-updater": "^6.8.9"
 	}
 }

--- a/apps/desktop/scripts/site-refresh.test.mjs
+++ b/apps/desktop/scripts/site-refresh.test.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+	refreshSiteIfOutdated,
+	recoverInterruptedSwap,
+	readMarker,
+	writeMarker,
+	BAK_PREFIX,
+} from '../lib/site-refresh.js';
+
+function tmpDir() {
+	return fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-site-refresh-' ) );
+}
+
+function writeFile( file, contents ) {
+	fs.mkdirSync( path.dirname( file ), { recursive: true } );
+	fs.writeFileSync( file, contents );
+}
+
+// A tiny WordPress-shaped tree: index.php satisfies the extraction check, and
+// the rest separates code from user data.
+function writeSite( wordpressDir, { code, wpConfig, db, upload } ) {
+	writeFile( path.join( wordpressDir, 'index.php' ), code );
+	writeFile(
+		path.join( wordpressDir, 'wp-content/plugins/cortext/cortext.php' ),
+		code
+	);
+	if ( wpConfig !== undefined ) {
+		writeFile( path.join( wordpressDir, 'wp-config.php' ), wpConfig );
+	}
+	if ( db !== undefined ) {
+		writeFile(
+			path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ),
+			db
+		);
+	}
+	if ( upload !== undefined ) {
+		writeFile(
+			path.join( wordpressDir, 'wp-content/uploads/photo.txt' ),
+			upload
+		);
+	}
+}
+
+// Build a snapshot.zip with a top-level `wordpress/` dir, like build-snapshot.
+function makeSnapshotZip( contents ) {
+	const src = tmpDir();
+	writeSite( path.join( src, 'wordpress' ), contents );
+	const zipPath = path.join( src, 'snapshot.zip' );
+	const result = spawnSync( 'zip', [ '-q', '-r', zipPath, 'wordpress' ], {
+		cwd: src,
+		stdio: [ 'ignore', 'ignore', 'ignore' ],
+	} );
+	assert.equal( result.status, 0, 'zip fixture built' );
+	return zipPath;
+}
+
+function read( file ) {
+	return fs.readFileSync( file, 'utf8' );
+}
+
+test( 'refresh updates code and preserves the database, uploads, and wp-config', () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeSite( wordpressDir, {
+		code: 'CODE v1',
+		wpConfig: 'WPCONFIG v1 SALT',
+		db: 'USER DATA',
+		upload: 'USER UPLOAD',
+	} );
+	writeMarker( siteRoot, '1.0.0' );
+
+	const snapshotZip = makeSnapshotZip( {
+		code: 'CODE v2',
+		wpConfig: 'WPCONFIG v2 FRESH',
+		db: 'SEED DATA',
+	} );
+
+	const refreshed = refreshSiteIfOutdated( {
+		snapshotZip,
+		siteRoot,
+		version: '2.0.0',
+	} );
+
+	assert.equal( refreshed, true );
+		// Snapshot code replaced the old code.
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'CODE v2' );
+	assert.equal(
+		read(
+			path.join( wordpressDir, 'wp-content/plugins/cortext/cortext.php' )
+		),
+		'CODE v2'
+	);
+		// User data and wp-config survived the swap.
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'USER DATA'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/uploads/photo.txt' ) ),
+		'USER UPLOAD'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-config.php' ) ),
+		'WPCONFIG v1 SALT'
+	);
+		// Marker moved forward, and no scratch dirs were left.
+	assert.equal( readMarker( siteRoot ), '2.0.0' );
+	const leftovers = fs
+		.readdirSync( siteRoot )
+		.filter(
+			( n ) => n.startsWith( BAK_PREFIX ) || n.startsWith( '.next-' )
+		);
+	assert.deepEqual( leftovers, [] );
+} );
+
+test( 'refresh is a no-op on the same version and never downgrades', () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeSite( wordpressDir, { code: 'CODE v2', db: 'USER DATA' } );
+	writeMarker( siteRoot, '2.0.0' );
+	const snapshotZip = makeSnapshotZip( { code: 'CODE other', db: 'SEED' } );
+
+	assert.equal(
+		refreshSiteIfOutdated( { snapshotZip, siteRoot, version: '2.0.0' } ),
+		false
+	);
+	assert.equal(
+		refreshSiteIfOutdated( { snapshotZip, siteRoot, version: '1.5.0' } ),
+		false
+	);
+		// Still untouched.
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'CODE v2' );
+	assert.equal( readMarker( siteRoot ), '2.0.0' );
+} );
+
+test( 'refresh without an extracted site defers to first-run extraction', () => {
+	const siteRoot = tmpDir();
+	const snapshotZip = makeSnapshotZip( { code: 'CODE v2', db: 'SEED' } );
+	assert.equal(
+		refreshSiteIfOutdated( { snapshotZip, siteRoot, version: '2.0.0' } ),
+		false
+	);
+	assert.equal( fs.existsSync( path.join( siteRoot, 'wordpress' ) ), false );
+} );
+
+test( 'recoverInterruptedSwap restores a stashed tree when wordpress is missing', () => {
+	const siteRoot = tmpDir();
+	fs.mkdirSync( siteRoot, { recursive: true } );
+	const bak = path.join( siteRoot, `${ BAK_PREFIX }123-456` );
+	writeFile( path.join( bak, 'index.php' ), 'RESTORED' );
+
+	recoverInterruptedSwap( siteRoot );
+
+	assert.equal(
+		read( path.join( siteRoot, 'wordpress/index.php' ) ),
+		'RESTORED'
+	);
+	assert.equal( fs.existsSync( bak ), false );
+} );
+
+test( 'refresh runs between same-core prereleases', () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeSite( wordpressDir, { code: 'CODE rc1', db: 'USER DATA' } );
+	writeMarker( siteRoot, '0.2.0-rc.1' );
+	const snapshotZip = makeSnapshotZip( { code: 'CODE rc2', db: 'SEED' } );
+
+	assert.equal(
+		refreshSiteIfOutdated( {
+			snapshotZip,
+			siteRoot,
+			version: '0.2.0-rc.2',
+		} ),
+		true
+	);
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'CODE rc2' );
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'USER DATA'
+	);
+	assert.equal( readMarker( siteRoot ), '0.2.0-rc.2' );
+} );
+
+test( 'recoverInterruptedSwap clears orphaned scratch dirs and leaves the live tree', () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeFile( path.join( wordpressDir, 'index.php' ), 'LIVE' );
+	const scratch = path.join( siteRoot, '.next-999-1' );
+	writeFile( path.join( scratch, 'wordpress/index.php' ), 'SCRATCH' );
+
+	recoverInterruptedSwap( siteRoot );
+
+	assert.equal( fs.existsSync( scratch ), false );
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'LIVE' );
+} );

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -2,6 +2,14 @@
 
 Running log for desktop-specific runtime and packaging decisions. Keep the detailed benchmark numbers in PR comments or artifacts unless they become stable product guidance.
 
+## 2026-06-19 — In-place auto-updates over GitHub Releases
+
+**Decision.** The signed desktop app now updates itself from GitHub Releases with `electron-updater`. The mac build ships both `dmg` and `zip`: users download the DMG for first install, while Squirrel.Mac installs the zip. The `github` publish config makes electron-builder write `latest-mac.yml` and `app-update.yml`, and Buildkite uploads the zip, blockmap, and `latest-mac.yml` to the same draft Release as the DMG. The plugin workflow still owns the Release; Buildkite only attaches desktop assets. Drafts remain hidden from the updater. Once a human publishes a Release, the installed app can pick it up. The app menu has one `autoInstallUpdates` checkbox plus a "Check for Updates..." / "Restart to Apply Update" item. On first launch after an app update, Cortext also refreshes the bundled WordPress and plugin code in the extracted site, preserving the SQLite database, uploads, and wp-config. WordPress handles any database upgrade on the next load.
+
+**Why GitHub Releases and not a self-hosted feed.** WordPress Studio uses the same Squirrel path, but its feed comes from WordPress.com and the Apps CDN. Cortext does not have that infrastructure. Reading assets from GitHub Releases keeps the release path small: we already create the Release, sign the app, and upload assets there. We borrowed Studio's runtime behavior (state tracking, manual vs silent dialogs, move-to-Applications prompt, retrying transient network errors), not its feed. The version marker refresh follows the same idea: swap code, leave user data alone.
+
+**Revisit when.** We ship Intel or universal builds, add beta/nightly channels, need wp-config migrations instead of carrying the old file forward, or replace the checkbox with a real preferences window.
+
 ## 2026-06-16 — Buildkite owns the signed macOS DMG
 
 **Decision.** GitHub Actions prepares the plugin ZIP, validates the release milestone, writes release notes, and creates or updates the draft GitHub Release. Buildkite is the only macOS DMG publisher: the release tag build builds the bundled PHP runtime and distribution snapshot, runs electron-builder, signs and notarizes the app, verifies the signed app, and uploads the DMG to the same draft Release.

--- a/docs/release.md
+++ b/docs/release.md
@@ -179,9 +179,14 @@ next milestone.
 
 ## Desktop app
 
-The desktop release builds a macOS DMG with electron-builder and attaches it to
-the same Release as the plugin ZIP. The release build is arm64-only, signed, and
-notarized by Buildkite. Release notes should tell people to move Cortext to
-Applications.
-The installed app checks GitHub Releases on launch and links to the download
-when a newer version exists, but it does not update itself.
+The desktop release builds a signed, notarized arm64 macOS app with
+electron-builder. Buildkite attaches the DMG to the same Release as the plugin
+ZIP, along with `latest-mac.yml` and the signed `*-mac.zip` that Squirrel.Mac
+installs. Release notes should tell people to move Cortext to Applications;
+in-place updates depend on that.
+
+The installed app checks the latest published GitHub Release on launch and every
+few hours after that. When a newer version is available, it downloads it in the
+background and asks the user to restart. Draft Releases are ignored. After an app
+update, Cortext refreshes the bundled WordPress and plugin code in the user's
+extracted site while keeping the database and uploads.


### PR DESCRIPTION
## What

Adds in-place updates for the signed macOS desktop app. Cortext now checks published GitHub Releases, downloads a newer build when one is available, and asks the user to restart once it is ready. The app menu gets update controls too. After an app update, Cortext refreshes the bundled WordPress/Cortext files in the extracted site without touching the user's database or uploads.

## Why

Desktop releases should not require a fresh DMG install every time. We also need the extracted WordPress site to pick up the app's bundled code without wiping local data.

## How

- Publishing the mac update feed next to the DMG on GitHub Releases.
- Tying download/install behavior to one app-menu setting.
- Refreshing bundled site files after an app update while carrying user data forward.

## Testing Instructions

1. Build a signed desktop release and confirm the DMG, mac zip, zip blockmap, and `latest-mac.yml` are present.
2. Install Cortext in Applications.
3. Publish a newer test Release and choose Cortext > Check for Updates.
4. Confirm Cortext downloads the update and asks to restart.
5. Restart into the new version and confirm existing local content and uploads are still there.
