### PR TITLE
Add sidebar settings view mode

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -14,13 +14,12 @@ import {
 import { displayShortcut } from '@wordpress/keycodes';
 import {
 	chevronDown,
-	globe,
+	cog,
 	home as homeIcon,
 	page,
 	plus,
 	search,
 	trash as trashIcon,
-	upload,
 	wordpress,
 } from '@wordpress/icons';
 
@@ -67,15 +66,16 @@ import SidebarFavorites from './SidebarFavorites';
 import SidebarResizeHandle from './SidebarResizeHandle';
 import SidebarRecents from './SidebarRecents';
 import SidebarSection from './SidebarSection';
+import SidebarSettingsNav from './SidebarSettingsNav';
 import { SidebarListSkeleton } from './Skeleton';
 import SidebarTrash, { computeSidebarTrashRoots } from './SidebarTrash';
 import ThemeToggle from './ThemeToggle';
 import {
 	computeDocumentUri,
-	IMPORT_URI,
+	isSettingsUri,
 	parseIdFromUri,
 	parseSplatUri,
-	PUBLISHED_DOCUMENTS_URI,
+	SETTINGS_URI,
 } from '../router/useResolveEntity';
 import { DOCUMENT_POST_TYPE, FULL_PAGE_COLLECTION_QUERY } from '../collections';
 import useDelayedFlag, {
@@ -99,10 +99,7 @@ import useSidebarDnd from './sidebar/useSidebarDnd';
 import useSidebarNavigation from './sidebar/useSidebarNavigation';
 import useSidebarTree, { ROOT_PARENT_ID } from './sidebar/useSidebarTree';
 import DocumentRow from './sidebar/DocumentRow';
-import {
-	isPublicWebAffordancesEnabled,
-	isWordPressAffordancesEnabled,
-} from '../settings';
+import { isWordPressAffordancesEnabled } from '../settings';
 
 export default function Sidebar( {
 	collapsed = false,
@@ -176,46 +173,48 @@ export default function Sidebar( {
 		120,
 		SKELETON_MIN_VISIBLE_MS
 	);
-	const {
-		navigate,
-		activeUri,
-		selectedId,
-		selectedCollectionId,
-		onSelect,
-		goHome,
-	} = useSidebarNavigation( { pages, homePath } );
+	const { navigate, selectedId, selectedCollectionId, onSelect, goHome } =
+		useSidebarNavigation( { pages, homePath } );
 	const { isSelected: isRowSelected, selectRecord: onRowSelect } =
 		useDocumentSelection( { selectedId, selectedCollectionId } );
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
 	const brandIconUrl = window.cortextSettings?.iconUrl ?? '';
-	const publicWebAffordances = isPublicWebAffordancesEnabled();
 	const wordpressAffordances = isWordPressAffordancesEnabled();
 	const commandPaletteShortcut = displayShortcut.primary( 'k' );
 	const brandLabel = __( 'Cortext', 'cortext' );
+	const isSettingsMode = isSettingsUri( routeUri );
 
 	const [ favoritesError, setFavoritesError ] = useState( null );
 	const [ duplicateNotice, setDuplicateNotice ] = useState( null );
+	const [ settingsReturnUri, setSettingsReturnUri ] = useState( null );
 	const {
 		isFavorite,
 		toggle: toggleFavorite,
 		disabled: areFavoriteActionsDisabled,
 	} = useFavoriteToggle( { onError: setFavoritesError } );
 	const { isSectionCollapsed, toggleSection } = useSidebarSections();
-	const goPublished = useCallback( () => {
+	const openSettings = useCallback( () => {
+		if ( isSettingsMode ) {
+			return;
+		}
+		setSettingsReturnUri( routeUri );
 		navigate( {
 			to: '/$',
-			params: { _splat: PUBLISHED_DOCUMENTS_URI },
+			params: { _splat: SETTINGS_URI },
 		} );
-	}, [ navigate ] );
-	const isPublishedActive =
-		publicWebAffordances && activeUri === PUBLISHED_DOCUMENTS_URI;
-	const goImport = useCallback( () => {
-		navigate( {
-			to: '/$',
-			params: { _splat: IMPORT_URI },
-		} );
-	}, [ navigate ] );
-	const isImportActive = activeUri === IMPORT_URI;
+	}, [ isSettingsMode, navigate, routeUri ] );
+	const closeSettings = useCallback( () => {
+		const returnUri = settingsReturnUri;
+		setSettingsReturnUri( null );
+		if ( returnUri ) {
+			navigate( {
+				to: '/$',
+				params: { _splat: returnUri },
+			} );
+			return;
+		}
+		navigate( { to: '/' } );
+	}, [ navigate, settingsReturnUri ] );
 	const toggleTrashPanel = useCallback( () => {
 		if ( collapsed ) {
 			setIsTrashPanelOpen( true );
@@ -303,6 +302,35 @@ export default function Sidebar( {
 			setIsTrashPanelOpen( false );
 		}
 	}, [ collapsed ] );
+
+	useEffect( () => {
+		if ( ! isSettingsMode ) {
+			return;
+		}
+
+		const handleKeyDown = ( event ) => {
+			if ( event.key !== 'Escape' || event.defaultPrevented ) {
+				return;
+			}
+
+			const target = event.target;
+			const targetElement =
+				target instanceof window.HTMLElement ? target : null;
+			if (
+				targetElement?.isContentEditable ||
+				targetElement?.closest( 'input, textarea, select' )
+			) {
+				return;
+			}
+
+			closeSettings();
+		};
+
+		window.addEventListener( 'keydown', handleKeyDown );
+		return () => {
+			window.removeEventListener( 'keydown', handleKeyDown );
+		};
+	}, [ closeSettings, isSettingsMode ] );
 
 	// --- Per-row selection helpers --------------------------------------
 
@@ -460,324 +488,376 @@ export default function Sidebar( {
 				/>
 			</div>
 			<div
-				className="cortext-sidebar__quick-actions"
-				role="toolbar"
-				aria-label={ __( 'Quick actions', 'cortext' ) }
+				className="cortext-sidebar__views"
+				data-settings={ isSettingsMode ? 'true' : 'false' }
 			>
-				<Button
-					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--search"
-					label={ __( 'Search or run a command', 'cortext' ) }
-					onClick={ () => openCommandPalette() }
+				<div
+					className="cortext-sidebar__view cortext-sidebar__view--main"
+					aria-hidden={ isSettingsMode }
+					{ ...( isSettingsMode ? { inert: '' } : {} ) }
 				>
-					<Icon icon={ search } size={ 16 } />
-					{ ! collapsed && (
-						<>
-							<span className="cortext-sidebar__quick-action-label">
-								{ __( 'Search or run a command', 'cortext' ) }
-							</span>
-							<kbd className="cortext-sidebar__quick-action-kbd">
-								{ commandPaletteShortcut }
-							</kbd>
-						</>
-					) }
-				</Button>
-				<Button
-					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--home"
-					label={ __( 'Home', 'cortext' ) }
-					disabled={ ! homePath || isResolvingHomePath }
-					onClick={ goHome }
-				>
-					<Icon icon={ homeIcon } size={ 16 } />
-					{ ! collapsed && <span>{ __( 'Home', 'cortext' ) }</span> }
-				</Button>
-				{ publicWebAffordances ? (
-					<Button
-						className="cortext-sidebar__quick-action cortext-sidebar__quick-action--published"
-						label={ __( 'Published', 'cortext' ) }
-						isPressed={ isPublishedActive }
-						onClick={ goPublished }
+					<div
+						className="cortext-sidebar__quick-actions"
+						role="toolbar"
+						aria-label={ __( 'Quick actions', 'cortext' ) }
 					>
-						<Icon icon={ globe } size={ 16 } />
-						{ ! collapsed && (
-							<span>{ __( 'Published', 'cortext' ) }</span>
-						) }
-					</Button>
-				) : null }
-				<Button
-					className="cortext-sidebar__quick-action cortext-sidebar__quick-action--import"
-					label={ __( 'Import', 'cortext' ) }
-					isPressed={ isImportActive }
-					onClick={ goImport }
-				>
-					<Icon icon={ upload } size={ 16 } />
-					{ ! collapsed && (
-						<span>{ __( 'Import', 'cortext' ) }</span>
-					) }
-				</Button>
-			</div>
-			{ ! collapsed && (
-				<DocumentsProvider { ...documentsHandlers }>
-					<div className="cortext-sidebar__content">
-						{ favoritesError ? (
-							<Notice
-								status="error"
-								onRemove={ () => setFavoritesError( null ) }
-							>
-								{ favoritesError }
-							</Notice>
-						) : null }
-						{ duplicateNotice ? (
-							<Notice
-								status="warning"
-								onRemove={ () => setDuplicateNotice( null ) }
-							>
-								{ duplicateNotice }
-							</Notice>
-						) : null }
-						<SidebarSection
-							id="recents"
-							title={ __( 'Recents', 'cortext' ) }
-							isCollapsed={ isSectionCollapsed( 'recents' ) }
-							onToggle={ () => toggleSection( 'recents' ) }
+						<Button
+							className="cortext-sidebar__quick-action cortext-sidebar__quick-action--search"
+							label={ __( 'Search or run a command', 'cortext' ) }
+							onClick={ () => openCommandPalette() }
 						>
-							<SidebarRecents />
-						</SidebarSection>
-
-						<SidebarSection
-							id="favorites"
-							title={ __( 'Favorites', 'cortext' ) }
-							isCollapsed={ isSectionCollapsed( 'favorites' ) }
-							onToggle={ () => toggleSection( 'favorites' ) }
-						>
-							<SidebarFavorites
-								favorites={ favorites }
-								pages={ pages }
-								collections={ collections ?? [] }
-								isResolving={ isResolvingFavorites }
-								isResolvingItems={
-									isResolvingPages || isResolvingCollections
-								}
-								isDisabled={ areFavoriteActionsDisabled }
-								onSelect={ selectFavorite }
-								onRemove={ toggleFavorite }
-								onReorder={ reorderFavorites }
-							/>
-						</SidebarSection>
-
-						<DndContext
-							sensors={ sensors }
-							collisionDetection={ pointerWithin }
-							onDragStart={ handlers.handleDragStart }
-							onDragOver={ handlers.handleDragOver }
-							onDragEnd={ handlers.handleDragEnd }
-							onDragCancel={ handlers.handleDragCancel }
-						>
-							<SidebarSection
-								id="pages"
-								title={ __( 'Documents', 'cortext' ) }
-								isCollapsed={ isSectionCollapsed( 'pages' ) }
-								onToggle={ () => toggleSection( 'pages' ) }
-								actions={
-									<div className="cortext-sidebar__split-action">
-										<Button
-											className="cortext-sidebar__section-action cortext-sidebar__split-action-primary"
-											icon={ plus }
-											size="small"
-											label={ __(
-												'New document',
-												'cortext'
-											) }
-											onClick={ createRootPage }
-										/>
-										<Dropdown
-											contentClassName="cortext-sidebar__create-menu"
-											popoverProps={ {
-												placement: 'bottom-end',
-											} }
-											renderToggle={ ( {
-												isOpen,
-												onToggle,
-											} ) => (
-												<Button
-													className="cortext-sidebar__section-action cortext-sidebar__split-action-toggle"
-													icon={ chevronDown }
-													size="small"
-													label={ __(
-														'Create a document or collection',
-														'cortext'
-													) }
-													onClick={ onToggle }
-													isPressed={ isOpen }
-													aria-expanded={ isOpen }
-												/>
-											) }
-											renderContent={ ( { onClose } ) => (
-												<MenuGroup>
-													<MenuItem
-														icon={ page }
-														onClick={ () => {
-															createRootPage();
-															onClose();
-														} }
-													>
-														{ __(
-															'New document',
-															'cortext'
-														) }
-													</MenuItem>
-													<MenuItem
-														icon={ collectionIcon }
-														onClick={ () => {
-															createRootCollection();
-															onClose();
-														} }
-													>
-														{ __(
-															'New collection',
-															'cortext'
-														) }
-													</MenuItem>
-												</MenuGroup>
-											) }
-										/>
-									</div>
-								}
-							>
-								{ isResolvingPages &&
-									pages.length === 0 &&
-									showPagesSkeleton && (
-										<SidebarListSkeleton itemCount={ 1 } />
-									) }
-								{ ! isResolvingPages && pages.length === 0 && (
-									<p className="cortext-sidebar__empty">
-										{ __( 'Nothing here yet.', 'cortext' ) }
-									</p>
-								) }
-								{ rootBranch.error && (
-									<p
-										className="cortext-sidebar__row-error"
-										role="alert"
-									>
+							<Icon icon={ search } size={ 16 } />
+							{ ! collapsed && (
+								<>
+									<span className="cortext-sidebar__quick-action-label">
 										{ __(
-											"We couldn't load these documents.",
+											'Search or run a command',
 											'cortext'
 										) }
-									</p>
-								) }
+									</span>
+									<kbd className="cortext-sidebar__quick-action-kbd">
+										{ commandPaletteShortcut }
+									</kbd>
+								</>
+							) }
+						</Button>
+						<Button
+							className="cortext-sidebar__quick-action cortext-sidebar__quick-action--home"
+							label={ __( 'Home', 'cortext' ) }
+							disabled={ ! homePath || isResolvingHomePath }
+							onClick={ goHome }
+						>
+							<Icon icon={ homeIcon } size={ 16 } />
+							{ ! collapsed && (
+								<span>{ __( 'Home', 'cortext' ) }</span>
+							) }
+						</Button>
+					</div>
+					{ ! collapsed && (
+						<DocumentsProvider { ...documentsHandlers }>
+							<div className="cortext-sidebar__content">
+								{ favoritesError ? (
+									<Notice
+										status="error"
+										onRemove={ () =>
+											setFavoritesError( null )
+										}
+									>
+										{ favoritesError }
+									</Notice>
+								) : null }
+								{ duplicateNotice ? (
+									<Notice
+										status="warning"
+										onRemove={ () =>
+											setDuplicateNotice( null )
+										}
+									>
+										{ duplicateNotice }
+									</Notice>
+								) : null }
+								<SidebarSection
+									id="recents"
+									title={ __( 'Recents', 'cortext' ) }
+									isCollapsed={ isSectionCollapsed(
+										'recents'
+									) }
+									onToggle={ () =>
+										toggleSection( 'recents' )
+									}
+								>
+									<SidebarRecents />
+								</SidebarSection>
 
-								<ul className="cortext-sidebar__list">
-									{ tree.map( ( node ) => (
-										<DocumentRow
-											key={ node.page.id }
-											record={ node.page }
-											childNodes={ node.children }
-											childBranch={ node.branch }
-											depth={ 0 }
-											{ ...rowChrome }
-										/>
-									) ) }
-									{ rootBranch.hasResolved &&
-										rootBranch.page <
-											rootBranch.totalPages && (
-											<li
-												className="cortext-sidebar__node cortext-sidebar__load-more-node"
-												style={ {
-													'--cortext-depth': 0,
-												} }
-											>
+								<SidebarSection
+									id="favorites"
+									title={ __( 'Favorites', 'cortext' ) }
+									isCollapsed={ isSectionCollapsed(
+										'favorites'
+									) }
+									onToggle={ () =>
+										toggleSection( 'favorites' )
+									}
+								>
+									<SidebarFavorites
+										favorites={ favorites }
+										pages={ pages }
+										collections={ collections ?? [] }
+										isResolving={ isResolvingFavorites }
+										isResolvingItems={
+											isResolvingPages ||
+											isResolvingCollections
+										}
+										isDisabled={
+											areFavoriteActionsDisabled
+										}
+										onSelect={ selectFavorite }
+										onRemove={ toggleFavorite }
+										onReorder={ reorderFavorites }
+									/>
+								</SidebarSection>
+
+								<DndContext
+									sensors={ sensors }
+									collisionDetection={ pointerWithin }
+									onDragStart={ handlers.handleDragStart }
+									onDragOver={ handlers.handleDragOver }
+									onDragEnd={ handlers.handleDragEnd }
+									onDragCancel={ handlers.handleDragCancel }
+								>
+									<SidebarSection
+										id="pages"
+										title={ __( 'Documents', 'cortext' ) }
+										isCollapsed={ isSectionCollapsed(
+											'pages'
+										) }
+										onToggle={ () =>
+											toggleSection( 'pages' )
+										}
+										actions={
+											<div className="cortext-sidebar__split-action">
 												<Button
-													className="cortext-sidebar__load-more"
-													size="compact"
-													isBusy={
-														rootBranch.isLoading
-													}
-													disabled={
-														rootBranch.isLoading
-													}
-													onClick={ () =>
-														loadMore(
-															ROOT_PARENT_ID
-														)
-													}
-												>
-													{ __(
-														'Show more',
+													className="cortext-sidebar__section-action cortext-sidebar__split-action-primary"
+													icon={ plus }
+													size="small"
+													label={ __(
+														'New document',
 														'cortext'
 													) }
-												</Button>
-											</li>
+													onClick={ createRootPage }
+												/>
+												<Dropdown
+													contentClassName="cortext-sidebar__create-menu"
+													popoverProps={ {
+														placement: 'bottom-end',
+													} }
+													renderToggle={ ( {
+														isOpen,
+														onToggle,
+													} ) => (
+														<Button
+															className="cortext-sidebar__section-action cortext-sidebar__split-action-toggle"
+															icon={ chevronDown }
+															size="small"
+															label={ __(
+																'Create a document or collection',
+																'cortext'
+															) }
+															onClick={ onToggle }
+															isPressed={ isOpen }
+															aria-expanded={
+																isOpen
+															}
+														/>
+													) }
+													renderContent={ ( {
+														onClose,
+													} ) => (
+														<MenuGroup>
+															<MenuItem
+																icon={ page }
+																onClick={ () => {
+																	createRootPage();
+																	onClose();
+																} }
+															>
+																{ __(
+																	'New document',
+																	'cortext'
+																) }
+															</MenuItem>
+															<MenuItem
+																icon={
+																	collectionIcon
+																}
+																onClick={ () => {
+																	createRootCollection();
+																	onClose();
+																} }
+															>
+																{ __(
+																	'New collection',
+																	'cortext'
+																) }
+															</MenuItem>
+														</MenuGroup>
+													) }
+												/>
+											</div>
+										}
+									>
+										{ isResolvingPages &&
+											pages.length === 0 &&
+											showPagesSkeleton && (
+												<SidebarListSkeleton
+													itemCount={ 1 }
+												/>
+											) }
+										{ ! isResolvingPages &&
+											pages.length === 0 && (
+												<p className="cortext-sidebar__empty">
+													{ __(
+														'Nothing here yet.',
+														'cortext'
+													) }
+												</p>
+											) }
+										{ rootBranch.error && (
+											<p
+												className="cortext-sidebar__row-error"
+												role="alert"
+											>
+												{ __(
+													"We couldn't load these documents.",
+													'cortext'
+												) }
+											</p>
 										) }
-								</ul>
-							</SidebarSection>
 
-							<DragOverlay>
-								{ draggedPage ? (
-									<div className="cortext-sidebar__drag-preview">
-										{ draggedPage.title?.rendered?.trim() ||
-											__( '(untitled)', 'cortext' ) }
-									</div>
-								) : null }
-							</DragOverlay>
-						</DndContext>
-					</div>
-					{ isTrashPanelOpen && (
-						<section
-							id="cortext-sidebar-trash-panel"
-							className="cortext-sidebar__trash-panel"
-							aria-label={ __( 'Trash', 'cortext' ) }
-						>
-							<div className="cortext-sidebar__trash-panel-header">
-								<h2 className="cortext-sidebar__section-title">
-									{ __( 'Trash', 'cortext' ) }
-								</h2>
+										<ul className="cortext-sidebar__list">
+											{ tree.map( ( node ) => (
+												<DocumentRow
+													key={ node.page.id }
+													record={ node.page }
+													childNodes={ node.children }
+													childBranch={ node.branch }
+													depth={ 0 }
+													{ ...rowChrome }
+												/>
+											) ) }
+											{ rootBranch.hasResolved &&
+												rootBranch.page <
+													rootBranch.totalPages && (
+													<li
+														className="cortext-sidebar__node cortext-sidebar__load-more-node"
+														style={ {
+															'--cortext-depth': 0,
+														} }
+													>
+														<Button
+															className="cortext-sidebar__load-more"
+															size="compact"
+															isBusy={
+																rootBranch.isLoading
+															}
+															disabled={
+																rootBranch.isLoading
+															}
+															onClick={ () =>
+																loadMore(
+																	ROOT_PARENT_ID
+																)
+															}
+														>
+															{ __(
+																'Show more',
+																'cortext'
+															) }
+														</Button>
+													</li>
+												) }
+										</ul>
+									</SidebarSection>
+
+									<DragOverlay>
+										{ draggedPage ? (
+											<div className="cortext-sidebar__drag-preview">
+												{ draggedPage.title?.rendered?.trim() ||
+													__(
+														'(untitled)',
+														'cortext'
+													) }
+											</div>
+										) : null }
+									</DragOverlay>
+								</DndContext>
 							</div>
-							<SidebarTrash
-								activePages={ pages }
-								selectedId={ selectedId }
-								selectedCollectionId={ selectedCollectionId }
-								onSelect={ onSelect }
-								trashedDocumentsState={ trashedDocumentsState }
-							/>
-						</section>
+							{ isTrashPanelOpen && (
+								<section
+									id="cortext-sidebar-trash-panel"
+									className="cortext-sidebar__trash-panel"
+									aria-label={ __( 'Trash', 'cortext' ) }
+								>
+									<div className="cortext-sidebar__trash-panel-header">
+										<h2 className="cortext-sidebar__section-title">
+											{ __( 'Trash', 'cortext' ) }
+										</h2>
+									</div>
+									<SidebarTrash
+										activePages={ pages }
+										selectedId={ selectedId }
+										selectedCollectionId={
+											selectedCollectionId
+										}
+										onSelect={ onSelect }
+										trashedDocumentsState={
+											trashedDocumentsState
+										}
+									/>
+								</section>
+							) }
+						</DocumentsProvider>
 					) }
-				</DocumentsProvider>
-			) }
-			<div className="cortext-sidebar__footer">
-				<div className="cortext-sidebar__footer-group cortext-sidebar__footer-group--navigation">
-					<Button
-						className="cortext-sidebar__footer-button cortext-sidebar__trash-footer"
-						label={ trashButtonLabel }
-						aria-expanded={ ! collapsed && isTrashPanelOpen }
-						aria-controls="cortext-sidebar-trash-panel"
-						isPressed={ ! collapsed && isTrashPanelOpen }
-						onClick={ toggleTrashPanel }
-					>
-						<Icon icon={ trashIcon } size={ 20 } />
-						{ trashCount > 0 && (
-							<span
-								className="cortext-sidebar__footer-count"
-								aria-hidden="true"
+					<div className="cortext-sidebar__footer">
+						<div className="cortext-sidebar__footer-group cortext-sidebar__footer-group--navigation">
+							<Button
+								className="cortext-sidebar__footer-button cortext-sidebar__trash-footer"
+								label={ trashButtonLabel }
+								aria-expanded={
+									! collapsed && isTrashPanelOpen
+								}
+								aria-controls="cortext-sidebar-trash-panel"
+								isPressed={ ! collapsed && isTrashPanelOpen }
+								onClick={ toggleTrashPanel }
 							>
-								{ trashCount > 99 ? '99+' : trashCount }
-							</span>
-						) }
-					</Button>
-				</div>
-				<div className="cortext-sidebar__footer-spacer" />
-				<div
-					className="cortext-sidebar__footer-separator"
-					aria-hidden="true"
-				/>
-				<div className="cortext-sidebar__footer-group cortext-sidebar__footer-group--preferences">
-					<ThemeToggle />
-					{ wordpressAffordances ? (
-						<Button
-							className="cortext-sidebar__back"
-							label={ __( 'Go to WordPress', 'cortext' ) }
-							href={ adminUrl }
-							icon={ <Icon icon={ wordpress } size={ 24 } /> }
+								<Icon icon={ trashIcon } size={ 20 } />
+								{ trashCount > 0 && (
+									<span
+										className="cortext-sidebar__footer-count"
+										aria-hidden="true"
+									>
+										{ trashCount > 99 ? '99+' : trashCount }
+									</span>
+								) }
+							</Button>
+						</div>
+						<div className="cortext-sidebar__footer-spacer" />
+						<div
+							className="cortext-sidebar__footer-separator"
+							aria-hidden="true"
 						/>
-					) : null }
+						<div className="cortext-sidebar__footer-group cortext-sidebar__footer-group--preferences">
+							<Button
+								className="cortext-sidebar__footer-button cortext-sidebar__settings-toggle"
+								label={ __( 'Settings', 'cortext' ) }
+								isPressed={ isSettingsMode }
+								onClick={ openSettings }
+							>
+								<Icon icon={ cog } size={ 20 } />
+							</Button>
+							<ThemeToggle />
+							{ wordpressAffordances ? (
+								<Button
+									className="cortext-sidebar__back"
+									label={ __( 'Go to WordPress', 'cortext' ) }
+									href={ adminUrl }
+									icon={
+										<Icon icon={ wordpress } size={ 24 } />
+									}
+								/>
+							) : null }
+						</div>
+					</div>
+				</div>
+				<div
+					className="cortext-sidebar__view cortext-sidebar__view--settings"
+					aria-hidden={ ! isSettingsMode }
+					{ ...( isSettingsMode ? {} : { inert: '' } ) }
+				>
+					<SidebarSettingsNav
+						collapsed={ collapsed }
+						onBack={ closeSettings }
+					/>
 				</div>
 			</div>
 			{ ! collapsed && (

--- a/src/components/Sidebar.scss
+++ b/src/components/Sidebar.scss
@@ -106,6 +106,59 @@
 		color: var(--cortext-text-strong);
 	}
 
+	&__views {
+		position: relative;
+		flex: 1 1 auto;
+		min-height: 0;
+		display: grid;
+		overflow: hidden;
+	}
+
+	&__view {
+		grid-area: 1 / 1;
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		min-height: 0;
+		transition: transform 160ms ease, opacity 160ms ease;
+	}
+
+	&__view--settings {
+		transform: translateX(100%);
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	&__views[data-settings="true"] {
+
+		.cortext-sidebar__view--main {
+			transform: translateX(-25%);
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		.cortext-sidebar__view--settings {
+			transform: translateX(0);
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+
+		&__view {
+			transition: none;
+		}
+	}
+
+	&__settings-nav {
+		align-items: stretch;
+	}
+
+	&__settings-title {
+		width: 100%;
+	}
+
 	&__quick-action-label {
 		flex: 1 1 auto;
 		min-width: 0;

--- a/src/components/SidebarSettingsNav.js
+++ b/src/components/SidebarSettingsNav.js
@@ -1,0 +1,76 @@
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { Button, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronLeft, globe, upload } from '@wordpress/icons';
+
+import {
+	SETTINGS_IMPORT_URI,
+	SETTINGS_PUBLISHED_URI,
+} from '../router/useResolveEntity';
+import { isPublicWebAffordancesEnabled } from '../settings';
+
+const NAV_ITEMS = [
+	{
+		key: 'import',
+		uri: SETTINGS_IMPORT_URI,
+		icon: upload,
+		label: () => __( 'Import', 'cortext' ),
+	},
+	{
+		key: 'published',
+		uri: SETTINGS_PUBLISHED_URI,
+		icon: globe,
+		label: () => __( 'Published', 'cortext' ),
+		isEnabled: isPublicWebAffordancesEnabled,
+	},
+];
+
+export default function SidebarSettingsNav( { collapsed, onBack } ) {
+	const navigate = useNavigate();
+	const params = useParams( { strict: false } );
+	const activeUri = params._splat ?? '';
+	const items = NAV_ITEMS.filter(
+		( item ) => ! item.isEnabled || item.isEnabled()
+	);
+
+	return (
+		<nav
+			className="cortext-sidebar__quick-actions cortext-sidebar__settings-nav"
+			aria-label={ __( 'Settings', 'cortext' ) }
+		>
+			<Button
+				className="cortext-sidebar__quick-action cortext-sidebar__settings-back"
+				label={ __( 'Back', 'cortext' ) }
+				onClick={ onBack }
+			>
+				<Icon icon={ chevronLeft } size={ 16 } />
+				{ ! collapsed && <span>{ __( 'Back', 'cortext' ) }</span> }
+			</Button>
+			{ ! collapsed && (
+				<h2 className="cortext-sidebar__section-title cortext-sidebar__settings-title">
+					{ __( 'Settings', 'cortext' ) }
+				</h2>
+			) }
+			{ items.map( ( item ) => {
+				const label = item.label();
+				return (
+					<Button
+						key={ item.key }
+						className="cortext-sidebar__quick-action cortext-sidebar__settings-item"
+						label={ label }
+						isPressed={ activeUri === item.uri }
+						onClick={ () =>
+							navigate( {
+								to: '/$',
+								params: { _splat: item.uri },
+							} )
+						}
+					>
+						<Icon icon={ item.icon } size={ 16 } />
+						{ ! collapsed && <span>{ label }</span> }
+					</Button>
+				);
+			} ) }
+		</nav>
+	);
+}

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -293,6 +293,18 @@ export default function EntityRoute( { history } ) {
 	] );
 
 	useEffect( () => {
+		if ( target.kind !== 'redirect' ) {
+			return;
+		}
+
+		navigate( {
+			to: '/$',
+			params: { _splat: target.to },
+			replace: true,
+		} );
+	}, [ target, navigate ] );
+
+	useEffect( () => {
 		if ( target.kind !== 'document' || target.id === null ) {
 			return;
 		}

--- a/src/router/entityRouteReducer.js
+++ b/src/router/entityRouteReducer.js
@@ -1,26 +1,31 @@
 import {
 	IMPORT_URI,
 	PUBLISHED_DOCUMENTS_URI,
+	SETTINGS_IMPORT_URI,
+	SETTINGS_PUBLISHED_URI,
+	SETTINGS_URI,
 	parseIdFromUri,
 } from './useResolveEntity';
 
-// Possible targets:
-//   - `published`: singleton splat for the Published documents screen.
-//   - `import`:    singleton splat for the Import screen.
-//   - `empty`:     no splat (workspace home).
-//   - `document`:  anything else with an id. Collections, pages, and rows all
-//                  fall here; the resolver discovers each document's
-//                  capabilities via the locator endpoint.
 export function parseTarget( splat, options = {} ) {
 	const { publicWebAffordances = true } = options;
 	if ( splat === PUBLISHED_DOCUMENTS_URI ) {
-		if ( ! publicWebAffordances ) {
-			return { kind: 'empty', tail: '' };
-		}
-		return { kind: 'published', tail: '' };
+		return { kind: 'redirect', to: SETTINGS_PUBLISHED_URI, tail: '' };
 	}
 	if ( splat === IMPORT_URI ) {
+		return { kind: 'redirect', to: SETTINGS_IMPORT_URI, tail: '' };
+	}
+	if ( splat === SETTINGS_URI ) {
+		return { kind: 'redirect', to: SETTINGS_IMPORT_URI, tail: '' };
+	}
+	if ( splat === SETTINGS_IMPORT_URI ) {
 		return { kind: 'import', tail: '' };
+	}
+	if ( splat === SETTINGS_PUBLISHED_URI ) {
+		if ( ! publicWebAffordances ) {
+			return { kind: 'redirect', to: SETTINGS_IMPORT_URI, tail: '' };
+		}
+		return { kind: 'published', tail: '' };
 	}
 	if ( ! splat ) {
 		return { kind: 'empty', tail: '' };
@@ -118,6 +123,8 @@ export function init( target ) {
 		active = { kind: 'published' };
 	} else if ( target.kind === 'import' ) {
 		active = { kind: 'import' };
+	} else if ( target.kind === 'redirect' ) {
+		active = { kind: 'loading' };
 	} else if ( target.kind === 'document' && target.id === null ) {
 		active = { kind: 'document-not-found' };
 	} else {

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -136,13 +136,10 @@ export function computeDocumentUri( entity ) {
 	return slug ? `${ slug }-${ entity.id }` : `${ entity.id }`;
 }
 
-// Singleton splat for the Published documents screen. The route reducer
-// matches the splat exactly; trailing segments fall through to the document
-// resolver and end up at "not found".
+export const SETTINGS_URI = 'settings';
+export const SETTINGS_IMPORT_URI = 'settings/import';
+export const SETTINGS_PUBLISHED_URI = 'settings/published';
 export const PUBLISHED_DOCUMENTS_URI = 'published';
-
-// Singleton splat for the Import screen, matched exactly like
-// PUBLISHED_DOCUMENTS_URI above.
 export const IMPORT_URI = 'import';
 
 // Strips the prefix from a splat URI and returns { prefix, tail }.
@@ -155,4 +152,8 @@ export function parseSplatUri( uri ) {
 		prefix: uri.slice( 0, slash ),
 		tail: uri.slice( slash + 1 ),
 	};
+}
+
+export function isSettingsUri( uri ) {
+	return uri === SETTINGS_URI || parseSplatUri( uri ).prefix === SETTINGS_URI;
 }

--- a/tests/js/components/SidebarSettingsNav.test.js
+++ b/tests/js/components/SidebarSettingsNav.test.js
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+let mockRouteUri = 'settings/import';
+let mockPublicWebAffordances = true;
+const mockNavigate = jest.fn();
+
+jest.mock( '@tanstack/react-router', () => ( {
+	useNavigate: () => mockNavigate,
+	useParams: () => ( { _splat: mockRouteUri } ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, label, isPressed, onClick, ...props } ) => (
+		<button
+			type="button"
+			aria-label={ label }
+			aria-pressed={ isPressed }
+			onClick={ onClick }
+			{ ...props }
+		>
+			{ children }
+		</button>
+	),
+	Icon: ( { icon } ) => <span data-testid={ `icon-${ icon }` } />,
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	chevronLeft: 'chevron-left',
+	globe: 'globe',
+	upload: 'upload',
+} ) );
+
+jest.mock( '../../../src/settings', () => ( {
+	isPublicWebAffordancesEnabled: () => mockPublicWebAffordances,
+} ) );
+
+import SidebarSettingsNav from '../../../src/components/SidebarSettingsNav';
+
+beforeEach( () => {
+	mockNavigate.mockReset();
+	mockRouteUri = 'settings/import';
+	mockPublicWebAffordances = true;
+} );
+
+describe( 'SidebarSettingsNav', () => {
+	it( 'calls onBack when Back is clicked', () => {
+		const onBack = jest.fn();
+		render( <SidebarSettingsNav collapsed={ false } onBack={ onBack } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Back' } ) );
+
+		expect( onBack ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'keeps Import visible and opens settings/import', () => {
+		render(
+			<SidebarSettingsNav collapsed={ false } onBack={ jest.fn() } />
+		);
+
+		const importButton = screen.getByRole( 'button', { name: 'Import' } );
+		expect( importButton ).toHaveAttribute( 'aria-pressed', 'true' );
+
+		fireEvent.click( importButton );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'settings/import' },
+		} );
+	} );
+
+	it( 'only shows Published when publishing tools are available', () => {
+		const { rerender } = render(
+			<SidebarSettingsNav collapsed={ false } onBack={ jest.fn() } />
+		);
+		expect(
+			screen.getByRole( 'button', { name: 'Published' } )
+		).toBeInTheDocument();
+
+		mockPublicWebAffordances = false;
+		rerender(
+			<SidebarSettingsNav collapsed={ false } onBack={ jest.fn() } />
+		);
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Published' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'presses the item for the current settings page', () => {
+		mockRouteUri = 'settings/published';
+
+		render(
+			<SidebarSettingsNav collapsed={ false } onBack={ jest.fn() } />
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'Import' } )
+		).toHaveAttribute( 'aria-pressed', 'false' );
+		expect(
+			screen.getByRole( 'button', { name: 'Published' } )
+		).toHaveAttribute( 'aria-pressed', 'true' );
+	} );
+} );

--- a/tests/js/entityRouteReducer.test.js
+++ b/tests/js/entityRouteReducer.test.js
@@ -10,6 +10,7 @@ const documentTarget = ( id ) => ( {
 	id,
 	tail: `${ id }`,
 } );
+const redirectTarget = ( to ) => ( { kind: 'redirect', to, tail: '' } );
 const publishedTarget = { kind: 'published', tail: '' };
 const importTarget = { kind: 'import', tail: '' };
 
@@ -24,35 +25,66 @@ function activate( state, target ) {
 
 describe( 'EntityRoute reducer', () => {
 	describe( 'parseTarget', () => {
-		it( 'maps a bare `published` splat to the published kind', () => {
-			expect( parseTarget( 'published' ) ).toEqual( {
-				kind: 'published',
-				tail: '',
-			} );
+		it( 'sends legacy `published` links to settings/published', () => {
+			expect( parseTarget( 'published' ) ).toEqual(
+				redirectTarget( 'settings/published' )
+			);
 		} );
 
-		it( 'treats `published` as empty when public web affordances are off', () => {
+		it( 'keeps legacy `published` links on the Published settings page before feature checks', () => {
 			expect(
 				parseTarget( 'published', { publicWebAffordances: false } )
-			).toEqual( {
-				kind: 'empty',
-				tail: '',
-			} );
+			).toEqual( redirectTarget( 'settings/published' ) );
 		} );
 
 		it( 'does not match `published/<anything>` (falls through to document)', () => {
 			expect( parseTarget( 'published/foo' ).kind ).toBe( 'document' );
 		} );
 
-		it( 'maps a bare `import` splat to the import kind', () => {
-			expect( parseTarget( 'import' ) ).toEqual( {
+		it( 'sends legacy `import` links to settings/import', () => {
+			expect( parseTarget( 'import' ) ).toEqual(
+				redirectTarget( 'settings/import' )
+			);
+		} );
+
+		it( 'leaves `import/<anything>` for document routing', () => {
+			expect( parseTarget( 'import/foo' ).kind ).toBe( 'document' );
+		} );
+
+		it( 'opens Import from the Settings landing route', () => {
+			expect( parseTarget( 'settings' ) ).toEqual(
+				redirectTarget( 'settings/import' )
+			);
+		} );
+
+		it( 'opens Import from settings/import', () => {
+			expect( parseTarget( 'settings/import' ) ).toEqual( {
 				kind: 'import',
 				tail: '',
 			} );
 		} );
 
-		it( 'does not match `import/<anything>` (falls through to document)', () => {
-			expect( parseTarget( 'import/foo' ).kind ).toBe( 'document' );
+		it( 'opens Published from settings/published when publishing tools are available', () => {
+			expect( parseTarget( 'settings/published' ) ).toEqual( {
+				kind: 'published',
+				tail: '',
+			} );
+		} );
+
+		it( 'falls back to Import when Published is unavailable', () => {
+			expect(
+				parseTarget( 'settings/published', {
+					publicWebAffordances: false,
+				} )
+			).toEqual( redirectTarget( 'settings/import' ) );
+		} );
+
+		it( 'leaves unknown settings pages for document routing', () => {
+			expect( parseTarget( 'settings/foo' ) ).toEqual( {
+				kind: 'document',
+				id: null,
+				tail: 'settings/foo',
+			} );
 		} );
 
 		it( 'maps an empty splat to the empty kind', () => {
@@ -101,6 +133,14 @@ describe( 'EntityRoute reducer', () => {
 		it( 'starts an import target on the import pane', () => {
 			expect( init( importTarget ).active ).toEqual( {
 				kind: 'import',
+			} );
+		} );
+
+		it( 'starts a deep-linked redirect on the loading pane', () => {
+			expect(
+				init( redirectTarget( 'settings/import' ) ).active
+			).toEqual( {
+				kind: 'loading',
 			} );
 		} );
 
@@ -178,6 +218,21 @@ describe( 'EntityRoute reducer', () => {
 				target: importTarget,
 			} );
 			expect( next.active ).toEqual( { kind: 'import' } );
+		} );
+
+		it( 'keeps the current pane visible while redirecting', () => {
+			const state = activate(
+				init( documentTarget( 1 ) ),
+				documentTarget( 1 )
+			);
+			const next = reducer( state, {
+				type: 'TARGET_CHANGED',
+				target: redirectTarget( 'settings/import' ),
+			} );
+			expect( next.target ).toEqual(
+				redirectTarget( 'settings/import' )
+			);
+			expect( next.active ).toBe( state.active );
 		} );
 
 		it( 'switches to empty immediately', () => {

--- a/tests/js/useResolveEntity.test.js
+++ b/tests/js/useResolveEntity.test.js
@@ -14,6 +14,7 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 import apiFetch from '@wordpress/api-fetch';
 import {
 	computeDocumentUri,
+	isSettingsUri,
 	parseIdFromUri,
 	useResolveDocument,
 } from '../../src/router/useResolveEntity';
@@ -46,6 +47,22 @@ describe( 'parseIdFromUri', () => {
 	it( 'returns null for a nullish uri', () => {
 		expect( parseIdFromUri( undefined ) ).toBeNull();
 		expect( parseIdFromUri( null ) ).toBeNull();
+	} );
+} );
+
+describe( 'isSettingsUri', () => {
+	it( 'recognizes the Settings landing route', () => {
+		expect( isSettingsUri( 'settings' ) ).toBe( true );
+	} );
+
+	it( 'recognizes Settings child routes', () => {
+		expect( isSettingsUri( 'settings/import' ) ).toBe( true );
+	} );
+
+	it( 'ignores lookalike document uris', () => {
+		expect( isSettingsUri( 'settings-42' ) ).toBe( false );
+		expect( isSettingsUri( 'about-us-42' ) ).toBe( false );
+		expect( isSettingsUri( '' ) ).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
## What

Adds a new Settings view mode and moves Import and Published to its sidebar, which can be opened with a cog icon.

Old links keep working: `?p=/import`, `?p=/published`, and `?p=/settings` now land on the new settings routes.

## Why

This opens the door to add more settings. Import and Published were too permanent in the quick actions, and they now have a proper place to be.

## Testing Instructions

1. Open Cortext and check that the sidebar quick actions show only Search and Home.
2. Click the Settings gear in the sidebar footer.
3. Confirm the settings nav slides in and shows Back plus Import.
4. Open Import and Published, when available, and confirm the canvas changes to the right screen.
5. Open Settings from a document, click Back, and confirm you return to that document.
6. Open Settings again, press Escape outside a text field, and confirm Settings closes.
7. Visit `?p=/import`, `?p=/published`, and `?p=/settings` and confirm each redirects to the new Settings route.

## Screen recording

https://github.com/user-attachments/assets/98711ffa-9d31-448d-abd6-a846c8ced8b2

