### PR TITLE
Add experiment controls to Cortext settings

### DIFF
--- a/includes/Admin/Screen.php
+++ b/includes/Admin/Screen.php
@@ -18,6 +18,7 @@ namespace Cortext\Admin;
 defined( 'ABSPATH' ) || exit;
 
 use Cortext\Runtime\Features;
+use Cortext\Runtime\Experiments;
 use Cortext\Theming\Preferences;
 
 final class Screen {
@@ -65,6 +66,24 @@ final class Screen {
 		return CORTEXT_URL . self::ICON_PATH;
 	}
 
+	/**
+	 * Returns the settings passed to the React shell at startup.
+	 *
+	 * @return array{adminUrl:string,capabilities:array{manageOptions:bool},experiments:array<string,bool>,features:array<string,bool>,iconUrl:string,menuSlug:string}
+	 */
+	public function client_settings(): array {
+		return array(
+			'adminUrl'     => admin_url(),
+			'capabilities' => array(
+				'manageOptions' => current_user_can( 'manage_options' ),
+			),
+			'experiments'  => ( new Experiments() )->to_client_settings(),
+			'features'     => ( new Features() )->to_client_settings(),
+			'iconUrl'      => $this->icon_url(),
+			'menuSlug'     => self::MENU_SLUG,
+		);
+	}
+
 	public function enqueue_assets( string $hook_suffix ): void {
 		if ( self::HOOK_SUFFIX !== $hook_suffix ) {
 			return;
@@ -103,14 +122,7 @@ final class Screen {
 
 		wp_add_inline_script(
 			self::SCRIPT_HANDLE,
-			'window.cortextSettings = ' . wp_json_encode(
-				array(
-					'adminUrl' => admin_url(),
-					'features' => ( new Features() )->to_client_settings(),
-					'iconUrl'  => $this->icon_url(),
-					'menuSlug' => self::MENU_SLUG,
-				)
-			) . ';',
+			'window.cortextSettings = ' . wp_json_encode( $this->client_settings() ) . ';',
 			'before'
 		);
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -30,6 +30,7 @@ use Cortext\PostType\TrashCascade;
 use Cortext\Rest\BacklinksController;
 use Cortext\Rest\DocumentLocatorController;
 use Cortext\Rest\DocumentsController;
+use Cortext\Rest\ExperimentsController;
 use Cortext\Rest\FavoritesController;
 use Cortext\Rest\FieldsController;
 use Cortext\Notion\Importer as NotionImporter;
@@ -78,6 +79,7 @@ final class Plugin {
 		( new BacklinksController() )->register();
 		( new DocumentLocatorController() )->register();
 		( new DocumentsController( null, $trash_cascade ) )->register();
+		( new ExperimentsController() )->register();
 		( new PostLocksController() )->register();
 		( new RecentsController() )->register();
 		( new RowsController() )->register();

--- a/includes/Rest/ExperimentsController.php
+++ b/includes/Rest/ExperimentsController.php
@@ -75,7 +75,7 @@ final class ExperimentsController {
 		if ( ! is_array( $enabled ) ) {
 			return new WP_Error(
 				'cortext_experiments_invalid_payload',
-				__( 'Experiment settings must be an object.', 'cortext' ),
+				__( 'Send experiment settings as an object.', 'cortext' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/includes/Rest/ExperimentsController.php
+++ b/includes/Rest/ExperimentsController.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * REST endpoint for site-wide Cortext experiments.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\Runtime\Experiments;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class ExperimentsController {
+
+	private const NAMESPACE = 'cortext/v1';
+
+	private Experiments $experiments;
+
+	public function __construct( ?Experiments $experiments = null ) {
+		$this->experiments = $experiments ?? new Experiments();
+	}
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/experiments',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_experiments' ),
+					'permission_callback' => array( $this, 'can_read' ),
+				),
+				array(
+					'methods'             => 'PUT',
+					'callback'            => array( $this, 'update_experiments' ),
+					'permission_callback' => array( $this, 'can_manage' ),
+					'args'                => array(
+						'enabled' => array(
+							'type'                 => 'object',
+							'required'             => true,
+							'additionalProperties' => array(
+								'type' => 'boolean',
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	public function can_read(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	public function can_manage(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	public function get_experiments(): WP_REST_Response {
+		return new WP_REST_Response( $this->response_data(), 200 );
+	}
+
+	public function update_experiments( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$enabled = $request->get_param( 'enabled' );
+		if ( ! is_array( $enabled ) ) {
+			return new WP_Error(
+				'cortext_experiments_invalid_payload',
+				__( 'Experiment settings must be an object.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$updated = $this->experiments->update( $enabled );
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+
+		return new WP_REST_Response( $this->response_data(), 200 );
+	}
+
+	/**
+	 * Builds the REST response payload.
+	 *
+	 * @return array{canManage:bool,experiments:array<int,array{id:string,label:string,description:string,group:string,enabled:bool}>}
+	 */
+	private function response_data(): array {
+		return array(
+			'canManage'   => current_user_can( 'manage_options' ),
+			'experiments' => $this->experiments->list(),
+		);
+	}
+}

--- a/includes/Runtime/Experiments.php
+++ b/includes/Runtime/Experiments.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Registry and stored settings for Cortext experiments.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Runtime;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Error;
+
+final class Experiments {
+
+	public const OPTION = 'cortext_experiments';
+
+	/**
+	 * Returns registered experiment metadata keyed by experiment ID.
+	 *
+	 * @return array<string,array{id:string,label:string,description:string,group:string,default:bool}>
+	 */
+	public function registered(): array {
+		/**
+		 * Filters registered Cortext experiments.
+		 *
+			 * Each experiment is an array with these keys:
+			 * - id: required, unique, case-sensitive identifier. It must start with an ASCII
+			 *   letter and contain only ASCII letters, digits, underscores, and hyphens.
+			 * - label: optional name shown to users. Defaults to the ID.
+			 * - description: optional description shown to users.
+			 * - group: optional group name. Defaults to "Other".
+			 * - default: optional initial enabled state. Defaults to false.
+		 *
+		 * @param array<int,array<string,mixed>> $experiments Registered experiments.
+		 */
+		$raw = apply_filters( 'cortext_experiments', array() );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$registered = array();
+		foreach ( $raw as $experiment ) {
+			if ( ! is_array( $experiment ) ) {
+				continue;
+			}
+			$id = isset( $experiment['id'] ) && is_string( $experiment['id'] ) ? $experiment['id'] : '';
+			if ( ! $this->is_valid_id( $id ) ) {
+				continue;
+			}
+			$registered[ $id ] = array(
+				'id'          => $id,
+				'label'       => isset( $experiment['label'] ) ? (string) $experiment['label'] : $id,
+				'description' => isset( $experiment['description'] ) ? (string) $experiment['description'] : '',
+				'group'       => isset( $experiment['group'] ) ? (string) $experiment['group'] : __( 'Other', 'cortext' ),
+				'default'     => isset( $experiment['default'] ) ? (bool) $experiment['default'] : false,
+			);
+		}
+
+		return $registered;
+	}
+
+	public function is_enabled( string $id ): bool {
+		$registered = $this->registered();
+		if ( ! $this->is_valid_id( $id ) || ! isset( $registered[ $id ] ) ) {
+			return false;
+		}
+
+		$stored = $this->stored_values( $registered );
+		return $stored[ $id ] ?? $registered[ $id ]['default'];
+	}
+
+	/**
+	 * Returns enabled state for client-side checks.
+	 *
+	 * @return array<string,bool>
+	 */
+	public function to_client_settings(): array {
+		$out = array();
+		foreach ( $this->list() as $experiment ) {
+			$out[ $experiment['id'] ] = $experiment['enabled'];
+		}
+		return $out;
+	}
+
+	/**
+	 * Returns registered experiments with resolved enabled states.
+	 *
+	 * @return array<int,array{id:string,label:string,description:string,group:string,enabled:bool}>
+	 */
+	public function list(): array {
+		$registered = $this->registered();
+		$stored     = $this->stored_values( $registered );
+		$out        = array();
+
+		foreach ( $registered as $id => $experiment ) {
+			$out[] = array(
+				'id'          => $id,
+				'label'       => $experiment['label'],
+				'description' => $experiment['description'],
+				'group'       => $experiment['group'],
+				'enabled'     => $stored[ $id ] ?? $experiment['default'],
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Updates known experiment values.
+	 *
+	 * @param array<string,mixed> $enabled Experiment ID to enabled value.
+	 * @return array<int,array{id:string,label:string,description:string,group:string,enabled:bool}>|WP_Error
+	 */
+	public function update( array $enabled ): array|WP_Error {
+		$registered = $this->registered();
+		$stored     = $this->stored_values( $registered );
+
+		foreach ( $enabled as $id => $value ) {
+			if ( ! is_string( $id ) || ! $this->is_valid_id( $id ) || ! isset( $registered[ $id ] ) ) {
+				return new WP_Error(
+					'cortext_experiments_unknown_id',
+					__( "The request includes an experiment that isn't registered.", 'cortext' ),
+					array( 'status' => 400 )
+				);
+			}
+			$stored[ $id ] = (bool) $value;
+		}
+
+		update_option( self::OPTION, $stored, false );
+		return $this->list();
+	}
+
+	/**
+	 * Reads stored values and ignores experiments that are no longer registered.
+	 *
+	 * @param array<string,array{id:string,label:string,description:string,group:string,default:bool}> $registered Registered experiments.
+	 * @return array<string,bool>
+	 */
+	private function stored_values( array $registered ): array {
+		$raw = get_option( self::OPTION, array() );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $raw as $id => $value ) {
+			if ( is_string( $id ) && $this->is_valid_id( $id ) && isset( $registered[ $id ] ) ) {
+				$out[ $id ] = (bool) $value;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Validates an experiment ID without normalizing it.
+	 *
+	 * Experiment IDs are case-sensitive API keys. Requiring an ASCII letter as the
+	 * first character prevents PHP from casting numeric string keys to integers.
+	 *
+	 * @param string $id Experiment ID.
+	 */
+	private function is_valid_id( string $id ): bool {
+		return 1 === preg_match( '/\A[A-Za-z][A-Za-z0-9_-]*\z/', $id );
+	}
+}

--- a/includes/Runtime/Experiments.php
+++ b/includes/Runtime/Experiments.php
@@ -73,7 +73,7 @@ final class Experiments {
 	}
 
 	/**
-	 * Returns enabled state for client-side checks.
+	 * Returns the enabled state of each experiment for client-side checks.
 	 *
 	 * @return array<string,bool>
 	 */
@@ -86,7 +86,7 @@ final class Experiments {
 	}
 
 	/**
-	 * Returns registered experiments with resolved enabled states.
+	 * Returns each registered experiment and whether it is enabled.
 	 *
 	 * @return array<int,array{id:string,label:string,description:string,group:string,enabled:bool}>
 	 */
@@ -109,9 +109,9 @@ final class Experiments {
 	}
 
 	/**
-	 * Updates known experiment values.
+	 * Updates the enabled state of registered experiments.
 	 *
-	 * @param array<string,mixed> $enabled Experiment ID to enabled value.
+	 * @param array<string,mixed> $enabled Experiment IDs mapped to enabled values.
 	 * @return array<int,array{id:string,label:string,description:string,group:string,enabled:bool}>|WP_Error
 	 */
 	public function update( array $enabled ): array|WP_Error {
@@ -122,7 +122,7 @@ final class Experiments {
 			if ( ! is_string( $id ) || ! $this->is_valid_id( $id ) || ! isset( $registered[ $id ] ) ) {
 				return new WP_Error(
 					'cortext_experiments_unknown_id',
-					__( "The request includes an experiment that isn't registered.", 'cortext' ),
+					__( "One or more experiments aren't registered.", 'cortext' ),
 					array( 'status' => 400 )
 				);
 			}

--- a/src/components/ExperimentsPane.js
+++ b/src/components/ExperimentsPane.js
@@ -101,7 +101,7 @@ export default function ExperimentsPane() {
 					canManage: false,
 					experiments: [],
 					isLoading: false,
-					error: __( "Couldn't load experiments.", 'cortext' ),
+					error: __( "We couldn't load experiments.", 'cortext' ),
 				} );
 			} );
 		return () => {
@@ -156,13 +156,10 @@ export default function ExperimentsPane() {
 						experiments: visibleExperiments ?? current.experiments,
 						error: null,
 					} ) );
-					createSuccessNotice(
-						__( 'Experiment updated.', 'cortext' ),
-						{
-							id: 'cortext-experiments-updated',
-							type: 'snackbar',
-						}
-					);
+					createSuccessNotice( __( 'Change saved.', 'cortext' ), {
+						id: 'cortext-experiments-updated',
+						type: 'snackbar',
+					} );
 				} catch {
 					if (
 						pendingChangesRef.current.get( id )?.version === version
@@ -185,7 +182,7 @@ export default function ExperimentsPane() {
 						} ) );
 					}
 					createErrorNotice(
-						__( "Couldn't update this experiment.", 'cortext' ),
+						__( "We couldn't save that change.", 'cortext' ),
 						{
 							id: 'cortext-experiments-update-failed',
 							type: 'snackbar',
@@ -240,10 +237,7 @@ export default function ExperimentsPane() {
 					className="cortext-experiments-pane__description"
 					variant="muted"
 				>
-					{ __(
-						'Try Cortext features that are still in development.',
-						'cortext'
-					) }
+					{ __( "Try features we're still working on.", 'cortext' ) }
 				</Text>
 			</VStack>
 			{ state.isLoading ? (
@@ -262,7 +256,7 @@ export default function ExperimentsPane() {
 			{ ! state.isLoading && ! state.error && ! state.canManage ? (
 				<Notice status="warning" isDismissible={ false }>
 					{ __(
-						'You need to be a site administrator to change experiments.',
+						'Only site administrators can turn experiments on or off.',
 						'cortext'
 					) }
 				</Notice>
@@ -272,7 +266,7 @@ export default function ExperimentsPane() {
 			state.canManage &&
 			state.experiments.length === 0 ? (
 				<Text variant="muted">
-					{ __( 'No experiments yet.', 'cortext' ) }
+					{ __( 'Nothing to try right now.', 'cortext' ) }
 				</Text>
 			) : null }
 			{ ! state.isLoading && ! state.error && state.canManage

--- a/src/components/ExperimentsPane.js
+++ b/src/components/ExperimentsPane.js
@@ -1,0 +1,245 @@
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Notice,
+	Spinner,
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHeading as Heading,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+import { syncCortextExperiments } from '../settings';
+
+import './ExperimentsPane.scss';
+
+function groupExperiments( experiments ) {
+	const groups = new Map();
+	for ( const experiment of experiments ?? [] ) {
+		const group = experiment.group || __( 'Other', 'cortext' );
+		if ( ! groups.has( group ) ) {
+			groups.set( group, [] );
+		}
+		groups.get( group ).push( experiment );
+	}
+	return Array.from( groups.entries() ).map( ( [ label, items ] ) => ( {
+		label,
+		items,
+	} ) );
+}
+
+export default function ExperimentsPane() {
+	const [ state, setState ] = useState( {
+		canManage: false,
+		experiments: [],
+		isLoading: true,
+		error: null,
+	} );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const isSavingRef = useRef( false );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
+
+	useEffect( () => {
+		let cancelled = false;
+		apiFetch( { path: '/cortext/v1/experiments' } )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setState( {
+					canManage: response?.canManage === true,
+					experiments: Array.isArray( response?.experiments )
+						? response.experiments
+						: [],
+					isLoading: false,
+					error: null,
+				} );
+			} )
+			.catch( () => {
+				if ( cancelled ) {
+					return;
+				}
+				setState( {
+					canManage: false,
+					experiments: [],
+					isLoading: false,
+					error: __( "Couldn't load experiments.", 'cortext' ),
+				} );
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const groups = useMemo(
+		() => groupExperiments( state.experiments ),
+		[ state.experiments ]
+	);
+
+	const updateExperiment = useCallback(
+		( id, enabled ) => {
+			if ( isSavingRef.current ) {
+				return;
+			}
+
+			const previousEnabled =
+				state.experiments.find( ( experiment ) => experiment.id === id )
+					?.enabled === true;
+			isSavingRef.current = true;
+			setIsSaving( true );
+			setState( ( current ) => ( {
+				...current,
+				experiments: current.experiments.map( ( experiment ) =>
+					experiment.id === id
+						? { ...experiment, enabled }
+						: experiment
+				),
+			} ) );
+			apiFetch( {
+				path: '/cortext/v1/experiments',
+				method: 'PUT',
+				data: { enabled: { [ id ]: enabled } },
+			} )
+				.then( ( response ) => {
+					const experiments = Array.isArray( response?.experiments )
+						? response.experiments
+						: null;
+					if ( experiments ) {
+						syncCortextExperiments( experiments );
+					}
+					setState( ( current ) => ( {
+						...current,
+						canManage: response?.canManage === true,
+						experiments: experiments ?? current.experiments,
+						error: null,
+					} ) );
+					createSuccessNotice(
+						__( 'Experiment updated.', 'cortext' ),
+						{
+							id: 'cortext-experiments-updated',
+							type: 'snackbar',
+						}
+					);
+				} )
+				.catch( () => {
+					setState( ( current ) => ( {
+						...current,
+						experiments: current.experiments.map( ( experiment ) =>
+							experiment.id === id
+								? {
+										...experiment,
+										enabled: previousEnabled,
+								  }
+								: experiment
+						),
+					} ) );
+					createErrorNotice(
+						__( "Couldn't update this experiment.", 'cortext' ),
+						{
+							id: 'cortext-experiments-update-failed',
+							type: 'snackbar',
+						}
+					);
+				} )
+				.finally( () => {
+					isSavingRef.current = false;
+					setIsSaving( false );
+				} );
+		},
+		[ createErrorNotice, createSuccessNotice, state.experiments ]
+	);
+
+	return (
+		<div className="cortext-experiments-pane">
+			<VStack spacing={ 2 }>
+				<Heading level={ 2 }>
+					{ __( 'Experiments', 'cortext' ) }
+				</Heading>
+				<Text
+					className="cortext-experiments-pane__description"
+					variant="muted"
+				>
+					{ __(
+						'Try Cortext features that are still in development.',
+						'cortext'
+					) }
+				</Text>
+			</VStack>
+			{ state.isLoading ? (
+				<div className="cortext-experiments-pane__loading">
+					<Spinner />
+					<Text variant="muted">
+						{ __( 'Loading experiments…', 'cortext' ) }
+					</Text>
+				</div>
+			) : null }
+			{ state.error ? (
+				<Notice status="error" isDismissible={ false }>
+					{ state.error }
+				</Notice>
+			) : null }
+			{ ! state.isLoading && ! state.error && ! state.canManage ? (
+				<Notice status="warning" isDismissible={ false }>
+					{ __(
+						'You need to be a site administrator to change experiments.',
+						'cortext'
+					) }
+				</Notice>
+			) : null }
+			{ ! state.isLoading &&
+			! state.error &&
+			state.canManage &&
+			state.experiments.length === 0 ? (
+				<Text variant="muted">
+					{ __( 'No experiments yet.', 'cortext' ) }
+				</Text>
+			) : null }
+			{ ! state.isLoading && ! state.error && state.canManage
+				? groups.map( ( group ) => (
+						<section
+							key={ group.label }
+							className="cortext-experiments-pane__group"
+						>
+							<Heading level={ 3 }>{ group.label }</Heading>
+							<div className="cortext-experiments-pane__toggles">
+								{ group.items.map( ( experiment ) => (
+									<div
+										key={ experiment.id }
+										className="cortext-experiments-pane__toggle"
+									>
+										<ToggleControl
+											label={ experiment.label }
+											help={ experiment.description }
+											checked={
+												experiment.enabled === true
+											}
+											disabled={ isSaving }
+											onChange={ ( enabled ) =>
+												updateExperiment(
+													experiment.id,
+													enabled
+												)
+											}
+										/>
+									</div>
+								) ) }
+							</div>
+						</section>
+				  ) )
+				: null }
+		</div>
+	);
+}

--- a/src/components/ExperimentsPane.js
+++ b/src/components/ExperimentsPane.js
@@ -40,6 +40,26 @@ function groupExperiments( experiments ) {
 	} ) );
 }
 
+function applyPendingChanges( experiments, pendingChanges ) {
+	return experiments.map( ( experiment ) =>
+		pendingChanges.has( experiment.id )
+			? {
+					...experiment,
+					enabled: pendingChanges.get( experiment.id ).enabled,
+			  }
+			: experiment
+	);
+}
+
+function getEnabledValues( experiments ) {
+	return new Map(
+		experiments.map( ( experiment ) => [
+			experiment.id,
+			experiment.enabled === true,
+		] )
+	);
+}
+
 export default function ExperimentsPane() {
 	const [ state, setState ] = useState( {
 		canManage: false,
@@ -47,8 +67,11 @@ export default function ExperimentsPane() {
 		isLoading: true,
 		error: null,
 	} );
-	const [ isSaving, setIsSaving ] = useState( false );
-	const isSavingRef = useRef( false );
+	const pendingChangesRef = useRef( new Map() );
+	const confirmedEnabledRef = useRef( new Map() );
+	const saveQueueRef = useRef( [] );
+	const isProcessingQueueRef = useRef( false );
+	const nextChangeVersionRef = useRef( 0 );
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 
@@ -59,11 +82,13 @@ export default function ExperimentsPane() {
 				if ( cancelled ) {
 					return;
 				}
+				const experiments = Array.isArray( response?.experiments )
+					? response.experiments
+					: [];
+				confirmedEnabledRef.current = getEnabledValues( experiments );
 				setState( {
 					canManage: response?.canManage === true,
-					experiments: Array.isArray( response?.experiments )
-						? response.experiments
-						: [],
+					experiments,
 					isLoading: false,
 					error: null,
 				} );
@@ -89,41 +114,46 @@ export default function ExperimentsPane() {
 		[ state.experiments ]
 	);
 
-	const updateExperiment = useCallback(
-		( id, enabled ) => {
-			if ( isSavingRef.current ) {
-				return;
-			}
+	const processSaveQueue = useCallback( async () => {
+		if ( isProcessingQueueRef.current ) {
+			return;
+		}
 
-			const previousEnabled =
-				state.experiments.find( ( experiment ) => experiment.id === id )
-					?.enabled === true;
-			isSavingRef.current = true;
-			setIsSaving( true );
-			setState( ( current ) => ( {
-				...current,
-				experiments: current.experiments.map( ( experiment ) =>
-					experiment.id === id
-						? { ...experiment, enabled }
-						: experiment
-				),
-			} ) );
-			apiFetch( {
-				path: '/cortext/v1/experiments',
-				method: 'PUT',
-				data: { enabled: { [ id ]: enabled } },
-			} )
-				.then( ( response ) => {
+		isProcessingQueueRef.current = true;
+		try {
+			while ( saveQueueRef.current.length > 0 ) {
+				const { id, enabled, version } = saveQueueRef.current.shift();
+				try {
+					const response = await apiFetch( {
+						path: '/cortext/v1/experiments',
+						method: 'PUT',
+						data: { enabled: { [ id ]: enabled } },
+					} );
 					const experiments = Array.isArray( response?.experiments )
 						? response.experiments
 						: null;
 					if ( experiments ) {
+						confirmedEnabledRef.current =
+							getEnabledValues( experiments );
 						syncCortextExperiments( experiments );
+					} else {
+						confirmedEnabledRef.current.set( id, enabled );
 					}
+					if (
+						pendingChangesRef.current.get( id )?.version === version
+					) {
+						pendingChangesRef.current.delete( id );
+					}
+					const visibleExperiments = experiments
+						? applyPendingChanges(
+								experiments,
+								new Map( pendingChangesRef.current )
+						  )
+						: null;
 					setState( ( current ) => ( {
 						...current,
 						canManage: response?.canManage === true,
-						experiments: experiments ?? current.experiments,
+						experiments: visibleExperiments ?? current.experiments,
 						error: null,
 					} ) );
 					createSuccessNotice(
@@ -133,19 +163,27 @@ export default function ExperimentsPane() {
 							type: 'snackbar',
 						}
 					);
-				} )
-				.catch( () => {
-					setState( ( current ) => ( {
-						...current,
-						experiments: current.experiments.map( ( experiment ) =>
-							experiment.id === id
-								? {
-										...experiment,
-										enabled: previousEnabled,
-								  }
-								: experiment
-						),
-					} ) );
+				} catch {
+					if (
+						pendingChangesRef.current.get( id )?.version === version
+					) {
+						pendingChangesRef.current.delete( id );
+						const confirmedEnabled =
+							confirmedEnabledRef.current.get( id );
+						setState( ( current ) => ( {
+							...current,
+							experiments: current.experiments.map(
+								( experiment ) =>
+									experiment.id === id &&
+									typeof confirmedEnabled === 'boolean'
+										? {
+												...experiment,
+												enabled: confirmedEnabled,
+										  }
+										: experiment
+							),
+						} ) );
+					}
 					createErrorNotice(
 						__( "Couldn't update this experiment.", 'cortext' ),
 						{
@@ -153,13 +191,43 @@ export default function ExperimentsPane() {
 							type: 'snackbar',
 						}
 					);
-				} )
-				.finally( () => {
-					isSavingRef.current = false;
-					setIsSaving( false );
-				} );
+				}
+			}
+		} finally {
+			isProcessingQueueRef.current = false;
+		}
+	}, [ createErrorNotice, createSuccessNotice ] );
+
+	const updateExperiment = useCallback(
+		( id, enabled ) => {
+			const currentExperiment = state.experiments.find(
+				( current ) => current.id === id
+			);
+			if ( ! currentExperiment ) {
+				return;
+			}
+
+			const currentEnabled = pendingChangesRef.current.has( id )
+				? pendingChangesRef.current.get( id ).enabled
+				: currentExperiment.enabled === true;
+			if ( currentEnabled === enabled ) {
+				return;
+			}
+
+			const version = ++nextChangeVersionRef.current;
+			pendingChangesRef.current.set( id, { enabled, version } );
+			setState( ( current ) => ( {
+				...current,
+				experiments: current.experiments.map( ( experiment ) =>
+					experiment.id === id
+						? { ...experiment, enabled }
+						: experiment
+				),
+			} ) );
+			saveQueueRef.current.push( { id, enabled, version } );
+			void processSaveQueue();
 		},
-		[ createErrorNotice, createSuccessNotice, state.experiments ]
+		[ processSaveQueue, state.experiments ]
 	);
 
 	return (
@@ -226,7 +294,6 @@ export default function ExperimentsPane() {
 											checked={
 												experiment.enabled === true
 											}
-											disabled={ isSaving }
 											onChange={ ( enabled ) =>
 												updateExperiment(
 													experiment.id,

--- a/src/components/ExperimentsPane.scss
+++ b/src/components/ExperimentsPane.scss
@@ -1,0 +1,71 @@
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
+
+.cortext-experiments-pane {
+	--cortext-experiments-surface: var(--cortext-canvas-surface);
+	--cortext-experiments-row-surface: #{$gray-100};
+	--cortext-experiments-border: var(--cortext-canvas-border);
+	--cortext-experiments-text: #{$gray-900};
+	--cortext-experiments-text-muted: #{$gray-700};
+	--wp-components-color-background: var(--cortext-experiments-surface);
+	--wp-components-color-foreground: var(--cortext-experiments-text);
+	--wp-components-color-gray-600: #{$gray-600};
+	--wp-components-color-gray-700: var(--cortext-experiments-text-muted);
+
+	/* prettier-ignore */
+	--wp-components-color-accent: var(--wp-admin-theme-color, var(--cortext-accent));
+
+	box-sizing: border-box;
+	flex: 1 1 auto;
+	min-height: 0;
+	height: 100%;
+	padding: $grid-unit-30 $grid-unit-40 $grid-unit-40;
+	overflow: auto;
+	color-scheme: light;
+	background: var(--cortext-experiments-surface);
+	color: var(--cortext-experiments-text);
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-40;
+
+	> * {
+		max-width: 720px;
+	}
+
+	&__description {
+		color: var(--cortext-experiments-text-muted);
+	}
+
+	&__loading {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+	}
+
+	&__group {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-20;
+		min-width: 0;
+	}
+
+	&__toggles {
+		display: flex;
+		flex-direction: column;
+		border: $border-width solid var(--cortext-experiments-border);
+		background: var(--cortext-experiments-row-surface);
+	}
+
+	&__toggle {
+		padding: $grid-unit-20;
+
+		& + & {
+			border-top: $border-width solid var(--cortext-experiments-border);
+		}
+
+		.components-base-control,
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
+	}
+}

--- a/src/components/SidebarSettingsNav.js
+++ b/src/components/SidebarSettingsNav.js
@@ -1,13 +1,17 @@
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { chevronLeft, globe, upload } from '@wordpress/icons';
+import { chevronLeft, globe, plugins, upload } from '@wordpress/icons';
 
 import {
+	SETTINGS_EXPERIMENTS_URI,
 	SETTINGS_IMPORT_URI,
 	SETTINGS_PUBLISHED_URI,
 } from '../router/useResolveEntity';
-import { isPublicWebAffordancesEnabled } from '../settings';
+import {
+	canManageCortextSettings,
+	isPublicWebAffordancesEnabled,
+} from '../settings';
 
 const NAV_ITEMS = [
 	{
@@ -22,6 +26,13 @@ const NAV_ITEMS = [
 		icon: globe,
 		label: () => __( 'Published', 'cortext' ),
 		isEnabled: isPublicWebAffordancesEnabled,
+	},
+	{
+		key: 'experiments',
+		uri: SETTINGS_EXPERIMENTS_URI,
+		icon: plugins,
+		label: () => __( 'Experiments', 'cortext' ),
+		isEnabled: canManageCortextSettings,
 	},
 ];
 

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -29,6 +29,7 @@ const Canvas = lazy( () =>
 );
 import CanvasSkeleton from '../components/CanvasSkeleton';
 import { RowMutationContext } from '../components/EditableCell';
+import ExperimentsPane from '../components/ExperimentsPane';
 import ImportPane from '../components/ImportPane';
 import PublishedDocumentsPane from '../components/PublishedDocumentsPane';
 import { CanvasProgressBar } from '../components/Skeleton';
@@ -173,9 +174,10 @@ export default function EntityRoute( { history } ) {
 			} );
 			return;
 		}
-		// Import and Published are light static panes. Use a plain fade so
-		// Chrome's default blend does not wash the transition to white.
+		// Settings panes are lightweight and mostly static. A plain fade keeps
+		// Chrome's default blend from washing out the transition to white.
 		if (
+			after.active.kind === 'experiments' ||
 			after.active.kind === 'import' ||
 			after.active.kind === 'published'
 		) {
@@ -483,6 +485,9 @@ export default function EntityRoute( { history } ) {
 						<PublishedDocumentsPane />
 					</WorkspacePane>
 				) : null }
+				<WorkspacePane active={ active.kind === 'experiments' }>
+					<ExperimentsPane />
+				</WorkspacePane>
 				<WorkspacePane active={ active.kind === 'import' }>
 					<ImportPane />
 				</WorkspacePane>

--- a/src/router/entityRouteReducer.js
+++ b/src/router/entityRouteReducer.js
@@ -1,6 +1,7 @@
 import {
 	IMPORT_URI,
 	PUBLISHED_DOCUMENTS_URI,
+	SETTINGS_EXPERIMENTS_URI,
 	SETTINGS_IMPORT_URI,
 	SETTINGS_PUBLISHED_URI,
 	SETTINGS_URI,
@@ -20,6 +21,9 @@ export function parseTarget( splat, options = {} ) {
 	}
 	if ( splat === SETTINGS_IMPORT_URI ) {
 		return { kind: 'import', tail: '' };
+	}
+	if ( splat === SETTINGS_EXPERIMENTS_URI ) {
+		return { kind: 'experiments', tail: '' };
 	}
 	if ( splat === SETTINGS_PUBLISHED_URI ) {
 		if ( ! publicWebAffordances ) {
@@ -50,6 +54,8 @@ export function reducer( state, action ) {
 				active = { kind: 'empty' };
 			} else if ( target.kind === 'published' ) {
 				active = { kind: 'published' };
+			} else if ( target.kind === 'experiments' ) {
+				active = { kind: 'experiments' };
 			} else if ( target.kind === 'import' ) {
 				active = { kind: 'import' };
 			} else if ( target.kind === 'document' ) {
@@ -121,6 +127,8 @@ export function init( target ) {
 		active = { kind: 'empty' };
 	} else if ( target.kind === 'published' ) {
 		active = { kind: 'published' };
+	} else if ( target.kind === 'experiments' ) {
+		active = { kind: 'experiments' };
 	} else if ( target.kind === 'import' ) {
 		active = { kind: 'import' };
 	} else if ( target.kind === 'redirect' ) {

--- a/src/router/useResolveEntity.js
+++ b/src/router/useResolveEntity.js
@@ -137,6 +137,7 @@ export function computeDocumentUri( entity ) {
 }
 
 export const SETTINGS_URI = 'settings';
+export const SETTINGS_EXPERIMENTS_URI = 'settings/experiments';
 export const SETTINGS_IMPORT_URI = 'settings/import';
 export const SETTINGS_PUBLISHED_URI = 'settings/published';
 export const PUBLISHED_DOCUMENTS_URI = 'published';

--- a/src/settings.js
+++ b/src/settings.js
@@ -3,9 +3,12 @@ const DEFAULT_FEATURES = {
 	wordpressAffordances: true,
 };
 
+function getSettings() {
+	return typeof window === 'undefined' ? undefined : window.cortextSettings;
+}
+
 function rawFeatureValue( key ) {
-	const settings =
-		typeof window === 'undefined' ? undefined : window.cortextSettings;
+	const settings = getSettings();
 	return settings?.features?.[ key ];
 }
 
@@ -26,4 +29,37 @@ export function isPublicWebAffordancesEnabled() {
 
 export function isWordPressAffordancesEnabled() {
 	return getCortextFeatures().wordpressAffordances !== false;
+}
+
+export function getCortextExperiments() {
+	const experiments = getSettings()?.experiments;
+	return experiments && typeof experiments === 'object' ? experiments : {};
+}
+
+export function syncCortextExperiments( experiments ) {
+	if ( typeof window === 'undefined' || ! Array.isArray( experiments ) ) {
+		return;
+	}
+
+	const settings = getSettings();
+	if ( ! settings || typeof settings !== 'object' ) {
+		window.cortextSettings = {};
+	}
+
+	window.cortextSettings.experiments = Object.fromEntries(
+		experiments
+			.filter( ( experiment ) => typeof experiment?.id === 'string' )
+			.map( ( experiment ) => [
+				experiment.id,
+				experiment.enabled === true,
+			] )
+	);
+}
+
+export function isExperimentEnabled( id ) {
+	return getCortextExperiments()?.[ id ] === true;
+}
+
+export function canManageCortextSettings() {
+	return getSettings()?.capabilities?.manageOptions === true;
 }

--- a/tests/js/components/ExperimentsPane.test.js
+++ b/tests/js/components/ExperimentsPane.test.js
@@ -166,8 +166,9 @@ describe( 'ExperimentsPane', () => {
 		expect( isExperimentEnabled( 'sample' ) ).toBe( true );
 	} );
 
-	it( 'disables every toggle while a save is pending', async () => {
-		let resolveSave;
+	it( 'keeps toggles interactive and queues their saves', async () => {
+		let resolveFirstSave;
+		let resolveSecondSave;
 		apiFetch
 			.mockResolvedValueOnce( {
 				canManage: true,
@@ -191,7 +192,13 @@ describe( 'ExperimentsPane', () => {
 			.mockImplementationOnce(
 				() =>
 					new Promise( ( resolve ) => {
-						resolveSave = resolve;
+						resolveFirstSave = resolve;
+					} )
+			)
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveSecondSave = resolve;
 					} )
 			);
 
@@ -202,15 +209,17 @@ describe( 'ExperimentsPane', () => {
 		fireEvent.click( first );
 
 		await waitFor( () => {
-			expect( first ).toBeDisabled();
-			expect( second ).toBeDisabled();
+			expect( first ).toBeChecked();
+			expect( first ).not.toBeDisabled();
+			expect( second ).not.toBeDisabled();
 		} );
 		fireEvent.click( second );
+		expect( second ).toBeChecked();
+		expect( second ).not.toBeDisabled();
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
-		expect( second ).not.toBeChecked();
 
 		await act( async () => {
-			resolveSave( {
+			resolveFirstSave( {
 				canManage: true,
 				experiments: [
 					{
@@ -231,11 +240,50 @@ describe( 'ExperimentsPane', () => {
 			} );
 		} );
 
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 3 ) );
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/cortext/v1/experiments',
+			method: 'PUT',
+			data: { enabled: { second: true } },
+		} );
 		expect( first ).not.toBeDisabled();
+		expect( first ).toBeChecked();
 		expect( second ).not.toBeDisabled();
+		expect( second ).toBeChecked();
+
+		await act( async () => {
+			resolveSecondSave( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'first',
+						label: 'First',
+						description: 'First description',
+						group: 'Labs',
+						enabled: true,
+					},
+					{
+						id: 'second',
+						label: 'Second',
+						description: 'Second description',
+						group: 'Labs',
+						enabled: true,
+					},
+				],
+			} );
+		} );
+
+		await waitFor( () => {
+			expect( first ).not.toBeDisabled();
+			expect( second ).not.toBeDisabled();
+		} );
+		expect( first ).toBeChecked();
+		expect( second ).toBeChecked();
 	} );
 
-	it( 'reverts only the failed experiment after a save failure', async () => {
+	it( 'keeps the latest value when the same toggle changes again', async () => {
+		let resolveFirstSave;
+		let rejectSecondSave;
 		apiFetch
 			.mockResolvedValueOnce( {
 				canManage: true,
@@ -247,29 +295,119 @@ describe( 'ExperimentsPane', () => {
 						group: 'Labs',
 						enabled: false,
 					},
-					{
-						id: 'unchanged',
-						label: 'Unchanged',
-						description: 'Unchanged description',
-						group: 'Labs',
-						enabled: true,
-					},
 				],
 			} )
-			.mockRejectedValueOnce( new Error( 'Nope' ) );
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveFirstSave = resolve;
+					} )
+			)
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve, reject ) => {
+						rejectSecondSave = reject;
+					} )
+			);
 
 		render( <ExperimentsPane /> );
 
 		const checkbox = await screen.findByRole( 'checkbox', {
 			name: /Sample/,
 		} );
-		const unchanged = screen.getByRole( 'checkbox', {
-			name: /Unchanged/,
-		} );
+		fireEvent.click( checkbox );
 		fireEvent.click( checkbox );
 
-		await waitFor( () => expect( checkbox ).not.toBeChecked() );
-		expect( unchanged ).toBeChecked();
+		expect( checkbox ).not.toBeChecked();
+		expect( checkbox ).not.toBeDisabled();
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+
+		await act( async () => {
+			resolveFirstSave( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'sample',
+						label: 'Sample',
+						description: 'Sample description',
+						group: 'Labs',
+						enabled: true,
+					},
+				],
+			} );
+		} );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 3 ) );
+		expect( checkbox ).not.toBeChecked();
+
+		await act( async () => {
+			rejectSecondSave( new Error( 'Nope' ) );
+		} );
+
+		await waitFor( () => expect( checkbox ).toBeChecked() );
+		expect( checkbox ).not.toBeDisabled();
+	} );
+
+	it( 'reverts only the failed experiment and continues queued saves', async () => {
+		let rejectFirstSave;
+		let resolveSecondSave;
+		apiFetch
+			.mockResolvedValueOnce( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'first',
+						label: 'First',
+						description: 'First description',
+						group: 'Labs',
+						enabled: false,
+					},
+					{
+						id: 'second',
+						label: 'Second',
+						description: 'Second description',
+						group: 'Labs',
+						enabled: false,
+					},
+				],
+			} )
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve, reject ) => {
+						rejectFirstSave = reject;
+					} )
+			)
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveSecondSave = resolve;
+					} )
+			);
+
+		render( <ExperimentsPane /> );
+
+		const first = await screen.findByRole( 'checkbox', {
+			name: /First/,
+		} );
+		const second = screen.getByRole( 'checkbox', {
+			name: /Second/,
+		} );
+		fireEvent.click( first );
+		fireEvent.click( second );
+
+		expect( first ).toBeChecked();
+		expect( second ).toBeChecked();
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+
+		await act( async () => {
+			rejectFirstSave( new Error( 'Nope' ) );
+		} );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 3 ) );
+		expect( first ).not.toBeChecked();
+		expect( first ).not.toBeDisabled();
+		expect( second ).toBeChecked();
+		expect( second ).not.toBeDisabled();
 		expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
 			"Couldn't update this experiment.",
 			expect.objectContaining( {
@@ -277,6 +415,32 @@ describe( 'ExperimentsPane', () => {
 				type: 'snackbar',
 			} )
 		);
+
+		await act( async () => {
+			resolveSecondSave( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'first',
+						label: 'First',
+						description: 'First description',
+						group: 'Labs',
+						enabled: false,
+					},
+					{
+						id: 'second',
+						label: 'Second',
+						description: 'Second description',
+						group: 'Labs',
+						enabled: true,
+					},
+				],
+			} );
+		} );
+
+		await waitFor( () => expect( second ).not.toBeDisabled() );
+		expect( first ).not.toBeChecked();
+		expect( second ).toBeChecked();
 	} );
 
 	it( 'shows an error when experiments fail to load', async () => {

--- a/tests/js/components/ExperimentsPane.test.js
+++ b/tests/js/components/ExperimentsPane.test.js
@@ -106,7 +106,7 @@ describe( 'ExperimentsPane', () => {
 
 		expect( screen.getByTestId( 'spinner' ) ).toBeInTheDocument();
 		expect(
-			await screen.findByText( 'No experiments yet.' )
+			await screen.findByText( 'Nothing to try right now.' )
 		).toBeInTheDocument();
 	} );
 
@@ -119,7 +119,7 @@ describe( 'ExperimentsPane', () => {
 
 		expect(
 			await screen.findByText(
-				'You need to be a site administrator to change experiments.'
+				'Only site administrators can turn experiments on or off.'
 			)
 		).toBeInTheDocument();
 		expect(
@@ -149,7 +149,7 @@ describe( 'ExperimentsPane', () => {
 			} )
 		);
 		expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
-			'Experiment updated.',
+			'Change saved.',
 			expect.objectContaining( {
 				id: 'cortext-experiments-updated',
 				type: 'snackbar',
@@ -285,7 +285,7 @@ describe( 'ExperimentsPane', () => {
 		expect( second ).toBeChecked();
 		expect( second ).not.toBeDisabled();
 		expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
-			"Couldn't update this experiment.",
+			"We couldn't save that change.",
 			expect.objectContaining( {
 				id: 'cortext-experiments-update-failed',
 				type: 'snackbar',
@@ -309,7 +309,7 @@ describe( 'ExperimentsPane', () => {
 		render( <ExperimentsPane /> );
 
 		expect(
-			await screen.findByText( "Couldn't load experiments." )
+			await screen.findByText( "We couldn't load experiments." )
 		).toBeInTheDocument();
 	} );
 } );

--- a/tests/js/components/ExperimentsPane.test.js
+++ b/tests/js/components/ExperimentsPane.test.js
@@ -61,6 +61,32 @@ import apiFetch from '@wordpress/api-fetch';
 import ExperimentsPane from '../../../src/components/ExperimentsPane';
 import { isExperimentEnabled } from '../../../src/settings';
 
+function experimentsResponse( enabledById = {}, { canManage = true } = {} ) {
+	return {
+		canManage,
+		experiments: Object.entries( enabledById ).map( ( [ id, enabled ] ) => {
+			const label = `${ id.charAt( 0 ).toUpperCase() }${ id.slice( 1 ) }`;
+			return {
+				id,
+				label,
+				description: `${ label } description`,
+				group: 'Labs',
+				enabled,
+			};
+		} ),
+	};
+}
+
+function deferred() {
+	let resolve;
+	let reject;
+	const promise = new Promise( ( promiseResolve, promiseReject ) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	} );
+	return { promise, resolve, reject };
+}
+
 beforeEach( () => {
 	apiFetch.mockReset();
 	mockCreateErrorNotice.mockReset();
@@ -74,10 +100,7 @@ afterEach( () => {
 
 describe( 'ExperimentsPane', () => {
 	it( 'shows an empty state when there are no experiments', async () => {
-		apiFetch.mockResolvedValueOnce( {
-			canManage: true,
-			experiments: [],
-		} );
+		apiFetch.mockResolvedValueOnce( experimentsResponse() );
 
 		render( <ExperimentsPane /> );
 
@@ -88,18 +111,9 @@ describe( 'ExperimentsPane', () => {
 	} );
 
 	it( 'shows a permission notice when the user cannot manage experiments', async () => {
-		apiFetch.mockResolvedValueOnce( {
-			canManage: false,
-			experiments: [
-				{
-					id: 'sample',
-					label: 'Sample',
-					description: 'Sample description',
-					group: 'Labs',
-					enabled: false,
-				},
-			],
-		} );
+		apiFetch.mockResolvedValueOnce(
+			experimentsResponse( { sample: false }, { canManage: false } )
+		);
 
 		render( <ExperimentsPane /> );
 
@@ -116,30 +130,8 @@ describe( 'ExperimentsPane', () => {
 	it( 'renders grouped toggles and saves changes', async () => {
 		window.cortextSettings.experiments.sample = false;
 		apiFetch
-			.mockResolvedValueOnce( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'sample',
-						label: 'Sample',
-						description: 'Sample description',
-						group: 'Labs',
-						enabled: false,
-					},
-				],
-			} )
-			.mockResolvedValueOnce( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'sample',
-						label: 'Sample',
-						description: 'Sample description',
-						group: 'Labs',
-						enabled: true,
-					},
-				],
-			} );
+			.mockResolvedValueOnce( experimentsResponse( { sample: false } ) )
+			.mockResolvedValueOnce( experimentsResponse( { sample: true } ) );
 
 		render( <ExperimentsPane /> );
 
@@ -167,40 +159,14 @@ describe( 'ExperimentsPane', () => {
 	} );
 
 	it( 'keeps toggles interactive and queues their saves', async () => {
-		let resolveFirstSave;
-		let resolveSecondSave;
+		const firstSave = deferred();
+		const secondSave = deferred();
 		apiFetch
-			.mockResolvedValueOnce( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'first',
-						label: 'First',
-						description: 'First description',
-						group: 'Labs',
-						enabled: false,
-					},
-					{
-						id: 'second',
-						label: 'Second',
-						description: 'Second description',
-						group: 'Labs',
-						enabled: false,
-					},
-				],
-			} )
-			.mockImplementationOnce(
-				() =>
-					new Promise( ( resolve ) => {
-						resolveFirstSave = resolve;
-					} )
+			.mockResolvedValueOnce(
+				experimentsResponse( { first: false, second: false } )
 			)
-			.mockImplementationOnce(
-				() =>
-					new Promise( ( resolve ) => {
-						resolveSecondSave = resolve;
-					} )
-			);
+			.mockReturnValueOnce( firstSave.promise )
+			.mockReturnValueOnce( secondSave.promise );
 
 		render( <ExperimentsPane /> );
 
@@ -219,25 +185,9 @@ describe( 'ExperimentsPane', () => {
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 
 		await act( async () => {
-			resolveFirstSave( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'first',
-						label: 'First',
-						description: 'First description',
-						group: 'Labs',
-						enabled: true,
-					},
-					{
-						id: 'second',
-						label: 'Second',
-						description: 'Second description',
-						group: 'Labs',
-						enabled: false,
-					},
-				],
-			} );
+			firstSave.resolve(
+				experimentsResponse( { first: true, second: false } )
+			);
 		} );
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 3 ) );
@@ -252,25 +202,9 @@ describe( 'ExperimentsPane', () => {
 		expect( second ).toBeChecked();
 
 		await act( async () => {
-			resolveSecondSave( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'first',
-						label: 'First',
-						description: 'First description',
-						group: 'Labs',
-						enabled: true,
-					},
-					{
-						id: 'second',
-						label: 'Second',
-						description: 'Second description',
-						group: 'Labs',
-						enabled: true,
-					},
-				],
-			} );
+			secondSave.resolve(
+				experimentsResponse( { first: true, second: true } )
+			);
 		} );
 
 		await waitFor( () => {
@@ -282,33 +216,12 @@ describe( 'ExperimentsPane', () => {
 	} );
 
 	it( 'keeps the latest value when the same toggle changes again', async () => {
-		let resolveFirstSave;
-		let rejectSecondSave;
+		const firstSave = deferred();
+		const secondSave = deferred();
 		apiFetch
-			.mockResolvedValueOnce( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'sample',
-						label: 'Sample',
-						description: 'Sample description',
-						group: 'Labs',
-						enabled: false,
-					},
-				],
-			} )
-			.mockImplementationOnce(
-				() =>
-					new Promise( ( resolve ) => {
-						resolveFirstSave = resolve;
-					} )
-			)
-			.mockImplementationOnce(
-				() =>
-					new Promise( ( resolve, reject ) => {
-						rejectSecondSave = reject;
-					} )
-			);
+			.mockResolvedValueOnce( experimentsResponse( { sample: false } ) )
+			.mockReturnValueOnce( firstSave.promise )
+			.mockReturnValueOnce( secondSave.promise );
 
 		render( <ExperimentsPane /> );
 
@@ -323,25 +236,14 @@ describe( 'ExperimentsPane', () => {
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 
 		await act( async () => {
-			resolveFirstSave( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'sample',
-						label: 'Sample',
-						description: 'Sample description',
-						group: 'Labs',
-						enabled: true,
-					},
-				],
-			} );
+			firstSave.resolve( experimentsResponse( { sample: true } ) );
 		} );
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 3 ) );
 		expect( checkbox ).not.toBeChecked();
 
 		await act( async () => {
-			rejectSecondSave( new Error( 'Nope' ) );
+			secondSave.reject( new Error( 'Nope' ) );
 		} );
 
 		await waitFor( () => expect( checkbox ).toBeChecked() );
@@ -349,40 +251,14 @@ describe( 'ExperimentsPane', () => {
 	} );
 
 	it( 'reverts only the failed experiment and continues queued saves', async () => {
-		let rejectFirstSave;
-		let resolveSecondSave;
+		const firstSave = deferred();
+		const secondSave = deferred();
 		apiFetch
-			.mockResolvedValueOnce( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'first',
-						label: 'First',
-						description: 'First description',
-						group: 'Labs',
-						enabled: false,
-					},
-					{
-						id: 'second',
-						label: 'Second',
-						description: 'Second description',
-						group: 'Labs',
-						enabled: false,
-					},
-				],
-			} )
-			.mockImplementationOnce(
-				() =>
-					new Promise( ( resolve, reject ) => {
-						rejectFirstSave = reject;
-					} )
+			.mockResolvedValueOnce(
+				experimentsResponse( { first: false, second: false } )
 			)
-			.mockImplementationOnce(
-				() =>
-					new Promise( ( resolve ) => {
-						resolveSecondSave = resolve;
-					} )
-			);
+			.mockReturnValueOnce( firstSave.promise )
+			.mockReturnValueOnce( secondSave.promise );
 
 		render( <ExperimentsPane /> );
 
@@ -400,7 +276,7 @@ describe( 'ExperimentsPane', () => {
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 
 		await act( async () => {
-			rejectFirstSave( new Error( 'Nope' ) );
+			firstSave.reject( new Error( 'Nope' ) );
 		} );
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 3 ) );
@@ -417,25 +293,9 @@ describe( 'ExperimentsPane', () => {
 		);
 
 		await act( async () => {
-			resolveSecondSave( {
-				canManage: true,
-				experiments: [
-					{
-						id: 'first',
-						label: 'First',
-						description: 'First description',
-						group: 'Labs',
-						enabled: false,
-					},
-					{
-						id: 'second',
-						label: 'Second',
-						description: 'Second description',
-						group: 'Labs',
-						enabled: true,
-					},
-				],
-			} );
+			secondSave.resolve(
+				experimentsResponse( { first: false, second: true } )
+			);
 		} );
 
 		await waitFor( () => expect( second ).not.toBeDisabled() );

--- a/tests/js/components/ExperimentsPane.test.js
+++ b/tests/js/components/ExperimentsPane.test.js
@@ -1,0 +1,291 @@
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
+
+const mockCreateErrorNotice = jest.fn();
+const mockCreateSuccessNotice = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Notice: ( { children, status } ) => (
+		<div role="status" data-status={ status }>
+			{ children }
+		</div>
+	),
+	Spinner: () => <span data-testid="spinner" />,
+	ToggleControl: ( { label, checked, disabled, help, onChange } ) => (
+		<label>
+			<span>{ label }</span>
+			<input
+				type="checkbox"
+				checked={ checked }
+				disabled={ disabled }
+				aria-describedby={ help ? `${ label }-help` : undefined }
+				onChange={ ( event ) => onChange( event.target.checked ) }
+			/>
+			{ help ? <span id={ `${ label }-help` }>{ help }</span> : null }
+		</label>
+	),
+	__experimentalHeading: ( { children, level = 2 } ) => {
+		const Tag = `h${ level }`;
+		return <Tag>{ children }</Tag>;
+	},
+	__experimentalText: ( { children } ) => <p>{ children }</p>,
+	__experimentalVStack: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		createErrorNotice: mockCreateErrorNotice,
+		createSuccessNotice: mockCreateSuccessNotice,
+	} ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: { name: 'core/notices' },
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import ExperimentsPane from '../../../src/components/ExperimentsPane';
+import { isExperimentEnabled } from '../../../src/settings';
+
+beforeEach( () => {
+	apiFetch.mockReset();
+	mockCreateErrorNotice.mockReset();
+	mockCreateSuccessNotice.mockReset();
+	window.cortextSettings = { experiments: {} };
+} );
+
+afterEach( () => {
+	delete window.cortextSettings;
+} );
+
+describe( 'ExperimentsPane', () => {
+	it( 'shows an empty state when there are no experiments', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			canManage: true,
+			experiments: [],
+		} );
+
+		render( <ExperimentsPane /> );
+
+		expect( screen.getByTestId( 'spinner' ) ).toBeInTheDocument();
+		expect(
+			await screen.findByText( 'No experiments yet.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows a permission notice when the user cannot manage experiments', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			canManage: false,
+			experiments: [
+				{
+					id: 'sample',
+					label: 'Sample',
+					description: 'Sample description',
+					group: 'Labs',
+					enabled: false,
+				},
+			],
+		} );
+
+		render( <ExperimentsPane /> );
+
+		expect(
+			await screen.findByText(
+				'You need to be a site administrator to change experiments.'
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'checkbox', { name: /Sample/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders grouped toggles and saves changes', async () => {
+		window.cortextSettings.experiments.sample = false;
+		apiFetch
+			.mockResolvedValueOnce( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'sample',
+						label: 'Sample',
+						description: 'Sample description',
+						group: 'Labs',
+						enabled: false,
+					},
+				],
+			} )
+			.mockResolvedValueOnce( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'sample',
+						label: 'Sample',
+						description: 'Sample description',
+						group: 'Labs',
+						enabled: true,
+					},
+				],
+			} );
+
+		render( <ExperimentsPane /> );
+
+		expect( await screen.findByText( 'Labs' ) ).toBeInTheDocument();
+		const checkbox = screen.getByRole( 'checkbox', { name: /Sample/ } );
+		expect( checkbox ).not.toBeChecked();
+
+		fireEvent.click( checkbox );
+
+		await waitFor( () =>
+			expect( apiFetch ).toHaveBeenLastCalledWith( {
+				path: '/cortext/v1/experiments',
+				method: 'PUT',
+				data: { enabled: { sample: true } },
+			} )
+		);
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
+			'Experiment updated.',
+			expect.objectContaining( {
+				id: 'cortext-experiments-updated',
+				type: 'snackbar',
+			} )
+		);
+		expect( isExperimentEnabled( 'sample' ) ).toBe( true );
+	} );
+
+	it( 'disables every toggle while a save is pending', async () => {
+		let resolveSave;
+		apiFetch
+			.mockResolvedValueOnce( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'first',
+						label: 'First',
+						description: 'First description',
+						group: 'Labs',
+						enabled: false,
+					},
+					{
+						id: 'second',
+						label: 'Second',
+						description: 'Second description',
+						group: 'Labs',
+						enabled: false,
+					},
+				],
+			} )
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveSave = resolve;
+					} )
+			);
+
+		render( <ExperimentsPane /> );
+
+		const first = await screen.findByRole( 'checkbox', { name: /First/ } );
+		const second = screen.getByRole( 'checkbox', { name: /Second/ } );
+		fireEvent.click( first );
+
+		await waitFor( () => {
+			expect( first ).toBeDisabled();
+			expect( second ).toBeDisabled();
+		} );
+		fireEvent.click( second );
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( second ).not.toBeChecked();
+
+		await act( async () => {
+			resolveSave( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'first',
+						label: 'First',
+						description: 'First description',
+						group: 'Labs',
+						enabled: true,
+					},
+					{
+						id: 'second',
+						label: 'Second',
+						description: 'Second description',
+						group: 'Labs',
+						enabled: false,
+					},
+				],
+			} );
+		} );
+
+		expect( first ).not.toBeDisabled();
+		expect( second ).not.toBeDisabled();
+	} );
+
+	it( 'reverts only the failed experiment after a save failure', async () => {
+		apiFetch
+			.mockResolvedValueOnce( {
+				canManage: true,
+				experiments: [
+					{
+						id: 'sample',
+						label: 'Sample',
+						description: 'Sample description',
+						group: 'Labs',
+						enabled: false,
+					},
+					{
+						id: 'unchanged',
+						label: 'Unchanged',
+						description: 'Unchanged description',
+						group: 'Labs',
+						enabled: true,
+					},
+				],
+			} )
+			.mockRejectedValueOnce( new Error( 'Nope' ) );
+
+		render( <ExperimentsPane /> );
+
+		const checkbox = await screen.findByRole( 'checkbox', {
+			name: /Sample/,
+		} );
+		const unchanged = screen.getByRole( 'checkbox', {
+			name: /Unchanged/,
+		} );
+		fireEvent.click( checkbox );
+
+		await waitFor( () => expect( checkbox ).not.toBeChecked() );
+		expect( unchanged ).toBeChecked();
+		expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+			"Couldn't update this experiment.",
+			expect.objectContaining( {
+				id: 'cortext-experiments-update-failed',
+				type: 'snackbar',
+			} )
+		);
+	} );
+
+	it( 'shows an error when experiments fail to load', async () => {
+		apiFetch.mockRejectedValueOnce( new Error( 'Nope' ) );
+
+		render( <ExperimentsPane /> );
+
+		expect(
+			await screen.findByText( "Couldn't load experiments." )
+		).toBeInTheDocument();
+	} );
+} );

--- a/tests/js/components/SidebarSettingsNav.test.js
+++ b/tests/js/components/SidebarSettingsNav.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 let mockRouteUri = 'settings/import';
+let mockCanManageSettings = true;
 let mockPublicWebAffordances = true;
 const mockNavigate = jest.fn();
 
@@ -31,10 +32,12 @@ jest.mock( '@wordpress/i18n', () => ( {
 jest.mock( '@wordpress/icons', () => ( {
 	chevronLeft: 'chevron-left',
 	globe: 'globe',
+	plugins: 'plugins',
 	upload: 'upload',
 } ) );
 
 jest.mock( '../../../src/settings', () => ( {
+	canManageCortextSettings: () => mockCanManageSettings,
 	isPublicWebAffordancesEnabled: () => mockPublicWebAffordances,
 } ) );
 
@@ -43,6 +46,7 @@ import SidebarSettingsNav from '../../../src/components/SidebarSettingsNav';
 beforeEach( () => {
 	mockNavigate.mockReset();
 	mockRouteUri = 'settings/import';
+	mockCanManageSettings = true;
 	mockPublicWebAffordances = true;
 } );
 
@@ -88,6 +92,39 @@ describe( 'SidebarSettingsNav', () => {
 		expect(
 			screen.queryByRole( 'button', { name: 'Published' } )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'only shows Experiments when settings can be managed', () => {
+		const { rerender } = render(
+			<SidebarSettingsNav collapsed={ false } onBack={ jest.fn() } />
+		);
+		expect(
+			screen.getByRole( 'button', { name: 'Experiments' } )
+		).toBeInTheDocument();
+
+		mockCanManageSettings = false;
+		rerender(
+			<SidebarSettingsNav collapsed={ false } onBack={ jest.fn() } />
+		);
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Experiments' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'opens settings/experiments', () => {
+		render(
+			<SidebarSettingsNav collapsed={ false } onBack={ jest.fn() } />
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Experiments' } )
+		);
+
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'settings/experiments' },
+		} );
 	} );
 
 	it( 'presses the item for the current settings page', () => {

--- a/tests/js/entityRouteReducer.test.js
+++ b/tests/js/entityRouteReducer.test.js
@@ -13,6 +13,7 @@ const documentTarget = ( id ) => ( {
 const redirectTarget = ( to ) => ( { kind: 'redirect', to, tail: '' } );
 const publishedTarget = { kind: 'published', tail: '' };
 const importTarget = { kind: 'import', tail: '' };
+const experimentsTarget = { kind: 'experiments', tail: '' };
 
 function activate( state, target ) {
 	let next = reducer( state, { type: 'TARGET_CHANGED', target } );
@@ -60,6 +61,13 @@ describe( 'EntityRoute reducer', () => {
 		it( 'opens Import from settings/import', () => {
 			expect( parseTarget( 'settings/import' ) ).toEqual( {
 				kind: 'import',
+				tail: '',
+			} );
+		} );
+
+		it( 'opens Experiments from settings/experiments', () => {
+			expect( parseTarget( 'settings/experiments' ) ).toEqual( {
+				kind: 'experiments',
 				tail: '',
 			} );
 		} );
@@ -133,6 +141,12 @@ describe( 'EntityRoute reducer', () => {
 		it( 'starts an import target on the import pane', () => {
 			expect( init( importTarget ).active ).toEqual( {
 				kind: 'import',
+			} );
+		} );
+
+		it( 'starts an experiments target on the experiments pane', () => {
+			expect( init( experimentsTarget ).active ).toEqual( {
+				kind: 'experiments',
 			} );
 		} );
 

--- a/tests/js/settings.test.js
+++ b/tests/js/settings.test.js
@@ -1,7 +1,11 @@
 import {
+	canManageCortextSettings,
 	getCortextFeatures,
+	getCortextExperiments,
+	isExperimentEnabled,
 	isPublicWebAffordancesEnabled,
 	isWordPressAffordancesEnabled,
+	syncCortextExperiments,
 } from '../../src/settings';
 
 describe( 'settings', () => {
@@ -46,5 +50,60 @@ describe( 'settings', () => {
 			wordpressAffordances: true,
 		} );
 		expect( isWordPressAffordancesEnabled() ).toBe( true );
+	} );
+
+	it( 'reads experiment flags from cortextSettings', () => {
+		window.cortextSettings = {
+			experiments: {
+				quickEditing: true,
+				slowEditing: false,
+			},
+		};
+
+		expect( getCortextExperiments() ).toEqual( {
+			quickEditing: true,
+			slowEditing: false,
+		} );
+		expect( isExperimentEnabled( 'quickEditing' ) ).toBe( true );
+		expect( isExperimentEnabled( 'slowEditing' ) ).toBe( false );
+		expect( isExperimentEnabled( 'missing' ) ).toBe( false );
+	} );
+
+	it( 'synchronizes experiment flags from the REST response', () => {
+		const settings = {
+			adminUrl: '/wp-admin/',
+			experiments: { oldExperiment: true },
+		};
+		window.cortextSettings = settings;
+
+		syncCortextExperiments( [
+			{ id: 'quickEditing', enabled: true },
+			{ id: 'slowEditing', enabled: false },
+		] );
+
+		expect( window.cortextSettings ).toBe( settings );
+		expect( getCortextExperiments() ).toEqual( {
+			quickEditing: true,
+			slowEditing: false,
+		} );
+		expect( isExperimentEnabled( 'quickEditing' ) ).toBe( true );
+		expect( isExperimentEnabled( 'oldExperiment' ) ).toBe( false );
+		expect( window.cortextSettings.adminUrl ).toBe( '/wp-admin/' );
+	} );
+
+	it( 'defaults experiment and capability helpers to disabled', () => {
+		expect( getCortextExperiments() ).toEqual( {} );
+		expect( isExperimentEnabled( 'quickEditing' ) ).toBe( false );
+		expect( canManageCortextSettings() ).toBe( false );
+	} );
+
+	it( 'reads manage options capability from cortextSettings', () => {
+		window.cortextSettings = {
+			capabilities: {
+				manageOptions: true,
+			},
+		};
+
+		expect( canManageCortextSettings() ).toBe( true );
 	} );
 } );

--- a/tests/php/test-admin-screen-client-settings.php
+++ b/tests/php/test-admin-screen-client-settings.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Tests for Cortext\Admin\Screen client settings.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Admin\Screen;
+use Cortext\Runtime\Experiments;
+use WorDBless\BaseTestCase;
+
+final class Test_Admin_Screen_Client_Settings extends BaseTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'cortext_experiments' );
+		delete_option( Experiments::OPTION );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_client_settings_include_experiments_and_capabilities(): void {
+		add_filter(
+			'cortext_experiments',
+			static fn () => array(
+				array(
+					'id'          => 'fast_mode',
+					'label'       => 'Fast mode',
+					'description' => 'Makes things faster.',
+				),
+			)
+		);
+		update_option( Experiments::OPTION, array( 'fast_mode' => true ), false );
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$settings = ( new Screen() )->client_settings();
+
+		$this->assertSame( array( 'fast_mode' => true ), $settings['experiments'] );
+		$this->assertTrue( $settings['capabilities']['manageOptions'] );
+		$this->assertSame( Screen::MENU_SLUG, $settings['menuSlug'] );
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+}

--- a/tests/php/test-rest-experiments-controller.php
+++ b/tests/php/test-rest-experiments-controller.php
@@ -109,7 +109,7 @@ final class Test_Rest_Experiments_Controller extends BaseTestCase {
 	/**
 	 * Updates experiment settings through REST.
 	 *
-	 * @param array<string,bool> $enabled Experiment enabled values.
+	 * @param array<string,bool> $enabled Experiment IDs mapped to enabled values.
 	 */
 	private function set_experiments( array $enabled ) {
 		$request = new WP_REST_Request( 'PUT', '/cortext/v1/experiments' );

--- a/tests/php/test-rest-experiments-controller.php
+++ b/tests/php/test-rest-experiments-controller.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Tests for Cortext\Rest\ExperimentsController.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Rest\ExperimentsController;
+use Cortext\Runtime\Experiments;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Experiments_Controller extends BaseTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new ExperimentsController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'cortext_experiments' );
+		delete_option( Experiments::OPTION );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_route_is_registered(): void {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/cortext/v1/experiments', $routes );
+	}
+
+	public function test_get_requires_edit_posts(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$response = $this->get_experiments();
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_get_returns_experiments_and_manage_capability(): void {
+		$this->register_sample_experiment();
+		wp_set_current_user( $this->create_user( 'editor' ) );
+
+		$response = $this->get_experiments();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertFalse( $response->get_data()['canManage'] );
+		$this->assertSame(
+			array(
+				array(
+					'id'          => 'fastMode',
+					'label'       => 'Fast mode',
+					'description' => 'Makes things faster.',
+					'group'       => 'Labs',
+					'enabled'     => false,
+				),
+			),
+			$response->get_data()['experiments']
+		);
+	}
+
+	public function test_put_requires_manage_options(): void {
+		$this->register_sample_experiment();
+		wp_set_current_user( $this->create_user( 'editor' ) );
+
+		$response = $this->set_experiments( array( 'fastMode' => true ) );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_put_rejects_unknown_ids(): void {
+		$this->register_sample_experiment();
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$response = $this->set_experiments( array( 'missing' => true ) );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_experiments_unknown_id', $response->get_data()['code'] );
+	}
+
+	public function test_put_updates_known_experiments(): void {
+		$this->register_sample_experiment();
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$response = $this->set_experiments( array( 'fastMode' => true ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['canManage'] );
+		$this->assertTrue( $response->get_data()['experiments'][0]['enabled'] );
+		$this->assertSame(
+			array( 'fastMode' => true ),
+			get_option( Experiments::OPTION, array() )
+		);
+	}
+
+	private function get_experiments() {
+		return rest_do_request( new WP_REST_Request( 'GET', '/cortext/v1/experiments' ) );
+	}
+
+	/**
+	 * Updates experiment settings through REST.
+	 *
+	 * @param array<string,bool> $enabled Experiment enabled values.
+	 */
+	private function set_experiments( array $enabled ) {
+		$request = new WP_REST_Request( 'PUT', '/cortext/v1/experiments' );
+		$request->set_body_params(
+			array(
+				'enabled' => $enabled,
+			)
+		);
+		return rest_do_request( $request );
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+
+	private function register_sample_experiment(): void {
+		add_filter(
+			'cortext_experiments',
+			static fn () => array(
+				array(
+					'id'          => 'fastMode',
+					'label'       => 'Fast mode',
+					'description' => 'Makes things faster.',
+					'group'       => 'Labs',
+				),
+			)
+		);
+	}
+}

--- a/tests/php/test-runtime-experiments.php
+++ b/tests/php/test-runtime-experiments.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Tests for Cortext experiment registry.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Runtime\Experiments;
+use WorDBless\BaseTestCase;
+
+final class Test_Runtime_Experiments extends BaseTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'cortext_experiments' );
+		delete_option( Experiments::OPTION );
+		parent::tear_down();
+	}
+
+	public function test_defaults_to_empty_registry(): void {
+		$experiments = new Experiments();
+
+		$this->assertSame( array(), $experiments->registered() );
+		$this->assertSame( array(), $experiments->list() );
+		$this->assertSame( array(), $experiments->to_client_settings() );
+		$this->assertFalse( $experiments->is_enabled( 'missing' ) );
+	}
+
+	public function test_registers_and_reads_enabled_values(): void {
+		$this->register_sample_experiments();
+		update_option(
+			Experiments::OPTION,
+			array(
+				'fast_mode' => true,
+				'old_mode'  => true,
+			),
+			false
+		);
+
+		$experiments = new Experiments();
+
+		$this->assertTrue( $experiments->is_enabled( 'fast_mode' ) );
+		$this->assertTrue( $experiments->is_enabled( 'default_on' ) );
+		$this->assertFalse( $experiments->is_enabled( 'old_mode' ) );
+		$this->assertSame(
+			array(
+				'fast_mode'  => true,
+				'default_on' => true,
+			),
+			$experiments->to_client_settings()
+		);
+	}
+
+	public function test_update_rejects_unknown_ids(): void {
+		$this->register_sample_experiments();
+
+		$result = ( new Experiments() )->update( array( 'missing' => true ) );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'cortext_experiments_unknown_id', $result->get_error_code() );
+		$this->assertSame( array(), get_option( Experiments::OPTION, array() ) );
+	}
+
+	public function test_update_stores_known_values(): void {
+		$this->register_sample_experiments();
+
+		$result = ( new Experiments() )->update(
+			array(
+				'fast_mode'  => true,
+				'default_on' => false,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array(
+				'fast_mode'  => true,
+				'default_on' => false,
+			),
+			get_option( Experiments::OPTION, array() )
+		);
+		$this->assertTrue( ( new Experiments() )->is_enabled( 'fast_mode' ) );
+		$this->assertFalse( ( new Experiments() )->is_enabled( 'default_on' ) );
+	}
+
+	public function test_partial_updates_preserve_other_experiment_values(): void {
+		$this->register_sample_experiments();
+		$experiments = new Experiments();
+
+		$experiments->update( array( 'fast_mode' => true ) );
+		$result = $experiments->update( array( 'default_on' => false ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array(
+				'fast_mode'  => true,
+				'default_on' => false,
+			),
+			get_option( Experiments::OPTION, array() )
+		);
+
+		$experiments->update( array( 'fast_mode' => false ) );
+		$this->assertSame(
+			array(
+				'fast_mode'  => false,
+				'default_on' => false,
+			),
+			get_option( Experiments::OPTION, array() )
+		);
+	}
+
+	public function test_preserves_case_sensitive_ids_across_registry_and_storage(): void {
+		add_filter(
+			'cortext_experiments',
+			static fn () => array(
+				array(
+					'id'          => 'quickEditing',
+					'label'       => 'Quick editing',
+					'description' => 'Edits content more quickly.',
+				),
+			)
+		);
+		update_option( Experiments::OPTION, array( 'quickediting' => true ), false );
+
+		$experiments = new Experiments();
+		$registered  = $experiments->registered();
+
+		$this->assertArrayHasKey( 'quickEditing', $registered );
+		$this->assertArrayNotHasKey( 'quickediting', $registered );
+		$this->assertSame( 'quickEditing', $registered['quickEditing']['id'] );
+		$this->assertSame( 'quickEditing', $experiments->list()[0]['id'] );
+		$this->assertFalse( $experiments->list()[0]['enabled'] );
+		$this->assertSame( array( 'quickEditing' => false ), $experiments->to_client_settings() );
+		$this->assertFalse( $experiments->is_enabled( 'quickEditing' ) );
+		$this->assertFalse( $experiments->is_enabled( 'quickediting' ) );
+
+		$result = $experiments->update( array( 'quickEditing' => true ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'quickEditing', $result[0]['id'] );
+		$this->assertTrue( $result[0]['enabled'] );
+		$this->assertSame( array( 'quickEditing' => true ), get_option( Experiments::OPTION, array() ) );
+		$this->assertTrue( $experiments->is_enabled( 'quickEditing' ) );
+		$this->assertSame( array( 'quickEditing' => true ), $experiments->to_client_settings() );
+	}
+
+	public function test_ignores_ids_outside_the_stable_id_contract(): void {
+		add_filter(
+			'cortext_experiments',
+			static fn () => array(
+				array( 'id' => 'Valid-ID_2' ),
+				array( 'id' => '_starts_with_underscore' ),
+				array( 'id' => '2starts_with_number' ),
+				array( 'id' => 'contains.dot' ),
+				array( 'id' => 'contains space' ),
+				array( 'id' => 123 ),
+			)
+		);
+
+		$this->assertSame( array( 'Valid-ID_2' ), array_keys( ( new Experiments() )->registered() ) );
+	}
+
+	private function register_sample_experiments(): void {
+		add_filter(
+			'cortext_experiments',
+			static fn () => array(
+				array(
+					'id'          => 'fast_mode',
+					'label'       => 'Fast mode',
+					'description' => 'Makes things faster.',
+					'group'       => 'Labs',
+				),
+				array(
+					'id'          => 'default_on',
+					'label'       => 'Default on',
+					'description' => 'Starts enabled.',
+					'default'     => true,
+				),
+			)
+		);
+	}
+}


### PR DESCRIPTION
## What

Adds an Experiments screen to Cortext settings. Admins can turn registered features on or off for the whole site. Changes save straight away, and quick clicks don't make the toggles flash or revert.

## Why

We need somewhere to try unfinished features without presenting them as permanent settings.
## How

- Registering experiments in PHP and storing their enabled state for the site.
- Restricting changes to administrators and queuing saves so an older response can't undo a newer click.

## Testing Instructions

1. Register two temporary experiments through the `cortext_experiments` filter.
2. Open Cortext → Settings → Experiments as an administrator.
3. Toggle both experiments quickly, then reload the page and confirm the values stick.
4. Open the Experiments URL as a non-administrator and confirm the controls are replaced by a permission notice.
5. Remove the temporary experiments and confirm the empty state appears.

## Screen recording


https://github.com/user-attachments/assets/f7813da2-dc9a-492f-9132-adb556d60f8e

