### PR TITLE
Tooling: Auto-merge minor and patch Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-merge
+
+on:
+    pull_request:
+        branches: [main]
+        types: [opened, reopened, synchronize]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    auto-merge:
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Read Dependabot metadata
+              id: metadata
+              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Enable auto-merge for minor and patch updates
+              if: |
+                  steps.metadata.outputs.maintainer-changes == 'false' &&
+                  (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+                  steps.metadata.outputs.update-type == 'version-update:semver-minor')
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+              run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## What

Auto-merges minor and patch Dependabot PRs once their required checks pass.

## Why

These routine dependency updates currently need a manual merge even when CI is green.

## Testing Instructions

Not applicable.
