### PR TITLE
Hide the block inserter on full-page collections

### DIFF
--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -85,6 +85,7 @@ function InserterToggle( { disabled = false } ) {
 
 function DocumentActions( {
 	disabled = false,
+	canInsertBlocks = true,
 	isActive,
 	postId,
 	topBarActions,
@@ -120,7 +121,9 @@ function DocumentActions( {
 	return (
 		<TopBarActionsFill>
 			<div className="cortext-document-actions">
-				<InserterToggle disabled={ disabled } />
+				{ canInsertBlocks ? (
+					<InserterToggle disabled={ disabled } />
+				) : null }
 				{ topBarActions }
 				<DocumentPublishToggle
 					postId={ postId }
@@ -241,7 +244,7 @@ function CanvasEditor( {
 		postType: post.type ?? postType,
 		enabled: isActive,
 	} );
-	const { resetPost } = useDispatch( editorStore );
+	const { resetPost, setIsInserterOpened } = useDispatch( editorStore );
 	const discard = useCallback( () => resetPost(), [ resetPost ] );
 	const lastNotifiedBacklinkSaveRef = useRef( null );
 
@@ -312,6 +315,14 @@ function CanvasEditor( {
 		[]
 	);
 
+	// A collection's data view owns the whole body. Clear the editor flag too,
+	// or the inserter will pop open again when the user returns to a page.
+	useEffect( () => {
+		if ( isCollection && isInserterOpened ) {
+			setIsInserterOpened( false );
+		}
+	}, [ isCollection, isInserterOpened, setIsInserterOpened ] );
+
 	const hasProperties = Array.isArray( fields ) && fields.length > 0;
 	const [ arePropertiesVisible, setArePropertiesVisible ] = useState( true );
 	const [ isPropertiesLayoutEditing, setIsPropertiesLayoutEditing ] =
@@ -351,6 +362,7 @@ function CanvasEditor( {
 			<CortextMentions />
 			<DocumentActions
 				disabled={ postLock.isReadOnly }
+				canInsertBlocks={ ! isCollection }
 				isActive={ isActive }
 				postId={ post.id }
 				topBarActions={ topBarActions }
@@ -382,7 +394,9 @@ function CanvasEditor( {
 					</>
 				}
 				secondarySidebar={
-					isInserterOpened ? <CortextInserterSidebar /> : null
+					! isCollection && isInserterOpened ? (
+						<CortextInserterSidebar />
+					) : null
 				}
 				sidebar={ <InspectorSidebarSlot /> }
 			/>

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -155,6 +155,21 @@ export function collectDuplicateHeaderClientIds(
 	return duplicateIds;
 }
 
+// A foreign data view lands in both lists: duplicate owners and new body
+// blocks. The duplicate pass removes it first, so skip it here instead of
+// dispatching removeBlock twice.
+export function collectCollectionBodyClientIdsToRemove(
+	collectionBodyClientIds,
+	snapshotClientIds,
+	removedClientIds
+) {
+	return collectionBodyClientIds.filter(
+		( clientId ) =>
+			! removedClientIds.has( clientId ) &&
+			! snapshotClientIds.has( clientId )
+	);
+}
+
 export function areCanvasReadyRequirementsMet( {
 	hasTitle,
 	needsCover = false,
@@ -779,13 +794,15 @@ function EnsureHeaderBlocks( { isLocked = false, postId, postType } ) {
 		}
 
 		if ( ownerBlockName && hasOwner && snapshot.initialized ) {
-			collectionBodyClientIds
-				.filter( ( clientId ) => ! snapshot.clientIds.has( clientId ) )
-				.forEach( ( clientId ) => {
-					removedClientIds.add( clientId );
-					updateBlockAttributes( clientId, { lock: {} } );
-					removeBlock( clientId, false );
-				} );
+			collectCollectionBodyClientIdsToRemove(
+				collectionBodyClientIds,
+				snapshot.clientIds,
+				removedClientIds
+			).forEach( ( clientId ) => {
+				removedClientIds.add( clientId );
+				updateBlockAttributes( clientId, { lock: {} } );
+				removeBlock( clientId, false );
+			} );
 		}
 
 		if ( isLocked ) {

--- a/tests/e2e/specs/editor-header-blocks.spec.js
+++ b/tests/e2e/specs/editor-header-blocks.spec.js
@@ -267,6 +267,12 @@ async function readCollectionBodyState( page, collectionId ) {
 						block.name === 'core/paragraph' &&
 						getParagraphText( block ) === blockedText
 				).length,
+				invalidDataViewCount: blocks.filter(
+					( block ) =>
+						block.name === 'cortext/data-view' &&
+						Number( block.attributes?.collectionId ) !==
+							Number( postId )
+				).length,
 				legacyLock: legacyBlock?.attributes?.lock ?? null,
 				legacyPresent: Boolean( legacyBlock ),
 				ownerCount: ownerBlocks.length,
@@ -310,6 +316,14 @@ async function attemptCollectionBodyMutations( page, collectionId ) {
 			dispatch.insertBlocks(
 				window.wp.blocks.createBlock( 'core/paragraph', {
 					content: blockedText,
+				} ),
+				blocks.length,
+				undefined,
+				false
+			);
+			dispatch.insertBlocks(
+				window.wp.blocks.createBlock( 'cortext/data-view', {
+					intent: 'create-inline',
 				} ),
 				blocks.length,
 				undefined,
@@ -609,6 +623,28 @@ test.describe( 'editor header blocks', () => {
 				`page=cortext&p=/${ fixture.row.id }`
 			);
 			await waitForEditorPost( page, fixture.row.id );
+			const addBlockButton = page.getByRole( 'button', {
+				name: 'Add block',
+				exact: true,
+			} );
+			await expect( addBlockButton ).toBeEnabled();
+			await addBlockButton.click();
+			await expect(
+				page.locator( '.cortext-inserter-sidebar' )
+			).toBeVisible();
+			await expect
+				.poll( () =>
+					page.evaluate( () =>
+						window.wp.data
+							.select( 'core/editor' )
+							.isInserterOpened()
+					)
+				)
+				.toBe( true );
+			await addBlockButton.click();
+			await expect(
+				page.locator( '.cortext-inserter-sidebar' )
+			).toHaveCount( 0 );
 			await exerciseHeaderGuard( page );
 		} finally {
 			await deleteIfCreated(
@@ -663,13 +699,22 @@ test.describe( 'editor header blocks', () => {
 				ownerCount: 1,
 			} );
 
-			await attemptCollectionBodyMutations( page, collection.id );
+			const pageErrors = [];
+			const onPageError = ( error ) => pageErrors.push( error.message );
+			page.on( 'pageerror', onPageError );
+			try {
+				await attemptCollectionBodyMutations( page, collection.id );
 
-			await expectCollectionBodyState( page, collection.id, {
-				blockedCount: 0,
-				legacyPresent: true,
-				ownerCount: 1,
-			} );
+				await expectCollectionBodyState( page, collection.id, {
+					blockedCount: 0,
+					invalidDataViewCount: 0,
+					legacyPresent: true,
+					ownerCount: 1,
+				} );
+			} finally {
+				page.off( 'pageerror', onPageError );
+			}
+			expect( pageErrors ).toEqual( [] );
 			await selectFirstBlockByName( page, POST_TITLE_BLOCK );
 			await expect(
 				editorCanvas.getByRole( 'button', {
@@ -684,7 +729,7 @@ test.describe( 'editor header blocks', () => {
 		}
 	} );
 
-	test( 'preserves legacy collection body blocks after switching documents', async ( {
+	test( 'closes the inserter when opening a collection and keeps its legacy body', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -721,6 +766,15 @@ test.describe( 'editor header blocks', () => {
 			);
 			await waitForEditorPost( page, sourcePage.id );
 			await expectParagraphsAfterTitle( page, [ BODY_A, BODY_B ] );
+			const addBlockButton = page.getByRole( 'button', {
+				name: 'Add block',
+				exact: true,
+			} );
+			await expect( addBlockButton ).toBeEnabled();
+			await addBlockButton.click();
+			await expect(
+				page.locator( '.cortext-inserter-sidebar' )
+			).toBeVisible();
 
 			await page
 				.locator( '.cortext-sidebar' )
@@ -730,6 +784,19 @@ test.describe( 'editor header blocks', () => {
 				} )
 				.click();
 			await waitForEditorPost( page, collection.id );
+			await expect( addBlockButton ).toHaveCount( 0 );
+			await expect(
+				page.locator( '.cortext-inserter-sidebar' )
+			).toHaveCount( 0 );
+			await expect
+				.poll( () =>
+					page.evaluate( () =>
+						window.wp.data
+							.select( 'core/editor' )
+							.isInserterOpened()
+					)
+				)
+				.toBe( false );
 			await expectCollectionBodyState( page, collection.id, {
 				blockedCount: 0,
 				legacyLock: {
@@ -740,6 +807,19 @@ test.describe( 'editor header blocks', () => {
 				legacyPresent: true,
 				ownerCount: 1,
 			} );
+
+			await page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: sourceTitle,
+					exact: true,
+				} )
+				.click();
+			await waitForEditorPost( page, sourcePage.id );
+			await expect( addBlockButton ).toBeEnabled();
+			await expect(
+				page.locator( '.cortext-inserter-sidebar' )
+			).toHaveCount( 0 );
 		} finally {
 			await deleteIfCreated(
 				requestUtils,

--- a/tests/js/components/EditorBody.test.js
+++ b/tests/js/components/EditorBody.test.js
@@ -77,6 +77,7 @@ jest.mock( '../../../src/hooks/afterNextPaint', () => ( {
 
 const {
 	areCanvasReadyRequirementsMet,
+	collectCollectionBodyClientIdsToRemove,
 	collectDuplicateHeaderClientIds,
 } = require( '../../../src/components/EditorBody' );
 
@@ -172,6 +173,26 @@ describe( 'collectDuplicateHeaderClientIds', () => {
 		expect(
 			collectDuplicateHeaderClientIds( blocks, OWNER, COLLECTION_ID )
 		).toEqual( [ 'cover-2', 'title-2' ] );
+	} );
+} );
+
+describe( 'collectCollectionBodyClientIdsToRemove', () => {
+	it( 'skips a data view already removed as a duplicate', () => {
+		const collectionBodyClientIds = [
+			'new-collection',
+			'new-paragraph',
+			'legacy-paragraph',
+		];
+		const snapshotClientIds = new Set( [ 'legacy-paragraph' ] );
+		const removedClientIds = new Set( [ 'new-collection' ] );
+
+		expect(
+			collectCollectionBodyClientIdsToRemove(
+				collectionBodyClientIds,
+				snapshotClientIds,
+				removedClientIds
+			)
+		).toEqual( [ 'new-paragraph' ] );
 	} );
 } );
 


### PR DESCRIPTION
## What

Full-page collections no longer show the "Add block" button. If the inserter is open when you navigate to a collection, it closes and stays closed when you return to the page. Pages and rows are unchanged.

## Why

The body of a full-page collection belongs to its data view. Before this fix, "Add block" opened an inserter that looked usable, then discarded whatever you chose. Picking "New collection" could also throw an editor error while the block was being removed.

## Testing Instructions

1. Open a page and click "Add block". Confirm the inserter opens.
2. Keep it open and navigate to a full-page collection. Confirm the button and sidebar disappear.
3. Return to the page. Confirm the button returns but the inserter stays closed.
4. Open a collection row as a full page and confirm "Add block" still works.