### PR TITLE
Add templates for documents and collection rows

### DIFF
--- a/cortext.php
+++ b/cortext.php
@@ -49,6 +49,7 @@ register_activation_hook(
 		// same registration runs again on `init` during normal boot via
 		// `Plugin::boot()`.
 		( new \Cortext\PostType\Document() )->register_post_type();
+		( new \Cortext\PostType\Template() )->register_post_type();
 		( new \Cortext\Taxonomy\TraitTaxonomy() )->register_taxonomy();
 		( new \Cortext\FieldValues\FieldValueIndex() )->activate();
 		flush_rewrite_rules();

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -27,6 +27,7 @@ use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
+use Cortext\PostType\Template as TemplatePostType;
 use Cortext\PostType\TrashCascade;
 use Cortext\Rest\BacklinksController;
 use Cortext\Rest\DocumentLocatorController;
@@ -41,6 +42,7 @@ use Cortext\Rest\RecentsController;
 use Cortext\Rest\RowsController;
 use Cortext\Rest\SampleContentController;
 use Cortext\Rest\SidebarTreePreferencesController;
+use Cortext\Rest\TemplatesController;
 use Cortext\Rest\WorkspaceHomeController;
 use Cortext\Taxonomy\MentionTaxonomy;
 use Cortext\Taxonomy\TraitTaxonomy;
@@ -64,6 +66,7 @@ final class Plugin {
 		( new TraitTaxonomy() )->register();
 		( new MentionTaxonomy() )->register();
 		( new Field() )->register();
+		( new TemplatePostType() )->register();
 		( new FieldValueIndex() )->register();
 
 		$archive_cascade = new ArchiveCascade();
@@ -89,6 +92,7 @@ final class Plugin {
 		( new RowsController() )->register();
 		( new SampleContentController() )->register();
 		( new SidebarTreePreferencesController() )->register();
+		( new TemplatesController() )->register();
 		( new WorkspaceHomeController() )->register();
 		( new NotionController() )->register();
 		( new NotionImporter() )->register();

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -107,12 +107,6 @@ final class Plugin {
 		( new Preferences() )->register();
 	}
 
-	/**
-	 * Registers experiments owned by the plugin.
-	 *
-	 * @param array<int,array<string,mixed>> $experiments Registered experiments.
-	 * @return array<int,array<string,mixed>>
-	 */
 	public function register_experiments( array $experiments ): array {
 		$experiments[] = array(
 			'id'          => Templates::EXPERIMENT_ID,

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -60,6 +60,8 @@ final class Plugin {
 	}
 
 	public function boot(): void {
+		add_filter( 'cortext_experiments', array( $this, 'register_experiments' ) );
+
 		( new Screen() )->register();
 		( new Document() )->register();
 		( new DocumentIdentity() )->register();
@@ -103,6 +105,24 @@ final class Plugin {
 		( new DataView() )->register();
 		( new CortextMedia() )->register();
 		( new Preferences() )->register();
+	}
+
+	/**
+	 * Registers experiments owned by the plugin.
+	 *
+	 * @param array<int,array<string,mixed>> $experiments Registered experiments.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function register_experiments( array $experiments ): array {
+		$experiments[] = array(
+			'id'          => Templates::EXPERIMENT_ID,
+			'label'       => __( 'Templates', 'cortext' ),
+			'description' => __( 'Create reusable starting points for documents and collection rows.', 'cortext' ),
+			'group'       => __( 'Content', 'cortext' ),
+			'default'     => false,
+		);
+
+		return $experiments;
 	}
 
 	private function __construct() {}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -111,7 +111,7 @@ final class Plugin {
 		$experiments[] = array(
 			'id'          => Templates::EXPERIMENT_ID,
 			'label'       => __( 'Templates', 'cortext' ),
-			'description' => __( 'Create reusable starting points for documents and collection rows.', 'cortext' ),
+			'description' => __( 'Start documents and collection rows from saved templates.', 'cortext' ),
 			'group'       => __( 'Content', 'cortext' ),
 			'default'     => false,
 		);

--- a/includes/PostType/Template.php
+++ b/includes/PostType/Template.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Registers the hidden template post type shared by page and row templates.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\PostType;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\Templates;
+
+final class Template {
+
+	public const POST_TYPE = 'crtxt_template';
+
+	public const META_KIND          = 'cortext_template_kind';
+	public const META_COLLECTION_ID = 'cortext_template_collection_id';
+	public const META_FIELD_VALUES  = 'cortext_template_field_values';
+
+	public function register(): void {
+		add_action( 'init', array( $this, 'register_post_type' ) );
+		add_action( 'init', array( $this, 'register_meta' ), 11 );
+		add_action( 'before_delete_post', array( $this, 'clear_deleted_default' ), 10, 2 );
+	}
+
+	public function register_post_type(): void {
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'labels'                => array(
+					'name'          => __( 'Cortext Templates', 'cortext' ),
+					'singular_name' => __( 'Cortext Template', 'cortext' ),
+				),
+				'public'                => false,
+				'publicly_queryable'    => false,
+				'exclude_from_search'   => true,
+				'show_ui'               => false,
+				'show_in_menu'          => false,
+				'show_in_rest'          => true,
+				'rest_base'             => 'crtxt_templates',
+				'rest_controller_class' => 'WP_REST_Posts_Controller',
+				'has_archive'           => false,
+				'hierarchical'          => false,
+				'supports'              => array(
+					'title',
+					'editor',
+					'revisions',
+					'custom-fields',
+				),
+				'capability_type'       => 'post',
+				'map_meta_cap'          => true,
+				'can_export'            => true,
+				'delete_with_user'      => false,
+			)
+		);
+	}
+
+	public function register_meta(): void {
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_KIND,
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'default'           => Templates::KIND_PAGE,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( Templates::KIND_PAGE, Templates::KIND_ROW ),
+					),
+				),
+				'auth_callback'     => static fn(): bool => current_user_can( 'edit_posts' ),
+				'sanitize_callback' => array( Templates::class, 'sanitize_kind' ),
+			)
+		);
+
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_COLLECTION_ID,
+			array(
+				'type'              => 'integer',
+				'single'            => true,
+				'default'           => 0,
+				'show_in_rest'      => true,
+				'auth_callback'     => static fn(): bool => current_user_can( 'edit_posts' ),
+				'sanitize_callback' => static fn( $value ): int => max( 0, (int) $value ),
+			)
+		);
+
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_FIELD_VALUES,
+			array(
+				'type'              => 'object',
+				'single'            => true,
+				'default'           => array(),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'additionalProperties' => true,
+					),
+				),
+				'auth_callback'     => static fn(): bool => current_user_can( 'edit_posts' ),
+				'sanitize_callback' => array( Templates::class, 'sanitize_field_values' ),
+			)
+		);
+	}
+
+	/**
+	 * Clears the page-template default option when its target is deleted.
+	 *
+	 * @param int      $post_id Deleted post id.
+	 * @param \WP_Post $post    Deleted post.
+	 */
+	public function clear_deleted_default( int $post_id, \WP_Post $post ): void {
+		if ( self::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		if ( (int) get_option( Templates::PAGE_DEFAULT_OPTION, 0 ) === $post_id ) {
+			delete_option( Templates::PAGE_DEFAULT_OPTION );
+		}
+	}
+}

--- a/includes/PostType/Template.php
+++ b/includes/PostType/Template.php
@@ -110,12 +110,6 @@ final class Template {
 		);
 	}
 
-	/**
-	 * Clears the page-template default option when its target is deleted.
-	 *
-	 * @param int      $post_id Deleted post id.
-	 * @param \WP_Post $post    Deleted post.
-	 */
 	public function clear_deleted_default( int $post_id, \WP_Post $post ): void {
 		if ( self::POST_TYPE !== $post->post_type ) {
 			return;

--- a/includes/PostType/Template.php
+++ b/includes/PostType/Template.php
@@ -24,7 +24,6 @@ final class Template {
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'init', array( $this, 'register_meta' ), 11 );
-		add_action( 'before_delete_post', array( $this, 'clear_deleted_default' ), 10, 2 );
 	}
 
 	public function register_post_type(): void {
@@ -108,14 +107,5 @@ final class Template {
 				'sanitize_callback' => array( Templates::class, 'sanitize_field_values' ),
 			)
 		);
-	}
-
-	public function clear_deleted_default( int $post_id, \WP_Post $post ): void {
-		if ( self::POST_TYPE !== $post->post_type ) {
-			return;
-		}
-		if ( (int) get_option( Templates::PAGE_DEFAULT_OPTION, 0 ) === $post_id ) {
-			delete_option( Templates::PAGE_DEFAULT_OPTION );
-		}
 	}
 }

--- a/includes/Rest/TemplatesController.php
+++ b/includes/Rest/TemplatesController.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * REST endpoints for Cortext templates.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Rest;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\PostType\Template as TemplatePostType;
+use Cortext\Templates;
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class TemplatesController {
+
+	private const NAMESPACE = 'cortext/v1';
+
+	public function __construct( private ?Templates $templates = null ) {
+		$this->templates = $templates ?? new Templates();
+	}
+
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/templates',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'list_templates' ),
+					'permission_callback' => array( $this, 'can_read' ),
+					'args'                => array(
+						'kind'          => array(
+							'type' => 'string',
+							'enum' => array( Templates::KIND_PAGE, Templates::KIND_ROW ),
+						),
+						'collection_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+				),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'create_template' ),
+					'permission_callback' => array( $this, 'can_read' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/templates/default',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_default' ),
+					'permission_callback' => array( $this, 'can_read' ),
+				),
+				array(
+					'methods'             => 'PUT',
+					'callback'            => array( $this, 'set_default' ),
+					'permission_callback' => array( $this, 'can_read' ),
+					'args'                => array(
+						'id' => array(
+							'type'     => array( 'integer', 'null' ),
+							'required' => false,
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/templates/from-document',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'create_from_document' ),
+					'permission_callback' => array( $this, 'can_read' ),
+					'args'                => array(
+						'document_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+							'minimum'  => 1,
+						),
+					),
+				),
+			)
+		);
+
+		$id_arg = array(
+			'id' => array(
+				'type'     => 'integer',
+				'required' => true,
+			),
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/templates/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_template' ),
+					'permission_callback' => array( $this, 'can_edit_template' ),
+					'args'                => $id_arg,
+				),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'update_template' ),
+					'permission_callback' => array( $this, 'can_edit_template' ),
+					'args'                => $id_arg,
+				),
+				array(
+					'methods'             => 'DELETE',
+					'callback'            => array( $this, 'delete_template' ),
+					'permission_callback' => array( $this, 'can_edit_template' ),
+					'args'                => $id_arg,
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/templates/(?P<id>\d+)/duplicate',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'duplicate_template' ),
+					'permission_callback' => array( $this, 'can_edit_template' ),
+					'args'                => $id_arg,
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/templates/(?P<id>\d+)/instantiate',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'instantiate_template' ),
+					'permission_callback' => array( $this, 'can_edit_template' ),
+					'args'                => $id_arg,
+				),
+			)
+		);
+	}
+
+	public function can_read(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Checks whether the current user can edit the target template.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return bool|WP_Error
+	 */
+	public function can_edit_template( WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$post = get_post( $id );
+
+		if ( ! $post instanceof WP_Post || TemplatePostType::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'cortext_template_not_found',
+				__( "Couldn't find that template.", 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return current_user_can( 'edit_post', $id );
+	}
+
+	public function list_templates( WP_REST_Request $request ): WP_REST_Response {
+		return new WP_REST_Response(
+			array(
+				'templates' => $this->templates->list(
+					array(
+						'kind'          => $request->get_param( 'kind' ),
+						'collection_id' => $request->get_param( 'collection_id' ),
+					)
+				),
+			),
+			200
+		);
+	}
+
+	public function create_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$template = $this->templates->create( $this->body_params( $request ) );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+		return new WP_REST_Response( array( 'template' => $template ), 201 );
+	}
+
+	public function create_from_document( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$template = $this->templates->create_from_document(
+			(int) $request->get_param( 'document_id' )
+		);
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+		return new WP_REST_Response( array( 'template' => $template ), 201 );
+	}
+
+	public function get_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$id       = (int) $request->get_param( 'id' );
+		$template = get_post( $id );
+		if ( ! $template instanceof WP_Post || TemplatePostType::POST_TYPE !== $template->post_type ) {
+			return new WP_Error(
+				'cortext_template_not_found',
+				__( "Couldn't find that template.", 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+		return new WP_REST_Response( array( 'template' => $this->templates->format_template( $template ) ), 200 );
+	}
+
+	public function update_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$template = $this->templates->update(
+			(int) $request->get_param( 'id' ),
+			$this->body_params( $request )
+		);
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+		return new WP_REST_Response( array( 'template' => $template ), 200 );
+	}
+
+	public function delete_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$id       = (int) $request->get_param( 'id' );
+		$previous = get_post( $id );
+		$deleted  = $this->templates->delete( $id );
+		if ( $deleted instanceof WP_Error ) {
+			return $deleted;
+		}
+		return new WP_REST_Response(
+			array(
+				'deleted'  => $deleted,
+				'previous' => $previous instanceof WP_Post ? $this->templates->format_template( $previous ) : null,
+			),
+			200
+		);
+	}
+
+	public function duplicate_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$template = $this->templates->duplicate( (int) $request->get_param( 'id' ) );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+		return new WP_REST_Response( array( 'template' => $template ), 201 );
+	}
+
+	public function instantiate_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$document = $this->templates->instantiate(
+			(int) $request->get_param( 'id' ),
+			$this->body_params( $request )
+		);
+		if ( $document instanceof WP_Error ) {
+			return $document;
+		}
+		return new WP_REST_Response( array( 'document' => $document ), 201 );
+	}
+
+	public function get_default(): WP_REST_Response {
+		return new WP_REST_Response(
+			array(
+				'template' => $this->templates->get_page_default(),
+			),
+			200
+		);
+	}
+
+	public function set_default( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$id       = $request->get_param( 'id' );
+		$template = $this->templates->set_page_default( null === $id ? null : (int) $id );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+		return new WP_REST_Response( array( 'template' => $template ), 200 );
+	}
+
+	/**
+	 * Returns request body parameters as an array.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return array<string,mixed>
+	 */
+	private function body_params( WP_REST_Request $request ): array {
+		$params = $request->get_json_params();
+		if ( ! is_array( $params ) || array() === $params ) {
+			$params = $request->get_body_params();
+		}
+		return is_array( $params ) ? $params : array();
+	}
+}

--- a/includes/Rest/TemplatesController.php
+++ b/includes/Rest/TemplatesController.php
@@ -163,12 +163,6 @@ final class TemplatesController {
 		return current_user_can( 'edit_posts' );
 	}
 
-	/**
-	 * Checks whether the current user can edit the target template.
-	 *
-	 * @param WP_REST_Request $request REST request.
-	 * @return bool|WP_Error
-	 */
 	public function can_edit_template( WP_REST_Request $request ) {
 		$id   = (int) $request->get_param( 'id' );
 		$post = get_post( $id );
@@ -293,12 +287,6 @@ final class TemplatesController {
 		return new WP_REST_Response( array( 'template' => $template ), 200 );
 	}
 
-	/**
-	 * Returns request body parameters as an array.
-	 *
-	 * @param WP_REST_Request $request REST request.
-	 * @return array<string,mixed>
-	 */
 	private function body_params( WP_REST_Request $request ): array {
 		$params = $request->get_json_params();
 		if ( ! is_array( $params ) || array() === $params ) {

--- a/includes/Rest/TemplatesController.php
+++ b/includes/Rest/TemplatesController.php
@@ -163,7 +163,7 @@ final class TemplatesController {
 		return current_user_can( 'edit_posts' );
 	}
 
-	public function can_edit_template( WP_REST_Request $request ) {
+	public function can_edit_template( WP_REST_Request $request ): bool|WP_Error {
 		$id   = (int) $request->get_param( 'id' );
 		$post = get_post( $id );
 

--- a/includes/Rest/TemplatesController.php
+++ b/includes/Rest/TemplatesController.php
@@ -58,25 +58,6 @@ final class TemplatesController {
 			)
 		);
 
-		register_rest_route(
-			self::NAMESPACE,
-			'/templates/from-document',
-			array(
-				array(
-					'methods'             => 'POST',
-					'callback'            => array( $this, 'create_from_document' ),
-					'permission_callback' => array( $this, 'can_read' ),
-					'args'                => array(
-						'document_id' => array(
-							'type'     => 'integer',
-							'required' => true,
-							'minimum'  => 1,
-						),
-					),
-				),
-			)
-		);
-
 		$id_arg = array(
 			'id' => array(
 				'type'     => 'integer',
@@ -89,33 +70,8 @@ final class TemplatesController {
 			'/templates/(?P<id>\d+)',
 			array(
 				array(
-					'methods'             => 'GET',
-					'callback'            => array( $this, 'get_template' ),
-					'permission_callback' => array( $this, 'can_edit_template' ),
-					'args'                => $id_arg,
-				),
-				array(
 					'methods'             => 'POST',
 					'callback'            => array( $this, 'update_template' ),
-					'permission_callback' => array( $this, 'can_edit_template' ),
-					'args'                => $id_arg,
-				),
-				array(
-					'methods'             => 'DELETE',
-					'callback'            => array( $this, 'delete_template' ),
-					'permission_callback' => array( $this, 'can_edit_template' ),
-					'args'                => $id_arg,
-				),
-			)
-		);
-
-		register_rest_route(
-			self::NAMESPACE,
-			'/templates/(?P<id>\d+)/duplicate',
-			array(
-				array(
-					'methods'             => 'POST',
-					'callback'            => array( $this, 'duplicate_template' ),
 					'permission_callback' => array( $this, 'can_edit_template' ),
 					'args'                => $id_arg,
 				),
@@ -177,29 +133,6 @@ final class TemplatesController {
 		return new WP_REST_Response( array( 'template' => $template ), 201 );
 	}
 
-	public function create_from_document( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$template = $this->templates->create_from_document(
-			(int) $request->get_param( 'document_id' )
-		);
-		if ( $template instanceof WP_Error ) {
-			return $template;
-		}
-		return new WP_REST_Response( array( 'template' => $template ), 201 );
-	}
-
-	public function get_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$id       = (int) $request->get_param( 'id' );
-		$template = get_post( $id );
-		if ( ! $template instanceof WP_Post || TemplatePostType::POST_TYPE !== $template->post_type ) {
-			return new WP_Error(
-				'cortext_template_not_found',
-				__( "Couldn't find that template.", 'cortext' ),
-				array( 'status' => 404 )
-			);
-		}
-		return new WP_REST_Response( array( 'template' => $this->templates->format_template( $template ) ), 200 );
-	}
-
 	public function update_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$template = $this->templates->update(
 			(int) $request->get_param( 'id' ),
@@ -209,30 +142,6 @@ final class TemplatesController {
 			return $template;
 		}
 		return new WP_REST_Response( array( 'template' => $template ), 200 );
-	}
-
-	public function delete_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$id       = (int) $request->get_param( 'id' );
-		$previous = get_post( $id );
-		$deleted  = $this->templates->delete( $id );
-		if ( $deleted instanceof WP_Error ) {
-			return $deleted;
-		}
-		return new WP_REST_Response(
-			array(
-				'deleted'  => $deleted,
-				'previous' => $previous instanceof WP_Post ? $this->templates->format_template( $previous ) : null,
-			),
-			200
-		);
-	}
-
-	public function duplicate_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$template = $this->templates->duplicate( (int) $request->get_param( 'id' ) );
-		if ( $template instanceof WP_Error ) {
-			return $template;
-		}
-		return new WP_REST_Response( array( 'template' => $template ), 201 );
 	}
 
 	public function instantiate_template( WP_REST_Request $request ): WP_REST_Response|WP_Error {

--- a/includes/Rest/TemplatesController.php
+++ b/includes/Rest/TemplatesController.php
@@ -60,29 +60,6 @@ final class TemplatesController {
 
 		register_rest_route(
 			self::NAMESPACE,
-			'/templates/default',
-			array(
-				array(
-					'methods'             => 'GET',
-					'callback'            => array( $this, 'get_default' ),
-					'permission_callback' => array( $this, 'can_read' ),
-				),
-				array(
-					'methods'             => 'PUT',
-					'callback'            => array( $this, 'set_default' ),
-					'permission_callback' => array( $this, 'can_read' ),
-					'args'                => array(
-						'id' => array(
-							'type'     => array( 'integer', 'null' ),
-							'required' => false,
-						),
-					),
-				),
-			)
-		);
-
-		register_rest_route(
-			self::NAMESPACE,
 			'/templates/from-document',
 			array(
 				array(
@@ -267,24 +244,6 @@ final class TemplatesController {
 			return $document;
 		}
 		return new WP_REST_Response( array( 'document' => $document ), 201 );
-	}
-
-	public function get_default(): WP_REST_Response {
-		return new WP_REST_Response(
-			array(
-				'template' => $this->templates->get_page_default(),
-			),
-			200
-		);
-	}
-
-	public function set_default( WP_REST_Request $request ): WP_REST_Response|WP_Error {
-		$id       = $request->get_param( 'id' );
-		$template = $this->templates->set_page_default( null === $id ? null : (int) $id );
-		if ( $template instanceof WP_Error ) {
-			return $template;
-		}
-		return new WP_REST_Response( array( 'template' => $template ), 200 );
 	}
 
 	private function body_params( WP_REST_Request $request ): array {

--- a/includes/Templates.php
+++ b/includes/Templates.php
@@ -314,7 +314,7 @@ final class Templates {
 		if ( self::KIND_PAGE !== $meta['kind'] ) {
 			return new WP_Error(
 				'cortext_template_default_invalid_kind',
-				__( 'Only page templates can be the default.', 'cortext' ),
+				__( 'Choose a document template as the default.', 'cortext' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/includes/Templates.php
+++ b/includes/Templates.php
@@ -1,0 +1,765 @@
+<?php
+/**
+ * Shared service for Cortext page and row templates.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\FieldValues\FieldValueIndex;
+use Cortext\PostType\Document;
+use Cortext\PostType\Template as TemplatePostType;
+use Cortext\Taxonomy\TraitTaxonomy;
+use WP_Error;
+use WP_Post;
+
+final class Templates {
+
+	public const KIND_PAGE = 'page';
+	public const KIND_ROW  = 'row';
+
+	public const PAGE_DEFAULT_OPTION = 'cortext_default_page_template_id';
+
+	private const TEMPLATE_HEADER_BLOCKS = array(
+		'core/post-title',
+		'cortext/document-cover',
+		'cortext/document-icon',
+		'cortext/document-properties',
+	);
+
+	public static function sanitize_kind( $value ): string {
+		$kind = is_string( $value ) ? sanitize_key( $value ) : '';
+		return self::KIND_ROW === $kind ? self::KIND_ROW : self::KIND_PAGE;
+	}
+
+	/**
+	 * Sanitizes the loose field-default map stored on row templates.
+	 *
+	 * @param mixed $value Raw meta value.
+	 * @return array<string,mixed>
+	 */
+	public static function sanitize_field_values( $value ): array {
+		if ( is_object( $value ) ) {
+			$value = (array) $value;
+		}
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$sanitized = array();
+		foreach ( $value as $key => $raw ) {
+			if ( ! is_string( $key ) || 1 !== preg_match( '/^field-[1-9][0-9]*$/', $key ) ) {
+				continue;
+			}
+			$sanitized[ $key ] = self::sanitize_field_value( $raw );
+		}
+		return $sanitized;
+	}
+
+	/**
+	 * Sanitizes one field value for template storage.
+	 *
+	 * @param mixed $value Raw field value.
+	 * @return mixed
+	 */
+	private static function sanitize_field_value( $value ) {
+		if ( is_array( $value ) ) {
+			return array_values(
+				array_map(
+					static fn( $entry ) => self::sanitize_scalar_field_value( $entry ),
+					$value
+				)
+			);
+		}
+		return self::sanitize_scalar_field_value( $value );
+	}
+
+	/**
+	 * Sanitizes one scalar field value for template storage.
+	 *
+	 * @param mixed $value Raw scalar field value.
+	 * @return bool|float|int|string|null
+	 */
+	private static function sanitize_scalar_field_value( $value ) {
+		if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) || null === $value ) {
+			return $value;
+		}
+		return sanitize_text_field( (string) $value );
+	}
+
+	/**
+	 * Lists templates matching the provided filters.
+	 *
+	 * @param array<string,mixed> $args Query args.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function list( array $args = array() ): array {
+		$kind          = isset( $args['kind'] ) ? self::sanitize_kind( $args['kind'] ) : null;
+		$collection_id = isset( $args['collection_id'] ) ? max( 0, (int) $args['collection_id'] ) : 0;
+
+		$query_args = array(
+			'post_type'           => TemplatePostType::POST_TYPE,
+			'post_status'         => array( 'private', 'draft', 'publish' ),
+			'posts_per_page'      => -1,
+			'orderby'             => 'modified',
+			'order'               => 'DESC',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+		);
+
+		$meta_query = array();
+		if ( null !== $kind ) {
+			$meta_query[] = array(
+				'key'   => TemplatePostType::META_KIND,
+				'value' => $kind,
+			);
+		}
+		if ( $collection_id > 0 ) {
+			$meta_query[] = array(
+				'key'   => TemplatePostType::META_COLLECTION_ID,
+				'value' => (string) $collection_id,
+			);
+		}
+		if ( count( $meta_query ) > 0 ) {
+			$query_args['meta_query'] = $meta_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		}
+
+		$posts = get_posts( $query_args );
+		return array_values(
+			array_filter(
+				array_map(
+					fn( WP_Post $post ): ?array => current_user_can( 'edit_post', $post->ID )
+						? $this->format_template( $post )
+						: null,
+					$posts
+				)
+			)
+		);
+	}
+
+	/**
+	 * Creates a template post.
+	 *
+	 * @param array<string,mixed> $payload Template payload.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function create( array $payload ) {
+		$normalized = $this->normalize_template_payload( $payload, true );
+		if ( $normalized instanceof WP_Error ) {
+			return $normalized;
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => TemplatePostType::POST_TYPE,
+				'post_status'  => 'private',
+				'post_title'   => $normalized['title'],
+				'post_content' => $normalized['content'],
+				'meta_input'   => array(
+					TemplatePostType::META_KIND          => $normalized['kind'],
+					TemplatePostType::META_COLLECTION_ID => $normalized['collection_id'],
+					TemplatePostType::META_FIELD_VALUES  => $normalized['field_values'],
+				),
+			),
+			true
+		);
+		if ( $post_id instanceof WP_Error ) {
+			return $post_id;
+		}
+
+		$post = get_post( (int) $post_id );
+		return $post instanceof WP_Post ? $this->format_template( $post ) : $this->insert_failed_error();
+	}
+
+	/**
+	 * Creates a template from an existing document or row.
+	 *
+	 * @param int $document_id Source document id.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function create_from_document( int $document_id ) {
+		$post = get_post( $document_id );
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'cortext_template_source_not_found',
+				__( "Couldn't find that document.", 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+		if ( ! current_user_can( 'edit_post', $document_id ) ) {
+			return new WP_Error(
+				'cortext_template_source_forbidden',
+				__( "You can't create a template from this document.", 'cortext' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$trait = ( new Documents() )->find_trait_for_document( $post );
+		if ( $trait instanceof WP_Post ) {
+			return $this->create(
+				array(
+					'kind'          => self::KIND_ROW,
+					'collection_id' => (int) $trait->ID,
+					'title'         => $post->post_title,
+					'content'       => $post->post_content,
+					'field_values'  => $this->field_values_from_row( $document_id, (int) $trait->ID ),
+				)
+			);
+		}
+
+		if ( Document::is_collection( $document_id ) ) {
+			return new WP_Error(
+				'cortext_template_source_collection',
+				__( "Collections can't be saved as templates yet.", 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return $this->create(
+			array(
+				'kind'    => self::KIND_PAGE,
+				'title'   => $post->post_title,
+				'content' => $post->post_content,
+			)
+		);
+	}
+
+	/**
+	 * Updates an existing template post.
+	 *
+	 * @param int                 $id      Template id.
+	 * @param array<string,mixed> $payload Template payload.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function update( int $id, array $payload ) {
+		$template = $this->get_template_post( $id );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+
+		$current = $this->template_meta( $template );
+		$merged  = array_merge(
+			array(
+				'kind'          => $current['kind'],
+				'collection_id' => $current['collection_id'],
+				'field_values'  => $current['field_values'],
+				'title'         => $template->post_title,
+				'content'       => $template->post_content,
+			),
+			$payload
+		);
+
+		$normalized = $this->normalize_template_payload( $merged, false );
+		if ( $normalized instanceof WP_Error ) {
+			return $normalized;
+		}
+
+		$result = wp_update_post(
+			array(
+				'ID'           => $id,
+				'post_title'   => $normalized['title'],
+				'post_content' => $normalized['content'],
+			),
+			true
+		);
+		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		update_post_meta( $id, TemplatePostType::META_KIND, $normalized['kind'] );
+		update_post_meta( $id, TemplatePostType::META_COLLECTION_ID, $normalized['collection_id'] );
+		update_post_meta( $id, TemplatePostType::META_FIELD_VALUES, $normalized['field_values'] );
+
+		$post = get_post( $id );
+		return $post instanceof WP_Post ? $this->format_template( $post ) : $this->template_not_found_error();
+	}
+
+	/**
+	 * Duplicates a template post.
+	 *
+	 * @param int $id Template id.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function duplicate( int $id ) {
+		$template = $this->get_template_post( $id );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+		$meta = $this->template_meta( $template );
+
+		return $this->create(
+			array(
+				/* translators: %s: source template title */
+				'title'         => sprintf( __( 'Copy of %s', 'cortext' ), $template->post_title ? $template->post_title : __( 'Untitled template', 'cortext' ) ),
+				'content'       => $template->post_content,
+				'kind'          => $meta['kind'],
+				'collection_id' => $meta['collection_id'],
+				'field_values'  => $meta['field_values'],
+			)
+		);
+	}
+
+	public function delete( int $id ): bool|WP_Error {
+		$template = $this->get_template_post( $id );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+
+		return (bool) wp_delete_post( $id, true );
+	}
+
+	/**
+	 * Instantiates a template into a page or row document.
+	 *
+	 * @param int                 $id   Template id.
+	 * @param array<string,mixed> $args Instantiation args.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function instantiate( int $id, array $args = array() ) {
+		$template = $this->get_template_post( $id );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+		$meta = $this->template_meta( $template );
+
+		if ( self::KIND_ROW === $meta['kind'] ) {
+			return $this->instantiate_row( $template, $meta, $args );
+		}
+
+		return $this->instantiate_page( $template, $args );
+	}
+
+	public function get_page_default(): ?array {
+		$id = (int) get_option( self::PAGE_DEFAULT_OPTION, 0 );
+		if ( $id < 1 ) {
+			return null;
+		}
+		$template = $this->get_template_post( $id );
+		if ( $template instanceof WP_Error ) {
+			delete_option( self::PAGE_DEFAULT_OPTION );
+			return null;
+		}
+		$meta = $this->template_meta( $template );
+		if ( self::KIND_PAGE !== $meta['kind'] ) {
+			delete_option( self::PAGE_DEFAULT_OPTION );
+			return null;
+		}
+		if ( ! current_user_can( 'edit_post', $id ) ) {
+			return null;
+		}
+		return $this->format_template( $template );
+	}
+
+	public function set_page_default( ?int $id ): array|WP_Error|null {
+		if ( null === $id || $id < 1 ) {
+			delete_option( self::PAGE_DEFAULT_OPTION );
+			return null;
+		}
+
+		$template = $this->get_template_post( $id );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+		$meta = $this->template_meta( $template );
+		if ( self::KIND_PAGE !== $meta['kind'] ) {
+			return new WP_Error(
+				'cortext_template_default_invalid_kind',
+				__( 'Only page templates can be the default.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+		if ( ! current_user_can( 'edit_post', $id ) ) {
+			return new WP_Error(
+				'cortext_template_default_forbidden',
+				__( "You can't use this template as the default.", 'cortext' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		update_option( self::PAGE_DEFAULT_OPTION, $id, false );
+		return $this->format_template( $template );
+	}
+
+	/**
+	 * Formats a template for the Cortext REST API.
+	 *
+	 * @param WP_Post $template Template post.
+	 * @return array<string,mixed>
+	 */
+	public function format_template( WP_Post $template ): array {
+		$meta = $this->template_meta( $template );
+		return array(
+			'id'            => (int) $template->ID,
+			'title'         => $template->post_title,
+			'content'       => $template->post_content,
+			'kind'          => $meta['kind'],
+			'collection_id' => $meta['collection_id'] > 0 ? $meta['collection_id'] : null,
+			'field_values'  => $meta['field_values'],
+			'modified'      => $template->post_modified_gmt,
+		);
+	}
+
+	/**
+	 * Normalizes and validates a template payload.
+	 *
+	 * @param array<string,mixed> $payload Template payload.
+	 * @param bool                $creating Whether this payload is for a create request.
+	 * @return array{title:string,content:string,kind:string,collection_id:int,field_values:array<string,mixed>}|WP_Error
+	 */
+	private function normalize_template_payload( array $payload, bool $creating ) {
+		$kind = self::sanitize_kind( $payload['kind'] ?? self::KIND_PAGE );
+
+		$title = isset( $payload['title'] ) ? trim( (string) $payload['title'] ) : '';
+		if ( '' === $title ) {
+			$title = $creating ? __( 'Untitled template', 'cortext' ) : '';
+		}
+
+		$content       = isset( $payload['content'] ) ? (string) $payload['content'] : '';
+		$collection_id = self::KIND_ROW === $kind ? max( 0, (int) ( $payload['collection_id'] ?? 0 ) ) : 0;
+		$field_values  = self::KIND_ROW === $kind
+			? self::sanitize_field_values( $payload['field_values'] ?? array() )
+			: array();
+
+		if ( self::KIND_ROW === $kind ) {
+			$collection = $this->validate_collection( $collection_id );
+			if ( $collection instanceof WP_Error ) {
+				return $collection;
+			}
+			$normalized_values = $this->normalize_field_values_for_collection( $collection_id, $field_values, true );
+			if ( $normalized_values instanceof WP_Error ) {
+				return $normalized_values;
+			}
+			$field_values = $normalized_values;
+		}
+
+		return array(
+			'title'         => $title,
+			'content'       => $content,
+			'kind'          => $kind,
+			'collection_id' => $collection_id,
+			'field_values'  => $field_values,
+		);
+	}
+
+	/**
+	 * Returns a template post by id.
+	 *
+	 * @param int $id Template post id.
+	 * @return WP_Post|WP_Error
+	 */
+	private function get_template_post( int $id ) {
+		$post = get_post( $id );
+		if ( ! $post instanceof WP_Post || TemplatePostType::POST_TYPE !== $post->post_type ) {
+			return $this->template_not_found_error();
+		}
+		return $post;
+	}
+
+	/**
+	 * Reads normalized template meta.
+	 *
+	 * @param WP_Post $template Template post.
+	 * @return array{kind:string,collection_id:int,field_values:array<string,mixed>}
+	 */
+	private function template_meta( WP_Post $template ): array {
+		return array(
+			'kind'          => self::sanitize_kind( get_post_meta( (int) $template->ID, TemplatePostType::META_KIND, true ) ),
+			'collection_id' => max( 0, (int) get_post_meta( (int) $template->ID, TemplatePostType::META_COLLECTION_ID, true ) ),
+			'field_values'  => self::sanitize_field_values( get_post_meta( (int) $template->ID, TemplatePostType::META_FIELD_VALUES, true ) ),
+		);
+	}
+
+	private function instantiate_page( WP_Post $template, array $args ) {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Document::POST_TYPE,
+				'post_status'  => 'draft',
+				'post_title'   => $template->post_title,
+				'post_content' => $this->starter_content( $template->post_content ),
+				'post_parent'  => max( 0, (int) ( $args['parent'] ?? 0 ) ),
+			),
+			true
+		);
+		if ( $post_id instanceof WP_Error ) {
+			return $post_id;
+		}
+
+		return $this->format_document_post( (int) $post_id );
+	}
+
+	private function instantiate_row( WP_Post $template, array $meta, array $args ) {
+		$collection_id = (int) $meta['collection_id'];
+		$collection    = $this->validate_collection( $collection_id );
+		if ( $collection instanceof WP_Error ) {
+			return $collection;
+		}
+
+		$override_values = self::sanitize_field_values( $args['field_values'] ?? array() );
+		$template_values = $this->normalize_field_values_for_collection( $collection_id, $meta['field_values'], false );
+		$override_values = $this->normalize_field_values_for_collection( $collection_id, $override_values, false );
+		$field_values    = array_merge(
+			$template_values instanceof WP_Error ? array() : $template_values,
+			$override_values instanceof WP_Error ? array() : $override_values
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Document::POST_TYPE,
+				'post_status'  => 'private',
+				'post_title'   => $template->post_title,
+				'post_content' => $this->starter_content( $template->post_content ),
+			),
+			true
+		);
+		if ( $post_id instanceof WP_Error ) {
+			return $post_id;
+		}
+		$post_id = (int) $post_id;
+
+		$term_id = TraitTaxonomy::term_id_for_trait( $collection_id );
+		if ( $term_id < 1 ) {
+			wp_delete_post( $post_id, true );
+			return $this->collection_not_found_error();
+		}
+		$set = wp_set_object_terms( $post_id, array( $term_id ), TraitTaxonomy::TAXONOMY, false );
+		if ( $set instanceof WP_Error ) {
+			wp_delete_post( $post_id, true );
+			return $set;
+		}
+
+		$written = $this->write_row_field_values( $post_id, $collection_id, $field_values );
+		if ( $written instanceof WP_Error ) {
+			wp_delete_post( $post_id, true );
+			return $written;
+		}
+
+		return $this->format_document_post( $post_id );
+	}
+
+	private function validate_collection( int $collection_id ): bool|WP_Error {
+		$post = get_post( $collection_id );
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type || ! Document::is_collection( $collection_id ) ) {
+			return $this->collection_not_found_error();
+		}
+		if ( ! current_user_can( 'edit_post', $collection_id ) ) {
+			return new WP_Error(
+				'cortext_template_collection_forbidden',
+				__( "You can't edit this collection.", 'cortext' ),
+				array( 'status' => 403 )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Normalizes row field defaults for a collection.
+	 *
+	 * @param int                 $collection_id Collection document id.
+	 * @param array<string,mixed> $values Raw field defaults.
+	 * @param bool                $reject_invalid Whether invalid field keys should fail the request.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private function normalize_field_values_for_collection( int $collection_id, array $values, bool $reject_invalid ) {
+		$field_ids = array_flip( Document::collection_field_ids( $collection_id ) );
+		$next      = array();
+
+		foreach ( $values as $key => $value ) {
+			$field_id = (int) substr( $key, 6 );
+			if ( $field_id < 1 || ! isset( $field_ids[ $field_id ] ) ) {
+				if ( $reject_invalid ) {
+					return $this->invalid_field_error( $key );
+				}
+				continue;
+			}
+
+			$type = (string) get_post_meta( $field_id, 'type', true );
+			if ( '' === $type || 'rollup' === $type ) {
+				if ( $reject_invalid ) {
+					return $this->invalid_field_error( $key );
+				}
+				continue;
+			}
+
+			$next[ $key ] = $this->normalize_value_for_type( $value, $type );
+		}
+
+		return $next;
+	}
+
+	/**
+	 * Normalizes a field default for a field type.
+	 *
+	 * @param mixed  $value Raw value.
+	 * @param string $type Field type.
+	 * @return mixed
+	 */
+	private function normalize_value_for_type( $value, string $type ) {
+		if ( 'checkbox' === $type ) {
+			return rest_sanitize_boolean( $value ) ? '1' : '0';
+		}
+		if ( in_array( $type, array( 'multiselect', 'relation' ), true ) ) {
+			return is_array( $value ) ? array_values( $value ) : array( $value );
+		}
+		return $value;
+	}
+
+	/**
+	 * Reads row field values into template defaults.
+	 *
+	 * @param int $row_id Row document id.
+	 * @param int $collection_id Collection document id.
+	 * @return array<string,mixed>
+	 */
+	private function field_values_from_row( int $row_id, int $collection_id ): array {
+		$values = array();
+		foreach ( Document::collection_field_ids( $collection_id ) as $field_id ) {
+			$type = (string) get_post_meta( $field_id, 'type', true );
+			if ( '' === $type || 'rollup' === $type ) {
+				continue;
+			}
+			$meta_values = get_post_meta( $row_id, Relations::meta_key( $field_id ), false );
+			$meta_values = array_values(
+				array_filter(
+					$meta_values,
+					static fn( $value ): bool => '' !== $value && null !== $value
+				)
+			);
+			if ( 0 === count( $meta_values ) ) {
+				continue;
+			}
+			$values[ 'field-' . $field_id ] = count( $meta_values ) === 1
+				? $meta_values[0]
+				: $meta_values;
+		}
+		return $values;
+	}
+
+	/**
+	 * Writes row template field values to a row document.
+	 *
+	 * @param int                 $row_id Row document id.
+	 * @param int                 $collection_id Collection document id.
+	 * @param array<string,mixed> $field_values Field defaults keyed by field id.
+	 * @return bool|WP_Error
+	 */
+	private function write_row_field_values( int $row_id, int $collection_id, array $field_values ): bool|WP_Error {
+		$index = new FieldValueIndex();
+
+		foreach ( $field_values as $key => $value ) {
+			$field_id = (int) substr( $key, 6 );
+			$type     = (string) get_post_meta( $field_id, 'type', true );
+			if ( 'relation' === $type ) {
+				$synced = Relations::sync_relation_value( $row_id, $field_id, $value );
+				if ( $synced instanceof WP_Error ) {
+					return $synced;
+				}
+				$index->index_row_field( $row_id, $field_id, $collection_id );
+				continue;
+			}
+
+			$meta_key = Relations::meta_key( $field_id );
+			if ( is_array( $value ) ) {
+				delete_post_meta( $row_id, $meta_key );
+				foreach ( $value as $entry ) {
+					if ( '' !== $entry && null !== $entry ) {
+						add_post_meta( $row_id, $meta_key, $entry );
+					}
+				}
+				$index->index_row_field( $row_id, $field_id, $collection_id );
+				continue;
+			}
+
+			if ( '' !== $value && null !== $value ) {
+				update_post_meta( $row_id, $meta_key, $value );
+			}
+			$index->index_row_field( $row_id, $field_id, $collection_id );
+		}
+
+		return true;
+	}
+
+	private function starter_content( string $content ): string {
+		if ( '' === trim( $content ) || ! str_contains( $content, '<!-- wp:' ) ) {
+			return $content;
+		}
+
+		$blocks   = parse_blocks( $content );
+		$filtered = array_values(
+			array_filter(
+				$blocks,
+				static fn( array $block ): bool => ! in_array( $block['blockName'] ?? null, self::TEMPLATE_HEADER_BLOCKS, true )
+			)
+		);
+
+		return serialize_blocks( $filtered );
+	}
+
+	/**
+	 * Formats a created Cortext document for the REST response.
+	 *
+	 * @param int $post_id Created document id.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private function format_document_post( int $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return $this->insert_failed_error();
+		}
+
+		return array(
+			'id'       => (int) $post->ID,
+			'title'    => array(
+				'raw'      => $post->post_title,
+				'rendered' => get_the_title( $post ),
+			),
+			'slug'     => (string) $post->post_name,
+			'restBase' => 'crtxt_documents',
+			'type'     => Document::POST_TYPE,
+			'parent'   => (int) $post->post_parent,
+		);
+	}
+
+	private function template_not_found_error(): WP_Error {
+		return new WP_Error(
+			'cortext_template_not_found',
+			__( "Couldn't find that template.", 'cortext' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	private function collection_not_found_error(): WP_Error {
+		return new WP_Error(
+			'cortext_template_collection_not_found',
+			__( "Couldn't find that collection.", 'cortext' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	private function invalid_field_error( string $key ): WP_Error {
+		return new WP_Error(
+			'cortext_template_field_invalid',
+			sprintf(
+				/* translators: %s: field key. */
+				__( 'Field "%s" is not part of this collection.', 'cortext' ),
+				$key
+			),
+			array(
+				'status' => 400,
+				'key'    => $key,
+			)
+		);
+	}
+
+	private function insert_failed_error(): WP_Error {
+		return new WP_Error(
+			'cortext_template_insert_failed',
+			__( "Couldn't create the template.", 'cortext' ),
+			array( 'status' => 500 )
+		);
+	}
+}

--- a/includes/Templates.php
+++ b/includes/Templates.php
@@ -38,12 +38,6 @@ final class Templates {
 		return self::KIND_ROW === $kind ? self::KIND_ROW : self::KIND_PAGE;
 	}
 
-	/**
-	 * Sanitizes the loose field-default map stored on row templates.
-	 *
-	 * @param mixed $value Raw meta value.
-	 * @return array<string,mixed>
-	 */
 	public static function sanitize_field_values( $value ): array {
 		if ( is_object( $value ) ) {
 			$value = (array) $value;
@@ -62,12 +56,6 @@ final class Templates {
 		return $sanitized;
 	}
 
-	/**
-	 * Sanitizes one field value for template storage.
-	 *
-	 * @param mixed $value Raw field value.
-	 * @return mixed
-	 */
 	private static function sanitize_field_value( $value ) {
 		if ( is_array( $value ) ) {
 			return array_values(
@@ -80,12 +68,6 @@ final class Templates {
 		return self::sanitize_scalar_field_value( $value );
 	}
 
-	/**
-	 * Sanitizes one scalar field value for template storage.
-	 *
-	 * @param mixed $value Raw scalar field value.
-	 * @return bool|float|int|string|null
-	 */
 	private static function sanitize_scalar_field_value( $value ) {
 		if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) || null === $value ) {
 			return $value;
@@ -93,12 +75,6 @@ final class Templates {
 		return sanitize_text_field( (string) $value );
 	}
 
-	/**
-	 * Lists templates matching the provided filters.
-	 *
-	 * @param array<string,mixed> $args Query args.
-	 * @return array<int,array<string,mixed>>
-	 */
 	public function list( array $args = array() ): array {
 		$kind          = isset( $args['kind'] ) ? self::sanitize_kind( $args['kind'] ) : null;
 		$collection_id = isset( $args['collection_id'] ) ? max( 0, (int) $args['collection_id'] ) : 0;
@@ -143,12 +119,6 @@ final class Templates {
 		);
 	}
 
-	/**
-	 * Creates a template post.
-	 *
-	 * @param array<string,mixed> $payload Template payload.
-	 * @return array<string,mixed>|WP_Error
-	 */
 	public function create( array $payload ) {
 		$normalized = $this->normalize_template_payload( $payload, true );
 		if ( $normalized instanceof WP_Error ) {
@@ -177,12 +147,6 @@ final class Templates {
 		return $post instanceof WP_Post ? $this->format_template( $post ) : $this->insert_failed_error();
 	}
 
-	/**
-	 * Creates a template from an existing document or row.
-	 *
-	 * @param int $document_id Source document id.
-	 * @return array<string,mixed>|WP_Error
-	 */
 	public function create_from_document( int $document_id ) {
 		$post = get_post( $document_id );
 		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
@@ -230,13 +194,6 @@ final class Templates {
 		);
 	}
 
-	/**
-	 * Updates an existing template post.
-	 *
-	 * @param int                 $id      Template id.
-	 * @param array<string,mixed> $payload Template payload.
-	 * @return array<string,mixed>|WP_Error
-	 */
 	public function update( int $id, array $payload ) {
 		$template = $this->get_template_post( $id );
 		if ( $template instanceof WP_Error ) {
@@ -280,12 +237,6 @@ final class Templates {
 		return $post instanceof WP_Post ? $this->format_template( $post ) : $this->template_not_found_error();
 	}
 
-	/**
-	 * Duplicates a template post.
-	 *
-	 * @param int $id Template id.
-	 * @return array<string,mixed>|WP_Error
-	 */
 	public function duplicate( int $id ) {
 		$template = $this->get_template_post( $id );
 		if ( $template instanceof WP_Error ) {
@@ -314,13 +265,6 @@ final class Templates {
 		return (bool) wp_delete_post( $id, true );
 	}
 
-	/**
-	 * Instantiates a template into a page or row document.
-	 *
-	 * @param int                 $id   Template id.
-	 * @param array<string,mixed> $args Instantiation args.
-	 * @return array<string,mixed>|WP_Error
-	 */
 	public function instantiate( int $id, array $args = array() ) {
 		$template = $this->get_template_post( $id );
 		if ( $template instanceof WP_Error ) {
@@ -386,12 +330,6 @@ final class Templates {
 		return $this->format_template( $template );
 	}
 
-	/**
-	 * Formats a template for the Cortext REST API.
-	 *
-	 * @param WP_Post $template Template post.
-	 * @return array<string,mixed>
-	 */
 	public function format_template( WP_Post $template ): array {
 		$meta = $this->template_meta( $template );
 		return array(
@@ -405,13 +343,6 @@ final class Templates {
 		);
 	}
 
-	/**
-	 * Normalizes and validates a template payload.
-	 *
-	 * @param array<string,mixed> $payload Template payload.
-	 * @param bool                $creating Whether this payload is for a create request.
-	 * @return array{title:string,content:string,kind:string,collection_id:int,field_values:array<string,mixed>}|WP_Error
-	 */
 	private function normalize_template_payload( array $payload, bool $creating ) {
 		$kind = self::sanitize_kind( $payload['kind'] ?? self::KIND_PAGE );
 
@@ -447,12 +378,6 @@ final class Templates {
 		);
 	}
 
-	/**
-	 * Returns a template post by id.
-	 *
-	 * @param int $id Template post id.
-	 * @return WP_Post|WP_Error
-	 */
 	private function get_template_post( int $id ) {
 		$post = get_post( $id );
 		if ( ! $post instanceof WP_Post || TemplatePostType::POST_TYPE !== $post->post_type ) {
@@ -461,12 +386,6 @@ final class Templates {
 		return $post;
 	}
 
-	/**
-	 * Reads normalized template meta.
-	 *
-	 * @param WP_Post $template Template post.
-	 * @return array{kind:string,collection_id:int,field_values:array<string,mixed>}
-	 */
 	private function template_meta( WP_Post $template ): array {
 		return array(
 			'kind'          => self::sanitize_kind( get_post_meta( (int) $template->ID, TemplatePostType::META_KIND, true ) ),
@@ -557,14 +476,6 @@ final class Templates {
 		return true;
 	}
 
-	/**
-	 * Normalizes row field defaults for a collection.
-	 *
-	 * @param int                 $collection_id Collection document id.
-	 * @param array<string,mixed> $values Raw field defaults.
-	 * @param bool                $reject_invalid Whether invalid field keys should fail the request.
-	 * @return array<string,mixed>|WP_Error
-	 */
 	private function normalize_field_values_for_collection( int $collection_id, array $values, bool $reject_invalid ) {
 		$field_ids = array_flip( Document::collection_field_ids( $collection_id ) );
 		$next      = array();
@@ -592,13 +503,6 @@ final class Templates {
 		return $next;
 	}
 
-	/**
-	 * Normalizes a field default for a field type.
-	 *
-	 * @param mixed  $value Raw value.
-	 * @param string $type Field type.
-	 * @return mixed
-	 */
 	private function normalize_value_for_type( $value, string $type ) {
 		if ( 'checkbox' === $type ) {
 			return rest_sanitize_boolean( $value ) ? '1' : '0';
@@ -609,13 +513,6 @@ final class Templates {
 		return $value;
 	}
 
-	/**
-	 * Reads row field values into template defaults.
-	 *
-	 * @param int $row_id Row document id.
-	 * @param int $collection_id Collection document id.
-	 * @return array<string,mixed>
-	 */
 	private function field_values_from_row( int $row_id, int $collection_id ): array {
 		$values = array();
 		foreach ( Document::collection_field_ids( $collection_id ) as $field_id ) {
@@ -640,14 +537,6 @@ final class Templates {
 		return $values;
 	}
 
-	/**
-	 * Writes row template field values to a row document.
-	 *
-	 * @param int                 $row_id Row document id.
-	 * @param int                 $collection_id Collection document id.
-	 * @param array<string,mixed> $field_values Field defaults keyed by field id.
-	 * @return bool|WP_Error
-	 */
 	private function write_row_field_values( int $row_id, int $collection_id, array $field_values ): bool|WP_Error {
 		$index = new FieldValueIndex();
 
@@ -700,12 +589,6 @@ final class Templates {
 		return serialize_blocks( $filtered );
 	}
 
-	/**
-	 * Formats a created Cortext document for the REST response.
-	 *
-	 * @param int $post_id Created document id.
-	 * @return array<string,mixed>|WP_Error
-	 */
 	private function format_document_post( int $post_id ) {
 		$post = get_post( $post_id );
 		if ( ! $post instanceof WP_Post ) {

--- a/includes/Templates.php
+++ b/includes/Templates.php
@@ -20,8 +20,9 @@ use WP_Post;
 
 final class Templates {
 
-	public const KIND_PAGE = 'page';
-	public const KIND_ROW  = 'row';
+	public const EXPERIMENT_ID = 'templates';
+	public const KIND_PAGE     = 'page';
+	public const KIND_ROW      = 'row';
 
 	public const PAGE_DEFAULT_OPTION = 'cortext_default_page_template_id';
 

--- a/includes/Templates.php
+++ b/includes/Templates.php
@@ -145,53 +145,6 @@ final class Templates {
 		return $post instanceof WP_Post ? $this->format_template( $post ) : $this->insert_failed_error();
 	}
 
-	public function create_from_document( int $document_id ) {
-		$post = get_post( $document_id );
-		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
-			return new WP_Error(
-				'cortext_template_source_not_found',
-				__( "Couldn't find that document.", 'cortext' ),
-				array( 'status' => 404 )
-			);
-		}
-		if ( ! current_user_can( 'edit_post', $document_id ) ) {
-			return new WP_Error(
-				'cortext_template_source_forbidden',
-				__( "You can't create a template from this document.", 'cortext' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		$trait = ( new Documents() )->find_trait_for_document( $post );
-		if ( $trait instanceof WP_Post ) {
-			return $this->create(
-				array(
-					'kind'          => self::KIND_ROW,
-					'collection_id' => (int) $trait->ID,
-					'title'         => $post->post_title,
-					'content'       => $post->post_content,
-					'field_values'  => $this->field_values_from_row( $document_id, (int) $trait->ID ),
-				)
-			);
-		}
-
-		if ( Document::is_collection( $document_id ) ) {
-			return new WP_Error(
-				'cortext_template_source_collection',
-				__( "Collections can't be saved as templates yet.", 'cortext' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		return $this->create(
-			array(
-				'kind'    => self::KIND_PAGE,
-				'title'   => $post->post_title,
-				'content' => $post->post_content,
-			)
-		);
-	}
-
 	public function update( int $id, array $payload ) {
 		$template = $this->get_template_post( $id );
 		if ( $template instanceof WP_Error ) {
@@ -233,34 +186,6 @@ final class Templates {
 
 		$post = get_post( $id );
 		return $post instanceof WP_Post ? $this->format_template( $post ) : $this->template_not_found_error();
-	}
-
-	public function duplicate( int $id ) {
-		$template = $this->get_template_post( $id );
-		if ( $template instanceof WP_Error ) {
-			return $template;
-		}
-		$meta = $this->template_meta( $template );
-
-		return $this->create(
-			array(
-				/* translators: %s: source template title */
-				'title'         => sprintf( __( 'Copy of %s', 'cortext' ), $template->post_title ? $template->post_title : __( 'Untitled template', 'cortext' ) ),
-				'content'       => $template->post_content,
-				'kind'          => $meta['kind'],
-				'collection_id' => $meta['collection_id'],
-				'field_values'  => $meta['field_values'],
-			)
-		);
-	}
-
-	public function delete( int $id ): bool|WP_Error {
-		$template = $this->get_template_post( $id );
-		if ( $template instanceof WP_Error ) {
-			return $template;
-		}
-
-		return (bool) wp_delete_post( $id, true );
 	}
 
 	public function instantiate( int $id, array $args = array() ) {
@@ -455,30 +380,6 @@ final class Templates {
 			return is_array( $value ) ? array_values( $value ) : array( $value );
 		}
 		return $value;
-	}
-
-	private function field_values_from_row( int $row_id, int $collection_id ): array {
-		$values = array();
-		foreach ( Document::collection_field_ids( $collection_id ) as $field_id ) {
-			$type = (string) get_post_meta( $field_id, 'type', true );
-			if ( '' === $type || 'rollup' === $type ) {
-				continue;
-			}
-			$meta_values = get_post_meta( $row_id, Relations::meta_key( $field_id ), false );
-			$meta_values = array_values(
-				array_filter(
-					$meta_values,
-					static fn( $value ): bool => '' !== $value && null !== $value
-				)
-			);
-			if ( 0 === count( $meta_values ) ) {
-				continue;
-			}
-			$values[ 'field-' . $field_id ] = count( $meta_values ) === 1
-				? $meta_values[0]
-				: $meta_values;
-		}
-		return $values;
 	}
 
 	private function write_row_field_values( int $row_id, int $collection_id, array $field_values ): bool|WP_Error {

--- a/includes/Templates.php
+++ b/includes/Templates.php
@@ -24,8 +24,6 @@ final class Templates {
 	public const KIND_PAGE     = 'page';
 	public const KIND_ROW      = 'row';
 
-	public const PAGE_DEFAULT_OPTION = 'cortext_default_page_template_id';
-
 	private const TEMPLATE_HEADER_BLOCKS = array(
 		'core/post-title',
 		'cortext/document-cover',
@@ -277,57 +275,6 @@ final class Templates {
 		}
 
 		return $this->instantiate_page( $template, $args );
-	}
-
-	public function get_page_default(): ?array {
-		$id = (int) get_option( self::PAGE_DEFAULT_OPTION, 0 );
-		if ( $id < 1 ) {
-			return null;
-		}
-		$template = $this->get_template_post( $id );
-		if ( $template instanceof WP_Error ) {
-			delete_option( self::PAGE_DEFAULT_OPTION );
-			return null;
-		}
-		$meta = $this->template_meta( $template );
-		if ( self::KIND_PAGE !== $meta['kind'] ) {
-			delete_option( self::PAGE_DEFAULT_OPTION );
-			return null;
-		}
-		if ( ! current_user_can( 'edit_post', $id ) ) {
-			return null;
-		}
-		return $this->format_template( $template );
-	}
-
-	public function set_page_default( ?int $id ): array|WP_Error|null {
-		if ( null === $id || $id < 1 ) {
-			delete_option( self::PAGE_DEFAULT_OPTION );
-			return null;
-		}
-
-		$template = $this->get_template_post( $id );
-		if ( $template instanceof WP_Error ) {
-			return $template;
-		}
-		$meta = $this->template_meta( $template );
-		if ( self::KIND_PAGE !== $meta['kind'] ) {
-			return new WP_Error(
-				'cortext_template_default_invalid_kind',
-				__( 'Choose a document template as the default.', 'cortext' ),
-				array( 'status' => 400 )
-			);
-		}
-		if ( ! current_user_can( 'edit_post', $id ) ) {
-			return new WP_Error(
-				'cortext_template_default_forbidden',
-				__( "You can't use this template as the default.", 'cortext' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		update_option( self::PAGE_DEFAULT_OPTION, $id, false );
-		return $this->format_template( $template );
 	}
 
 	public function format_template( WP_Post $template ): array {

--- a/includes/Templates.php
+++ b/includes/Templates.php
@@ -309,7 +309,7 @@ final class Templates {
 			if ( $collection instanceof WP_Error ) {
 				return $collection;
 			}
-			$normalized_values = $this->normalize_field_values_for_collection( $collection_id, $field_values, true );
+			$normalized_values = $this->normalize_field_values_for_collection( $collection_id, $field_values, $creating );
 			if ( $normalized_values instanceof WP_Error ) {
 				return $normalized_values;
 			}
@@ -369,10 +369,7 @@ final class Templates {
 		$override_values = self::sanitize_field_values( $args['field_values'] ?? array() );
 		$template_values = $this->normalize_field_values_for_collection( $collection_id, $meta['field_values'], false );
 		$override_values = $this->normalize_field_values_for_collection( $collection_id, $override_values, false );
-		$field_values    = array_merge(
-			$template_values instanceof WP_Error ? array() : $template_values,
-			$override_values instanceof WP_Error ? array() : $override_values
-		);
+		$field_values    = array_merge( $template_values, $override_values );
 
 		$post_id = wp_insert_post(
 			array(

--- a/src/components/CollectionDataViews.grid.scss
+++ b/src/components/CollectionDataViews.grid.scss
@@ -27,12 +27,27 @@ $grid-card-content-hover-background: #f3f3f3;
 	}
 
 	&__new-row-card-wrapper {
+		position: relative;
 		box-sizing: border-box;
 		width: 100%;
 		height: 100%;
 		min-height: var(--cortext-grid-card-height, 220px);
 		min-width: 0;
 		order: 1;
+	}
+
+	&__new-row-card-wrapper &__new-row-controls {
+		position: relative;
+		height: 100%;
+	}
+
+	&__new-row-card-wrapper &__new-row-template-menu.components-button {
+		position: absolute;
+		top: $grid-unit-10;
+		right: $grid-unit-10;
+		z-index: 1;
+		background: rgba(255, 255, 255, 0.86);
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 	}
 
 	&__new-row-card.components-button {

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1719,7 +1719,7 @@ export default function CollectionDataViews( {
 										<GridNewRowPortal
 											wrapperRef={ tableWrapperRef }
 											collectionId={ collectionId }
-											view={ dataViewsView }
+											view={ view }
 											fields={ fields }
 											onCreated={ onCreated }
 											hasRows={ dataFiltered.length > 0 }

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -1719,7 +1719,7 @@ export default function CollectionDataViews( {
 										<GridNewRowPortal
 											wrapperRef={ tableWrapperRef }
 											collectionId={ collectionId }
-											view={ view }
+											view={ dataViewsView }
 											fields={ fields }
 											onCreated={ onCreated }
 											hasRows={ dataFiltered.length > 0 }

--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -1193,6 +1193,20 @@ tr:has(.cortext-title-cell--is-opening)
 		padding: $grid-unit-05 $grid-unit-10;
 	}
 
+	&__new-row-controls {
+		display: flex;
+		align-items: stretch;
+		gap: $grid-unit-05;
+		width: 100%;
+		min-width: 0;
+	}
+
+	&__new-row-controls--footer {
+		display: inline-flex;
+		width: auto;
+		max-width: 100%;
+	}
+
 	&__new-row.components-button {
 		flex: 1 1 auto;
 		justify-content: flex-start;
@@ -1201,18 +1215,15 @@ tr:has(.cortext-title-cell--is-opening)
 		color: $gray-700;
 		text-decoration: none;
 
+		.cortext-data-view__new-row-controls--footer & {
+			flex: 0 0 auto;
+			width: auto;
+		}
+
 		&:hover:not(:disabled) {
 			background: $gray-100;
 			color: $gray-900;
 		}
-	}
-
-	&__new-row-controls {
-		display: flex;
-		align-items: stretch;
-		gap: $grid-unit-05;
-		width: 100%;
-		min-width: 0;
 	}
 
 	&__new-row-template-menu.components-button {

--- a/src/components/CollectionDataViews.scss
+++ b/src/components/CollectionDataViews.scss
@@ -1194,8 +1194,32 @@ tr:has(.cortext-title-cell--is-opening)
 	}
 
 	&__new-row.components-button {
+		flex: 1 1 auto;
 		justify-content: flex-start;
+		min-width: 0;
 		width: 100%;
+		color: $gray-700;
+		text-decoration: none;
+
+		&:hover:not(:disabled) {
+			background: $gray-100;
+			color: $gray-900;
+		}
+	}
+
+	&__new-row-controls {
+		display: flex;
+		align-items: stretch;
+		gap: $grid-unit-05;
+		width: 100%;
+		min-width: 0;
+	}
+
+	&__new-row-template-menu.components-button {
+		flex: 0 0 $grid-unit-40;
+		justify-content: center;
+		width: $grid-unit-40;
+		min-width: $grid-unit-40;
 		color: $gray-700;
 		text-decoration: none;
 

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -1,8 +1,32 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Notice } from '@wordpress/components';
-import { useCallback, useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import {
+	Button,
+	Dropdown,
+	MenuGroup,
+	MenuItem,
+	Notice,
+} from '@wordpress/components';
+import {
+	lazy,
+	Suspense,
+	useCallback,
+	useMemo,
+	useState,
+} from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { chevronDown, page, plus } from '@wordpress/icons';
+
+import {
+	createTemplate,
+	instantiateTemplate,
+	notifyTemplatesChanged,
+	TEMPLATE_KIND_ROW,
+	useTemplates,
+} from '../templates';
+
+const TemplateEditorModal = lazy( () =>
+	import( /* webpackChunkName: "editor" */ './TemplateEditorModal' )
+);
 
 // Pull a simple `is` prefill from the active filters. Multi-value operators
 // are ignored for now; this path only handles one scalar value per field.
@@ -45,12 +69,18 @@ export default function DataViewNewRowButton( {
 	presentation = 'footer',
 } ) {
 	const [ isCreating, setIsCreating ] = useState( false );
+	const [ isCreatingTemplate, setIsCreatingTemplate ] = useState( false );
+	const [ editingTemplateId, setEditingTemplateId ] = useState( null );
 	const [ error, setError ] = useState( null );
+	const { templates, isResolving: areTemplatesResolving } = useTemplates( {
+		kind: TEMPLATE_KIND_ROW,
+		collectionId,
+	} );
 
 	const prefillableFieldIds = useMemo(
 		() =>
 			new Set(
-				fields
+				( fields ?? [] )
 					.filter(
 						( f ) =>
 							f.editable !== false && f.cortextType !== 'rollup'
@@ -60,50 +90,178 @@ export default function DataViewNewRowButton( {
 		[ fields ]
 	);
 
-	const onClick = useCallback( async () => {
-		setIsCreating( true );
+	const defaultTemplate = useMemo(
+		() =>
+			templates.find(
+				( template ) => template.id === view?.defaultRowTemplateId
+			) ?? null,
+		[ templates, view?.defaultRowTemplateId ]
+	);
+	const implicitTemplate =
+		defaultTemplate ?? ( templates.length === 1 ? templates[ 0 ] : null );
+
+	const createRow = useCallback(
+		async ( template = null ) => {
+			setIsCreating( true );
+			setError( null );
+			const meta = prefillFromFilters(
+				view?.filters,
+				prefillableFieldIds
+			);
+			try {
+				const created = template?.id
+					? await instantiateTemplate( template.id, {
+							field_values: meta,
+					  } )
+					: await apiFetch( {
+							path: '/wp/v2/crtxt_documents',
+							method: 'POST',
+							data: {
+								status: 'private',
+								title: '',
+								cortext_trait: collectionId,
+								...( Object.keys( meta ).length
+									? { meta }
+									: {} ),
+							},
+					  } );
+				onCreated( created );
+			} catch ( err ) {
+				setError(
+					err?.message ?? __( "Couldn't create the row.", 'cortext' )
+				);
+			} finally {
+				setIsCreating( false );
+			}
+		},
+		[ collectionId, view, prefillableFieldIds, onCreated ]
+	);
+
+	const createRowTemplate = useCallback( async () => {
+		if ( ! collectionId ) {
+			return;
+		}
+		setIsCreatingTemplate( true );
 		setError( null );
-		const meta = prefillFromFilters( view?.filters, prefillableFieldIds );
 		try {
-			const created = await apiFetch( {
-				path: '/wp/v2/crtxt_documents',
-				method: 'POST',
-				data: {
-					status: 'private',
-					title: '',
-					cortext_trait: collectionId,
-					...( Object.keys( meta ).length ? { meta } : {} ),
-				},
+			const template = await createTemplate( {
+				kind: TEMPLATE_KIND_ROW,
+				collection_id: collectionId,
+				title: __( 'Untitled template', 'cortext' ),
 			} );
-			onCreated( created );
+			notifyTemplatesChanged( {
+				kind: TEMPLATE_KIND_ROW,
+				collectionId,
+			} );
+			if ( template?.id ) {
+				setEditingTemplateId( template.id );
+			}
 		} catch ( err ) {
 			setError(
-				err?.message ?? __( 'Could not create a document.', 'cortext' )
+				err?.message ?? __( "Couldn't create the template.", 'cortext' )
 			);
 		} finally {
-			setIsCreating( false );
+			setIsCreatingTemplate( false );
 		}
-	}, [ collectionId, view, prefillableFieldIds, onCreated ] );
+	}, [ collectionId ] );
 
-	const button = (
+	const primaryClassName =
+		'cortext-data-view__new-row' +
+		( presentation === 'grid-card'
+			? ' cortext-data-view__new-row-card'
+			: '' ) +
+		( presentation === 'list-row'
+			? ' cortext-data-view__new-row-list'
+			: '' );
+
+	const primaryButton = (
 		<Button
-			className={
-				'cortext-data-view__new-row' +
-				( presentation === 'grid-card'
-					? ' cortext-data-view__new-row-card'
-					: '' ) +
-				( presentation === 'list-row'
-					? ' cortext-data-view__new-row-list'
-					: '' )
-			}
+			className={ primaryClassName }
 			variant="tertiary"
 			icon={ plus }
-			onClick={ onClick }
+			onClick={ () => createRow( implicitTemplate ) }
 			isBusy={ isCreating }
-			disabled={ disabled || isCreating || ! collectionId }
+			disabled={
+				disabled ||
+				isCreating ||
+				areTemplatesResolving ||
+				! collectionId
+			}
 		>
 			{ __( 'New', 'cortext' ) }
 		</Button>
+	);
+	const optionsMenu = (
+		<Dropdown
+			popoverProps={ { placement: 'bottom-start' } }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					className="cortext-data-view__new-row-template-menu"
+					variant="tertiary"
+					icon={ chevronDown }
+					onClick={ onToggle }
+					label={ __( 'New row menu', 'cortext' ) }
+					disabled={
+						disabled ||
+						isCreating ||
+						isCreatingTemplate ||
+						areTemplatesResolving ||
+						! collectionId
+					}
+					isPressed={ isOpen }
+					aria-expanded={ isOpen }
+				/>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<>
+					<MenuGroup>
+						<MenuItem
+							icon={ plus }
+							onClick={ () => {
+								createRow();
+								onClose();
+							} }
+						>
+							{ __( 'Blank row', 'cortext' ) }
+						</MenuItem>
+						{ templates.map( ( template ) => (
+							<MenuItem
+								key={ template.id }
+								icon={ page }
+								onClick={ () => {
+									createRow( template );
+									onClose();
+								} }
+							>
+								{ sprintf(
+									/* translators: %s: template title. */
+									__( 'New from %s', 'cortext' ),
+									template.title ||
+										__( 'Untitled template', 'cortext' )
+								) }
+							</MenuItem>
+						) ) }
+					</MenuGroup>
+					<MenuGroup>
+						<MenuItem
+							icon={ page }
+							onClick={ () => {
+								createRowTemplate();
+								onClose();
+							} }
+						>
+							{ __( 'New template', 'cortext' ) }
+						</MenuItem>
+					</MenuGroup>
+				</>
+			) }
+		/>
+	);
+	const controls = (
+		<div className="cortext-data-view__new-row-controls">
+			{ primaryButton }
+			{ optionsMenu }
+		</div>
 	);
 	const notice = error ? (
 		<Notice
@@ -114,20 +272,33 @@ export default function DataViewNewRowButton( {
 			{ error }
 		</Notice>
 	) : null;
+	const templateEditor = editingTemplateId ? (
+		<Suspense fallback={ null }>
+			<TemplateEditorModal
+				collectionId={ collectionId }
+				fields={ fields ?? [] }
+				kind={ TEMPLATE_KIND_ROW }
+				templateId={ editingTemplateId }
+				onClose={ () => setEditingTemplateId( null ) }
+			/>
+		</Suspense>
+	) : null;
 
 	if ( presentation === 'grid-card' ) {
 		return (
 			<div className="cortext-data-view__new-row-card-wrapper">
-				{ button }
+				{ controls }
 				{ notice }
+				{ templateEditor }
 			</div>
 		);
 	}
 
 	return (
 		<>
-			{ button }
+			{ controls }
 			{ notice }
+			{ templateEditor }
 		</>
 	);
 }

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -257,8 +257,11 @@ export default function DataViewNewRowButton( {
 			) }
 		/>
 	);
+	const controlsClassName =
+		'cortext-data-view__new-row-controls' +
+		` cortext-data-view__new-row-controls--${ presentation }`;
 	const controls = (
-		<div className="cortext-data-view__new-row-controls">
+		<div className={ controlsClassName }>
 			{ primaryButton }
 			{ optionsMenu }
 		</div>

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -30,10 +30,8 @@ const TemplateEditorModal = lazy( () =>
 	import( /* webpackChunkName: "editor" */ './TemplateEditorModal' )
 );
 
-// Pull a simple `is` prefill from the active filters. Multi-value operators
-// are ignored for now; this path only handles one scalar value per field.
-// Filters already run on GET /cortext/v1/rows, so prefill is only a convenience
-// for new rows, not the reason filtering works.
+// Only scalar `is` filters can be copied without changing their meaning.
+// Filtering itself remains server-side.
 function prefillFromFilters( filters, fieldIds ) {
 	const prefill = {};
 	if ( ! Array.isArray( filters ) ) {

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -21,8 +21,10 @@ import {
 	instantiateTemplate,
 	notifyTemplatesChanged,
 	TEMPLATE_KIND_ROW,
+	TEMPLATES_EXPERIMENT_ID,
 	useTemplates,
 } from '../templates';
+import { isExperimentEnabled } from '../settings';
 
 const TemplateEditorModal = lazy( () =>
 	import( /* webpackChunkName: "editor" */ './TemplateEditorModal' )
@@ -68,6 +70,7 @@ export default function DataViewNewRowButton( {
 	disabled,
 	presentation = 'footer',
 } ) {
+	const templatesEnabled = isExperimentEnabled( TEMPLATES_EXPERIMENT_ID );
 	const [ isCreating, setIsCreating ] = useState( false );
 	const [ isCreatingTemplate, setIsCreatingTemplate ] = useState( false );
 	const [ editingTemplateId, setEditingTemplateId ] = useState( null );
@@ -75,6 +78,7 @@ export default function DataViewNewRowButton( {
 	const { templates, isResolving: areTemplatesResolving } = useTemplates( {
 		kind: TEMPLATE_KIND_ROW,
 		collectionId,
+		enabled: templatesEnabled,
 	} );
 
 	const prefillableFieldIds = useMemo(
@@ -97,8 +101,9 @@ export default function DataViewNewRowButton( {
 			) ?? null,
 		[ templates, view?.defaultRowTemplateId ]
 	);
-	const implicitTemplate =
-		defaultTemplate ?? ( templates.length === 1 ? templates[ 0 ] : null );
+	const implicitTemplate = templatesEnabled
+		? defaultTemplate ?? ( templates.length === 1 ? templates[ 0 ] : null )
+		: null;
 
 	const createRow = useCallback(
 		async ( template = null ) => {
@@ -184,14 +189,14 @@ export default function DataViewNewRowButton( {
 			disabled={
 				disabled ||
 				isCreating ||
-				areTemplatesResolving ||
+				( templatesEnabled && areTemplatesResolving ) ||
 				! collectionId
 			}
 		>
 			{ __( 'New', 'cortext' ) }
 		</Button>
 	);
-	const optionsMenu = (
+	const optionsMenu = templatesEnabled ? (
 		<Dropdown
 			popoverProps={ { placement: 'bottom-start' } }
 			renderToggle={ ( { isOpen, onToggle } ) => (
@@ -256,7 +261,7 @@ export default function DataViewNewRowButton( {
 				</>
 			) }
 		/>
-	);
+	) : null;
 	const controlsClassName =
 		'cortext-data-view__new-row-controls' +
 		` cortext-data-view__new-row-controls--${ presentation }`;
@@ -275,17 +280,18 @@ export default function DataViewNewRowButton( {
 			{ error }
 		</Notice>
 	) : null;
-	const templateEditor = editingTemplateId ? (
-		<Suspense fallback={ null }>
-			<TemplateEditorModal
-				collectionId={ collectionId }
-				fields={ fields ?? [] }
-				kind={ TEMPLATE_KIND_ROW }
-				templateId={ editingTemplateId }
-				onClose={ () => setEditingTemplateId( null ) }
-			/>
-		</Suspense>
-	) : null;
+	const templateEditor =
+		templatesEnabled && editingTemplateId ? (
+			<Suspense fallback={ null }>
+				<TemplateEditorModal
+					collectionId={ collectionId }
+					fields={ fields ?? [] }
+					kind={ TEMPLATE_KIND_ROW }
+					templateId={ editingTemplateId }
+					onClose={ () => setEditingTemplateId( null ) }
+				/>
+			</Suspense>
+		) : null;
 
 	if ( presentation === 'grid-card' ) {
 		return (

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -203,7 +203,7 @@ export default function DataViewNewRowButton( {
 					variant="tertiary"
 					icon={ chevronDown }
 					onClick={ onToggle }
-					label={ __( 'New row menu', 'cortext' ) }
+					label={ __( 'Choose how to create a row', 'cortext' ) }
 					disabled={
 						disabled ||
 						isCreating ||
@@ -238,7 +238,7 @@ export default function DataViewNewRowButton( {
 							>
 								{ sprintf(
 									/* translators: %s: template title. */
-									__( 'New from %s', 'cortext' ),
+									__( 'Create from %s', 'cortext' ),
 									template.title ||
 										__( 'Untitled template', 'cortext' )
 								) }

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -92,17 +92,6 @@ export default function DataViewNewRowButton( {
 		[ fields ]
 	);
 
-	const defaultTemplate = useMemo(
-		() =>
-			templates.find(
-				( template ) => template.id === view?.defaultRowTemplateId
-			) ?? null,
-		[ templates, view?.defaultRowTemplateId ]
-	);
-	const implicitTemplate = templatesEnabled
-		? defaultTemplate ?? ( templates.length === 1 ? templates[ 0 ] : null )
-		: null;
-
 	const createRow = useCallback(
 		async ( template = null ) => {
 			setIsCreating( true );
@@ -182,14 +171,9 @@ export default function DataViewNewRowButton( {
 			className={ primaryClassName }
 			variant="tertiary"
 			icon={ plus }
-			onClick={ () => createRow( implicitTemplate ) }
+			onClick={ () => createRow() }
 			isBusy={ isCreating }
-			disabled={
-				disabled ||
-				isCreating ||
-				( templatesEnabled && areTemplatesResolving ) ||
-				! collectionId
-			}
+			disabled={ disabled || isCreating || ! collectionId }
 		>
 			{ __( 'New', 'cortext' ) }
 		</Button>

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -246,7 +246,9 @@ export default function DataViewNewRowButton( {
 	) : null;
 	const controlsClassName =
 		'cortext-data-view__new-row-controls' +
-		` cortext-data-view__new-row-controls--${ presentation }`;
+		( presentation === 'footer'
+			? ' cortext-data-view__new-row-controls--footer'
+			: '' );
 	const controls = templatesEnabled ? (
 		<div className={ controlsClassName }>
 			{ primaryButton }

--- a/src/components/DataViewNewRowButton.js
+++ b/src/components/DataViewNewRowButton.js
@@ -247,11 +247,13 @@ export default function DataViewNewRowButton( {
 	const controlsClassName =
 		'cortext-data-view__new-row-controls' +
 		` cortext-data-view__new-row-controls--${ presentation }`;
-	const controls = (
+	const controls = templatesEnabled ? (
 		<div className={ controlsClassName }>
 			{ primaryButton }
 			{ optionsMenu }
 		</div>
+	) : (
+		primaryButton
 	);
 	const notice = error ? (
 		<Notice

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -2037,6 +2037,7 @@ export default function EditorBody( {
 	isDocumentCanvas = false,
 	isLocked = false,
 	isSurfaceFocusPending = false,
+	showIdentityActions = true,
 	postId,
 	postType,
 	extraStyles,
@@ -2154,11 +2155,13 @@ export default function EditorBody( {
 				<BlockCanvas height="100%" styles={ styles }>
 					<BlockCanvasStyleProvider>
 						<CanvasMenuToolbarGuard />
-						<DocumentIdentityActions
-							isLocked={ isReadOnly }
-							postId={ postId }
-							postType={ postType }
-						/>
+						{ showIdentityActions ? (
+							<DocumentIdentityActions
+								isLocked={ isReadOnly }
+								postId={ postId }
+								postType={ postType }
+							/>
+						) : null }
 						<EnsureHeaderBlocks
 							isLocked={ isReadOnly }
 							postId={ postId }

--- a/src/components/RowProperties.js
+++ b/src/components/RowProperties.js
@@ -1029,6 +1029,7 @@ export default function RowProperties( {
 	rowId: providedRowId,
 } ) {
 	const {
+		saveRowField,
 		optionOverrides,
 		updateFieldOptions,
 		formatOverrides,
@@ -1179,6 +1180,13 @@ export default function RowProperties( {
 		},
 		[]
 	);
+	const persistFieldValue = useCallback(
+		( nextRowId, fieldId, value ) =>
+			saveRowField
+				? saveRowField( nextRowId, fieldId, value )
+				: saveRowDocumentField( nextRowId, fieldId, value ),
+		[ saveRowField ]
+	);
 
 	const flushQueuedFieldSave = useCallback(
 		async ( fieldId, { rethrow = false } = {} ) => {
@@ -1191,7 +1199,7 @@ export default function RowProperties( {
 			clearSaveTimer( fieldId );
 
 			try {
-				const updated = await saveRowDocumentField(
+				const updated = await persistFieldValue(
 					entry.rowId,
 					fieldId,
 					entry.value
@@ -1236,6 +1244,7 @@ export default function RowProperties( {
 			clearLocalFieldValue,
 			clearSaveTimer,
 			collectionId,
+			persistFieldValue,
 			refreshRows,
 		]
 	);
@@ -1288,7 +1297,7 @@ export default function RowProperties( {
 
 			for ( const [ fieldId, entry ] of entries ) {
 				try {
-					const updated = await saveRowDocumentField(
+					const updated = await persistFieldValue(
 						entry.rowId,
 						fieldId,
 						entry.value
@@ -1328,6 +1337,7 @@ export default function RowProperties( {
 			applyCommittedFieldValue,
 			clearLocalFieldValue,
 			collectionId,
+			persistFieldValue,
 			refreshRows,
 		]
 	);

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -626,7 +626,7 @@ export default function Sidebar( {
 								) : null }
 								{ templatesEnabled && templateNotice ? (
 									<Notice
-										status="info"
+										status="error"
 										onRemove={ () =>
 											setTemplateNotice( null )
 										}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,7 +1,14 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import {
+	lazy,
+	Suspense,
+	useState,
+	useMemo,
+	useCallback,
+	useEffect,
+} from '@wordpress/element';
 import { useParams } from '@tanstack/react-router';
 import {
 	Button,
@@ -95,12 +102,27 @@ import {
 	useDocumentSelection,
 	useFavoriteToggle,
 } from '../documents';
+import {
+	createTemplate,
+	notifyTemplatesChanged,
+	TEMPLATE_KIND_PAGE,
+	TEMPLATES_EXPERIMENT_ID,
+	useInstantiateTemplate,
+	useTemplates,
+} from '../templates';
 import useSidebarDnd from './sidebar/useSidebarDnd';
 import useSidebarNavigation from './sidebar/useSidebarNavigation';
 import useSidebarTree, { ROOT_PARENT_ID } from './sidebar/useSidebarTree';
 import DocumentRow from './sidebar/DocumentRow';
-import { isWordPressAffordancesEnabled } from '../settings';
+import {
+	isExperimentEnabled,
+	isWordPressAffordancesEnabled,
+} from '../settings';
 import { useSurfaceFocusIntent } from './SurfaceFocusContext';
+
+const TemplateEditorModal = lazy( () =>
+	import( /* webpackChunkName: "editor" */ './TemplateEditorModal' )
+);
 
 export default function Sidebar( {
 	collapsed = false,
@@ -193,9 +215,18 @@ export default function Sidebar( {
 	const commandPaletteShortcut = displayShortcut.primary( 'k' );
 	const brandLabel = __( 'Cortext', 'cortext' );
 	const isSettingsMode = isSettingsUri( routeUri );
+	const templatesEnabled = isExperimentEnabled( TEMPLATES_EXPERIMENT_ID );
+	const { templates: pageTemplates } = useTemplates( {
+		kind: TEMPLATE_KIND_PAGE,
+		enabled: templatesEnabled,
+	} );
+	const instantiateTemplate = useInstantiateTemplate();
 
 	const [ favoritesError, setFavoritesError ] = useState( null );
 	const [ duplicateNotice, setDuplicateNotice ] = useState( null );
+	const [ templateNotice, setTemplateNotice ] = useState( null );
+	const [ isCreatingTemplate, setIsCreatingTemplate ] = useState( false );
+	const [ editingTemplateId, setEditingTemplateId ] = useState( null );
 	const [ settingsReturnUri, setSettingsReturnUri ] = useState( null );
 	const {
 		isFavorite,
@@ -408,6 +439,17 @@ export default function Sidebar( {
 		},
 		[ create, openAfterCreate, refreshBranch ]
 	);
+	const createFromTemplateAndOpen = useCallback(
+		async ( template, input = {} ) => {
+			if ( ! template?.id ) {
+				return createAndOpen( input );
+			}
+			return openAfterCreate(
+				await instantiateTemplate( template.id, input )
+			);
+		},
+		[ createAndOpen, instantiateTemplate, openAfterCreate ]
+	);
 	const createCollectionAndOpen = useCallback(
 		async ( input ) => {
 			const created = await createCollection( input );
@@ -432,6 +474,27 @@ export default function Sidebar( {
 		( parentId ) => createCollectionAndOpen( { parent: parentId } ),
 		[ createCollectionAndOpen ]
 	);
+	const createPageTemplate = useCallback( async () => {
+		setIsCreatingTemplate( true );
+		setTemplateNotice( null );
+		try {
+			const template = await createTemplate( {
+				kind: TEMPLATE_KIND_PAGE,
+				title: __( 'Untitled template', 'cortext' ),
+			} );
+			notifyTemplatesChanged( { kind: TEMPLATE_KIND_PAGE } );
+			if ( template?.id ) {
+				setEditingTemplateId( template.id );
+			}
+		} catch ( error ) {
+			setTemplateNotice(
+				error?.message ??
+					__( "Couldn't create the template.", 'cortext' )
+			);
+		} finally {
+			setIsCreatingTemplate( false );
+		}
+	}, [] );
 
 	// Props shared by every DocumentRow in the Pages tree.
 	const rowChrome = {
@@ -451,6 +514,16 @@ export default function Sidebar( {
 		autoRenameId,
 		onAutoRenameConsumed: () => setAutoRenameId( null ),
 		onCreateChild: createChildPage,
+		...( templatesEnabled
+			? {
+					onCreateBlankChild: createChildPage,
+					pageTemplates,
+					onCreateChildFromTemplate: ( parentId, template ) =>
+						createFromTemplateAndOpen( template, {
+							parent: parentId,
+						} ),
+			  }
+			: {} ),
 		onCreateChildCollection: createChildCollection,
 	};
 
@@ -566,6 +639,16 @@ export default function Sidebar( {
 										{ duplicateNotice }
 									</Notice>
 								) : null }
+								{ templatesEnabled && templateNotice ? (
+									<Notice
+										status="info"
+										onRemove={ () =>
+											setTemplateNotice( null )
+										}
+									>
+										{ templateNotice }
+									</Notice>
+								) : null }
 								<SidebarSection
 									id="recents"
 									title={ __( 'Recents', 'cortext' ) }
@@ -662,36 +745,125 @@ export default function Sidebar( {
 													) }
 													renderContent={ ( {
 														onClose,
-													} ) => (
-														<MenuGroup>
-															<MenuItem
-																icon={ page }
-																onClick={ () => {
-																	createRootPage();
-																	onClose();
-																} }
-															>
-																{ __(
-																	'New document',
-																	'cortext'
-																) }
-															</MenuItem>
-															<MenuItem
-																icon={
-																	collectionIcon
-																}
-																onClick={ () => {
-																	createRootCollection();
-																	onClose();
-																} }
-															>
-																{ __(
-																	'New collection',
-																	'cortext'
-																) }
-															</MenuItem>
-														</MenuGroup>
-													) }
+													} ) =>
+														templatesEnabled ? (
+															<>
+																<MenuGroup>
+																	<MenuItem
+																		icon={
+																			page
+																		}
+																		onClick={ () => {
+																			createRootPage();
+																			onClose();
+																		} }
+																	>
+																		{ __(
+																			'Blank document',
+																			'cortext'
+																		) }
+																	</MenuItem>
+																	{ pageTemplates.map(
+																		(
+																			template
+																		) => (
+																			<MenuItem
+																				key={
+																					template.id
+																				}
+																				icon={
+																					page
+																				}
+																				onClick={ () => {
+																					createFromTemplateAndOpen(
+																						template
+																					);
+																					onClose();
+																				} }
+																			>
+																				{ sprintf(
+																					/* translators: %s: template title */
+																					__(
+																						'New from %s',
+																						'cortext'
+																					),
+																					template.title ||
+																						__(
+																							'Untitled template',
+																							'cortext'
+																						)
+																				) }
+																			</MenuItem>
+																		)
+																	) }
+																	<MenuItem
+																		icon={
+																			page
+																		}
+																		disabled={
+																			isCreatingTemplate
+																		}
+																		onClick={ () => {
+																			createPageTemplate();
+																			onClose();
+																		} }
+																	>
+																		{ __(
+																			'New template',
+																			'cortext'
+																		) }
+																	</MenuItem>
+																</MenuGroup>
+																<MenuGroup>
+																	<MenuItem
+																		icon={
+																			collectionIcon
+																		}
+																		onClick={ () => {
+																			createRootCollection();
+																			onClose();
+																		} }
+																	>
+																		{ __(
+																			'New collection',
+																			'cortext'
+																		) }
+																	</MenuItem>
+																</MenuGroup>
+															</>
+														) : (
+															<MenuGroup>
+																<MenuItem
+																	icon={
+																		page
+																	}
+																	onClick={ () => {
+																		createRootPage();
+																		onClose();
+																	} }
+																>
+																	{ __(
+																		'New document',
+																		'cortext'
+																	) }
+																</MenuItem>
+																<MenuItem
+																	icon={
+																		collectionIcon
+																	}
+																	onClick={ () => {
+																		createRootCollection();
+																		onClose();
+																	} }
+																>
+																	{ __(
+																		'New collection',
+																		'cortext'
+																	) }
+																</MenuItem>
+															</MenuGroup>
+														)
+													}
 												/>
 											</div>
 										}
@@ -877,6 +1049,15 @@ export default function Sidebar( {
 					onToggleCollapsed={ onToggleCollapsed }
 				/>
 			) }
+			{ templatesEnabled && editingTemplateId ? (
+				<Suspense fallback={ null }>
+					<TemplateEditorModal
+						kind={ TEMPLATE_KIND_PAGE }
+						templateId={ editingTemplateId }
+						onClose={ () => setEditingTemplateId( null ) }
+					/>
+				</Suspense>
+			) : null }
 		</aside>
 	);
 }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -432,11 +432,11 @@ export default function Sidebar( {
 			if ( ! template?.id ) {
 				return createAndOpen( input );
 			}
-			return openAfterCreate(
-				await instantiateTemplate( template.id, input )
-			);
+			const created = await instantiateTemplate( template.id, input );
+			refreshBranch( created?.parent ?? input?.parent ?? ROOT_PARENT_ID );
+			return openAfterCreate( created );
 		},
-		[ createAndOpen, instantiateTemplate, openAfterCreate ]
+		[ createAndOpen, instantiateTemplate, openAfterCreate, refreshBranch ]
 	);
 	const createCollectionAndOpen = useCallback(
 		async ( input ) => {

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -32,9 +32,7 @@ import {
 
 import './Sidebar.scss';
 
-// Sidebar toggle: panel outline with a vertical accent on
-// the left side. Same icon for both states; the aria-label tells the
-// user what the toggle will do.
+// The aria-label, rather than the icon, communicates the collapsed state.
 const sidebarToggleIcon = (
 	<svg
 		xmlns="http://www.w3.org/2000/svg"
@@ -284,8 +282,7 @@ export default function Sidebar( {
 	);
 	const selectFavorite = useCallback(
 		( favorite ) => {
-			// Use `isRowSelected` as the shared selected-state check. Post IDs
-			// are globally unique, so the same id cannot point at two documents.
+			// Post IDs are global, so a shared predicate cannot select two records.
 			if ( isRowSelected( favorite ) ) {
 				return false;
 			}
@@ -298,10 +295,8 @@ export default function Sidebar( {
 		[ isRowSelected, navigate ]
 	);
 
-	// `draggedId` and `activeDrop` flow into the per-row callbacks below, so
-	// the DnD hook has to resolve before any `useCallback` that lists them as
-	// deps. Otherwise their `const` bindings sit in the temporal dead zone
-	// when the callback's dep array is evaluated and React throws on render.
+	// These values appear in dependency arrays below, so initialize them before
+	// React evaluates those arrays and hits their temporal dead zone.
 	const { sensors, draggedId, draggedPage, activeDrop, handlers } =
 		useSidebarDnd( {
 			pages,
@@ -373,8 +368,6 @@ export default function Sidebar( {
 		};
 	}, [ closeSettings, isSettingsMode ] );
 
-	// --- Per-row selection helpers --------------------------------------
-
 	const onSetRowHome = useCallback(
 		async ( record ) => {
 			const ident = favoriteIdentForRecord( record );
@@ -398,9 +391,6 @@ export default function Sidebar( {
 		[ home ]
 	);
 
-	// Wire callbacks that `useDocumentActions` needs (rename, trash, duplicate)
-	// from DocumentRow / SidebarTrash. Create goes through `useCreateDocument`
-	// at the top of Sidebar and bypasses the provider.
 	const documentsHandlers = useMemo(
 		() => ( {
 			selectedCollectionId,
@@ -416,8 +406,6 @@ export default function Sidebar( {
 
 	const create = useCreateDocument();
 	const createCollection = useCreateCollectionDocument();
-	// After creating a page or collection, open it and put its sidebar row into
-	// rename mode.
 	const openAfterCreate = useCallback(
 		( created ) => {
 			if ( created?.id ) {
@@ -496,7 +484,6 @@ export default function Sidebar( {
 		}
 	}, [] );
 
-	// Props shared by every DocumentRow in the Pages tree.
 	const rowChrome = {
 		expandedIds,
 		draggedId,
@@ -526,8 +513,6 @@ export default function Sidebar( {
 			: {} ),
 		onCreateChildCollection: createChildCollection,
 	};
-
-	// --- Render ------------------------------------------------------------
 
 	return (
 		<aside

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -769,7 +769,7 @@ export default function Sidebar( {
 																				{ sprintf(
 																					/* translators: %s: template title */
 																					__(
-																						'New from %s',
+																						'Create from %s',
 																						'cortext'
 																					),
 																					template.title ||

--- a/src/components/TemplateEditorModal.js
+++ b/src/components/TemplateEditorModal.js
@@ -93,9 +93,8 @@ export default function TemplateEditorModal( {
 	const apiRef = useRef( null );
 	const [ error, setError ] = useState( null );
 	const [ fieldValues, setFieldValues ] = useState( {} );
-	// Source of truth for in-flight saves. updateTemplate rewrites the whole
-	// field_values map server-side, so row-template property writes must be
-	// serialized and based on the latest acknowledged or optimistic map.
+	// The API replaces the entire map, so overlapping saves must run in order
+	// or a slower response can overwrite a newer field value.
 	const fieldValuesRef = useRef( fieldValues );
 	const fieldSaveChainRef = useRef( Promise.resolve() );
 	const { record, isResolving } = useEntityRecord(

--- a/src/components/TemplateEditorModal.js
+++ b/src/components/TemplateEditorModal.js
@@ -1,0 +1,281 @@
+import {
+	Button,
+	Modal,
+	Notice,
+	SlotFillProvider,
+	Spinner,
+} from '@wordpress/components';
+import { useEntityRecord } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { EditorProvider, store as editorStore } from '@wordpress/editor';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
+
+import './RowDetailView.scss';
+
+import { getEditorSettings } from './initEditor';
+import { DocumentPropertiesProvider } from './DocumentPropertiesContext';
+import { EditorSurfaceProvider } from './EditorSurfaceContext';
+import EditorBody from './EditorBody';
+import CortextLinkSuggestions from './CortextLinkSuggestions';
+import { RowMutationContext } from './EditableCell';
+import useAutosave from '../hooks/useAutosave';
+import {
+	TEMPLATE_KIND_ROW,
+	TEMPLATE_POST_TYPE,
+	notifyTemplatesChanged,
+	updateTemplate,
+} from '../templates';
+
+const TEMPLATE_EDITOR_CSS = `
+	body {
+		background: #fff;
+	}
+
+	.editor-styles-wrapper {
+		box-sizing: border-box;
+		min-height: 100%;
+		padding: 24px 32px 48px;
+	}
+
+	.editor-styles-wrapper .wp-block-post-content {
+		margin-block-start: 0;
+	}
+
+	.editor-styles-wrapper > .block-editor-block-list__layout,
+	.editor-styles-wrapper .block-editor-block-list__layout.is-root-container {
+		min-height: 180px;
+	}
+`;
+
+const TEMPLATE_EXTRA_STYLES = [ { css: TEMPLATE_EDITOR_CSS } ];
+
+function TemplateAutosaveBridge( { onApi, onSaved } ) {
+	const { flushNow, status } = useAutosave( {
+		debounceMs: 0,
+		minSaveIntervalMs: 0,
+	} );
+	const { resetPost } = useDispatch( editorStore );
+	const discard = useCallback( () => resetPost(), [ resetPost ] );
+
+	useEffect( () => {
+		onApi?.( { flushNow, discard } );
+		return () => onApi?.( null );
+	}, [ discard, flushNow, onApi ] );
+
+	useEffect( () => {
+		if ( status === 'saved' ) {
+			onSaved?.();
+		}
+	}, [ onSaved, status ] );
+
+	return null;
+}
+
+function fieldValuesFromRecord( record ) {
+	return record?.meta?.cortext_template_field_values ?? {};
+}
+
+export default function TemplateEditorModal( {
+	collectionId = null,
+	fields = [],
+	kind,
+	onClose,
+	templateId,
+} ) {
+	const apiRef = useRef( null );
+	const [ error, setError ] = useState( null );
+	const [ fieldValues, setFieldValues ] = useState( {} );
+	// Source of truth for in-flight saves. updateTemplate rewrites the whole
+	// field_values map server-side, so row-template property writes must be
+	// serialized and based on the latest acknowledged or optimistic map.
+	const fieldValuesRef = useRef( fieldValues );
+	const fieldSaveChainRef = useRef( Promise.resolve() );
+	const { record, isResolving } = useEntityRecord(
+		'postType',
+		TEMPLATE_POST_TYPE,
+		templateId
+	);
+	const isRowTemplate = kind === TEMPLATE_KIND_ROW;
+
+	useEffect( () => {
+		if ( record ) {
+			const next = fieldValuesFromRecord( record );
+			fieldValuesRef.current = next;
+			setFieldValues( next );
+		}
+	}, [ record ] );
+
+	const closeAfterSave = useCallback( async () => {
+		setError( null );
+		const didSave = await apiRef.current?.flushNow?.();
+		if ( didSave === false ) {
+			setError( __( "Couldn't save the template.", 'cortext' ) );
+			return;
+		}
+		onClose?.();
+	}, [ onClose ] );
+
+	const saveTemplateField = useCallback(
+		( rowId, fieldId, value ) => {
+			const save = async () => {
+				const nextValues = {
+					...fieldValuesRef.current,
+					[ fieldId ]: value,
+				};
+				fieldValuesRef.current = nextValues;
+				setFieldValues( nextValues );
+				const template = await updateTemplate( rowId, {
+					field_values: nextValues,
+				} );
+				const savedValues = template?.field_values ?? nextValues;
+				fieldValuesRef.current = savedValues;
+				setFieldValues( savedValues );
+				notifyTemplatesChanged( { kind, collectionId } );
+				return {
+					id: rowId,
+					meta: savedValues,
+					cortext_hydrated_meta: {},
+				};
+			};
+			const request = fieldSaveChainRef.current.then( save, save );
+			fieldSaveChainRef.current = request.catch( () => {} );
+			return request;
+		},
+		[ collectionId, kind ]
+	);
+
+	const mutationContext = useMemo(
+		() => ( {
+			saveRowField: isRowTemplate ? saveTemplateField : null,
+			canEditCells: true,
+			layoutType: 'modal',
+			optionOverrides: {},
+			updateFieldOptions: () => {},
+			formatOverrides: {},
+			updateFieldFormat: () => {},
+			refreshRows: () => {},
+		} ),
+		[ isRowTemplate, saveTemplateField ]
+	);
+
+	const templateRow = useMemo(
+		() =>
+			record
+				? {
+						...record,
+						id: templateId,
+						title: record.title,
+						meta: fieldValues,
+						cortext_hydrated_meta: {},
+				  }
+				: null,
+		[ fieldValues, record, templateId ]
+	);
+
+	const handleSaved = useCallback( () => {
+		notifyTemplatesChanged( { kind, collectionId } );
+	}, [ collectionId, kind ] );
+
+	return (
+		<Modal
+			className="cortext-row-detail-modal"
+			title={ __( 'Template', 'cortext' ) }
+			onRequestClose={ closeAfterSave }
+			__experimentalHideHeader
+		>
+			<div className="cortext-row-detail cortext-row-detail--modal">
+				<div
+					className="cortext-row-detail__frame"
+					data-properties-visible="true"
+				>
+					<div className="cortext-row-detail__header">
+						<div
+							className="cortext-row-detail__toolbar"
+							role="toolbar"
+							aria-label={ __( 'Template actions', 'cortext' ) }
+						>
+							<div className="cortext-row-detail__toolbar-group cortext-row-detail__toolbar-group--end">
+								<Button
+									className="cortext-row-detail__toolbar-button cortext-row-detail__toolbar-button--close"
+									icon={ closeSmall }
+									label={ __( 'Close', 'cortext' ) }
+									onClick={ closeAfterSave }
+								/>
+							</div>
+						</div>
+					</div>
+					{ error ? (
+						<Notice
+							className="cortext-row-detail__notice"
+							status="error"
+							isDismissible
+							onRemove={ () => setError( null ) }
+						>
+							{ error }
+						</Notice>
+					) : null }
+					{ isResolving || ! record ? (
+						<div className="cortext-row-detail__pane cortext-row-detail__pane--loading">
+							<Spinner />
+						</div>
+					) : (
+						<EditorProvider
+							post={ record }
+							settings={ getEditorSettings() }
+							useSubRegistry
+						>
+							<CortextLinkSuggestions />
+							<SlotFillProvider>
+								<EditorSurfaceProvider
+									hasBlockInspector={ false }
+								>
+									<RowMutationContext.Provider
+										value={ mutationContext }
+									>
+										<DocumentPropertiesProvider
+											collectionId={ collectionId }
+											rowId={ templateId }
+											fields={
+												isRowTemplate ? fields : []
+											}
+											allFields={
+												isRowTemplate ? fields : []
+											}
+											detailLayoutEntries={ [] }
+											fallbackRecord={ templateRow }
+											isVisible
+										>
+											<TemplateAutosaveBridge
+												onApi={ ( api ) => {
+													apiRef.current = api;
+												} }
+												onSaved={ handleSaved }
+											/>
+											<EditorBody
+												isActive
+												showIdentityActions={ false }
+												postId={ templateId }
+												postType={ TEMPLATE_POST_TYPE }
+												extraStyles={
+													TEMPLATE_EXTRA_STYLES
+												}
+											/>
+										</DocumentPropertiesProvider>
+									</RowMutationContext.Provider>
+								</EditorSurfaceProvider>
+							</SlotFillProvider>
+						</EditorProvider>
+					) }
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/src/components/TemplateEditorModal.js
+++ b/src/components/TemplateEditorModal.js
@@ -186,7 +186,11 @@ export default function TemplateEditorModal( {
 	return (
 		<Modal
 			className="cortext-row-detail-modal"
-			title={ __( 'Template', 'cortext' ) }
+			title={
+				isRowTemplate
+					? __( 'Row template', 'cortext' )
+					: __( 'Document template', 'cortext' )
+			}
 			onRequestClose={ closeAfterSave }
 			__experimentalHideHeader
 		>
@@ -199,7 +203,14 @@ export default function TemplateEditorModal( {
 						<div
 							className="cortext-row-detail__toolbar"
 							role="toolbar"
-							aria-label={ __( 'Template actions', 'cortext' ) }
+							aria-label={
+								isRowTemplate
+									? __( 'Row template actions', 'cortext' )
+									: __(
+											'Document template actions',
+											'cortext'
+									  )
+							}
 						>
 							<div className="cortext-row-detail__toolbar-group cortext-row-detail__toolbar-group--end">
 								<Button

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -120,6 +120,7 @@ export default function DocumentRow( {
 		typeof isHome === 'function' ? isHome( record ) : !! isHome;
 	const isBeingDragged = draggedId === recordId;
 	const isDropTarget = activeDrop && activeDrop.targetId === recordId;
+	const templatesEnabled = typeof onCreateBlankChild === 'function';
 
 	const [ isRenaming, setIsRenaming ] = useState( false );
 	const [ draftTitle, setDraftTitle ] = useState( '' );
@@ -338,46 +339,52 @@ export default function DocumentRow( {
 							<>
 								{ features.canCreateChild && (
 									<MenuGroup>
-										<MenuItem
-											icon="admin-page"
-											onClick={ () => {
-												onCreateBlankChild?.(
-													recordId
-												);
-												onClose();
-											} }
-										>
-											{ __(
-												'Blank document inside',
-												'cortext'
-											) }
-										</MenuItem>
-										{ pageTemplates.map( ( template ) => (
-											<MenuItem
-												key={ template.id }
-												icon="admin-page"
-												onClick={ () => {
-													onCreateChildFromTemplate?.(
-														recordId,
-														template
-													);
-													onClose();
-												} }
-											>
-												{ sprintf(
-													/* translators: %s: template title */
-													__(
-														'New from %s inside',
+										{ templatesEnabled ? (
+											<>
+												<MenuItem
+													icon="admin-page"
+													onClick={ () => {
+														onCreateBlankChild(
+															recordId
+														);
+														onClose();
+													} }
+												>
+													{ __(
+														'Blank document inside',
 														'cortext'
-													),
-													template.title ||
-														__(
-															'Untitled template',
-															'cortext'
-														)
+													) }
+												</MenuItem>
+												{ pageTemplates.map(
+													( template ) => (
+														<MenuItem
+															key={ template.id }
+															icon="admin-page"
+															onClick={ () => {
+																onCreateChildFromTemplate?.(
+																	recordId,
+																	template
+																);
+																onClose();
+															} }
+														>
+															{ sprintf(
+																/* translators: %s: template title */
+																__(
+																	'New from %s inside',
+																	'cortext'
+																),
+																template.title ||
+																	__(
+																		'Untitled template',
+																		'cortext'
+																	)
+															) }
+														</MenuItem>
+													)
 												) }
-											</MenuItem>
-										) ) }
+											</>
+										) : null }
 										<MenuItem
 											icon={ collectionIcon }
 											onClick={ () => {

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -21,45 +21,6 @@ import { collectionIcon } from '../cortextIcons';
 import { useDocumentActions, useDocumentRecord } from '../../documents';
 import { useSurfaceFocusIntent } from '../SurfaceFocusContext';
 
-/**
- * Sidebar row shared by pages and collections. The document layer tells it
- * which controls to show: tree controls, child rows, drop zones, and the
- * add-child button.
- *
- * `record` is the raw entity. `childNodes` comes from the page tree when the
- * row can have children; descendants render through this same component.
- *
- * `isFavorite`, `isHome`, and `isSelected` can be predicates. Sidebar owns
- * those checks, so the row does not need to know which list or route id to
- * inspect for each kind.
- *
- * @param {Object}                            props
- * @param {Object}                            props.record                      Raw document record.
- * @param {Array}                             [props.childNodes]                Child tree nodes (hierarchy only).
- * @param {Object}                            [props.childBranch]               Lazy-loaded child branch state.
- * @param {number}                            [props.depth]                     Nesting depth, 0 at the root.
- * @param {Set<number>}                       props.expandedIds                 Currently expanded row ids.
- * @param {?number}                           [props.draggedId]                 Id of the row being dragged.
- * @param {?{zone: string, targetId: number}} [props.activeDrop]                Active drop target metadata.
- * @param {boolean}                           [props.isHidden]                  True when an ancestor is collapsed.
- * @param {Function|boolean}                  props.isSelected                  Selection predicate or flag.
- * @param {Function}                          props.onSelect                    Called with the record on title click.
- * @param {Function}                          props.onToggleExpand              Called with the record id on chevron click.
- * @param {Function}                          props.onLoadMore                  Called with the parent id from a branch Show more button.
- * @param {Function}                          props.onCreateChild               Called with the parent id from the add-child button.
- * @param {Function}                          [props.onCreateBlankChild]        Called with the parent id to create a blank child page.
- * @param {Array}                             [props.pageTemplates]             Page templates available for child creation.
- * @param {Function}                          [props.onCreateChildFromTemplate] Called with parent id and template.
- * @param {Function}                          [props.onCreateChildCollection]   Called with the parent id to create a child collection.
- * @param {Function|boolean}                  props.isFavorite                  Favorite predicate or flag.
- * @param {boolean}                           [props.isFavoriteDisabled]        Disable favorite toggling.
- * @param {Function}                          props.onToggleFavorite            Called with the record from the menu.
- * @param {Function|boolean}                  props.isHome                      Home predicate or flag.
- * @param {Function}                          props.onSetHome                   Called with the record from the menu.
- * @param {boolean}                           [props.isHomeUpdating]            Disable set-as-home while a save is in flight.
- * @param {?number}                           [props.autoRenameId]              Row id that should immediately enter rename mode.
- * @param {Function}                          props.onAutoRenameConsumed        Called once rename mode has opened.
- */
 export default function DocumentRow( {
 	record,
 	childNodes = [],
@@ -126,8 +87,6 @@ export default function DocumentRow( {
 	const [ draftTitle, setDraftTitle ] = useState( '' );
 	const renameInputRef = useRef( null );
 
-	// The parent sets `autoRenameId` after create or duplicate so this row
-	// opens its title editor as soon as it renders.
 	useEffect( () => {
 		if ( autoRenameId === recordId ) {
 			setDraftTitle( record.title?.raw ?? record.title?.rendered ?? '' );
@@ -142,8 +101,7 @@ export default function DocumentRow( {
 		onAutoRenameConsumed,
 	] );
 
-	// TextControl keeps the real input inside its wrapper; focus and select
-	// that inner input when rename mode opens.
+	// TextControl owns the input, so the wrapper ref cannot be focused directly.
 	useEffect( () => {
 		if ( isRenaming && renameInputRef.current ) {
 			const input = renameInputRef.current.querySelector( 'input' );
@@ -170,8 +128,7 @@ export default function DocumentRow( {
 		setIsRenaming( true );
 	}
 
-	// Drag source. The existing DnD hook still expects page:/collection:
-	// prefixes, so keep that id shape while the row itself stays shared.
+	// useSidebarDnd still parses these legacy prefixes.
 	const {
 		attributes,
 		listeners,
@@ -181,8 +138,6 @@ export default function DocumentRow( {
 		data: { pageId: recordId },
 	} );
 
-	// Hierarchical rows accept before/inside/after drops. Leaves only accept
-	// before/after, matching what the REST guard allows.
 	const dropBefore = useDroppable( {
 		id: `before:${ recordId }`,
 		data: { zone: 'before', pageId: recordId },

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -306,7 +306,7 @@ export default function DocumentRow( {
 													} }
 												>
 													{ __(
-														'Blank document inside',
+														'Add blank document',
 														'cortext'
 													) }
 												</MenuItem>
@@ -326,7 +326,7 @@ export default function DocumentRow( {
 															{ sprintf(
 																/* translators: %s: template title */
 																__(
-																	'New from %s inside',
+																	'Add document from %s',
 																	'cortext'
 																),
 																template.title ||

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -34,28 +34,31 @@ import { useSurfaceFocusIntent } from '../SurfaceFocusContext';
  * inspect for each kind.
  *
  * @param {Object}                            props
- * @param {Object}                            props.record                    Raw document record.
- * @param {Array}                             [props.childNodes]              Child tree nodes (hierarchy only).
- * @param {Object}                            [props.childBranch]             Lazy-loaded child branch state.
- * @param {number}                            [props.depth]                   Nesting depth, 0 at the root.
- * @param {Set<number>}                       props.expandedIds               Currently expanded row ids.
- * @param {?number}                           [props.draggedId]               Id of the row being dragged.
- * @param {?{zone: string, targetId: number}} [props.activeDrop]              Active drop target metadata.
- * @param {boolean}                           [props.isHidden]                True when an ancestor is collapsed.
- * @param {Function|boolean}                  props.isSelected                Selection predicate or flag.
- * @param {Function}                          props.onSelect                  Called with the record on title click.
- * @param {Function}                          props.onToggleExpand            Called with the record id on chevron click.
- * @param {Function}                          props.onLoadMore                Called with the parent id from a branch Show more button.
- * @param {Function}                          props.onCreateChild             Called with the parent id from the add-child button.
- * @param {Function}                          [props.onCreateChildCollection] Called with the parent id to create a child collection.
- * @param {Function|boolean}                  props.isFavorite                Favorite predicate or flag.
- * @param {boolean}                           [props.isFavoriteDisabled]      Disable favorite toggling.
- * @param {Function}                          props.onToggleFavorite          Called with the record from the menu.
- * @param {Function|boolean}                  props.isHome                    Home predicate or flag.
- * @param {Function}                          props.onSetHome                 Called with the record from the menu.
- * @param {boolean}                           [props.isHomeUpdating]          Disable set-as-home while a save is in flight.
- * @param {?number}                           [props.autoRenameId]            Row id that should immediately enter rename mode.
- * @param {Function}                          props.onAutoRenameConsumed      Called once rename mode has opened.
+ * @param {Object}                            props.record                      Raw document record.
+ * @param {Array}                             [props.childNodes]                Child tree nodes (hierarchy only).
+ * @param {Object}                            [props.childBranch]               Lazy-loaded child branch state.
+ * @param {number}                            [props.depth]                     Nesting depth, 0 at the root.
+ * @param {Set<number>}                       props.expandedIds                 Currently expanded row ids.
+ * @param {?number}                           [props.draggedId]                 Id of the row being dragged.
+ * @param {?{zone: string, targetId: number}} [props.activeDrop]                Active drop target metadata.
+ * @param {boolean}                           [props.isHidden]                  True when an ancestor is collapsed.
+ * @param {Function|boolean}                  props.isSelected                  Selection predicate or flag.
+ * @param {Function}                          props.onSelect                    Called with the record on title click.
+ * @param {Function}                          props.onToggleExpand              Called with the record id on chevron click.
+ * @param {Function}                          props.onLoadMore                  Called with the parent id from a branch Show more button.
+ * @param {Function}                          props.onCreateChild               Called with the parent id from the add-child button.
+ * @param {Function}                          [props.onCreateBlankChild]        Called with the parent id to create a blank child page.
+ * @param {Array}                             [props.pageTemplates]             Page templates available for child creation.
+ * @param {Function}                          [props.onCreateChildFromTemplate] Called with parent id and template.
+ * @param {Function}                          [props.onCreateChildCollection]   Called with the parent id to create a child collection.
+ * @param {Function|boolean}                  props.isFavorite                  Favorite predicate or flag.
+ * @param {boolean}                           [props.isFavoriteDisabled]        Disable favorite toggling.
+ * @param {Function}                          props.onToggleFavorite            Called with the record from the menu.
+ * @param {Function|boolean}                  props.isHome                      Home predicate or flag.
+ * @param {Function}                          props.onSetHome                   Called with the record from the menu.
+ * @param {boolean}                           [props.isHomeUpdating]            Disable set-as-home while a save is in flight.
+ * @param {?number}                           [props.autoRenameId]              Row id that should immediately enter rename mode.
+ * @param {Function}                          props.onAutoRenameConsumed        Called once rename mode has opened.
  */
 export default function DocumentRow( {
 	record,
@@ -71,6 +74,9 @@ export default function DocumentRow( {
 	onToggleExpand,
 	onLoadMore,
 	onCreateChild,
+	onCreateBlankChild,
+	pageTemplates = [],
+	onCreateChildFromTemplate,
 	onCreateChildCollection,
 	isFavorite,
 	isFavoriteDisabled = false,
@@ -333,6 +339,46 @@ export default function DocumentRow( {
 								{ features.canCreateChild && (
 									<MenuGroup>
 										<MenuItem
+											icon="admin-page"
+											onClick={ () => {
+												onCreateBlankChild?.(
+													recordId
+												);
+												onClose();
+											} }
+										>
+											{ __(
+												'Blank document inside',
+												'cortext'
+											) }
+										</MenuItem>
+										{ pageTemplates.map( ( template ) => (
+											<MenuItem
+												key={ template.id }
+												icon="admin-page"
+												onClick={ () => {
+													onCreateChildFromTemplate?.(
+														recordId,
+														template
+													);
+													onClose();
+												} }
+											>
+												{ sprintf(
+													/* translators: %s: template title */
+													__(
+														'New from %s inside',
+														'cortext'
+													),
+													template.title ||
+														__(
+															'Untitled template',
+															'cortext'
+														)
+												) }
+											</MenuItem>
+										) ) }
+										<MenuItem
 											icon={ collectionIcon }
 											onClick={ () => {
 												onCreateChildCollection?.(
@@ -473,6 +519,11 @@ export default function DocumentRow( {
 								onToggleExpand={ onToggleExpand }
 								onLoadMore={ onLoadMore }
 								onCreateChild={ onCreateChild }
+								onCreateBlankChild={ onCreateBlankChild }
+								pageTemplates={ pageTemplates }
+								onCreateChildFromTemplate={
+									onCreateChildFromTemplate
+								}
 								onCreateChildCollection={
 									onCreateChildCollection
 								}

--- a/src/templates/actions.js
+++ b/src/templates/actions.js
@@ -2,6 +2,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 export const TEMPLATE_POST_TYPE = 'crtxt_template';
+export const TEMPLATES_EXPERIMENT_ID = 'templates';
 export const TEMPLATE_KIND_PAGE = 'page';
 export const TEMPLATE_KIND_ROW = 'row';
 

--- a/src/templates/actions.js
+++ b/src/templates/actions.js
@@ -1,0 +1,87 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+export const TEMPLATE_POST_TYPE = 'crtxt_template';
+export const TEMPLATE_KIND_PAGE = 'page';
+export const TEMPLATE_KIND_ROW = 'row';
+
+export async function fetchTemplates( { kind, collectionId } = {} ) {
+	const query = {};
+	if ( kind ) {
+		query.kind = kind;
+	}
+	if ( collectionId ) {
+		query.collection_id = collectionId;
+	}
+	const response = await apiFetch( {
+		path: addQueryArgs( '/cortext/v1/templates', query ),
+	} );
+	return response?.templates ?? [];
+}
+
+export async function createTemplate( data = {} ) {
+	const response = await apiFetch( {
+		path: '/cortext/v1/templates',
+		method: 'POST',
+		data,
+	} );
+	return response?.template ?? null;
+}
+
+export async function createTemplateFromDocument( documentId ) {
+	const response = await apiFetch( {
+		path: '/cortext/v1/templates/from-document',
+		method: 'POST',
+		data: { document_id: documentId },
+	} );
+	return response?.template ?? null;
+}
+
+export async function updateTemplate( id, data = {} ) {
+	const response = await apiFetch( {
+		path: `/cortext/v1/templates/${ id }`,
+		method: 'POST',
+		data,
+	} );
+	return response?.template ?? null;
+}
+
+export async function duplicateTemplate( id ) {
+	const response = await apiFetch( {
+		path: `/cortext/v1/templates/${ id }/duplicate`,
+		method: 'POST',
+	} );
+	return response?.template ?? null;
+}
+
+export async function deleteTemplate( id ) {
+	return apiFetch( {
+		path: `/cortext/v1/templates/${ id }`,
+		method: 'DELETE',
+	} );
+}
+
+export async function instantiateTemplate( id, data = {} ) {
+	const response = await apiFetch( {
+		path: `/cortext/v1/templates/${ id }/instantiate`,
+		method: 'POST',
+		data,
+	} );
+	return response?.document ?? null;
+}
+
+export async function fetchDefaultPageTemplate() {
+	const response = await apiFetch( {
+		path: '/cortext/v1/templates/default',
+	} );
+	return response?.template ?? null;
+}
+
+export async function setDefaultPageTemplate( id ) {
+	const response = await apiFetch( {
+		path: '/cortext/v1/templates/default',
+		method: 'PUT',
+		data: { id: id ?? null },
+	} );
+	return response?.template ?? null;
+}

--- a/src/templates/actions.js
+++ b/src/templates/actions.js
@@ -70,19 +70,3 @@ export async function instantiateTemplate( id, data = {} ) {
 	} );
 	return response?.document ?? null;
 }
-
-export async function fetchDefaultPageTemplate() {
-	const response = await apiFetch( {
-		path: '/cortext/v1/templates/default',
-	} );
-	return response?.template ?? null;
-}
-
-export async function setDefaultPageTemplate( id ) {
-	const response = await apiFetch( {
-		path: '/cortext/v1/templates/default',
-		method: 'PUT',
-		data: { id: id ?? null },
-	} );
-	return response?.template ?? null;
-}

--- a/src/templates/actions.js
+++ b/src/templates/actions.js
@@ -29,15 +29,6 @@ export async function createTemplate( data = {} ) {
 	return response?.template ?? null;
 }
 
-export async function createTemplateFromDocument( documentId ) {
-	const response = await apiFetch( {
-		path: '/cortext/v1/templates/from-document',
-		method: 'POST',
-		data: { document_id: documentId },
-	} );
-	return response?.template ?? null;
-}
-
 export async function updateTemplate( id, data = {} ) {
 	const response = await apiFetch( {
 		path: `/cortext/v1/templates/${ id }`,
@@ -45,21 +36,6 @@ export async function updateTemplate( id, data = {} ) {
 		data,
 	} );
 	return response?.template ?? null;
-}
-
-export async function duplicateTemplate( id ) {
-	const response = await apiFetch( {
-		path: `/cortext/v1/templates/${ id }/duplicate`,
-		method: 'POST',
-	} );
-	return response?.template ?? null;
-}
-
-export async function deleteTemplate( id ) {
-	return apiFetch( {
-		path: `/cortext/v1/templates/${ id }`,
-		method: 'DELETE',
-	} );
 }
 
 export async function instantiateTemplate( id, data = {} ) {

--- a/src/templates/hooks.js
+++ b/src/templates/hooks.js
@@ -39,13 +39,19 @@ function matchesTemplateChange( detail, kind, collectionId ) {
 	return true;
 }
 
-export function useTemplates( { kind, collectionId } = {} ) {
+export function useTemplates( { kind, collectionId, enabled = true } = {} ) {
 	const [ templates, setTemplates ] = useState( [] );
-	const [ isResolving, setIsResolving ] = useState( true );
+	const [ isResolving, setIsResolving ] = useState( enabled );
 	const [ error, setError ] = useState( null );
-	const queryKey = `${ kind ?? '' }:${ collectionId ?? '' }`;
+	const queryKey = `${ kind ?? '' }:${ collectionId ?? '' }:${ enabled }`;
 
 	const refresh = useCallback( async () => {
+		if ( ! enabled ) {
+			setTemplates( [] );
+			setIsResolving( false );
+			setError( null );
+			return [];
+		}
 		setIsResolving( true );
 		setError( null );
 		try {
@@ -59,9 +65,16 @@ export function useTemplates( { kind, collectionId } = {} ) {
 		} finally {
 			setIsResolving( false );
 		}
-	}, [ kind, collectionId ] );
+	}, [ kind, collectionId, enabled ] );
 
 	useEffect( () => {
+		if ( ! enabled ) {
+			setTemplates( [] );
+			setIsResolving( false );
+			setError( null );
+			return undefined;
+		}
+
 		let cancelled = false;
 		setIsResolving( true );
 		setError( null );
@@ -87,7 +100,7 @@ export function useTemplates( { kind, collectionId } = {} ) {
 	}, [ queryKey ] );
 
 	useEffect( () => {
-		if ( typeof window === 'undefined' ) {
+		if ( ! enabled || typeof window === 'undefined' ) {
 			return undefined;
 		}
 		const onTemplatesChanged = ( event ) => {
@@ -101,7 +114,7 @@ export function useTemplates( { kind, collectionId } = {} ) {
 				TEMPLATES_CHANGED_EVENT,
 				onTemplatesChanged
 			);
-	}, [ collectionId, kind, refresh ] );
+	}, [ collectionId, enabled, kind, refresh ] );
 
 	return useMemo(
 		() => ( { templates, isResolving, error, refresh } ),

--- a/src/templates/hooks.js
+++ b/src/templates/hooks.js
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+import {
+	createTemplate,
+	createTemplateFromDocument,
+	duplicateTemplate,
+	fetchDefaultPageTemplate,
+	fetchTemplates,
+	instantiateTemplate,
+	setDefaultPageTemplate,
+} from './actions';
+import {
+	afterDocumentTrash,
+	applyInvalidationPack,
+} from '../documents/invalidation';
+
+const TEMPLATES_CHANGED_EVENT = 'cortext:templates-changed';
+
+export function notifyTemplatesChanged( detail = {} ) {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	window.dispatchEvent(
+		new window.CustomEvent( TEMPLATES_CHANGED_EVENT, { detail } )
+	);
+}
+
+function matchesTemplateChange( detail, kind, collectionId ) {
+	if ( detail?.kind && detail.kind !== kind ) {
+		return false;
+	}
+	if (
+		detail?.collectionId &&
+		Number( detail.collectionId ) !== Number( collectionId )
+	) {
+		return false;
+	}
+	return true;
+}
+
+export function useTemplates( { kind, collectionId } = {} ) {
+	const [ templates, setTemplates ] = useState( [] );
+	const [ isResolving, setIsResolving ] = useState( true );
+	const [ error, setError ] = useState( null );
+	const queryKey = `${ kind ?? '' }:${ collectionId ?? '' }`;
+
+	const refresh = useCallback( async () => {
+		setIsResolving( true );
+		setError( null );
+		try {
+			const next = await fetchTemplates( { kind, collectionId } );
+			setTemplates( next );
+			return next;
+		} catch ( nextError ) {
+			setTemplates( [] );
+			setError( nextError );
+			return [];
+		} finally {
+			setIsResolving( false );
+		}
+	}, [ kind, collectionId ] );
+
+	useEffect( () => {
+		let cancelled = false;
+		setIsResolving( true );
+		setError( null );
+		fetchTemplates( { kind, collectionId } )
+			.then( ( next ) => {
+				if ( ! cancelled ) {
+					setTemplates( next );
+					setIsResolving( false );
+				}
+			} )
+			.catch( ( nextError ) => {
+				if ( ! cancelled ) {
+					setTemplates( [] );
+					setError( nextError );
+					setIsResolving( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+		// `queryKey` encodes the two query inputs and keeps the effect compact.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ queryKey ] );
+
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return undefined;
+		}
+		const onTemplatesChanged = ( event ) => {
+			if ( matchesTemplateChange( event.detail, kind, collectionId ) ) {
+				refresh();
+			}
+		};
+		window.addEventListener( TEMPLATES_CHANGED_EVENT, onTemplatesChanged );
+		return () =>
+			window.removeEventListener(
+				TEMPLATES_CHANGED_EVENT,
+				onTemplatesChanged
+			);
+	}, [ collectionId, kind, refresh ] );
+
+	return useMemo(
+		() => ( { templates, isResolving, error, refresh } ),
+		[ templates, isResolving, error, refresh ]
+	);
+}
+
+export function useDefaultPageTemplate() {
+	const [ template, setTemplate ] = useState( null );
+	const [ isResolving, setIsResolving ] = useState( true );
+	const [ error, setError ] = useState( null );
+
+	const refresh = useCallback( async () => {
+		setIsResolving( true );
+		setError( null );
+		try {
+			const next = await fetchDefaultPageTemplate();
+			setTemplate( next );
+			return next;
+		} catch ( nextError ) {
+			setTemplate( null );
+			setError( nextError );
+			return null;
+		} finally {
+			setIsResolving( false );
+		}
+	}, [] );
+
+	useEffect( () => {
+		refresh();
+	}, [ refresh ] );
+
+	const setDefault = useCallback( async ( id ) => {
+		const next = await setDefaultPageTemplate( id );
+		setTemplate( next );
+		return next;
+	}, [] );
+
+	return useMemo(
+		() => ( { template, isResolving, error, refresh, setDefault } ),
+		[ template, isResolving, error, refresh, setDefault ]
+	);
+}
+
+export function useCreateTemplate() {
+	return useCallback( async ( data = {} ) => createTemplate( data ), [] );
+}
+
+export function useCreateTemplateFromDocument() {
+	return useCallback(
+		async ( documentId ) => createTemplateFromDocument( documentId ),
+		[]
+	);
+}
+
+export function useDuplicateTemplate() {
+	return useCallback( async ( id ) => duplicateTemplate( id ), [] );
+}
+
+export function useInstantiateTemplate() {
+	const { invalidateResolution } = useDispatch( 'core' );
+	return useCallback(
+		async ( id, data = {} ) => {
+			const created = await instantiateTemplate( id, data );
+			if ( created?.id ) {
+				applyInvalidationPack(
+					invalidateResolution,
+					afterDocumentTrash
+				);
+			}
+			return created;
+		},
+		[ invalidateResolution ]
+	);
+}

--- a/src/templates/hooks.js
+++ b/src/templates/hooks.js
@@ -43,7 +43,6 @@ export function useTemplates( { kind, collectionId, enabled = true } = {} ) {
 	const [ templates, setTemplates ] = useState( [] );
 	const [ isResolving, setIsResolving ] = useState( enabled );
 	const [ error, setError ] = useState( null );
-	const queryKey = `${ kind ?? '' }:${ collectionId ?? '' }:${ enabled }`;
 
 	const refresh = useCallback( async () => {
 		if ( ! enabled ) {
@@ -95,9 +94,7 @@ export function useTemplates( { kind, collectionId, enabled = true } = {} ) {
 		return () => {
 			cancelled = true;
 		};
-		// `queryKey` encodes the two query inputs and keeps the effect compact.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ queryKey ] );
+	}, [ kind, collectionId, enabled ] );
 
 	useEffect( () => {
 		if ( ! enabled || typeof window === 'undefined' ) {

--- a/src/templates/hooks.js
+++ b/src/templates/hooks.js
@@ -5,10 +5,8 @@ import {
 	createTemplate,
 	createTemplateFromDocument,
 	duplicateTemplate,
-	fetchDefaultPageTemplate,
 	fetchTemplates,
 	instantiateTemplate,
-	setDefaultPageTemplate,
 } from './actions';
 import {
 	afterDocumentTrash,
@@ -116,43 +114,6 @@ export function useTemplates( { kind, collectionId, enabled = true } = {} ) {
 	return useMemo(
 		() => ( { templates, isResolving, error, refresh } ),
 		[ templates, isResolving, error, refresh ]
-	);
-}
-
-export function useDefaultPageTemplate() {
-	const [ template, setTemplate ] = useState( null );
-	const [ isResolving, setIsResolving ] = useState( true );
-	const [ error, setError ] = useState( null );
-
-	const refresh = useCallback( async () => {
-		setIsResolving( true );
-		setError( null );
-		try {
-			const next = await fetchDefaultPageTemplate();
-			setTemplate( next );
-			return next;
-		} catch ( nextError ) {
-			setTemplate( null );
-			setError( nextError );
-			return null;
-		} finally {
-			setIsResolving( false );
-		}
-	}, [] );
-
-	useEffect( () => {
-		refresh();
-	}, [ refresh ] );
-
-	const setDefault = useCallback( async ( id ) => {
-		const next = await setDefaultPageTemplate( id );
-		setTemplate( next );
-		return next;
-	}, [] );
-
-	return useMemo(
-		() => ( { template, isResolving, error, refresh, setDefault } ),
-		[ template, isResolving, error, refresh, setDefault ]
 	);
 }
 

--- a/src/templates/hooks.js
+++ b/src/templates/hooks.js
@@ -1,13 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 
-import {
-	createTemplate,
-	createTemplateFromDocument,
-	duplicateTemplate,
-	fetchTemplates,
-	instantiateTemplate,
-} from './actions';
+import { fetchTemplates, instantiateTemplate } from './actions';
 import {
 	afterDocumentTrash,
 	applyInvalidationPack,
@@ -115,21 +109,6 @@ export function useTemplates( { kind, collectionId, enabled = true } = {} ) {
 		() => ( { templates, isResolving, error, refresh } ),
 		[ templates, isResolving, error, refresh ]
 	);
-}
-
-export function useCreateTemplate() {
-	return useCallback( async ( data = {} ) => createTemplate( data ), [] );
-}
-
-export function useCreateTemplateFromDocument() {
-	return useCallback(
-		async ( documentId ) => createTemplateFromDocument( documentId ),
-		[]
-	);
-}
-
-export function useDuplicateTemplate() {
-	return useCallback( async ( id ) => duplicateTemplate( id ), [] );
 }
 
 export function useInstantiateTemplate() {

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -1,0 +1,2 @@
+export * from './actions';
+export * from './hooks';

--- a/tests/e2e/specs/templates.spec.js
+++ b/tests/e2e/specs/templates.spec.js
@@ -1,0 +1,199 @@
+/**
+ * E2E coverage for shared page and row template instantiation.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+test.describe( 'Templates', () => {
+	test( 'instantiates page and row templates as snapshots', async ( {
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		const suffix = Date.now().toString( 36 ).slice( -4 );
+
+		try {
+			const sourcePage = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: `E2E Page Template Source ${ suffix }`,
+					status: 'private',
+					content:
+						'<!-- wp:paragraph --><p>Original page body</p><!-- /wp:paragraph -->',
+				},
+			} );
+			fixture.sourcePageId = sourcePage.id;
+
+			const pageTemplateResponse = await requestUtils.rest( {
+				method: 'POST',
+				path: '/cortext/v1/templates/from-document',
+				data: {
+					document_id: fixture.sourcePageId,
+				},
+			} );
+			fixture.pageTemplateId = pageTemplateResponse.template.id;
+
+			const pageResponse = await requestUtils.rest( {
+				method: 'POST',
+				path: `/cortext/v1/templates/${ fixture.pageTemplateId }/instantiate`,
+			} );
+			fixture.pageId = pageResponse.document.id;
+
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/cortext/v1/templates/${ fixture.pageTemplateId }`,
+				data: {
+					content:
+						'<!-- wp:paragraph --><p>Mutated page body</p><!-- /wp:paragraph -->',
+				},
+			} );
+
+			const page = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_documents/${ fixture.pageId }`,
+				params: { context: 'edit' },
+			} );
+			expect( page.content.raw ).toContain( 'Original page body' );
+			expect( page.content.raw ).not.toContain( 'Mutated page body' );
+
+			const collection = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: `E2E Template Rows ${ suffix }`,
+					status: 'private',
+				},
+			} );
+			fixture.collectionId = collection.id;
+
+			const field = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_fields',
+				data: {
+					title: `Status ${ suffix }`,
+					status: 'private',
+					meta: { type: 'text' },
+				},
+			} );
+			fixture.fieldId = field.id;
+
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/wp/v2/crtxt_documents/${ fixture.collectionId }`,
+				data: {
+					meta: { cortext_fields: [ String( fixture.fieldId ) ] },
+				},
+			} );
+
+			const sourceRow = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: `E2E Row Template Source ${ suffix }`,
+					status: 'private',
+					cortext_trait: fixture.collectionId,
+					content:
+						'<!-- wp:paragraph --><p>Original row body</p><!-- /wp:paragraph -->',
+					meta: {
+						[ `field-${ fixture.fieldId }` ]: 'template default',
+					},
+				},
+			} );
+			fixture.sourceRowId = sourceRow.id;
+
+			const rowTemplateResponse = await requestUtils.rest( {
+				method: 'POST',
+				path: '/cortext/v1/templates/from-document',
+				data: {
+					document_id: fixture.sourceRowId,
+				},
+			} );
+			fixture.rowTemplateId = rowTemplateResponse.template.id;
+
+			const rowResponse = await requestUtils.rest( {
+				method: 'POST',
+				path: `/cortext/v1/templates/${ fixture.rowTemplateId }/instantiate`,
+				data: {
+					field_values: {
+						[ `field-${ fixture.fieldId }` ]: 'filter prefill',
+					},
+				},
+			} );
+			fixture.rowId = rowResponse.document.id;
+
+			await requestUtils.rest( {
+				method: 'POST',
+				path: `/cortext/v1/templates/${ fixture.rowTemplateId }`,
+				data: {
+					content:
+						'<!-- wp:paragraph --><p>Mutated row body</p><!-- /wp:paragraph -->',
+					field_values: {
+						[ `field-${ fixture.fieldId }` ]: 'mutated default',
+					},
+				},
+			} );
+
+			const row = await requestUtils.rest( {
+				path: `/wp/v2/crtxt_documents/${ fixture.rowId }`,
+				params: { context: 'edit' },
+			} );
+			expect( row.content.raw ).toContain( 'Original row body' );
+			expect( row.content.raw ).not.toContain( 'Mutated row body' );
+			expect( row.meta[ `field-${ fixture.fieldId }` ] ).toBe(
+				'filter prefill'
+			);
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.rowId && `/wp/v2/crtxt_documents/${ fixture.rowId }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.pageId && `/wp/v2/crtxt_documents/${ fixture.pageId }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.sourceRowId &&
+					`/wp/v2/crtxt_documents/${ fixture.sourceRowId }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.sourcePageId &&
+					`/wp/v2/crtxt_documents/${ fixture.sourcePageId }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.rowTemplateId &&
+					`/cortext/v1/templates/${ fixture.rowTemplateId }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.pageTemplateId &&
+					`/cortext/v1/templates/${ fixture.pageTemplateId }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.collectionId &&
+					`/wp/v2/crtxt_documents/${ fixture.collectionId }`
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.fieldId && `/wp/v2/crtxt_fields/${ fixture.fieldId }`
+			);
+		}
+	} );
+} );

--- a/tests/e2e/specs/templates.spec.js
+++ b/tests/e2e/specs/templates.spec.js
@@ -1,7 +1,3 @@
-/**
- * E2E coverage for shared page and row template instantiation.
- */
-
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 async function deleteIfCreated( requestUtils, path ) {
@@ -15,7 +11,7 @@ async function deleteIfCreated( requestUtils, path ) {
 			params: { force: true },
 		} );
 	} catch {
-		// Best-effort cleanup; the record may already be gone.
+		// Cleanup is idempotent; the record may already be gone.
 	}
 }
 

--- a/tests/e2e/specs/templates.spec.js
+++ b/tests/e2e/specs/templates.spec.js
@@ -23,23 +23,14 @@ test.describe( 'Templates', () => {
 		const suffix = Date.now().toString( 36 ).slice( -4 );
 
 		try {
-			const sourcePage = await requestUtils.rest( {
-				method: 'POST',
-				path: '/wp/v2/crtxt_documents',
-				data: {
-					title: `E2E Page Template Source ${ suffix }`,
-					status: 'private',
-					content:
-						'<!-- wp:paragraph --><p>Original page body</p><!-- /wp:paragraph -->',
-				},
-			} );
-			fixture.sourcePageId = sourcePage.id;
-
 			const pageTemplateResponse = await requestUtils.rest( {
 				method: 'POST',
-				path: '/cortext/v1/templates/from-document',
+				path: '/cortext/v1/templates',
 				data: {
-					document_id: fixture.sourcePageId,
+					kind: 'page',
+					title: `E2E Page Template Source ${ suffix }`,
+					content:
+						'<!-- wp:paragraph --><p>Original page body</p><!-- /wp:paragraph -->',
 				},
 			} );
 			fixture.pageTemplateId = pageTemplateResponse.template.id;
@@ -95,27 +86,18 @@ test.describe( 'Templates', () => {
 				},
 			} );
 
-			const sourceRow = await requestUtils.rest( {
-				method: 'POST',
-				path: '/wp/v2/crtxt_documents',
-				data: {
-					title: `E2E Row Template Source ${ suffix }`,
-					status: 'private',
-					cortext_trait: fixture.collectionId,
-					content:
-						'<!-- wp:paragraph --><p>Original row body</p><!-- /wp:paragraph -->',
-					meta: {
-						[ `field-${ fixture.fieldId }` ]: 'template default',
-					},
-				},
-			} );
-			fixture.sourceRowId = sourceRow.id;
-
 			const rowTemplateResponse = await requestUtils.rest( {
 				method: 'POST',
-				path: '/cortext/v1/templates/from-document',
+				path: '/cortext/v1/templates',
 				data: {
-					document_id: fixture.sourceRowId,
+					kind: 'row',
+					collection_id: fixture.collectionId,
+					title: `E2E Row Template Source ${ suffix }`,
+					content:
+						'<!-- wp:paragraph --><p>Original row body</p><!-- /wp:paragraph -->',
+					field_values: {
+						[ `field-${ fixture.fieldId }` ]: 'template default',
+					},
 				},
 			} );
 			fixture.rowTemplateId = rowTemplateResponse.template.id;
@@ -163,23 +145,13 @@ test.describe( 'Templates', () => {
 			);
 			await deleteIfCreated(
 				requestUtils,
-				fixture.sourceRowId &&
-					`/wp/v2/crtxt_documents/${ fixture.sourceRowId }`
-			);
-			await deleteIfCreated(
-				requestUtils,
-				fixture.sourcePageId &&
-					`/wp/v2/crtxt_documents/${ fixture.sourcePageId }`
-			);
-			await deleteIfCreated(
-				requestUtils,
 				fixture.rowTemplateId &&
-					`/cortext/v1/templates/${ fixture.rowTemplateId }`
+					`/wp/v2/crtxt_templates/${ fixture.rowTemplateId }`
 			);
 			await deleteIfCreated(
 				requestUtils,
 				fixture.pageTemplateId &&
-					`/cortext/v1/templates/${ fixture.pageTemplateId }`
+					`/wp/v2/crtxt_templates/${ fixture.pageTemplateId }`
 			);
 			await deleteIfCreated(
 				requestUtils,

--- a/tests/js/components/DataViewNewRowButton.test.js
+++ b/tests/js/components/DataViewNewRowButton.test.js
@@ -1,0 +1,286 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( value ) => value,
+	sprintf: ( template, value ) => template.replace( '%s', value ),
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	chevronDown: 'chevronDown',
+	page: 'page',
+	plus: 'plus',
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	return {
+		__esModule: true,
+		Button: ( { children, label, onClick, disabled, isBusy } ) => (
+			<button
+				type="button"
+				aria-label={ label }
+				onClick={ onClick }
+				disabled={ disabled || isBusy }
+			>
+				{ children || label }
+			</button>
+		),
+		Dropdown: ( { renderToggle, renderContent } ) => {
+			const [ isOpen, setIsOpen ] = React.useState( false );
+			return (
+				<div>
+					{ renderToggle( {
+						isOpen,
+						onToggle: () => setIsOpen( ( current ) => ! current ),
+					} ) }
+					{ isOpen ? (
+						<div role="menu">
+							{ renderContent( {
+								onClose: () => setIsOpen( false ),
+							} ) }
+						</div>
+					) : null }
+				</div>
+			);
+		},
+		MenuGroup: ( { children } ) => <div>{ children }</div>,
+		MenuItem: ( { children, onClick } ) => (
+			<button type="button" role="menuitem" onClick={ onClick }>
+				{ children }
+			</button>
+		),
+		Notice: ( { children } ) => <div role="alert">{ children }</div>,
+	};
+} );
+
+jest.mock( '../../../src/templates', () => ( {
+	__esModule: true,
+	createTemplate: jest.fn(),
+	instantiateTemplate: jest.fn(),
+	notifyTemplatesChanged: jest.fn(),
+	TEMPLATE_KIND_ROW: 'row',
+	useTemplates: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/components/TemplateEditorModal', () => ( props ) => (
+	<div data-testid="template-editor-modal">{ props.templateId }</div>
+) );
+
+import DataViewNewRowButton from '../../../src/components/DataViewNewRowButton';
+import {
+	createTemplate,
+	instantiateTemplate,
+	notifyTemplatesChanged,
+	useTemplates,
+} from '../../../src/templates';
+
+const fields = [
+	{ id: 'field-1', editable: true, cortextType: 'text' },
+	{ id: 'field-2', editable: false, cortextType: 'text' },
+	{ id: 'field-3', editable: true, cortextType: 'rollup' },
+	{ id: 'title', editable: true, cortextType: 'title' },
+];
+
+beforeEach( () => {
+	apiFetch.mockReset();
+	createTemplate.mockReset();
+	instantiateTemplate.mockReset();
+	notifyTemplatesChanged.mockReset();
+	useTemplates.mockReset();
+	useTemplates.mockReturnValue( { templates: [] } );
+} );
+
+function renderButton( props = {} ) {
+	return render(
+		<DataViewNewRowButton
+			collectionId={ 7 }
+			view={ { filters: [] } }
+			fields={ fields }
+			onCreated={ jest.fn() }
+			{ ...props }
+		/>
+	);
+}
+
+describe( 'DataViewNewRowButton templates', () => {
+	it( 'uses the view default template and sends eligible filter prefills as overrides', async () => {
+		const onCreated = jest.fn();
+		const template = { id: 10, title: 'Task starter' };
+		// A second template keeps the `templates.length === 1` fallback from
+		// reaching id 10, so the assertion below only passes if the
+		// defaultRowTemplateId lookup resolves it.
+		useTemplates.mockReturnValue( {
+			templates: [ template, { id: 11, title: 'Other starter' } ],
+		} );
+		instantiateTemplate.mockResolvedValueOnce( { id: 99 } );
+
+		renderButton( {
+			onCreated,
+			view: {
+				defaultRowTemplateId: 10,
+				filters: [
+					{ field: 'field-1', operator: 'is', value: 'Active' },
+					{ field: 'field-2', operator: 'is', value: 'Ignored' },
+					{ field: 'field-3', operator: 'is', value: 'Rollup' },
+					{ field: 'field-1', operator: 'isAny', value: 'Skipped' },
+				],
+			},
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'New' } ) );
+
+		await waitFor( () =>
+			expect( instantiateTemplate ).toHaveBeenCalledWith( 10, {
+				field_values: { 'field-1': 'Active' },
+			} )
+		);
+		expect( onCreated ).toHaveBeenCalledWith( { id: 99 } );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not create a blank row while row templates are still loading', () => {
+		useTemplates.mockReturnValue( {
+			templates: [],
+			isResolving: true,
+		} );
+
+		renderButton( {
+			view: {
+				defaultRowTemplateId: 10,
+				filters: [],
+			},
+		} );
+
+		const primaryButton = screen.getByRole( 'button', { name: 'New' } );
+		const optionsButton = screen.getByRole( 'button', {
+			name: 'New row menu',
+		} );
+
+		expect( primaryButton ).toBeDisabled();
+		expect( optionsButton ).toBeDisabled();
+
+		fireEvent.click( primaryButton );
+
+		expect( instantiateTemplate ).not.toHaveBeenCalled();
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'creates from a selected template in the options menu', async () => {
+		useTemplates.mockReturnValue( {
+			templates: [
+				{ id: 10, title: 'Alpha' },
+				{ id: 11, title: 'Beta' },
+			],
+		} );
+		instantiateTemplate.mockResolvedValueOnce( { id: 100 } );
+
+		renderButton();
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'New row menu' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'menuitem', {
+				name: 'New from Alpha',
+			} )
+		);
+
+		await waitFor( () =>
+			expect( instantiateTemplate ).toHaveBeenCalledWith( 10, {
+				field_values: {},
+			} )
+		);
+	} );
+
+	it( 'creates a blank row when the picker blank action is selected', async () => {
+		const onCreated = jest.fn();
+		useTemplates.mockReturnValue( {
+			templates: [
+				{ id: 10, title: 'Alpha' },
+				{ id: 11, title: 'Beta' },
+			],
+		} );
+		apiFetch.mockResolvedValueOnce( { id: 101 } );
+
+		renderButton( { onCreated } );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'New row menu' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'menuitem', {
+				name: 'Blank row',
+			} )
+		);
+
+		await waitFor( () =>
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/wp/v2/crtxt_documents',
+				method: 'POST',
+				data: {
+					status: 'private',
+					title: '',
+					cortext_trait: 7,
+				},
+			} )
+		);
+		expect( onCreated ).toHaveBeenCalledWith( { id: 101 } );
+	} );
+
+	it( 'uses the only available template without opening a picker', async () => {
+		const template = { id: 22, title: 'Only template' };
+		useTemplates.mockReturnValue( { templates: [ template ] } );
+		instantiateTemplate.mockResolvedValueOnce( { id: 102 } );
+
+		renderButton();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'New' } ) );
+
+		expect(
+			screen.queryByRole( 'menuitem', {
+				name: 'New from Only template',
+			} )
+		).toBeNull();
+		await waitFor( () =>
+			expect( instantiateTemplate ).toHaveBeenCalledWith( 22, {
+				field_values: {},
+			} )
+		);
+	} );
+
+	it( 'creates a template and opens it in the template editor', async () => {
+		createTemplate.mockResolvedValueOnce( { id: 123 } );
+
+		renderButton();
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'New row menu' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'menuitem', {
+				name: 'New template',
+			} )
+		);
+
+		await waitFor( () =>
+			expect( createTemplate ).toHaveBeenCalledWith( {
+				kind: 'row',
+				collection_id: 7,
+				title: 'Untitled template',
+			} )
+		);
+		expect( notifyTemplatesChanged ).toHaveBeenCalledWith( {
+			kind: 'row',
+			collectionId: 7,
+		} );
+		expect(
+			await screen.findByTestId( 'template-editor-modal' )
+		).toHaveTextContent( '123' );
+	} );
+} );

--- a/tests/js/components/DataViewNewRowButton.test.js
+++ b/tests/js/components/DataViewNewRowButton.test.js
@@ -165,7 +165,7 @@ describe( 'DataViewNewRowButton templates', () => {
 
 		const primaryButton = screen.getByRole( 'button', { name: 'New' } );
 		const optionsButton = screen.getByRole( 'button', {
-			name: 'New row menu',
+			name: 'Choose how to create a row',
 		} );
 
 		expect( primaryButton ).toBeDisabled();
@@ -189,7 +189,9 @@ describe( 'DataViewNewRowButton templates', () => {
 			enabled: false,
 		} );
 		expect(
-			screen.queryByRole( 'button', { name: 'New row menu' } )
+			screen.queryByRole( 'button', {
+				name: 'Choose how to create a row',
+			} )
 		).toBeNull();
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'New' } ) );
@@ -210,11 +212,13 @@ describe( 'DataViewNewRowButton templates', () => {
 		renderButton();
 
 		fireEvent.click(
-			screen.getByRole( 'button', { name: 'New row menu' } )
+			screen.getByRole( 'button', {
+				name: 'Choose how to create a row',
+			} )
 		);
 		fireEvent.click(
 			screen.getByRole( 'menuitem', {
-				name: 'New from Alpha',
+				name: 'Create from Alpha',
 			} )
 		);
 
@@ -238,7 +242,9 @@ describe( 'DataViewNewRowButton templates', () => {
 		renderButton( { onCreated } );
 
 		fireEvent.click(
-			screen.getByRole( 'button', { name: 'New row menu' } )
+			screen.getByRole( 'button', {
+				name: 'Choose how to create a row',
+			} )
 		);
 		fireEvent.click(
 			screen.getByRole( 'menuitem', {
@@ -271,7 +277,7 @@ describe( 'DataViewNewRowButton templates', () => {
 
 		expect(
 			screen.queryByRole( 'menuitem', {
-				name: 'New from Only template',
+				name: 'Create from Only template',
 			} )
 		).toBeNull();
 		await waitFor( () =>
@@ -287,7 +293,9 @@ describe( 'DataViewNewRowButton templates', () => {
 		renderButton();
 
 		fireEvent.click(
-			screen.getByRole( 'button', { name: 'New row menu' } )
+			screen.getByRole( 'button', {
+				name: 'Choose how to create a row',
+			} )
 		);
 		fireEvent.click(
 			screen.getByRole( 'menuitem', {

--- a/tests/js/components/DataViewNewRowButton.test.js
+++ b/tests/js/components/DataViewNewRowButton.test.js
@@ -65,6 +65,7 @@ jest.mock( '../../../src/templates', () => ( {
 	instantiateTemplate: jest.fn(),
 	notifyTemplatesChanged: jest.fn(),
 	TEMPLATE_KIND_ROW: 'row',
+	TEMPLATES_EXPERIMENT_ID: 'templates',
 	useTemplates: jest.fn(),
 } ) );
 
@@ -88,12 +89,19 @@ const fields = [
 ];
 
 beforeEach( () => {
+	window.cortextSettings = {
+		experiments: { templates: true },
+	};
 	apiFetch.mockReset();
 	createTemplate.mockReset();
 	instantiateTemplate.mockReset();
 	notifyTemplatesChanged.mockReset();
 	useTemplates.mockReset();
 	useTemplates.mockReturnValue( { templates: [] } );
+} );
+
+afterEach( () => {
+	delete window.cortextSettings;
 } );
 
 function renderButton( props = {} ) {
@@ -169,6 +177,27 @@ describe( 'DataViewNewRowButton templates', () => {
 
 		expect( instantiateTemplate ).not.toHaveBeenCalled();
 		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'creates a blank row without template controls when the experiment is disabled', async () => {
+		window.cortextSettings.experiments.templates = false;
+		apiFetch.mockResolvedValueOnce( { id: 103 } );
+
+		renderButton();
+
+		expect( useTemplates ).toHaveBeenCalledWith( {
+			kind: 'row',
+			collectionId: 7,
+			enabled: false,
+		} );
+		expect(
+			screen.queryByRole( 'button', { name: 'New row menu' } )
+		).toBeNull();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'New' } ) );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( instantiateTemplate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'creates from a selected template in the options menu', async () => {

--- a/tests/js/components/DataViewNewRowButton.test.js
+++ b/tests/js/components/DataViewNewRowButton.test.js
@@ -120,9 +120,7 @@ describe( 'DataViewNewRowButton templates', () => {
 	it( 'uses the view default template and sends eligible filter prefills as overrides', async () => {
 		const onCreated = jest.fn();
 		const template = { id: 10, title: 'Task starter' };
-		// A second template keeps the `templates.length === 1` fallback from
-		// reaching id 10, so the assertion below only passes if the
-		// defaultRowTemplateId lookup resolves it.
+		// Prevent the single-template fallback from masking the default lookup.
 		useTemplates.mockReturnValue( {
 			templates: [ template, { id: 11, title: 'Other starter' } ],
 		} );

--- a/tests/js/components/DataViewNewRowButton.test.js
+++ b/tests/js/components/DataViewNewRowButton.test.js
@@ -21,10 +21,18 @@ jest.mock( '@wordpress/components', () => {
 	const React = require( 'react' );
 	return {
 		__esModule: true,
-		Button: ( { children, label, onClick, disabled, isBusy } ) => (
+		Button: ( {
+			children,
+			className,
+			label,
+			onClick,
+			disabled,
+			isBusy,
+		} ) => (
 			<button
 				type="button"
 				aria-label={ label }
+				className={ className }
 				onClick={ onClick }
 				disabled={ disabled || isBusy }
 			>
@@ -144,7 +152,7 @@ describe( 'DataViewNewRowButton templates', () => {
 		window.cortextSettings.experiments.templates = false;
 		apiFetch.mockResolvedValueOnce( { id: 103 } );
 
-		renderButton();
+		const { container } = renderButton();
 
 		expect( useTemplates ).toHaveBeenCalledWith( {
 			kind: 'row',
@@ -155,6 +163,9 @@ describe( 'DataViewNewRowButton templates', () => {
 			screen.queryByRole( 'button', {
 				name: 'Choose how to create a row',
 			} )
+		).toBeNull();
+		expect(
+			container.querySelector( '.cortext-data-view__new-row-controls' )
 		).toBeNull();
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'New' } ) );

--- a/tests/js/components/DataViewNewRowButton.test.js
+++ b/tests/js/components/DataViewNewRowButton.test.js
@@ -117,64 +117,27 @@ function renderButton( props = {} ) {
 }
 
 describe( 'DataViewNewRowButton templates', () => {
-	it( 'uses the view default template and sends eligible filter prefills as overrides', async () => {
-		const onCreated = jest.fn();
-		const template = { id: 10, title: 'Task starter' };
-		// Prevent the single-template fallback from masking the default lookup.
-		useTemplates.mockReturnValue( {
-			templates: [ template, { id: 11, title: 'Other starter' } ],
-		} );
-		instantiateTemplate.mockResolvedValueOnce( { id: 99 } );
-
-		renderButton( {
-			onCreated,
-			view: {
-				defaultRowTemplateId: 10,
-				filters: [
-					{ field: 'field-1', operator: 'is', value: 'Active' },
-					{ field: 'field-2', operator: 'is', value: 'Ignored' },
-					{ field: 'field-3', operator: 'is', value: 'Rollup' },
-					{ field: 'field-1', operator: 'isAny', value: 'Skipped' },
-				],
-			},
-		} );
-
-		fireEvent.click( screen.getByRole( 'button', { name: 'New' } ) );
-
-		await waitFor( () =>
-			expect( instantiateTemplate ).toHaveBeenCalledWith( 10, {
-				field_values: { 'field-1': 'Active' },
-			} )
-		);
-		expect( onCreated ).toHaveBeenCalledWith( { id: 99 } );
-		expect( apiFetch ).not.toHaveBeenCalled();
-	} );
-
-	it( 'does not create a blank row while row templates are still loading', () => {
+	it( 'creates a blank row while row templates are still loading', async () => {
 		useTemplates.mockReturnValue( {
 			templates: [],
 			isResolving: true,
 		} );
+		apiFetch.mockResolvedValueOnce( { id: 99 } );
 
-		renderButton( {
-			view: {
-				defaultRowTemplateId: 10,
-				filters: [],
-			},
-		} );
+		renderButton();
 
 		const primaryButton = screen.getByRole( 'button', { name: 'New' } );
 		const optionsButton = screen.getByRole( 'button', {
 			name: 'Choose how to create a row',
 		} );
 
-		expect( primaryButton ).toBeDisabled();
+		expect( primaryButton ).toBeEnabled();
 		expect( optionsButton ).toBeDisabled();
 
 		fireEvent.click( primaryButton );
 
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
 		expect( instantiateTemplate ).not.toHaveBeenCalled();
-		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
 
 	it( 'creates a blank row without template controls when the experiment is disabled', async () => {
@@ -266,25 +229,17 @@ describe( 'DataViewNewRowButton templates', () => {
 		expect( onCreated ).toHaveBeenCalledWith( { id: 101 } );
 	} );
 
-	it( 'uses the only available template without opening a picker', async () => {
+	it( 'creates a blank row when only one template is available', async () => {
 		const template = { id: 22, title: 'Only template' };
 		useTemplates.mockReturnValue( { templates: [ template ] } );
-		instantiateTemplate.mockResolvedValueOnce( { id: 102 } );
+		apiFetch.mockResolvedValueOnce( { id: 102 } );
 
 		renderButton();
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'New' } ) );
 
-		expect(
-			screen.queryByRole( 'menuitem', {
-				name: 'Create from Only template',
-			} )
-		).toBeNull();
-		await waitFor( () =>
-			expect( instantiateTemplate ).toHaveBeenCalledWith( 22, {
-				field_values: {},
-			} )
-		);
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( instantiateTemplate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'creates a template and opens it in the template editor', async () => {

--- a/tests/js/components/TemplateEditorModal.test.js
+++ b/tests/js/components/TemplateEditorModal.test.js
@@ -1,0 +1,181 @@
+import { act, render, waitFor } from '@testing-library/react';
+
+let mockSaveRowField;
+
+jest.mock( '@wordpress/components', () => ( {
+	__esModule: true,
+	Button: ( { children, label, onClick } ) => (
+		<button type="button" onClick={ onClick }>
+			{ children ?? label }
+		</button>
+	),
+	Modal: ( { children } ) => <div>{ children }</div>,
+	Notice: ( { children } ) => <div role="alert">{ children }</div>,
+	SlotFillProvider: ( { children } ) => <>{ children }</>,
+	Spinner: () => <div>Loading</div>,
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	__esModule: true,
+	useEntityRecord: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useDispatch: jest.fn( () => ( { resetPost: jest.fn() } ) ),
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	__esModule: true,
+	EditorProvider: ( { children } ) => <>{ children }</>,
+	store: 'editor-store',
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( value ) => value,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	closeSmall: 'closeSmall',
+} ) );
+
+jest.mock( '../../../src/hooks/useAutosave', () => ( {
+	__esModule: true,
+	default: () => ( { flushNow: jest.fn().mockResolvedValue( true ) } ),
+} ) );
+
+jest.mock( '../../../src/components/initEditor', () => ( {
+	getEditorSettings: () => ( {} ),
+} ) );
+
+jest.mock( '../../../src/components/DocumentPropertiesContext', () => ( {
+	DocumentPropertiesProvider: ( { children } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '../../../src/components/EditorSurfaceContext', () => ( {
+	EditorSurfaceProvider: ( { children } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '../../../src/components/CortextLinkSuggestions', () => () => null );
+
+jest.mock( '../../../src/components/EditableCell', () => {
+	const { createContext } = require( '@wordpress/element' );
+	return {
+		__esModule: true,
+		RowMutationContext: createContext( {} ),
+	};
+} );
+
+jest.mock( '../../../src/components/EditorBody', () => {
+	const React = require( 'react' );
+	const {
+		RowMutationContext,
+	} = require( '../../../src/components/EditableCell' );
+
+	return {
+		__esModule: true,
+		default: function MockEditorBody() {
+			mockSaveRowField =
+				React.useContext( RowMutationContext ).saveRowField;
+			return <div data-testid="editor-body" />;
+		},
+	};
+} );
+
+jest.mock( '../../../src/templates', () => ( {
+	__esModule: true,
+	TEMPLATE_KIND_ROW: 'row',
+	TEMPLATE_POST_TYPE: 'crtxt_template',
+	notifyTemplatesChanged: jest.fn(),
+	updateTemplate: jest.fn(),
+} ) );
+
+import { useEntityRecord } from '@wordpress/core-data';
+import TemplateEditorModal from '../../../src/components/TemplateEditorModal';
+import { notifyTemplatesChanged, updateTemplate } from '../../../src/templates';
+
+describe( 'TemplateEditorModal', () => {
+	beforeEach( () => {
+		mockSaveRowField = null;
+		updateTemplate.mockReset();
+		notifyTemplatesChanged.mockReset();
+		useEntityRecord.mockReturnValue( {
+			isResolving: false,
+			record: {
+				id: 123,
+				title: { raw: 'Template' },
+				meta: { cortext_template_field_values: {} },
+			},
+		} );
+	} );
+
+	it( 'serializes row template field saves against the latest field value map', async () => {
+		let resolveFirst;
+		let resolveSecond;
+		updateTemplate
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveFirst = resolve;
+					} )
+			)
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveSecond = resolve;
+					} )
+			);
+
+		render(
+			<TemplateEditorModal
+				collectionId={ 7 }
+				fields={ [] }
+				kind="row"
+				templateId={ 123 }
+			/>
+		);
+
+		await waitFor( () =>
+			expect( mockSaveRowField ).toEqual( expect.any( Function ) )
+		);
+
+		let firstSave;
+		let secondSave;
+		await act( async () => {
+			firstSave = mockSaveRowField( 123, 'field-1', 'Open' );
+			secondSave = mockSaveRowField( 123, 'field-2', 'High' );
+			await Promise.resolve();
+		} );
+
+		expect( updateTemplate ).toHaveBeenCalledTimes( 1 );
+		expect( updateTemplate ).toHaveBeenNthCalledWith( 1, 123, {
+			field_values: { 'field-1': 'Open' },
+		} );
+
+		await act( async () => {
+			resolveFirst( {
+				field_values: { 'field-1': 'Open' },
+			} );
+			await firstSave;
+		} );
+
+		await waitFor( () =>
+			expect( updateTemplate ).toHaveBeenCalledTimes( 2 )
+		);
+		expect( updateTemplate ).toHaveBeenNthCalledWith( 2, 123, {
+			field_values: { 'field-1': 'Open', 'field-2': 'High' },
+		} );
+
+		await act( async () => {
+			resolveSecond( {
+				field_values: { 'field-1': 'Open', 'field-2': 'High' },
+			} );
+			await secondSave;
+		} );
+
+		expect( notifyTemplatesChanged ).toHaveBeenCalledWith( {
+			kind: 'row',
+			collectionId: 7,
+		} );
+	} );
+} );

--- a/tests/js/components/sidebar/DocumentRow.test.js
+++ b/tests/js/components/sidebar/DocumentRow.test.js
@@ -274,6 +274,7 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 	it( 'creates a child document from a page template in the menu', () => {
 		const template = { id: 9, title: 'Brief' };
 		const { container, props } = renderRow( {
+			onCreateBlankChild: jest.fn(),
 			pageTemplates: [ template ],
 			onCreateChildFromTemplate: jest.fn(),
 		} );
@@ -287,6 +288,25 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 			1,
 			template
 		);
+	} );
+
+	it( 'hides template actions when the experiment is disabled', () => {
+		const { container } = renderRow( {
+			pageTemplates: [ { id: 9, title: 'Brief' } ],
+			onCreateChildFromTemplate: jest.fn(),
+		} );
+		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
+
+		expect(
+			screen.queryByRole( 'menuitem', {
+				name: 'Blank document inside',
+			} )
+		).toBeNull();
+		expect(
+			screen.queryByRole( 'menuitem', {
+				name: 'New from Brief inside',
+			} )
+		).toBeNull();
 	} );
 
 	it( 'does not show the child collection action for collections', () => {

--- a/tests/js/components/sidebar/DocumentRow.test.js
+++ b/tests/js/components/sidebar/DocumentRow.test.js
@@ -271,6 +271,24 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 		expect( props.onCreateChildCollection ).toHaveBeenCalledWith( 1 );
 	} );
 
+	it( 'creates a child document from a page template in the menu', () => {
+		const template = { id: 9, title: 'Brief' };
+		const { container, props } = renderRow( {
+			pageTemplates: [ template ],
+			onCreateChildFromTemplate: jest.fn(),
+		} );
+		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
+		fireEvent.click(
+			screen.getByRole( 'menuitem', {
+				name: 'New from Brief inside',
+			} )
+		);
+		expect( props.onCreateChildFromTemplate ).toHaveBeenCalledWith(
+			1,
+			template
+		);
+	} );
+
 	it( 'does not show the child collection action for collections', () => {
 		const { container } = renderRow( { record: makeCollection() } );
 		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );

--- a/tests/js/components/sidebar/DocumentRow.test.js
+++ b/tests/js/components/sidebar/DocumentRow.test.js
@@ -269,7 +269,7 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 		fireEvent.click( container.querySelector( '.cortext-sidebar__menu' ) );
 		fireEvent.click(
 			screen.getByRole( 'menuitem', {
-				name: 'New from Brief inside',
+				name: 'Add document from Brief',
 			} )
 		);
 		expect( props.onCreateChildFromTemplate ).toHaveBeenCalledWith(
@@ -287,12 +287,12 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 
 		expect(
 			screen.queryByRole( 'menuitem', {
-				name: 'Blank document inside',
+				name: 'Add blank document',
 			} )
 		).toBeNull();
 		expect(
 			screen.queryByRole( 'menuitem', {
-				name: 'New from Brief inside',
+				name: 'Add document from Brief',
 			} )
 		).toBeNull();
 	} );

--- a/tests/js/components/sidebar/DocumentRow.test.js
+++ b/tests/js/components/sidebar/DocumentRow.test.js
@@ -1,15 +1,3 @@
-/**
- * Render and prop-contract tests for `src/components/sidebar/DocumentRow.js`.
- *
- * DocumentRow has two modes derived from the record's capabilities:
- *  - hierarchy (pages and collections without a trait term): real chevron,
- *    recursive children, three drop zones, add-child button.
- *  - leaf (rows — documents tagged with a trait term): chevron placeholder,
- *    no children, two drop zones, no add-child.
- *
- * The `documents` module is mocked so tests can inspect actions and feature
- * resolution without mounting the full sidebar provider stack each time.
- */
 import { fireEvent, render, screen } from '@testing-library/react';
 import { DndContext } from '@dnd-kit/core';
 
@@ -466,7 +454,6 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 			childNodes: [ { page: child, children: [] } ],
 			expandedIds: new Set( [ 1 ] ),
 		} );
-		// Two rows total: root + child.
 		expect(
 			container.querySelectorAll( '.cortext-sidebar__row' )
 		).toHaveLength( 2 );
@@ -556,8 +543,6 @@ describe( 'DocumentRow (leaf mode)', () => {
 	} );
 
 	it( 'does not render child rows even when childNodes are passed', () => {
-		// Leaves never render child branches. Ignore passed nodes so stale tree
-		// data cannot show rows under a collection.
 		const stray = makeRow( {
 			id: 8,
 			title: { rendered: 'Stray', raw: 'Stray' },

--- a/tests/js/templates/actions.test.js
+++ b/tests/js/templates/actions.test.js
@@ -1,0 +1,121 @@
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+import {
+	createTemplate,
+	createTemplateFromDocument,
+	deleteTemplate,
+	duplicateTemplate,
+	fetchDefaultPageTemplate,
+	fetchTemplates,
+	instantiateTemplate,
+	setDefaultPageTemplate,
+	updateTemplate,
+} from '../../../src/templates/actions';
+
+beforeEach( () => {
+	apiFetch.mockReset();
+} );
+
+describe( 'template REST actions', () => {
+	it( 'fetches templates with kind and collection filters', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			templates: [ { id: 1, kind: 'row' } ],
+		} );
+
+		const templates = await fetchTemplates( {
+			kind: 'row',
+			collectionId: 7,
+		} );
+
+		expect( templates ).toEqual( [ { id: 1, kind: 'row' } ] );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/templates?kind=row&collection_id=7',
+		} );
+	} );
+
+	it( 'creates, updates, duplicates, deletes, and instantiates templates through the shared endpoint', async () => {
+		apiFetch
+			.mockResolvedValueOnce( { template: { id: 2 } } )
+			.mockResolvedValueOnce( { template: { id: 2, title: 'Renamed' } } )
+			.mockResolvedValueOnce( { template: { id: 3 } } )
+			.mockResolvedValueOnce( { deleted: true } )
+			.mockResolvedValueOnce( { document: { id: 4 } } );
+
+		await expect(
+			createTemplate( { kind: 'page', title: 'Brief' } )
+		).resolves.toEqual( { id: 2 } );
+		await expect(
+			updateTemplate( 2, { title: 'Renamed' } )
+		).resolves.toEqual( { id: 2, title: 'Renamed' } );
+		await expect( duplicateTemplate( 2 ) ).resolves.toEqual( { id: 3 } );
+		await expect( deleteTemplate( 2 ) ).resolves.toEqual( {
+			deleted: true,
+		} );
+		await expect(
+			instantiateTemplate( 3, { parent: 9 } )
+		).resolves.toEqual( { id: 4 } );
+
+		expect( apiFetch ).toHaveBeenNthCalledWith( 1, {
+			path: '/cortext/v1/templates',
+			method: 'POST',
+			data: { kind: 'page', title: 'Brief' },
+		} );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
+			path: '/cortext/v1/templates/2',
+			method: 'POST',
+			data: { title: 'Renamed' },
+		} );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 3, {
+			path: '/cortext/v1/templates/2/duplicate',
+			method: 'POST',
+		} );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 4, {
+			path: '/cortext/v1/templates/2',
+			method: 'DELETE',
+		} );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 5, {
+			path: '/cortext/v1/templates/3/instantiate',
+			method: 'POST',
+			data: { parent: 9 },
+		} );
+	} );
+
+	it( 'creates a template from an existing document', async () => {
+		apiFetch.mockResolvedValueOnce( { template: { id: 12 } } );
+
+		await expect( createTemplateFromDocument( 42 ) ).resolves.toEqual( {
+			id: 12,
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/templates/from-document',
+			method: 'POST',
+			data: { document_id: 42 },
+		} );
+	} );
+
+	it( 'gets and sets the workspace page default template', async () => {
+		apiFetch
+			.mockResolvedValueOnce( { template: { id: 5 } } )
+			.mockResolvedValueOnce( { template: null } );
+
+		await expect( fetchDefaultPageTemplate() ).resolves.toEqual( {
+			id: 5,
+		} );
+		await expect( setDefaultPageTemplate( null ) ).resolves.toBeNull();
+
+		expect( apiFetch ).toHaveBeenNthCalledWith( 1, {
+			path: '/cortext/v1/templates/default',
+		} );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
+			path: '/cortext/v1/templates/default',
+			method: 'PUT',
+			data: { id: null },
+		} );
+	} );
+} );

--- a/tests/js/templates/actions.test.js
+++ b/tests/js/templates/actions.test.js
@@ -7,9 +7,6 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 
 import {
 	createTemplate,
-	createTemplateFromDocument,
-	deleteTemplate,
-	duplicateTemplate,
 	fetchTemplates,
 	instantiateTemplate,
 	updateTemplate,
@@ -36,12 +33,10 @@ describe( 'template REST actions', () => {
 		} );
 	} );
 
-	it( 'creates, updates, duplicates, deletes, and instantiates templates through the shared endpoint', async () => {
+	it( 'creates, updates, and instantiates templates', async () => {
 		apiFetch
 			.mockResolvedValueOnce( { template: { id: 2 } } )
 			.mockResolvedValueOnce( { template: { id: 2, title: 'Renamed' } } )
-			.mockResolvedValueOnce( { template: { id: 3 } } )
-			.mockResolvedValueOnce( { deleted: true } )
 			.mockResolvedValueOnce( { document: { id: 4 } } );
 
 		await expect(
@@ -50,12 +45,8 @@ describe( 'template REST actions', () => {
 		await expect(
 			updateTemplate( 2, { title: 'Renamed' } )
 		).resolves.toEqual( { id: 2, title: 'Renamed' } );
-		await expect( duplicateTemplate( 2 ) ).resolves.toEqual( { id: 3 } );
-		await expect( deleteTemplate( 2 ) ).resolves.toEqual( {
-			deleted: true,
-		} );
 		await expect(
-			instantiateTemplate( 3, { parent: 9 } )
+			instantiateTemplate( 2, { parent: 9 } )
 		).resolves.toEqual( { id: 4 } );
 
 		expect( apiFetch ).toHaveBeenNthCalledWith( 1, {
@@ -69,32 +60,9 @@ describe( 'template REST actions', () => {
 			data: { title: 'Renamed' },
 		} );
 		expect( apiFetch ).toHaveBeenNthCalledWith( 3, {
-			path: '/cortext/v1/templates/2/duplicate',
-			method: 'POST',
-		} );
-		expect( apiFetch ).toHaveBeenNthCalledWith( 4, {
-			path: '/cortext/v1/templates/2',
-			method: 'DELETE',
-		} );
-		expect( apiFetch ).toHaveBeenNthCalledWith( 5, {
-			path: '/cortext/v1/templates/3/instantiate',
+			path: '/cortext/v1/templates/2/instantiate',
 			method: 'POST',
 			data: { parent: 9 },
 		} );
 	} );
-
-	it( 'creates a template from an existing document', async () => {
-		apiFetch.mockResolvedValueOnce( { template: { id: 12 } } );
-
-		await expect( createTemplateFromDocument( 42 ) ).resolves.toEqual( {
-			id: 12,
-		} );
-
-		expect( apiFetch ).toHaveBeenCalledWith( {
-			path: '/cortext/v1/templates/from-document',
-			method: 'POST',
-			data: { document_id: 42 },
-		} );
-	} );
-
 } );

--- a/tests/js/templates/actions.test.js
+++ b/tests/js/templates/actions.test.js
@@ -10,10 +10,8 @@ import {
 	createTemplateFromDocument,
 	deleteTemplate,
 	duplicateTemplate,
-	fetchDefaultPageTemplate,
 	fetchTemplates,
 	instantiateTemplate,
-	setDefaultPageTemplate,
 	updateTemplate,
 } from '../../../src/templates/actions';
 
@@ -99,23 +97,4 @@ describe( 'template REST actions', () => {
 		} );
 	} );
 
-	it( 'gets and sets the workspace page default template', async () => {
-		apiFetch
-			.mockResolvedValueOnce( { template: { id: 5 } } )
-			.mockResolvedValueOnce( { template: null } );
-
-		await expect( fetchDefaultPageTemplate() ).resolves.toEqual( {
-			id: 5,
-		} );
-		await expect( setDefaultPageTemplate( null ) ).resolves.toBeNull();
-
-		expect( apiFetch ).toHaveBeenNthCalledWith( 1, {
-			path: '/cortext/v1/templates/default',
-		} );
-		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
-			path: '/cortext/v1/templates/default',
-			method: 'PUT',
-			data: { id: null },
-		} );
-	} );
 } );

--- a/tests/js/templates/hooks.test.js
+++ b/tests/js/templates/hooks.test.js
@@ -1,0 +1,172 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useDispatch: jest.fn(),
+} ) );
+
+import { useDispatch } from '@wordpress/data';
+import { afterDocumentTrash } from '../../../src/documents/invalidation';
+import {
+	notifyTemplatesChanged,
+	useCreateTemplate,
+	useCreateTemplateFromDocument,
+	useDefaultPageTemplate,
+	useDuplicateTemplate,
+	useInstantiateTemplate,
+	useTemplates,
+} from '../../../src/templates/hooks';
+
+beforeEach( () => {
+	apiFetch.mockReset();
+	useDispatch.mockReset();
+} );
+
+describe( 'template hooks', () => {
+	it( 'loads and refreshes templates for a kind and collection', async () => {
+		apiFetch
+			.mockResolvedValueOnce( { templates: [ { id: 1 } ] } )
+			.mockResolvedValueOnce( { templates: [ { id: 2 } ] } );
+
+		const { result } = renderHook( () =>
+			useTemplates( { kind: 'row', collectionId: 7 } )
+		);
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+		expect( result.current.templates ).toEqual( [ { id: 1 } ] );
+
+		let refreshed;
+		await act( async () => {
+			refreshed = await result.current.refresh();
+		} );
+
+		expect( refreshed ).toEqual( [ { id: 2 } ] );
+		expect( result.current.templates ).toEqual( [ { id: 2 } ] );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 1, {
+			path: '/cortext/v1/templates?kind=row&collection_id=7',
+		} );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
+			path: '/cortext/v1/templates?kind=row&collection_id=7',
+		} );
+	} );
+
+	it( 'refreshes matching template queries after a template change event', async () => {
+		apiFetch
+			.mockResolvedValueOnce( { templates: [ { id: 1 } ] } )
+			.mockResolvedValueOnce( { templates: [ { id: 2 } ] } );
+
+		const { result } = renderHook( () =>
+			useTemplates( { kind: 'row', collectionId: 7 } )
+		);
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+
+		await act( async () => {
+			notifyTemplatesChanged( { kind: 'row', collectionId: 7 } );
+		} );
+
+		await waitFor( () =>
+			expect( result.current.templates ).toEqual( [ { id: 2 } ] )
+		);
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'loads and updates the workspace page default template', async () => {
+		apiFetch
+			.mockResolvedValueOnce( { template: { id: 4 } } )
+			.mockResolvedValueOnce( { template: { id: 8 } } );
+
+		const { result } = renderHook( () => useDefaultPageTemplate() );
+
+		await waitFor( () =>
+			expect( result.current.isResolving ).toBe( false )
+		);
+		expect( result.current.template ).toEqual( { id: 4 } );
+
+		let next;
+		await act( async () => {
+			next = await result.current.setDefault( 8 );
+		} );
+
+		expect( next ).toEqual( { id: 8 } );
+		expect( result.current.template ).toEqual( { id: 8 } );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
+			path: '/cortext/v1/templates/default',
+			method: 'PUT',
+			data: { id: 8 },
+		} );
+	} );
+
+	it( 'exposes create, create-from-document, and duplicate mutation hooks', async () => {
+		apiFetch
+			.mockResolvedValueOnce( { template: { id: 14 } } )
+			.mockResolvedValueOnce( { template: { id: 16 } } )
+			.mockResolvedValueOnce( { template: { id: 15 } } );
+
+		const { result: createResult } = renderHook( () =>
+			useCreateTemplate()
+		);
+		const { result: createFromDocumentResult } = renderHook( () =>
+			useCreateTemplateFromDocument()
+		);
+		const { result: duplicateResult } = renderHook( () =>
+			useDuplicateTemplate()
+		);
+
+		await expect(
+			createResult.current( { kind: 'page', title: 'Brief' } )
+		).resolves.toEqual( { id: 14 } );
+		await expect( createFromDocumentResult.current( 23 ) ).resolves.toEqual(
+			{ id: 16 }
+		);
+		await expect( duplicateResult.current( 14 ) ).resolves.toEqual( {
+			id: 15,
+		} );
+
+		expect( apiFetch ).toHaveBeenNthCalledWith( 1, {
+			path: '/cortext/v1/templates',
+			method: 'POST',
+			data: { kind: 'page', title: 'Brief' },
+		} );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
+			path: '/cortext/v1/templates/from-document',
+			method: 'POST',
+			data: { document_id: 23 },
+		} );
+		expect( apiFetch ).toHaveBeenNthCalledWith( 3, {
+			path: '/cortext/v1/templates/14/duplicate',
+			method: 'POST',
+		} );
+	} );
+
+	it( 'invalidates document lists after instantiating a template', async () => {
+		const invalidateResolution = jest.fn();
+		useDispatch.mockReturnValue( { invalidateResolution } );
+		apiFetch.mockResolvedValueOnce( { document: { id: 11 } } );
+
+		const { result } = renderHook( () => useInstantiateTemplate() );
+
+		await act( async () => {
+			await result.current( 9, { parent: 3 } );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/cortext/v1/templates/9/instantiate',
+			method: 'POST',
+			data: { parent: 3 },
+		} );
+		expect( invalidateResolution ).toHaveBeenCalledTimes(
+			afterDocumentTrash.length
+		);
+	} );
+} );

--- a/tests/js/templates/hooks.test.js
+++ b/tests/js/templates/hooks.test.js
@@ -29,6 +29,25 @@ beforeEach( () => {
 } );
 
 describe( 'template hooks', () => {
+	it( 'does not resolve templates while the experiment is disabled', async () => {
+		const { result } = renderHook( () =>
+			useTemplates( {
+				kind: 'row',
+				collectionId: 7,
+				enabled: false,
+			} )
+		);
+
+		expect( result.current.templates ).toEqual( [] );
+		expect( result.current.isResolving ).toBe( false );
+		let refreshed;
+		await act( async () => {
+			refreshed = await result.current.refresh();
+		} );
+		expect( refreshed ).toEqual( [] );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
 	it( 'loads and refreshes templates for a kind and collection', async () => {
 		apiFetch
 			.mockResolvedValueOnce( { templates: [ { id: 1 } ] } )

--- a/tests/js/templates/hooks.test.js
+++ b/tests/js/templates/hooks.test.js
@@ -17,7 +17,6 @@ import {
 	notifyTemplatesChanged,
 	useCreateTemplate,
 	useCreateTemplateFromDocument,
-	useDefaultPageTemplate,
 	useDuplicateTemplate,
 	useInstantiateTemplate,
 	useTemplates,
@@ -98,32 +97,6 @@ describe( 'template hooks', () => {
 			expect( result.current.templates ).toEqual( [ { id: 2 } ] )
 		);
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
-	} );
-
-	it( 'loads and updates the workspace page default template', async () => {
-		apiFetch
-			.mockResolvedValueOnce( { template: { id: 4 } } )
-			.mockResolvedValueOnce( { template: { id: 8 } } );
-
-		const { result } = renderHook( () => useDefaultPageTemplate() );
-
-		await waitFor( () =>
-			expect( result.current.isResolving ).toBe( false )
-		);
-		expect( result.current.template ).toEqual( { id: 4 } );
-
-		let next;
-		await act( async () => {
-			next = await result.current.setDefault( 8 );
-		} );
-
-		expect( next ).toEqual( { id: 8 } );
-		expect( result.current.template ).toEqual( { id: 8 } );
-		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
-			path: '/cortext/v1/templates/default',
-			method: 'PUT',
-			data: { id: 8 },
-		} );
 	} );
 
 	it( 'exposes create, create-from-document, and duplicate mutation hooks', async () => {

--- a/tests/js/templates/hooks.test.js
+++ b/tests/js/templates/hooks.test.js
@@ -15,9 +15,6 @@ import { useDispatch } from '@wordpress/data';
 import { afterDocumentTrash } from '../../../src/documents/invalidation';
 import {
 	notifyTemplatesChanged,
-	useCreateTemplate,
-	useCreateTemplateFromDocument,
-	useDuplicateTemplate,
 	useInstantiateTemplate,
 	useTemplates,
 } from '../../../src/templates/hooks';
@@ -97,48 +94,6 @@ describe( 'template hooks', () => {
 			expect( result.current.templates ).toEqual( [ { id: 2 } ] )
 		);
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
-	} );
-
-	it( 'exposes create, create-from-document, and duplicate mutation hooks', async () => {
-		apiFetch
-			.mockResolvedValueOnce( { template: { id: 14 } } )
-			.mockResolvedValueOnce( { template: { id: 16 } } )
-			.mockResolvedValueOnce( { template: { id: 15 } } );
-
-		const { result: createResult } = renderHook( () =>
-			useCreateTemplate()
-		);
-		const { result: createFromDocumentResult } = renderHook( () =>
-			useCreateTemplateFromDocument()
-		);
-		const { result: duplicateResult } = renderHook( () =>
-			useDuplicateTemplate()
-		);
-
-		await expect(
-			createResult.current( { kind: 'page', title: 'Brief' } )
-		).resolves.toEqual( { id: 14 } );
-		await expect( createFromDocumentResult.current( 23 ) ).resolves.toEqual(
-			{ id: 16 }
-		);
-		await expect( duplicateResult.current( 14 ) ).resolves.toEqual( {
-			id: 15,
-		} );
-
-		expect( apiFetch ).toHaveBeenNthCalledWith( 1, {
-			path: '/cortext/v1/templates',
-			method: 'POST',
-			data: { kind: 'page', title: 'Brief' },
-		} );
-		expect( apiFetch ).toHaveBeenNthCalledWith( 2, {
-			path: '/cortext/v1/templates/from-document',
-			method: 'POST',
-			data: { document_id: 23 },
-		} );
-		expect( apiFetch ).toHaveBeenNthCalledWith( 3, {
-			path: '/cortext/v1/templates/14/duplicate',
-			method: 'POST',
-		} );
 	} );
 
 	it( 'invalidates document lists after instantiating a template', async () => {

--- a/tests/php/test-plugin.php
+++ b/tests/php/test-plugin.php
@@ -26,7 +26,7 @@ final class Test_Plugin extends BaseTestCase {
 			array(
 				'id'          => Templates::EXPERIMENT_ID,
 				'label'       => 'Templates',
-				'description' => 'Create reusable starting points for documents and collection rows.',
+				'description' => 'Start documents and collection rows from saved templates.',
 				'group'       => 'Content',
 				'default'     => false,
 			),

--- a/tests/php/test-plugin.php
+++ b/tests/php/test-plugin.php
@@ -10,11 +10,27 @@ declare( strict_types=1 );
 namespace Cortext\Tests;
 
 use Cortext\Plugin;
+use Cortext\Templates;
 use WorDBless\BaseTestCase;
 
 final class Test_Plugin extends BaseTestCase {
 
 	public function test_instance_is_idempotent(): void {
 		$this->assertSame( Plugin::instance(), Plugin::instance() );
+	}
+
+	public function test_registers_templates_as_disabled_experiment(): void {
+		$experiments = Plugin::instance()->register_experiments( array() );
+
+		$this->assertSame(
+			array(
+				'id'          => Templates::EXPERIMENT_ID,
+				'label'       => 'Templates',
+				'description' => 'Create reusable starting points for documents and collection rows.',
+				'group'       => 'Content',
+				'default'     => false,
+			),
+			$experiments[0]
+		);
 	}
 }

--- a/tests/php/test-rest-templates-controller.php
+++ b/tests/php/test-rest-templates-controller.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * Tests for Cortext template REST endpoints and instantiation behaviour.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\PostType\Document;
+use Cortext\PostType\Field;
+use Cortext\PostType\Template as TemplatePostType;
+use Cortext\Relations;
+use Cortext\Rest\TemplatesController;
+use Cortext\Taxonomy\TraitTaxonomy;
+use Cortext\Templates;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+final class Test_Rest_Templates_Controller extends BaseTestCase {
+
+	use InMemoryPostsQuery;
+	use InMemoryTermStore;
+
+	private TemplatePostType $template_post_type;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Document() )->register_post_type();
+		( new Field() )->register_post_type();
+		( new TraitTaxonomy() )->register_taxonomy();
+		$trait_taxonomy = new TraitTaxonomy();
+		add_action( 'added_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'updated_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'deleted_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'before_delete_post', array( $trait_taxonomy, 'sync_term_on_delete' ), 10, 2 );
+
+		$this->template_post_type = new TemplatePostType();
+		$this->template_post_type->register_post_type();
+		$this->template_post_type->register_meta();
+		add_action( 'before_delete_post', array( $this->template_post_type, 'clear_deleted_default' ), 10, 2 );
+
+		$this->install_in_memory_posts_query();
+		$this->install_in_memory_term_store();
+
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		( new TemplatesController() )->register();
+		do_action( 'rest_api_init' );
+	}
+
+	public function tear_down(): void {
+		remove_action( 'before_delete_post', array( $this->template_post_type, 'clear_deleted_default' ), 10 );
+		delete_option( Templates::PAGE_DEFAULT_OPTION );
+		$this->uninstall_in_memory_posts_query();
+		$this->uninstall_in_memory_term_store();
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	public function test_route_is_registered(): void {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/cortext/v1/templates', $routes );
+		$this->assertArrayHasKey( '/cortext/v1/templates/default', $routes );
+		$this->assertArrayHasKey( '/cortext/v1/templates/from-document', $routes );
+	}
+
+	public function test_registers_hidden_template_post_type_with_rest_support(): void {
+		$this->assertTrue( post_type_exists( TemplatePostType::POST_TYPE ) );
+
+		$object = get_post_type_object( TemplatePostType::POST_TYPE );
+		$this->assertNotNull( $object );
+		$this->assertFalse( $object->show_ui );
+		$this->assertFalse( $object->show_in_menu );
+		$this->assertTrue( $object->show_in_rest );
+		$this->assertTrue( post_type_supports( TemplatePostType::POST_TYPE, 'title' ) );
+		$this->assertTrue( post_type_supports( TemplatePostType::POST_TYPE, 'editor' ) );
+		$this->assertTrue( post_type_supports( TemplatePostType::POST_TYPE, 'revisions' ) );
+	}
+
+	public function test_requires_edit_posts_capability(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$response = $this->request( 'GET', '/cortext/v1/templates' );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_crud_and_duplicate_page_templates(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$create = $this->request(
+			'POST',
+			'/cortext/v1/templates',
+			array(
+				'kind'    => Templates::KIND_PAGE,
+				'title'   => 'Meeting notes',
+				'content' => '<!-- wp:paragraph --><p>Agenda</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertSame( 201, $create->get_status() );
+		$template = $create->get_data()['template'];
+		$this->assertSame( 'Meeting notes', $template['title'] );
+		$this->assertSame( Templates::KIND_PAGE, $template['kind'] );
+		$this->assertNull( $template['collection_id'] );
+
+		$list = $this->request(
+			'GET',
+			'/cortext/v1/templates',
+			array( 'kind' => Templates::KIND_PAGE )
+		);
+		$this->assertSame( array( $template['id'] ), array_column( $list->get_data()['templates'], 'id' ) );
+
+		$update = $this->request(
+			'POST',
+			'/cortext/v1/templates/' . $template['id'],
+			array(
+				'title'   => 'Renamed template',
+				'content' => '<!-- wp:paragraph --><p>Updated</p><!-- /wp:paragraph -->',
+			)
+		);
+		$this->assertSame( 200, $update->get_status() );
+		$this->assertSame( 'Renamed template', $update->get_data()['template']['title'] );
+
+		$duplicate = $this->request( 'POST', '/cortext/v1/templates/' . $template['id'] . '/duplicate' );
+		$this->assertSame( 201, $duplicate->get_status() );
+		$this->assertSame( 'Copy of Renamed template', $duplicate->get_data()['template']['title'] );
+		$this->assertStringContainsString( 'Updated', $duplicate->get_data()['template']['content'] );
+
+		$delete = $this->request( 'DELETE', '/cortext/v1/templates/' . $template['id'] );
+		$this->assertSame( 200, $delete->get_status() );
+		$this->assertTrue( $delete->get_data()['deleted'] );
+		$this->assertNull( get_post( (int) $template['id'] ) );
+	}
+
+	public function test_page_default_is_saved_returned_and_cleared_when_deleted(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$template_id = $this->create_template(
+			array(
+				'kind'  => Templates::KIND_PAGE,
+				'title' => 'Default page',
+			)
+		);
+
+		$set = $this->request(
+			'PUT',
+			'/cortext/v1/templates/default',
+			array( 'id' => $template_id )
+		);
+		$this->assertSame( 200, $set->get_status() );
+		$this->assertSame( $template_id, $set->get_data()['template']['id'] );
+
+		$get = $this->request( 'GET', '/cortext/v1/templates/default' );
+		$this->assertSame( $template_id, $get->get_data()['template']['id'] );
+
+		$delete = $this->request( 'DELETE', '/cortext/v1/templates/' . $template_id );
+		$this->assertSame( 200, $delete->get_status() );
+		$this->assertSame( 0, (int) get_option( Templates::PAGE_DEFAULT_OPTION, 0 ) );
+
+		$get_after_delete = $this->request( 'GET', '/cortext/v1/templates/default' );
+		$this->assertNull( $get_after_delete->get_data()['template'] );
+	}
+
+	public function test_page_default_read_without_template_access_does_not_clear_default(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$template_id = $this->create_template(
+			array(
+				'kind'  => Templates::KIND_PAGE,
+				'title' => 'Private default page',
+			)
+		);
+
+		$set = $this->request(
+			'PUT',
+			'/cortext/v1/templates/default',
+			array( 'id' => $template_id )
+		);
+		$this->assertSame( 200, $set->get_status() );
+
+		wp_set_current_user( $this->create_user( 'author' ) );
+
+		$get = $this->request( 'GET', '/cortext/v1/templates/default' );
+		$this->assertSame( 200, $get->get_status() );
+		$this->assertNull( $get->get_data()['template'] );
+		$this->assertSame( $template_id, (int) get_option( Templates::PAGE_DEFAULT_OPTION, 0 ) );
+	}
+
+	public function test_row_template_cannot_be_workspace_page_default(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'Tasks' );
+		$template_id   = $this->create_template(
+			array(
+				'kind'          => Templates::KIND_ROW,
+				'collection_id' => $collection_id,
+				'title'         => 'Task row',
+			)
+		);
+
+		$response = $this->request(
+			'PUT',
+			'/cortext/v1/templates/default',
+			array( 'id' => $template_id )
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_template_default_invalid_kind', $response->get_data()['code'] );
+	}
+
+	public function test_instantiate_page_template_copies_title_blocks_and_parent(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$parent_id   = $this->create_document( 'Parent' );
+		$template_id = $this->create_template(
+			array(
+				'kind'    => Templates::KIND_PAGE,
+				'title'   => 'Project brief',
+				'content' => '<!-- wp:post-title /--><!-- wp:cortext/document-icon /--><!-- wp:paragraph --><p>Brief body</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$response = $this->request(
+			'POST',
+			'/cortext/v1/templates/' . $template_id . '/instantiate',
+			array( 'parent' => $parent_id )
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$document_id = (int) $response->get_data()['document']['id'];
+		$document    = get_post( $document_id );
+		$this->assertNotNull( $document );
+		$this->assertSame( Document::POST_TYPE, $document->post_type );
+		$this->assertSame( 'Project brief', $document->post_title );
+		$this->assertSame( $parent_id, (int) $document->post_parent );
+		$this->assertStringContainsString( 'Brief body', $document->post_content );
+		$this->assertStringNotContainsString( 'post-title', $document->post_content );
+		$this->assertStringNotContainsString( 'document-icon', $document->post_content );
+	}
+
+	public function test_creates_page_template_from_existing_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$document_id = $this->create_document( 'Spec page' );
+		wp_update_post(
+			array(
+				'ID'           => $document_id,
+				'post_content' => '<!-- wp:paragraph --><p>Starter body</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$response = $this->request(
+			'POST',
+			'/cortext/v1/templates/from-document',
+			array( 'document_id' => $document_id )
+		);
+
+		$this->assertSame( 201, $response->get_status(), wp_json_encode( $response->get_data() ) );
+		$template = $response->get_data()['template'];
+		$this->assertSame( Templates::KIND_PAGE, $template['kind'] );
+		$this->assertSame( 'Spec page', $template['title'] );
+		$this->assertStringContainsString( 'Starter body', $template['content'] );
+	}
+
+	public function test_creates_row_template_from_existing_row_with_field_defaults(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'Tasks' );
+		$status_id     = $this->attach_field( $collection_id, 'Status', 'text' );
+		$tag_id        = $this->attach_field( $collection_id, 'Tags', 'multiselect' );
+		$rollup_id     = $this->attach_field( $collection_id, 'Rollup', 'rollup' );
+		$row_id        = $this->create_row( $collection_id, 'Bug bash' );
+
+		wp_update_post(
+			array(
+				'ID'           => $row_id,
+				'post_content' => '<!-- wp:paragraph --><p>Row starter</p><!-- /wp:paragraph -->',
+			)
+		);
+		update_post_meta( $row_id, Relations::meta_key( $status_id ), 'todo' );
+		add_post_meta( $row_id, Relations::meta_key( $tag_id ), 'frontend' );
+		add_post_meta( $row_id, Relations::meta_key( $tag_id ), 'urgent' );
+		update_post_meta( $row_id, Relations::meta_key( $rollup_id ), 'ignored' );
+
+		$response = $this->request(
+			'POST',
+			'/cortext/v1/templates/from-document',
+			array( 'document_id' => $row_id )
+		);
+
+		$this->assertSame( 201, $response->get_status(), wp_json_encode( $response->get_data() ) );
+		$template = $response->get_data()['template'];
+		$this->assertSame( Templates::KIND_ROW, $template['kind'] );
+		$this->assertSame( $collection_id, $template['collection_id'] );
+		$this->assertSame( 'Bug bash', $template['title'] );
+		$this->assertStringContainsString( 'Row starter', $template['content'] );
+		$this->assertSame( 'todo', $template['field_values'][ 'field-' . $status_id ] );
+		$this->assertSame( array( 'frontend', 'urgent' ), $template['field_values'][ 'field-' . $tag_id ] );
+		$this->assertArrayNotHasKey( 'field-' . $rollup_id, $template['field_values'] );
+	}
+
+	public function test_collections_cannot_be_saved_as_templates_from_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'Tasks' );
+
+		$response = $this->request(
+			'POST',
+			'/cortext/v1/templates/from-document',
+			array( 'document_id' => $collection_id )
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_template_source_collection', $response->get_data()['code'] );
+	}
+
+	public function test_instantiate_row_template_applies_defaults_with_request_prefills_taking_priority(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'Tasks' );
+		$status_id     = $this->attach_field( $collection_id, 'Status', 'text' );
+		$owner_id      = $this->attach_field( $collection_id, 'Owner', 'text' );
+		$tags_id       = $this->attach_field( $collection_id, 'Tags', 'multiselect' );
+		$template_id   = $this->create_template(
+			array(
+				'kind'          => Templates::KIND_ROW,
+				'collection_id' => $collection_id,
+				'title'         => 'Task starter',
+				'content'       => '<!-- wp:paragraph --><p>Row body</p><!-- /wp:paragraph -->',
+				'field_values'  => array(
+					'field-' . $status_id => 'todo',
+					'field-' . $owner_id  => 'template owner',
+					'field-' . $tags_id   => array( 'frontend', 'urgent' ),
+				),
+			)
+		);
+
+		$response = $this->request(
+			'POST',
+			'/cortext/v1/templates/' . $template_id . '/instantiate',
+			array(
+				'field_values' => array(
+					'field-' . $status_id => 'filtered status',
+				),
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$row_id = (int) $response->get_data()['document']['id'];
+		$row    = get_post( $row_id );
+
+		$this->assertNotNull( $row );
+		$this->assertSame( 'Task starter', $row->post_title );
+		$this->assertSame( 'private', $row->post_status );
+		$this->assertStringContainsString( 'Row body', $row->post_content );
+		$this->assertSame( 'filtered status', get_post_meta( $row_id, Relations::meta_key( $status_id ), true ) );
+		$this->assertSame( 'template owner', get_post_meta( $row_id, Relations::meta_key( $owner_id ), true ) );
+		$this->assertSame( array( 'frontend', 'urgent' ), get_post_meta( $row_id, Relations::meta_key( $tags_id ), false ) );
+
+		$term_id = TraitTaxonomy::term_id_for_trait( $collection_id );
+		$this->assertTrue( has_term( $term_id, TraitTaxonomy::TAXONOMY, $row_id ) );
+	}
+
+	public function test_rejects_row_template_defaults_for_fields_outside_collection(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'Tasks' );
+
+		$response = $this->request(
+			'POST',
+			'/cortext/v1/templates',
+			array(
+				'kind'          => Templates::KIND_ROW,
+				'collection_id' => $collection_id,
+				'title'         => 'Invalid row template',
+				'field_values'  => array(
+					'field-99999' => 'outside',
+				),
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_template_field_invalid', $response->get_data()['code'] );
+	}
+
+	private function request( string $method, string $path, array $params = array() ) {
+		$request = new WP_REST_Request( $method, $path );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		if ( in_array( $method, array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true ) ) {
+			$request->set_body_params( $params );
+		}
+		return rest_do_request( $request );
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
+	}
+
+	private function create_document( string $title ): int {
+		$id = (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+			)
+		);
+		$this->assertGreaterThan( 0, $id );
+		return $id;
+	}
+
+	private function create_collection( string $title ): int {
+		$collection_id = $this->create_document( $title );
+		$this->attach_field( $collection_id, 'Title', 'text' );
+		$this->assertGreaterThan( 0, TraitTaxonomy::term_id_for_trait( $collection_id ) );
+		return $collection_id;
+	}
+
+	private function create_row( int $collection_id, string $title ): int {
+		$row_id  = $this->create_document( $title );
+		$term_id = TraitTaxonomy::term_id_for_trait( $collection_id );
+		$this->assertGreaterThan( 0, $term_id );
+		wp_set_object_terms( $row_id, array( $term_id ), TraitTaxonomy::TAXONOMY, false );
+		return $row_id;
+	}
+
+	private function attach_field( int $collection_id, string $title, string $type ): int {
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+				'meta_input'  => array( 'type' => $type ),
+			)
+		);
+		$this->assertGreaterThan( 0, $field_id );
+		add_post_meta( $collection_id, 'cortext_fields', (string) $field_id );
+		return $field_id;
+	}
+
+	private function create_template( array $args ): int {
+		$response = $this->request( 'POST', '/cortext/v1/templates', $args );
+		$this->assertSame( 201, $response->get_status(), wp_json_encode( $response->get_data() ) );
+		return (int) $response->get_data()['template']['id'];
+	}
+}

--- a/tests/php/test-rest-templates-controller.php
+++ b/tests/php/test-rest-templates-controller.php
@@ -63,7 +63,7 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 		$routes = rest_get_server()->get_routes();
 
 		$this->assertArrayHasKey( '/cortext/v1/templates', $routes );
-		$this->assertArrayHasKey( '/cortext/v1/templates/from-document', $routes );
+		$this->assertArrayHasKey( '/cortext/v1/templates/(?P<id>\d+)/instantiate', $routes );
 	}
 
 	public function test_registers_hidden_template_post_type_with_rest_support(): void {
@@ -87,7 +87,7 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 		$this->assertSame( 403, $response->get_status() );
 	}
 
-	public function test_crud_and_duplicate_page_templates(): void {
+	public function test_create_list_and_update_page_templates(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
 
 		$create = $this->request(
@@ -123,16 +123,6 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 		);
 		$this->assertSame( 200, $update->get_status() );
 		$this->assertSame( 'Renamed template', $update->get_data()['template']['title'] );
-
-		$duplicate = $this->request( 'POST', '/cortext/v1/templates/' . $template['id'] . '/duplicate' );
-		$this->assertSame( 201, $duplicate->get_status() );
-		$this->assertSame( 'Copy of Renamed template', $duplicate->get_data()['template']['title'] );
-		$this->assertStringContainsString( 'Updated', $duplicate->get_data()['template']['content'] );
-
-		$delete = $this->request( 'DELETE', '/cortext/v1/templates/' . $template['id'] );
-		$this->assertSame( 200, $delete->get_status() );
-		$this->assertTrue( $delete->get_data()['deleted'] );
-		$this->assertNull( get_post( (int) $template['id'] ) );
 	}
 
 	public function test_instantiate_page_template_copies_title_blocks_and_parent(): void {
@@ -162,79 +152,6 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 		$this->assertStringContainsString( 'Brief body', $document->post_content );
 		$this->assertStringNotContainsString( 'post-title', $document->post_content );
 		$this->assertStringNotContainsString( 'document-icon', $document->post_content );
-	}
-
-	public function test_creates_page_template_from_existing_document(): void {
-		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$document_id = $this->create_document( 'Spec page' );
-		wp_update_post(
-			array(
-				'ID'           => $document_id,
-				'post_content' => '<!-- wp:paragraph --><p>Starter body</p><!-- /wp:paragraph -->',
-			)
-		);
-
-		$response = $this->request(
-			'POST',
-			'/cortext/v1/templates/from-document',
-			array( 'document_id' => $document_id )
-		);
-
-		$this->assertSame( 201, $response->get_status(), wp_json_encode( $response->get_data() ) );
-		$template = $response->get_data()['template'];
-		$this->assertSame( Templates::KIND_PAGE, $template['kind'] );
-		$this->assertSame( 'Spec page', $template['title'] );
-		$this->assertStringContainsString( 'Starter body', $template['content'] );
-	}
-
-	public function test_creates_row_template_from_existing_row_with_field_defaults(): void {
-		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$collection_id = $this->create_collection( 'Tasks' );
-		$status_id     = $this->attach_field( $collection_id, 'Status', 'text' );
-		$tag_id        = $this->attach_field( $collection_id, 'Tags', 'multiselect' );
-		$rollup_id     = $this->attach_field( $collection_id, 'Rollup', 'rollup' );
-		$row_id        = $this->create_row( $collection_id, 'Bug bash' );
-
-		wp_update_post(
-			array(
-				'ID'           => $row_id,
-				'post_content' => '<!-- wp:paragraph --><p>Row starter</p><!-- /wp:paragraph -->',
-			)
-		);
-		update_post_meta( $row_id, Relations::meta_key( $status_id ), 'todo' );
-		add_post_meta( $row_id, Relations::meta_key( $tag_id ), 'frontend' );
-		add_post_meta( $row_id, Relations::meta_key( $tag_id ), 'urgent' );
-		update_post_meta( $row_id, Relations::meta_key( $rollup_id ), 'ignored' );
-
-		$response = $this->request(
-			'POST',
-			'/cortext/v1/templates/from-document',
-			array( 'document_id' => $row_id )
-		);
-
-		$this->assertSame( 201, $response->get_status(), wp_json_encode( $response->get_data() ) );
-		$template = $response->get_data()['template'];
-		$this->assertSame( Templates::KIND_ROW, $template['kind'] );
-		$this->assertSame( $collection_id, $template['collection_id'] );
-		$this->assertSame( 'Bug bash', $template['title'] );
-		$this->assertStringContainsString( 'Row starter', $template['content'] );
-		$this->assertSame( 'todo', $template['field_values'][ 'field-' . $status_id ] );
-		$this->assertSame( array( 'frontend', 'urgent' ), $template['field_values'][ 'field-' . $tag_id ] );
-		$this->assertArrayNotHasKey( 'field-' . $rollup_id, $template['field_values'] );
-	}
-
-	public function test_collections_cannot_be_saved_as_templates_from_document(): void {
-		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$collection_id = $this->create_collection( 'Tasks' );
-
-		$response = $this->request(
-			'POST',
-			'/cortext/v1/templates/from-document',
-			array( 'document_id' => $collection_id )
-		);
-
-		$this->assertSame( 400, $response->get_status() );
-		$this->assertSame( 'cortext_template_source_collection', $response->get_data()['code'] );
 	}
 
 	public function test_instantiate_row_template_applies_defaults_with_request_prefills_taking_priority(): void {

--- a/tests/php/test-rest-templates-controller.php
+++ b/tests/php/test-rest-templates-controller.php
@@ -42,7 +42,6 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 		$this->template_post_type = new TemplatePostType();
 		$this->template_post_type->register_post_type();
 		$this->template_post_type->register_meta();
-		add_action( 'before_delete_post', array( $this->template_post_type, 'clear_deleted_default' ), 10, 2 );
 
 		$this->install_in_memory_posts_query();
 		$this->install_in_memory_term_store();
@@ -53,8 +52,6 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 	}
 
 	public function tear_down(): void {
-		remove_action( 'before_delete_post', array( $this->template_post_type, 'clear_deleted_default' ), 10 );
-		delete_option( Templates::PAGE_DEFAULT_OPTION );
 		$this->uninstall_in_memory_posts_query();
 		$this->uninstall_in_memory_term_store();
 		wp_set_current_user( 0 );
@@ -66,7 +63,6 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 		$routes = rest_get_server()->get_routes();
 
 		$this->assertArrayHasKey( '/cortext/v1/templates', $routes );
-		$this->assertArrayHasKey( '/cortext/v1/templates/default', $routes );
 		$this->assertArrayHasKey( '/cortext/v1/templates/from-document', $routes );
 	}
 
@@ -137,79 +133,6 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 		$this->assertSame( 200, $delete->get_status() );
 		$this->assertTrue( $delete->get_data()['deleted'] );
 		$this->assertNull( get_post( (int) $template['id'] ) );
-	}
-
-	public function test_page_default_is_saved_returned_and_cleared_when_deleted(): void {
-		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$template_id = $this->create_template(
-			array(
-				'kind'  => Templates::KIND_PAGE,
-				'title' => 'Default page',
-			)
-		);
-
-		$set = $this->request(
-			'PUT',
-			'/cortext/v1/templates/default',
-			array( 'id' => $template_id )
-		);
-		$this->assertSame( 200, $set->get_status() );
-		$this->assertSame( $template_id, $set->get_data()['template']['id'] );
-
-		$get = $this->request( 'GET', '/cortext/v1/templates/default' );
-		$this->assertSame( $template_id, $get->get_data()['template']['id'] );
-
-		$delete = $this->request( 'DELETE', '/cortext/v1/templates/' . $template_id );
-		$this->assertSame( 200, $delete->get_status() );
-		$this->assertSame( 0, (int) get_option( Templates::PAGE_DEFAULT_OPTION, 0 ) );
-
-		$get_after_delete = $this->request( 'GET', '/cortext/v1/templates/default' );
-		$this->assertNull( $get_after_delete->get_data()['template'] );
-	}
-
-	public function test_page_default_read_without_template_access_does_not_clear_default(): void {
-		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$template_id = $this->create_template(
-			array(
-				'kind'  => Templates::KIND_PAGE,
-				'title' => 'Private default page',
-			)
-		);
-
-		$set = $this->request(
-			'PUT',
-			'/cortext/v1/templates/default',
-			array( 'id' => $template_id )
-		);
-		$this->assertSame( 200, $set->get_status() );
-
-		wp_set_current_user( $this->create_user( 'author' ) );
-
-		$get = $this->request( 'GET', '/cortext/v1/templates/default' );
-		$this->assertSame( 200, $get->get_status() );
-		$this->assertNull( $get->get_data()['template'] );
-		$this->assertSame( $template_id, (int) get_option( Templates::PAGE_DEFAULT_OPTION, 0 ) );
-	}
-
-	public function test_row_template_cannot_be_workspace_page_default(): void {
-		wp_set_current_user( $this->create_user( 'administrator' ) );
-		$collection_id = $this->create_collection( 'Tasks' );
-		$template_id   = $this->create_template(
-			array(
-				'kind'          => Templates::KIND_ROW,
-				'collection_id' => $collection_id,
-				'title'         => 'Task row',
-			)
-		);
-
-		$response = $this->request(
-			'PUT',
-			'/cortext/v1/templates/default',
-			array( 'id' => $template_id )
-		);
-
-		$this->assertSame( 400, $response->get_status() );
-		$this->assertSame( 'cortext_template_default_invalid_kind', $response->get_data()['code'] );
 	}
 
 	public function test_instantiate_page_template_copies_title_blocks_and_parent(): void {

--- a/tests/php/test-rest-templates-controller.php
+++ b/tests/php/test-rest-templates-controller.php
@@ -304,6 +304,35 @@ final class Test_Rest_Templates_Controller extends BaseTestCase {
 		$this->assertSame( 'cortext_template_field_invalid', $response->get_data()['code'] );
 	}
 
+	public function test_update_drops_defaults_for_fields_removed_from_collection(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'Tasks' );
+		$status_id     = $this->attach_field( $collection_id, 'Status', 'text' );
+		$template_id   = $this->create_template(
+			array(
+				'kind'          => Templates::KIND_ROW,
+				'collection_id' => $collection_id,
+				'title'         => 'Task starter',
+				'field_values'  => array(
+					'field-' . $status_id => 'todo',
+				),
+			)
+		);
+
+		delete_post_meta( $collection_id, 'cortext_fields', (string) $status_id );
+
+		$response = $this->request(
+			'POST',
+			'/cortext/v1/templates/' . $template_id,
+			array( 'title' => 'Renamed starter' )
+		);
+
+		$this->assertSame( 200, $response->get_status(), wp_json_encode( $response->get_data() ) );
+		$template = $response->get_data()['template'];
+		$this->assertSame( 'Renamed starter', $template['title'] );
+		$this->assertArrayNotHasKey( 'field-' . $status_id, $template['field_values'] );
+	}
+
 	private function request( string $method, string $path, array $params = array() ) {
 		$request = new WP_REST_Request( $method, $path );
 		foreach ( $params as $key => $value ) {


### PR DESCRIPTION
## What

Part of #134 and #111.

Adds document and row templates behind a new Templates experiment, which is off by default. Once enabled, the New menus let users create and edit templates, then use them to start documents, nested documents, or collection rows.

Templates work as snapshots: editing one later will not change anything already created from it. For rows, active filter values override matching defaults from the template.

## Testing Instructions

1. Go to Settings > Experiments and enable Templates.
2. From the Documents sidebar, create a template with a title and some content. Then create a document from it and check that both were copied.
3. Open an existing document's actions. Add a blank document and one from the template, then check that both appear under the document.
4. Open a collection and create a row template with content and property values. Create a row from it and check the copied values.
5. Disable Templates and confirm that its actions disappear without affecting the usual New actions.
