### PR TITLE
Check Windows Azure signing credentials on every build

### DIFF
--- a/.buildkite/commands/verify-windows-signing.ps1
+++ b/.buildkite/commands/verify-windows-signing.ps1
@@ -1,0 +1,58 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Verifies this agent can set up Azure Artifact Signing for Cortext.
+
+    Cortext has no Windows build yet, so there is nothing to sign. This job
+    proves the credential path works now, so the NSIS build lands on a queue
+    that is already known good instead of debugging both at once.
+#>
+
+# PowerShell does not abort on a failed *native* command, only on failed cmdlets.
+$ErrorActionPreference = 'Stop'
+
+# setup_azure_trusted_signing.ps1 checks these too, but exits on the first one
+# missing — a build per gap. Report them all at once.
+$requiredInputs = @(
+    'AZURE_TENANT_ID'
+    'AZURE_CLIENT_ID'
+    'AZURE_CLIENT_SECRET'
+    'AZURE_ENDPOINT'
+    'AZURE_CODE_SIGNING_ACCOUNT'
+    'AZURE_CERTIFICATE_PROFILE'
+)
+
+Write-Output "--- :key: Checking Azure Artifact Signing credentials"
+$missing = $requiredInputs | Where-Object {
+    [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+}
+if ($missing) {
+    Write-Output "^^^ +++"
+    throw "Not set on this agent: $($missing -join ', ')."
+}
+Write-Output "All $($requiredInputs.Count) credentials are present."
+
+Write-Output "--- :lock: Running setup_azure_trusted_signing.ps1"
+# Comes from the a8c-ci-toolkit plugin, which puts its `bin` on PATH.
+$setupScript = (Get-Command setup_azure_trusted_signing.ps1 -ErrorAction Stop).Source
+& $setupScript
+if ($LASTEXITCODE -ne 0) {
+    Write-Output "^^^ +++"
+    throw "setup_azure_trusted_signing.ps1 failed with exit code ${LASTEXITCODE}."
+}
+
+Write-Output "--- :white_check_mark: Checking what the setup exported"
+foreach ($name in @('SIGNTOOL_PATH', 'AZURE_CODE_SIGNING_DLIB', 'AZURE_METADATA_JSON')) {
+    $value = [Environment]::GetEnvironmentVariable($name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        Write-Output "^^^ +++"
+        throw "$name was not exported."
+    }
+    if (-not (Test-Path -LiteralPath $value)) {
+        Write-Output "^^^ +++"
+        throw "$name points at a missing path: $value"
+    }
+    Write-Output "$name = $value"
+}
+
+Write-Output "Azure Artifact Signing is ready on this agent."

--- a/.buildkite/commands/verify-windows-signing.ps1
+++ b/.buildkite/commands/verify-windows-signing.ps1
@@ -2,10 +2,6 @@
 <#
 .SYNOPSIS
     Verifies this agent can set up Azure Artifact Signing for Cortext.
-
-    Cortext has no Windows build yet, so there is nothing to sign. This job
-    proves the credential path works now, so the NSIS build lands on a queue
-    that is already known good instead of debugging both at once.
 #>
 
 # PowerShell does not abort on a failed *native* command, only on failed cmdlets.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: mac
-
+# IMAGE_ID selects the macOS agent image. It is inert on the Windows queue.
 env:
   IMAGE_ID: $IMAGE_ID
 
 steps:
   - label: ":apple: Build, sign, notarize desktop DMG"
     key: release-desktop
+    agents:
+      queue: mac
     command: .buildkite/commands/release-desktop.sh
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     artifact_paths:
@@ -18,3 +18,16 @@ steps:
     notify:
       - github_commit_status:
           context: Build, Sign & Notarize Desktop
+
+  # Cortext ships no Windows build yet. This keeps the signing credentials under
+  # continuous check so the future NSIS build starts from a known-good queue.
+  # The NVM plugin is absent because it is bash-only and cannot run here.
+  - label: ":windows: Verify Azure Artifact Signing setup"
+    key: verify-windows-signing
+    agents:
+      queue: windows
+    command: powershell -NoProfile -ExecutionPolicy Bypass -File .buildkite/commands/verify-windows-signing.ps1
+    plugins: [$CI_TOOLKIT_PLUGIN]
+    notify:
+      - github_commit_status:
+          context: Verify Azure Artifact Signing setup

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# IMAGE_ID selects the macOS agent image. It is inert on the Windows queue.
 env:
   IMAGE_ID: $IMAGE_ID
 
@@ -19,9 +18,9 @@ steps:
       - github_commit_status:
           context: Build, Sign & Notarize Desktop
 
-  # Cortext ships no Windows build yet. This keeps the signing credentials under
-  # continuous check so the future NSIS build starts from a known-good queue.
-  # The NVM plugin is absent because it is bash-only and cannot run here.
+  # Cortext ships no Windows build yet.
+  # This is just a walking skeleton to ensure code signing is at least set up correctly.
+  # See https://linear.app/a8c/issue/AINFRA-2751
   - label: ":windows: Verify Azure Artifact Signing setup"
     key: verify-windows-signing
     agents:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -2,7 +2,7 @@
 
 # Sourced by the pipeline-upload step so these values land in the rendered pipeline.yml.
 
-CI_TOOLKIT_PLUGIN_VERSION='6.0.1'
+CI_TOOLKIT_PLUGIN_VERSION='6.2.0'
 NVM_PLUGIN_VERSION='0.6.0'
 XCODE_VERSION=$(sed -E 's/^~> ?//' .xcode-version)
 


### PR DESCRIPTION
Set up a walking skeleton for Windows CI code signing, to be used once the Windows build is ready.

See [AINFRA-2751](https://linear.app/a8c/issue/AINFRA-2751).

<details>
<summary>AI-generated details</summary>

## Why

[AINFRA-2751](https://linear.app/a8c/issue/AINFRA-2751) asks to enable Azure Artifact Signing for "the Windows 11 x64 Electron/NSIS build Cortext is adding".

That build does not exist and is not in flight. `apps/desktop/package.json` declares a `mac` target only, `scripts/install-runtime.mjs` throws on any non-`darwin` platform, and #196 scoped the desktop app to "DMG first, Windows/Linux formats later". The Linear issue got ahead of the repo.

So rather than build the port speculatively or close the issue with nothing, this adds a walking skeleton: a real job on `queue: windows` that proves the signing credential path works. It answers three of the issue's four asks with CI evidence, and means the eventual NSIS build attaches to a queue already known to be good instead of debugging the port and the credentials simultaneously.

The toolkit pin has to move to 6.2.0 regardless — `setup_azure_trusted_signing.ps1` only landed in 6.1.0.

## Intentional tradeoffs

**The step runs on pull requests.** `build_pull_request_forks` is disabled on this pipeline, so the people who can trigger it are the people who can push to `main` — the trust boundary is unchanged, and it is what makes this change verifiable before merge. Nothing is signed, so the issue's "PR builds stay unsigned" still holds.

**No unit test.** The script is CI-only glue whose every branch asserts on Windows-agent state, and the repo has no PowerShell test runner. The job itself is the test and it runs on every PR. Its branches were exercised locally under `pwsh` against a stubbed setup script — all-missing, blank-vs-unset, non-zero setup exit, nothing exported, exported path absent, and the fully configured case.

## Gotchas

Confirming the certificate CN is exactly `Automattic Inc.` is deliberately **not** covered — that needs a real signed artifact and belongs with the NSIS build.

`queue: mac` moves from the pipeline root onto the macOS step so neither step depends on which level wins.

## How to test

Watch this PR's Buildkite build:

- Green `Verify Azure Artifact Signing setup` means the six Azure secrets reach this pipeline on `queue: windows` and the toolkit setup script (including its own signing smoke test) works here.
- Red at the credential check is itself the answer to the issue's first ask, and turns it into a concrete secrets request.
- `Build, Sign & Notarize Desktop` should stay green under toolkit 6.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ruqi9tecCK7Ty6X8b79Z6

</details>