### PR TITLE
Desktop: authenticate local runtime requests

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -67,6 +67,16 @@ uses `router.php` for the rewrite behavior WordPress normally gets from
 nginx or Apache. Once PHP reports that it is accepting connections, the
 window loads `http://127.0.0.1:9402/wp-admin/admin.php?page=cortext`.
 
+Each launch creates a new 256-bit authentication token in memory. Electron
+adds it to requests for the local runtime, and the runtime rejects requests
+without the matching token before serving WordPress or static files. The token
+is passed to the runtime through its environment and is never written to disk,
+included in a URL, or added to benchmark results. This protects the local admin
+session from web pages and accidental localhost clients. It does not protect
+against native processes running as the same macOS user, which can already read
+that user's Cortext data. The loopback address and port remain
+`127.0.0.1:9402`.
+
 In a dev run, DevTools open by default; set `CORTEXT_DEVTOOLS=0` to turn them
 off. The packaged build never opens them. Closing the window kills the PHP
 process.
@@ -178,10 +188,9 @@ npm --prefix apps/desktop run snapshot
 npm --prefix apps/desktop run test:e2e
 ```
 
-The test removes `~/Library/Application Support/cortext-desktop/`, starts
-Electron, waits for the window to reach the Cortext admin page, and checks
-that `#cortext-root` is visible. It takes about 7 seconds locally once the
-snapshot exists.
+The test uses a temporary Electron user-data directory, starts Electron, waits
+for the window to reach the Cortext admin page, and checks that `#cortext-root`
+is visible. It takes about 7 seconds locally once the snapshot exists.
 
 ## Runtime files
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -74,9 +74,12 @@ preferences such as theme and sidebar layout survive restarts; the token itself
 is never stored in that session. Its HTTP cache is disabled, and cookies,
 service workers, and Cache API data for the runtime are cleared at launch.
 Requests that leave the runtime origin are stripped of the header and cannot
-regain it by redirecting back. External top-level links open in the system
-browser, external frames and document redirects are blocked, and internal
-popups stay in the protected session.
+regain it by redirecting back. Only requests coming from a Cortext frame carry
+the token, so embedded third-party content such as an Embed block renders while
+staying outside the boundary: neither the frame, nor a frame nested inside it,
+nor a service worker or popup it opens can reach the runtime. External
+top-level links open in the system browser, an embedded frame cannot steer the
+app window, and internal popups stay in the protected session.
 
 The runtime rejects requests without the matching token before serving
 WordPress or static files. The token is passed through the runtime environment
@@ -203,9 +206,9 @@ npm --prefix apps/desktop run test:e2e
 ```
 
 The test passes a temporary `--user-data-dir` to Electron, starts the app, and
-checks the protected session, external navigation boundary, internal popups,
-real menu Reload behavior, direct unauthenticated requests, and the rendered
-Cortext canvas. It does not read or remove the developer's normal desktop
+checks the protected session, external navigation boundary, embedded
+third-party frames, internal popups, real menu Reload behavior, direct
+unauthenticated requests, and the rendered Cortext canvas. It does not read or remove the developer's normal desktop
 profile.
 
 ## Runtime files

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -67,15 +67,29 @@ uses `router.php` for the rewrite behavior WordPress normally gets from
 nginx or Apache. Once PHP reports that it is accepting connections, the
 window loads `http://127.0.0.1:9402/wp-admin/admin.php?page=cortext`.
 
-Each launch creates a new 256-bit authentication token in memory. Electron
-adds it to requests for the local runtime, and the runtime rejects requests
-without the matching token before serving WordPress or static files. The token
-is passed to the runtime through its environment and is never written to disk,
-included in a URL, or added to benchmark results. This protects the local admin
-session from web pages and accidental localhost clients. It does not protect
-against native processes running as the same macOS user, which can already read
-that user's Cortext data. The loopback address and port remain
-`127.0.0.1:9402`.
+Each launch creates a new 256-bit authentication token in memory. Every Cortext
+window uses one dedicated Electron session, which adds the token to requests
+for the local runtime. The session remains persistent so browser-backed product
+preferences such as theme and sidebar layout survive restarts; the token itself
+is never stored in that session. Its HTTP cache is disabled, and cookies,
+service workers, and Cache API data for the runtime are cleared at launch.
+Requests that leave the runtime origin are stripped of the header and cannot
+regain it by redirecting back. External top-level links open in the system
+browser, external frames and document redirects are blocked, and internal
+popups stay in the protected session.
+
+The runtime rejects requests without the matching token before serving
+WordPress or static files. The token is passed through the runtime environment
+and is never written to disk, included in a URL, logged, forwarded to PHP by
+Caddy, or added to benchmark results. This protects the local admin session
+from web pages and accidental localhost clients. It does not protect against
+native processes running as the same macOS user, which can already read that
+user's Cortext data. The loopback address and port remain `127.0.0.1:9402`.
+
+Desktop hides the publishing and copy-link controls. Published localhost URLs
+are also protected by the token, so they are intentionally not shareable in
+Safari or another client; publishing remains available when Cortext runs as a
+WordPress plugin on a web site.
 
 In a dev run, DevTools open by default; set `CORTEXT_DEVTOOLS=0` to turn them
 off. The packaged build never opens them. Closing the window kills the PHP
@@ -188,9 +202,11 @@ npm --prefix apps/desktop run snapshot
 npm --prefix apps/desktop run test:e2e
 ```
 
-The test uses a temporary Electron user-data directory, starts Electron, waits
-for the window to reach the Cortext admin page, and checks that `#cortext-root`
-is visible. It takes about 7 seconds locally once the snapshot exists.
+The test passes a temporary `--user-data-dir` to Electron, starts the app, and
+checks the protected session, external navigation boundary, internal popups,
+real menu Reload behavior, direct unauthenticated requests, and the rendered
+Cortext canvas. It does not read or remove the developer's normal desktop
+profile.
 
 ## Runtime files
 

--- a/apps/desktop/lib/runtime-session.js
+++ b/apps/desktop/lib/runtime-session.js
@@ -1,0 +1,84 @@
+function hasOrigin( requestUrl, origin ) {
+	try {
+		return new URL( requestUrl ).origin === origin;
+	} catch {
+		return false;
+	}
+}
+
+function installRuntimeAuthHeader(
+	runtimeSession,
+	{ authHeader, authToken, runtimeOrigin }
+) {
+	if ( typeof authToken !== 'string' || ! authToken.trim() ) {
+		throw new Error(
+			'installRuntimeAuthHeader requires a non-empty authToken.'
+		);
+	}
+	if ( typeof authHeader !== 'string' || ! authHeader.trim() ) {
+		throw new Error(
+			'installRuntimeAuthHeader requires a non-empty authHeader.'
+		);
+	}
+
+	const normalizedOrigin = new URL( runtimeOrigin ).origin;
+	const normalizedAuthHeader = authHeader.toLowerCase();
+	const redirectedOutsideRuntime = new Set();
+	const filter = { urls: [ '<all_urls>' ] };
+
+	const onBeforeRedirect = ( details ) => {
+		if (
+			! hasOrigin( details.url, normalizedOrigin ) ||
+			! hasOrigin( details.redirectURL, normalizedOrigin )
+		) {
+			redirectedOutsideRuntime.add( details.id );
+		}
+	};
+	const onBeforeSendHeaders = ( details, callback ) => {
+		const requestHeaders = { ...details.requestHeaders };
+		for ( const header of Object.keys( requestHeaders ) ) {
+			if ( header.toLowerCase() === normalizedAuthHeader ) {
+				delete requestHeaders[ header ];
+			}
+		}
+
+		if (
+			hasOrigin( details.url, normalizedOrigin ) &&
+			! redirectedOutsideRuntime.has( details.id )
+		) {
+			requestHeaders[ authHeader ] = authToken;
+		} else if ( ! hasOrigin( details.url, normalizedOrigin ) ) {
+			// Keep the whole redirect chain unauthenticated if it ever leaves the
+			// private runtime origin.
+			redirectedOutsideRuntime.add( details.id );
+		}
+
+		callback( { requestHeaders } );
+	};
+	const clearRequest = ( details ) => {
+		redirectedOutsideRuntime.delete( details.id );
+	};
+
+	runtimeSession.webRequest.onBeforeRedirect( filter, onBeforeRedirect );
+	runtimeSession.webRequest.onBeforeSendHeaders(
+		filter,
+		onBeforeSendHeaders
+	);
+	runtimeSession.webRequest.onCompleted( filter, clearRequest );
+	runtimeSession.webRequest.onErrorOccurred( filter, clearRequest );
+
+	let installed = true;
+	return () => {
+		if ( ! installed ) {
+			return;
+		}
+		installed = false;
+		runtimeSession.webRequest.onBeforeRedirect( null );
+		runtimeSession.webRequest.onBeforeSendHeaders( null );
+		runtimeSession.webRequest.onCompleted( null );
+		runtimeSession.webRequest.onErrorOccurred( null );
+		redirectedOutsideRuntime.clear();
+	};
+}
+
+module.exports = { hasOrigin, installRuntimeAuthHeader };

--- a/apps/desktop/lib/runtime-session.js
+++ b/apps/desktop/lib/runtime-session.js
@@ -6,9 +6,29 @@ function hasOrigin( requestUrl, origin ) {
 	}
 }
 
+// Chromium resolves `frame.origin` through `about:blank` and `about:srcdoc`
+// inheritance, so embedded third-party content cannot borrow the runtime origin
+// by nesting a frame or opening a popup.
+function isTrustedRuntimeFrame( frame, runtimeOrigin, trustedDocumentUrls ) {
+	if ( ! frame ) {
+		// Service workers and main-process requests arrive without a frame, and
+		// embedded content can register a worker, so no frame is never Cortext.
+		return false;
+	}
+	try {
+		return (
+			frame.origin === runtimeOrigin ||
+			trustedDocumentUrls.includes( frame.url )
+		);
+	} catch {
+		// Reading a frame that was disposed mid-request throws.
+		return false;
+	}
+}
+
 function installRuntimeAuthHeader(
 	runtimeSession,
-	{ authHeader, authToken, runtimeOrigin }
+	{ authHeader, authToken, runtimeOrigin, trustedDocumentUrls = [] }
 ) {
 	if ( typeof authToken !== 'string' || ! authToken.trim() ) {
 		throw new Error(
@@ -44,7 +64,12 @@ function installRuntimeAuthHeader(
 
 		if (
 			hasOrigin( details.url, normalizedOrigin ) &&
-			! redirectedOutsideRuntime.has( details.id )
+			! redirectedOutsideRuntime.has( details.id ) &&
+			isTrustedRuntimeFrame(
+				details.frame,
+				normalizedOrigin,
+				trustedDocumentUrls
+			)
 		) {
 			requestHeaders[ authHeader ] = authToken;
 		} else if ( ! hasOrigin( details.url, normalizedOrigin ) ) {
@@ -81,4 +106,8 @@ function installRuntimeAuthHeader(
 	};
 }
 
-module.exports = { hasOrigin, installRuntimeAuthHeader };
+module.exports = {
+	hasOrigin,
+	installRuntimeAuthHeader,
+	isTrustedRuntimeFrame,
+};

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -6,6 +6,8 @@ const path = require( 'path' );
 
 const DEFAULT_PORT = 9402;
 const DEFAULT_READY_PATH = '/wp-includes/images/blank.gif';
+const RUNTIME_AUTH_HEADER = 'X-Cortext-Desktop-Token';
+const RUNTIME_AUTH_ENV = 'CORTEXT_DESKTOP_AUTH_TOKEN';
 const EXPLORATION_OBJECT_CACHE_MARKER =
 	'Cortext Desktop APCu object-cache exploration drop-in';
 
@@ -131,6 +133,17 @@ function configureDesktopUpdateLock( wordpressDir, appDir ) {
 	);
 }
 
+function configureRuntimeRouter( wordpressDir, appDir ) {
+	const sourcePath = path.join( appDir, 'runtime/router.php' );
+	if ( ! fs.existsSync( sourcePath ) ) {
+		throw new Error(
+			`Authenticated desktop router not found at ${ sourcePath }.`
+		);
+	}
+
+	fs.copyFileSync( sourcePath, path.join( wordpressDir, 'router.php' ) );
+}
+
 function configurePreloadFiles( wordpressDir, appDir ) {
 	const files = [
 		[ 'preload.php', 'cortext-preload.php' ],
@@ -230,11 +243,12 @@ function addProcess( handle, name, command, args, options = {} ) {
 	return child;
 }
 
-function waitForHttpReady( handle, port, timeoutMs = 30000 ) {
+function waitForHttpReady( handle, port, authToken, timeoutMs = 30000 ) {
 	return new Promise( ( resolve, reject ) => {
 		let settled = false;
 		let lastFailure = null;
 		let probeTimer = null;
+		const activeRequests = new Set();
 		const timeout = setTimeout( () => {
 			fail(
 				new Error(
@@ -253,6 +267,10 @@ function waitForHttpReady( handle, port, timeoutMs = 30000 ) {
 			if ( probeTimer ) {
 				clearTimeout( probeTimer );
 			}
+			for ( const request of activeRequests ) {
+				request.destroy();
+			}
+			activeRequests.clear();
 			for ( const fn of cleanupFns ) {
 				fn();
 			}
@@ -291,40 +309,106 @@ function waitForHttpReady( handle, port, timeoutMs = 30000 ) {
 			} );
 		}
 
-		const probe = () => {
-			const req = http.get(
-				{
-					host: '127.0.0.1',
-					port,
-					path: DEFAULT_READY_PATH,
-					timeout: 1000,
-				},
-				( res ) => {
-					res.resume();
-					if ( res.statusCode && res.statusCode < 500 ) {
-						pass();
-						return;
+		const requestStatus = ( headers = {} ) =>
+			new Promise( ( resolveStatus, rejectRequest ) => {
+				const request = http.get(
+					{
+						host: '127.0.0.1',
+						port,
+						path: DEFAULT_READY_PATH,
+						timeout: 1000,
+						headers,
+					},
+					( response ) => {
+						response.resume();
+						response.once( 'end', () => {
+							resolveStatus( response.statusCode );
+						} );
 					}
-					lastFailure = `HTTP ${ res.statusCode }`;
-					probeTimer = setTimeout( probe, 250 );
-				}
-			);
-			req.on( 'timeout', () => {
-				req.destroy( new Error( 'HTTP probe timed out' ) );
+				);
+				activeRequests.add( request );
+				request.once( 'close', () => {
+					activeRequests.delete( request );
+				} );
+				request.once( 'timeout', () => {
+					request.destroy( new Error( 'HTTP probe timed out' ) );
+				} );
+				request.once( 'error', rejectRequest );
 			} );
-			req.on( 'error', ( err ) => {
-				lastFailure = err.message;
+
+		const probe = async () => {
+			if ( settled ) {
+				return;
+			}
+
+			try {
+				const unauthenticatedStatus = await requestStatus();
+				if ( settled ) {
+					return;
+				}
+				if ( unauthenticatedStatus !== 403 ) {
+					fail(
+						new Error(
+							`Runtime security check failed: unauthenticated request returned HTTP ${ unauthenticatedStatus }.`
+						)
+					);
+					return;
+				}
+
+				const invalidTokenStatus = await requestStatus( {
+					[ RUNTIME_AUTH_HEADER ]: `${ authToken }-invalid`,
+				} );
+				if ( settled ) {
+					return;
+				}
+				if ( invalidTokenStatus !== 403 ) {
+					fail(
+						new Error(
+							`Runtime security check failed: invalid token request returned HTTP ${ invalidTokenStatus }.`
+						)
+					);
+					return;
+				}
+
+				const authenticatedStatus = await requestStatus( {
+					[ RUNTIME_AUTH_HEADER ]: authToken,
+				} );
+				if ( settled ) {
+					return;
+				}
+				if (
+					authenticatedStatus &&
+					authenticatedStatus >= 200 &&
+					authenticatedStatus < 400
+				) {
+					pass();
+					return;
+				}
+				fail(
+					new Error(
+						`Runtime security check failed: authenticated request returned HTTP ${ authenticatedStatus }.`
+					)
+				);
+			} catch ( error ) {
+				lastFailure = error.message;
 				if ( ! settled ) {
 					probeTimer = setTimeout( probe, 250 );
 				}
-			} );
+			}
 		};
 
 		probe();
 	} );
 }
 
-function startPhpCli( handle, wordpressDir, port, appDir, runtimeStateDir ) {
+function startPhpCli(
+	handle,
+	wordpressDir,
+	port,
+	appDir,
+	runtimeStateDir,
+	authToken
+) {
 	const phpBin = resolveExecutable(
 		'CORTEXT_PHP_BIN',
 		path.join( appDir, 'runtime/bin/php' ),
@@ -351,7 +435,10 @@ function startPhpCli( handle, wordpressDir, port, appDir, runtimeStateDir ) {
 		wordpressDir,
 		routerPath,
 	];
-	const phpEnv = { ...process.env };
+	const phpEnv = {
+		...process.env,
+		[ RUNTIME_AUTH_ENV ]: authToken,
+	};
 	if ( workers ) {
 		phpEnv.PHP_CLI_SERVER_WORKERS = workers;
 	}
@@ -362,7 +449,7 @@ function startPhpCli( handle, wordpressDir, port, appDir, runtimeStateDir ) {
 	} );
 }
 
-function startFrankenPhp( handle, wordpressDir, port, appDir ) {
+function startFrankenPhp( handle, wordpressDir, port, appDir, authToken ) {
 	const frankenBin = resolveExecutable(
 		'CORTEXT_FRANKENPHP_BIN',
 		path.join( appDir, 'runtime/bin/frankenphp' ),
@@ -390,6 +477,7 @@ function startFrankenPhp( handle, wordpressDir, port, appDir ) {
 			cwd: wordpressDir,
 			env: {
 				...process.env,
+				[ RUNTIME_AUTH_ENV ]: authToken,
 				CORTEXT_PORT: String( port ),
 				CORTEXT_WORDPRESS_ROOT: wordpressDir,
 				CORTEXT_CADDY_STORAGE: path.join( handle.stateDir, 'caddy' ),
@@ -446,7 +534,8 @@ function startPhpFpmCaddy(
 	wordpressDir,
 	port,
 	appDir,
-	runtimeStateDir
+	runtimeStateDir,
+	authToken
 ) {
 	const phpFpmBin = resolveExecutable(
 		'CORTEXT_PHP_FPM_BIN',
@@ -475,7 +564,13 @@ function startPhpFpmCaddy(
 		'php-fpm',
 		phpFpmBin,
 		[ '-F', '-O', '-y', fpm.configPath ],
-		{ cwd: wordpressDir, env: process.env }
+		{
+			cwd: wordpressDir,
+			env: {
+				...process.env,
+				[ RUNTIME_AUTH_ENV ]: authToken,
+			},
+		}
 	);
 	addProcess(
 		handle,
@@ -486,6 +581,7 @@ function startPhpFpmCaddy(
 			cwd: wordpressDir,
 			env: {
 				...process.env,
+				[ RUNTIME_AUTH_ENV ]: authToken,
 				CORTEXT_PORT: String( port ),
 				CORTEXT_WORDPRESS_ROOT: wordpressDir,
 				CORTEXT_PHP_FPM_SOCKET: fpm.socketPath,
@@ -502,7 +598,12 @@ function startRuntime( {
 	runtime = process.env.CORTEXT_RUNTIME,
 	runtimeStateDir,
 	onUnexpectedExit,
+	authToken,
 } ) {
+	if ( typeof authToken !== 'string' || authToken.trim().length === 0 ) {
+		throw new TypeError( 'startRuntime requires a non-empty authToken.' );
+	}
+
 	const normalized = normalizeRuntime( runtime );
 	const handle = {
 		runtime: normalized,
@@ -517,17 +618,30 @@ function startRuntime( {
 	handle.stateDir = stateDir;
 
 	configureObjectCacheDropIn( wordpressDir, appDir );
+	configureRuntimeRouter( wordpressDir, appDir );
 	configureDesktopUpdateLock( wordpressDir, appDir );
 
 	if ( normalized === 'php' ) {
-		startPhpCli( handle, wordpressDir, port, appDir, stateDir );
+		startPhpCli( handle, wordpressDir, port, appDir, stateDir, authToken );
 	} else if ( normalized === 'franken' ) {
-		startFrankenPhp( handle, wordpressDir, port, appDir );
+		startFrankenPhp( handle, wordpressDir, port, appDir, authToken );
 	} else if ( normalized === 'php-fpm' ) {
-		startPhpFpmCaddy( handle, wordpressDir, port, appDir, stateDir );
+		startPhpFpmCaddy(
+			handle,
+			wordpressDir,
+			port,
+			appDir,
+			stateDir,
+			authToken
+		);
 	}
 
-	handle.ready = waitForHttpReady( handle, port );
+	handle.ready = waitForHttpReady( handle, port, authToken ).catch(
+		( error ) => {
+			stopRuntime( handle );
+			throw error;
+		}
+	);
 	return handle;
 }
 
@@ -568,6 +682,7 @@ function stopRuntime( handle ) {
 
 module.exports = {
 	DEFAULT_PORT,
+	RUNTIME_AUTH_HEADER,
 	normalizeRuntime,
 	startRuntime,
 	stopRuntime,

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -1,9 +1,12 @@
 const { app, BrowserWindow, Menu } = require( 'electron' );
 const { spawnSync } = require( 'child_process' );
+const crypto = require( 'crypto' );
 const path = require( 'path' );
 const fs = require( 'fs' );
+const { pathToFileURL } = require( 'url' );
 const {
 	DEFAULT_PORT: PORT,
+	RUNTIME_AUTH_HEADER,
 	startRuntime,
 	stopRuntime,
 } = require( './lib/runtime' );
@@ -26,9 +29,124 @@ const settings = require( './lib/settings' );
 const RESOURCES_DIR = app.isPackaged ? process.resourcesPath : __dirname;
 const SNAPSHOT_ZIP = path.join( RESOURCES_DIR, 'snapshot.zip' );
 const APP_ICON = path.join( __dirname, 'assets/icon.png' );
+const LOADING_PAGE = path.resolve( __dirname, 'loading.html' );
+const LOADING_URL = pathToFileURL( LOADING_PAGE ).href;
+const RUNTIME_ORIGIN = `http://127.0.0.1:${ PORT }`;
 
 let runtimeHandle = null;
 let quitting = false;
+
+function configureE2EUserData() {
+	if ( process.env.CORTEXT_E2E !== '1' ) {
+		return;
+	}
+
+	const configuredPath = process.env.CORTEXT_E2E_USER_DATA_DIR;
+	if ( ! configuredPath ) {
+		throw new Error(
+			'CORTEXT_E2E_USER_DATA_DIR is required when CORTEXT_E2E=1.'
+		);
+	}
+
+	const userDataPath = path.resolve( configuredPath );
+	fs.mkdirSync( userDataPath, { recursive: true } );
+	if ( ! fs.statSync( userDataPath ).isDirectory() ) {
+		throw new Error(
+			`CORTEXT_E2E_USER_DATA_DIR is not a directory: ${ userDataPath }`
+		);
+	}
+	app.setPath( 'userData', userDataPath );
+}
+
+function hasOrigin( requestUrl, origin ) {
+	try {
+		return new URL( requestUrl ).origin === origin;
+	} catch {
+		return false;
+	}
+}
+
+function getRequestHeader( requestHeaders, name ) {
+	const headerName = Object.keys( requestHeaders ).find(
+		( header ) => header.toLowerCase() === name.toLowerCase()
+	);
+	return headerName ? requestHeaders[ headerName ] : undefined;
+}
+
+function hasTrustedRuntimeInitiator( details, webContents ) {
+	if (
+		details.webContentsId !== webContents.id ||
+		webContents.isDestroyed()
+	) {
+		return false;
+	}
+
+	const currentUrl = webContents.getURL();
+	const isSameOriginRequest =
+		getRequestHeader(
+			details.requestHeaders,
+			'Sec-Fetch-Site'
+		)?.toLowerCase() === 'same-origin';
+	if (
+		details.resourceType === 'mainFrame' ||
+		details.resourceType === 'subFrame'
+	) {
+		if (
+			details.resourceType === 'mainFrame' &&
+			currentUrl === LOADING_URL
+		) {
+			return true;
+		}
+		if (
+			details.resourceType === 'mainFrame' &&
+			! hasOrigin( currentUrl, RUNTIME_ORIGIN )
+		) {
+			return false;
+		}
+		return isSameOriginRequest;
+	}
+
+	return (
+		isSameOriginRequest &&
+		( hasOrigin( details.frame?.url, RUNTIME_ORIGIN ) ||
+			hasOrigin( details.referrer, RUNTIME_ORIGIN ) )
+	);
+}
+
+function installRuntimeAuthHeader( webContents, authToken ) {
+	// Observe every destination so a redirect cannot carry the private header
+	// away from the runtime. Only Cortext content in this window may receive it.
+	webContents.session.webRequest.onBeforeSendHeaders(
+		{ urls: [ '<all_urls>' ] },
+		( details, callback ) => {
+			const existingHeaders = Object.keys(
+				details.requestHeaders
+			).filter(
+				( header ) =>
+					header.toLowerCase() === RUNTIME_AUTH_HEADER.toLowerCase()
+			);
+			const shouldAuthenticate =
+				hasOrigin( details.url, RUNTIME_ORIGIN ) &&
+				hasTrustedRuntimeInitiator( details, webContents );
+
+			if ( existingHeaders.length === 0 && ! shouldAuthenticate ) {
+				callback( {} );
+				return;
+			}
+
+			const requestHeaders = { ...details.requestHeaders };
+			for ( const header of existingHeaders ) {
+				delete requestHeaders[ header ];
+			}
+			if ( shouldAuthenticate ) {
+				requestHeaders[ RUNTIME_AUTH_HEADER ] = authToken;
+			}
+			callback( { requestHeaders } );
+		}
+	);
+}
+
+configureE2EUserData();
 
 function getSiteRoot() {
 	return path.join( app.getPath( 'userData' ), 'site' );
@@ -123,6 +241,8 @@ async function loadSite( win ) {
 app.whenReady().then( async () => {
 	let win = null;
 	try {
+		const authToken = crypto.randomBytes( 32 ).toString( 'hex' );
+
 		if (
 			process.platform === 'darwin' &&
 			app.dock &&
@@ -133,9 +253,10 @@ app.whenReady().then( async () => {
 
 		refreshMenu();
 		win = createWindow();
+		installRuntimeAuthHeader( win.webContents, authToken );
 		// Load the loading screen before any site refresh so users never stare at
 		// a blank window.
-		await win.loadFile( path.resolve( __dirname, 'loading.html' ) );
+		await win.loadFile( LOADING_PAGE );
 
 		const siteRoot = getSiteRoot();
 		recoverInterruptedSwap( siteRoot );
@@ -151,6 +272,7 @@ app.whenReady().then( async () => {
 
 		runtimeHandle = startRuntime( {
 			appDir: RESOURCES_DIR,
+			authToken,
 			wordpressDir,
 			runtimeStateDir: path.join(
 				app.getPath( 'temp' ),

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -13,6 +13,7 @@ const {
 const {
 	hasOrigin,
 	installRuntimeAuthHeader,
+	isTrustedRuntimeFrame,
 } = require( './lib/runtime-session' );
 const {
 	scheduleUpdateCheck,
@@ -39,6 +40,8 @@ const ERROR_PAGE = path.resolve( __dirname, 'error.html' );
 const ERROR_URL = pathToFileURL( ERROR_PAGE ).href;
 const RUNTIME_ORIGIN = `http://127.0.0.1:${ PORT }`;
 const RUNTIME_SESSION_PARTITION = 'persist:cortext';
+// The local shell pages Cortext loads itself, before and instead of the runtime.
+const TRUSTED_DOCUMENT_URLS = [ LOADING_URL, ERROR_URL ];
 
 let runtimeHandle = null;
 let removeRuntimeAuthHeader = null;
@@ -92,14 +95,33 @@ function refreshMenu() {
 	);
 }
 
-function isAllowedDocumentUrl( url, isMainFrame ) {
+function isAllowedTopLevelUrl( url ) {
+	return (
+		hasOrigin( url, RUNTIME_ORIGIN ) ||
+		TRUSTED_DOCUMENT_URLS.includes( url )
+	);
+}
+
+// Third-party frames may render so blocks such as Embed keep working. They
+// cannot reach the runtime: the token only rides on requests whose frame origin
+// is Cortext's own, and that origin is inherited, not claimed.
+function isAllowedFrameUrl( url ) {
+	if ( url === 'about:blank' || url === 'about:srcdoc' ) {
+		return true;
+	}
+	// The editor canvas is a blob: frame, which carries the runtime origin.
 	if ( hasOrigin( url, RUNTIME_ORIGIN ) ) {
 		return true;
 	}
-	if ( ! isMainFrame ) {
-		return url === 'about:blank' || url === 'about:srcdoc';
+	try {
+		return [ 'http:', 'https:' ].includes( new URL( url ).protocol );
+	} catch {
+		return false;
 	}
-	return url === LOADING_URL || url === ERROR_URL;
+}
+
+function isAllowedDocumentUrl( url, isMainFrame ) {
+	return isMainFrame ? isAllowedTopLevelUrl( url ) : isAllowedFrameUrl( url );
 }
 
 function openExternalUrl( url ) {
@@ -150,11 +172,22 @@ function configureTrustedWindow( win, runtimeSession ) {
 
 	const { webContents } = win;
 	webContents.on( 'will-navigate', ( event ) => {
-		if ( isAllowedDocumentUrl( event.url, true ) ) {
+		if ( ! isAllowedTopLevelUrl( event.url ) ) {
+			event.preventDefault();
+			openExternalUrl( event.url );
 			return;
 		}
-		event.preventDefault();
-		openExternalUrl( event.url );
+		// An embedded frame must not be able to steer the app window, even to a
+		// runtime address.
+		if (
+			! isTrustedRuntimeFrame(
+				event.initiator,
+				RUNTIME_ORIGIN,
+				TRUSTED_DOCUMENT_URLS
+			)
+		) {
+			event.preventDefault();
+		}
 	} );
 	webContents.on( 'will-frame-navigate', ( event ) => {
 		if ( event.isMainFrame || isAllowedDocumentUrl( event.url, false ) ) {
@@ -271,6 +304,7 @@ app.whenReady().then( async () => {
 			authHeader: RUNTIME_AUTH_HEADER,
 			authToken,
 			runtimeOrigin: RUNTIME_ORIGIN,
+			trustedDocumentUrls: TRUSTED_DOCUMENT_URLS,
 		} );
 
 		if (

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu } = require( 'electron' );
+const { app, BrowserWindow, Menu, session, shell } = require( 'electron' );
 const { spawnSync } = require( 'child_process' );
 const crypto = require( 'crypto' );
 const path = require( 'path' );
@@ -10,6 +10,10 @@ const {
 	startRuntime,
 	stopRuntime,
 } = require( './lib/runtime' );
+const {
+	hasOrigin,
+	installRuntimeAuthHeader,
+} = require( './lib/runtime-session' );
 const {
 	scheduleUpdateCheck,
 	checkForUpdatesInteractive,
@@ -31,122 +35,15 @@ const SNAPSHOT_ZIP = path.join( RESOURCES_DIR, 'snapshot.zip' );
 const APP_ICON = path.join( __dirname, 'assets/icon.png' );
 const LOADING_PAGE = path.resolve( __dirname, 'loading.html' );
 const LOADING_URL = pathToFileURL( LOADING_PAGE ).href;
+const ERROR_PAGE = path.resolve( __dirname, 'error.html' );
+const ERROR_URL = pathToFileURL( ERROR_PAGE ).href;
 const RUNTIME_ORIGIN = `http://127.0.0.1:${ PORT }`;
+const RUNTIME_SESSION_PARTITION = 'persist:cortext';
 
 let runtimeHandle = null;
+let removeRuntimeAuthHeader = null;
 let quitting = false;
-
-function configureE2EUserData() {
-	if ( process.env.CORTEXT_E2E !== '1' ) {
-		return;
-	}
-
-	const configuredPath = process.env.CORTEXT_E2E_USER_DATA_DIR;
-	if ( ! configuredPath ) {
-		throw new Error(
-			'CORTEXT_E2E_USER_DATA_DIR is required when CORTEXT_E2E=1.'
-		);
-	}
-
-	const userDataPath = path.resolve( configuredPath );
-	fs.mkdirSync( userDataPath, { recursive: true } );
-	if ( ! fs.statSync( userDataPath ).isDirectory() ) {
-		throw new Error(
-			`CORTEXT_E2E_USER_DATA_DIR is not a directory: ${ userDataPath }`
-		);
-	}
-	app.setPath( 'userData', userDataPath );
-}
-
-function hasOrigin( requestUrl, origin ) {
-	try {
-		return new URL( requestUrl ).origin === origin;
-	} catch {
-		return false;
-	}
-}
-
-function getRequestHeader( requestHeaders, name ) {
-	const headerName = Object.keys( requestHeaders ).find(
-		( header ) => header.toLowerCase() === name.toLowerCase()
-	);
-	return headerName ? requestHeaders[ headerName ] : undefined;
-}
-
-function hasTrustedRuntimeInitiator( details, webContents ) {
-	if (
-		details.webContentsId !== webContents.id ||
-		webContents.isDestroyed()
-	) {
-		return false;
-	}
-
-	const currentUrl = webContents.getURL();
-	const isSameOriginRequest =
-		getRequestHeader(
-			details.requestHeaders,
-			'Sec-Fetch-Site'
-		)?.toLowerCase() === 'same-origin';
-	if (
-		details.resourceType === 'mainFrame' ||
-		details.resourceType === 'subFrame'
-	) {
-		if (
-			details.resourceType === 'mainFrame' &&
-			currentUrl === LOADING_URL
-		) {
-			return true;
-		}
-		if (
-			details.resourceType === 'mainFrame' &&
-			! hasOrigin( currentUrl, RUNTIME_ORIGIN )
-		) {
-			return false;
-		}
-		return isSameOriginRequest;
-	}
-
-	return (
-		isSameOriginRequest &&
-		( hasOrigin( details.frame?.url, RUNTIME_ORIGIN ) ||
-			hasOrigin( details.referrer, RUNTIME_ORIGIN ) )
-	);
-}
-
-function installRuntimeAuthHeader( webContents, authToken ) {
-	// Observe every destination so a redirect cannot carry the private header
-	// away from the runtime. Only Cortext content in this window may receive it.
-	webContents.session.webRequest.onBeforeSendHeaders(
-		{ urls: [ '<all_urls>' ] },
-		( details, callback ) => {
-			const existingHeaders = Object.keys(
-				details.requestHeaders
-			).filter(
-				( header ) =>
-					header.toLowerCase() === RUNTIME_AUTH_HEADER.toLowerCase()
-			);
-			const shouldAuthenticate =
-				hasOrigin( details.url, RUNTIME_ORIGIN ) &&
-				hasTrustedRuntimeInitiator( details, webContents );
-
-			if ( existingHeaders.length === 0 && ! shouldAuthenticate ) {
-				callback( {} );
-				return;
-			}
-
-			const requestHeaders = { ...details.requestHeaders };
-			for ( const header of existingHeaders ) {
-				delete requestHeaders[ header ];
-			}
-			if ( shouldAuthenticate ) {
-				requestHeaders[ RUNTIME_AUTH_HEADER ] = authToken;
-			}
-			callback( { requestHeaders } );
-		}
-	);
-}
-
-configureE2EUserData();
+const childWindows = new Set();
 
 function getSiteRoot() {
 	return path.join( app.getPath( 'userData' ), 'site' );
@@ -195,23 +92,143 @@ function refreshMenu() {
 	);
 }
 
-function createWindow() {
+function isAllowedDocumentUrl( url, isMainFrame ) {
+	if ( hasOrigin( url, RUNTIME_ORIGIN ) ) {
+		return true;
+	}
+	if ( ! isMainFrame ) {
+		return url === 'about:blank' || url === 'about:srcdoc';
+	}
+	return url === LOADING_URL || url === ERROR_URL;
+}
+
+function openExternalUrl( url ) {
+	let protocol;
+	try {
+		protocol = new URL( url ).protocol;
+	} catch {
+		return;
+	}
+	if ( ! [ 'http:', 'https:', 'mailto:' ].includes( protocol ) ) {
+		return;
+	}
+
+	setImmediate( () => {
+		shell.openExternal( url ).catch( ( error ) => {
+			console.error(
+				'[cortext-desktop] failed to open external link:',
+				error
+			);
+		} );
+	} );
+}
+
+function secureWebPreferences( webPreferences, runtimeSession ) {
+	const inheritedPreferences = { ...( webPreferences || {} ) };
+	delete inheritedPreferences.partition;
+	delete inheritedPreferences.preload;
+	delete inheritedPreferences.session;
+	return {
+		...inheritedPreferences,
+		session: runtimeSession,
+		contextIsolation: true,
+		nodeIntegration: false,
+		nodeIntegrationInWorker: false,
+		nodeIntegrationInSubFrames: false,
+		sandbox: true,
+		webviewTag: false,
+		webSecurity: true,
+		allowRunningInsecureContent: false,
+	};
+}
+
+function configureTrustedWindow( win, runtimeSession ) {
+	win.on( 'page-title-updated', ( event ) => {
+		event.preventDefault();
+		win.setTitle( 'Cortext' );
+	} );
+
+	const { webContents } = win;
+	webContents.on( 'will-navigate', ( event ) => {
+		if ( isAllowedDocumentUrl( event.url, true ) ) {
+			return;
+		}
+		event.preventDefault();
+		openExternalUrl( event.url );
+	} );
+	webContents.on( 'will-frame-navigate', ( event ) => {
+		if ( event.isMainFrame || isAllowedDocumentUrl( event.url, false ) ) {
+			return;
+		}
+		event.preventDefault();
+	} );
+	webContents.on( 'will-redirect', ( event ) => {
+		if ( isAllowedDocumentUrl( event.url, event.isMainFrame ) ) {
+			return;
+		}
+		event.preventDefault();
+	} );
+	webContents.setWindowOpenHandler( ( { url } ) => {
+		if ( ! hasOrigin( url, RUNTIME_ORIGIN ) ) {
+			openExternalUrl( url );
+			return { action: 'deny' };
+		}
+
+		return {
+			action: 'allow',
+			createWindow: ( options ) =>
+				createInternalWindow( options, runtimeSession, win )
+					.webContents,
+		};
+	} );
+}
+
+function createInternalWindow( options, runtimeSession, parent ) {
+	const windowOptions = { ...options };
+	const { webPreferences } = windowOptions;
+	delete windowOptions.webPreferences;
+	if (
+		windowOptions.webContents &&
+		windowOptions.webContents.session !== runtimeSession
+	) {
+		windowOptions.webContents.close( { waitForBeforeUnload: false } );
+		throw new Error(
+			'Refusing to create an internal window outside the runtime session.'
+		);
+	}
+	const child = new BrowserWindow( {
+		...windowOptions,
+		parent,
+		title: 'Cortext',
+		icon: APP_ICON,
+		backgroundColor: '#1d1d1d',
+		webPreferences: secureWebPreferences( webPreferences, runtimeSession ),
+	} );
+	if ( child.webContents.session !== runtimeSession ) {
+		child.destroy();
+		throw new Error(
+			'Internal window was created outside the runtime session.'
+		);
+	}
+	childWindows.add( child );
+	child.once( 'closed', () => {
+		childWindows.delete( child );
+	} );
+	configureTrustedWindow( child, runtimeSession );
+	return child;
+}
+
+function createWindow( runtimeSession ) {
 	const win = new BrowserWindow( {
 		width: 1280,
 		height: 800,
 		title: 'Cortext',
 		icon: APP_ICON,
 		backgroundColor: '#1d1d1d',
-		webPreferences: {
-			contextIsolation: true,
-		},
+		webPreferences: secureWebPreferences( {}, runtimeSession ),
 	} );
 
-	win.on( 'page-title-updated', ( event ) => {
-		event.preventDefault();
-		win.setTitle( 'Cortext' );
-	} );
-
+	configureTrustedWindow( win, runtimeSession );
 	return win;
 }
 
@@ -234,7 +251,7 @@ async function loadSite( win ) {
 		} );
 	} catch ( err ) {
 		console.error( '[cortext-desktop] failed to reach PHP server:', err );
-		await win.loadFile( path.resolve( __dirname, 'error.html' ) );
+		await win.loadFile( ERROR_PAGE );
 	}
 }
 
@@ -242,6 +259,19 @@ app.whenReady().then( async () => {
 	let win = null;
 	try {
 		const authToken = crypto.randomBytes( 32 ).toString( 'hex' );
+		const runtimeSession = session.fromPartition(
+			RUNTIME_SESSION_PARTITION,
+			{ cache: false }
+		);
+		await runtimeSession.clearStorageData( {
+			origin: RUNTIME_ORIGIN,
+			storages: [ 'cookies', 'serviceworkers', 'cachestorage' ],
+		} );
+		removeRuntimeAuthHeader = installRuntimeAuthHeader( runtimeSession, {
+			authHeader: RUNTIME_AUTH_HEADER,
+			authToken,
+			runtimeOrigin: RUNTIME_ORIGIN,
+		} );
 
 		if (
 			process.platform === 'darwin' &&
@@ -252,8 +282,7 @@ app.whenReady().then( async () => {
 		}
 
 		refreshMenu();
-		win = createWindow();
-		installRuntimeAuthHeader( win.webContents, authToken );
+		win = createWindow( runtimeSession );
 		// Load the loading screen before any site refresh so users never stare at
 		// a blank window.
 		await win.loadFile( LOADING_PAGE );
@@ -289,20 +318,29 @@ app.whenReady().then( async () => {
 	} catch ( err ) {
 		console.error( '[cortext-desktop]', err );
 		if ( win ) {
-			win.loadFile( path.resolve( __dirname, 'error.html' ) );
+			win.loadFile( ERROR_PAGE );
 		} else {
 			app.quit();
 		}
 	}
 } );
 
+function stopDesktopRuntime() {
+	stopRuntime( runtimeHandle );
+	runtimeHandle = null;
+	if ( removeRuntimeAuthHeader ) {
+		removeRuntimeAuthHeader();
+		removeRuntimeAuthHeader = null;
+	}
+}
+
 app.on( 'window-all-closed', () => {
 	quitting = true;
-	stopRuntime( runtimeHandle );
+	stopDesktopRuntime();
 	app.quit();
 } );
 
 app.on( 'before-quit', () => {
 	quitting = true;
-	stopRuntime( runtimeHandle );
+	stopDesktopRuntime();
 } );

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -42,6 +42,10 @@
 				"to": "runtime/bin/php"
 			},
 			{
+				"from": "runtime/router.php",
+				"to": "runtime/router.php"
+			},
+			{
 				"from": "runtime/mu-plugins/cortext-update-lock.php",
 				"to": "runtime/mu-plugins/cortext-update-lock.php"
 			}

--- a/apps/desktop/runtime/Caddyfile.frankenphp
+++ b/apps/desktop/runtime/Caddyfile.frankenphp
@@ -6,6 +6,9 @@
 }
 
 http://127.0.0.1:{$CORTEXT_PORT} {
+	@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN}`
+	respond @unauthorized "Forbidden" 403
+
 	root * "{$CORTEXT_WORDPRESS_ROOT}"
 	encode zstd gzip
 	php_server {

--- a/apps/desktop/runtime/Caddyfile.frankenphp
+++ b/apps/desktop/runtime/Caddyfile.frankenphp
@@ -3,16 +3,31 @@
 	auto_https off
 	persist_config off
 	storage file_system {$CORTEXT_CADDY_STORAGE}
+
+	# Error events retain the original request, so redact the private header
+	# at the logger as well as removing it before PHP.
+	log default {
+		format filter {
+			fields {
+				request>headers>X-Cortext-Desktop-Token delete
+			}
+		}
+	}
 }
 
 http://127.0.0.1:{$CORTEXT_PORT} {
-	@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN}`
-	respond @unauthorized "Forbidden" 403
+	# `route` preserves this literal order. Without it, Caddy sorts
+	# request_header ahead of respond and authentication always fails.
+	route {
+		@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN}`
+		respond @unauthorized "Forbidden" 403
 
-	root * "{$CORTEXT_WORDPRESS_ROOT}"
-	encode zstd gzip
-	php_server {
+		request_header -X-Cortext-Desktop-Token
 		root "{$CORTEXT_WORDPRESS_ROOT}"
-		worker worker.php {$CORTEXT_FRANKEN_WORKERS}
+		encode zstd gzip
+		php_server {
+			root "{$CORTEXT_WORDPRESS_ROOT}"
+			worker worker.php {$CORTEXT_FRANKEN_WORKERS}
+		}
 	}
 }

--- a/apps/desktop/runtime/Caddyfile.php-fpm
+++ b/apps/desktop/runtime/Caddyfile.php-fpm
@@ -6,6 +6,9 @@
 }
 
 http://127.0.0.1:{$CORTEXT_PORT} {
+	@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN}`
+	respond @unauthorized "Forbidden" 403
+
 	root * "{$CORTEXT_WORDPRESS_ROOT}"
 	encode zstd gzip
 	php_fastcgi unix/{$CORTEXT_PHP_FPM_SOCKET}

--- a/apps/desktop/runtime/Caddyfile.php-fpm
+++ b/apps/desktop/runtime/Caddyfile.php-fpm
@@ -3,14 +3,29 @@
 	auto_https off
 	persist_config off
 	storage file_system {$CORTEXT_CADDY_STORAGE}
+
+	# Error events retain the original request, so redact the private header
+	# at the logger as well as removing it before PHP.
+	log default {
+		format filter {
+			fields {
+				request>headers>X-Cortext-Desktop-Token delete
+			}
+		}
+	}
 }
 
 http://127.0.0.1:{$CORTEXT_PORT} {
-	@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN}`
-	respond @unauthorized "Forbidden" 403
+	# `route` preserves this literal order. Without it, Caddy sorts
+	# request_header ahead of respond and authentication always fails.
+	route {
+		@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN}`
+		respond @unauthorized "Forbidden" 403
 
-	root * "{$CORTEXT_WORDPRESS_ROOT}"
-	encode zstd gzip
-	php_fastcgi unix/{$CORTEXT_PHP_FPM_SOCKET}
-	file_server
+		request_header -X-Cortext-Desktop-Token
+		root * "{$CORTEXT_WORDPRESS_ROOT}"
+		encode zstd gzip
+		php_fastcgi unix/{$CORTEXT_PHP_FPM_SOCKET}
+		file_server
+	}
 }

--- a/apps/desktop/runtime/router.php
+++ b/apps/desktop/runtime/router.php
@@ -7,6 +7,22 @@
  * The desktop snapshot copies this file into the bundled site.
  */
 
+$expected_token = getenv( 'CORTEXT_DESKTOP_AUTH_TOKEN' );
+$provided_token = $_SERVER['HTTP_X_CORTEXT_DESKTOP_TOKEN'] ?? '';
+
+if (
+	! is_string( $expected_token ) ||
+	$expected_token === '' ||
+	! is_string( $provided_token ) ||
+	! hash_equals( $expected_token, $provided_token )
+) {
+	http_response_code( 403 );
+	header( 'Cache-Control: no-store' );
+	header( 'Content-Type: text/plain; charset=utf-8' );
+	echo 'Forbidden';
+	exit;
+}
+
 $uri = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 if ( $uri !== '/' && file_exists( __DIR__ . $uri ) ) {
 	return false;

--- a/apps/desktop/scripts/bench-runtime.mjs
+++ b/apps/desktop/scripts/bench-runtime.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { createRequire } from 'node:module';
 import {
 	existsSync,
@@ -16,6 +17,7 @@ const require = createRequire( import.meta.url );
 const {
 	DEFAULT_PORT,
 	normalizeRuntime,
+	RUNTIME_AUTH_HEADER,
 	startRuntime,
 	stopRuntime,
 } = require( '../lib/runtime' );
@@ -112,11 +114,19 @@ function redirectedPath( location ) {
 	return `${ url.pathname }${ url.search }`;
 }
 
-function requestPath( endpoint, redirects = 0, startedAt = performance.now() ) {
+function requestPath(
+	endpoint,
+	authToken,
+	redirects = 0,
+	startedAt = performance.now()
+) {
 	return new Promise( ( resolveRequest, rejectRequest ) => {
 		const req = http.get(
 			{
 				host: '127.0.0.1',
+				headers: {
+					[ RUNTIME_AUTH_HEADER ]: authToken,
+				},
 				port: DEFAULT_PORT,
 				path: endpoint.path,
 				timeout: 30000,
@@ -137,6 +147,7 @@ function requestPath( endpoint, redirects = 0, startedAt = performance.now() ) {
 								...endpoint,
 								path: redirectedPath( location ),
 							},
+							authToken,
 							redirects + 1,
 							startedAt
 						).then( resolveRequest, rejectRequest );
@@ -194,14 +205,14 @@ function summarize( samples ) {
 	};
 }
 
-async function runEndpoint( endpoint, warmup, iterations ) {
+async function runEndpoint( endpoint, warmup, iterations, authToken ) {
 	for ( let index = 0; index < warmup; index++ ) {
-		await requestPath( endpoint );
+		await requestPath( endpoint, authToken );
 	}
 
 	const samples = [];
 	for ( let index = 0; index < iterations; index++ ) {
-		samples.push( await requestPath( endpoint ) );
+		samples.push( await requestPath( endpoint, authToken ) );
 	}
 
 	return summarize( samples );
@@ -302,10 +313,12 @@ async function main() {
 
 	const workDir = resolve( DESKTOP_DIR, '.runtime-bench', options.runtime );
 	const wordpressDir = unzipSnapshot( workDir );
+	const authToken = randomBytes( 32 ).toString( 'hex' );
 	process.env.CORTEXT_RUNTIME_QUIET = process.env.CORTEXT_RUNTIME_QUIET || '1';
 	let unexpectedExit = null;
 	const handle = startRuntime( {
 		appDir: DESKTOP_DIR,
+		authToken,
 		wordpressDir,
 		runtime: options.runtime,
 		runtimeStateDir: resolve( workDir, 'state' ),
@@ -326,7 +339,8 @@ async function main() {
 			scenarios[ endpoint.name ] = await runEndpoint(
 				endpoint,
 				options.warmup,
-				options.iterations
+				options.iterations,
+				authToken
 			);
 		}
 

--- a/apps/desktop/scripts/caddy-auth.test.mjs
+++ b/apps/desktop/scripts/caddy-auth.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const CONFIGS = [
+	{
+		name: 'PHP-FPM',
+		path: new URL( '../runtime/Caddyfile.php-fpm', import.meta.url ),
+		upstreamDirective: 'php_fastcgi ',
+	},
+	{
+		name: 'FrankenPHP',
+		path: new URL( '../runtime/Caddyfile.frankenphp', import.meta.url ),
+		upstreamDirective: 'php_server {',
+	},
+];
+
+for ( const config of CONFIGS ) {
+	test( `${ config.name } authenticates before removing the private header`, () => {
+		const caddyfile = fs.readFileSync( config.path, 'utf8' );
+		const authenticateAt = caddyfile.indexOf(
+			'respond @unauthorized "Forbidden" 403'
+		);
+		const removeHeaderAt = caddyfile.indexOf(
+			'request_header -X-Cortext-Desktop-Token'
+		);
+		const upstreamAt = caddyfile.indexOf( config.upstreamDirective );
+
+		assert.notEqual( authenticateAt, -1 );
+		assert.notEqual( removeHeaderAt, -1 );
+		assert.notEqual( upstreamAt, -1 );
+		assert.ok( authenticateAt < removeHeaderAt );
+		assert.ok( removeHeaderAt < upstreamAt );
+	} );
+
+	test( `${ config.name } filters the private header from error logs`, () => {
+		const caddyfile = fs.readFileSync( config.path, 'utf8' );
+
+		assert.match(
+			caddyfile,
+			/log default \{[\s\S]*format filter \{[\s\S]*request>headers>X-Cortext-Desktop-Token delete/
+		);
+	} );
+}

--- a/apps/desktop/scripts/router-auth.test.mjs
+++ b/apps/desktop/scripts/router-auth.test.mjs
@@ -1,0 +1,278 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import runtime from '../lib/runtime.js';
+
+const { RUNTIME_AUTH_HEADER, startRuntime, stopRuntime } = runtime;
+const AUTH_TOKEN = 'test-runtime-auth-token';
+const DESKTOP_DIR = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'..'
+);
+
+function makeFixture() {
+	const wordpressDir = fs.mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-router-auth-' )
+	);
+	fs.copyFileSync(
+		new URL( '../runtime/router.php', import.meta.url ),
+		path.join( wordpressDir, 'router.php' )
+	);
+	fs.writeFileSync(
+		path.join( wordpressDir, 'index.php' ),
+		"<?php header( 'Content-Type: text/plain' ); echo 'dynamic';"
+	);
+	fs.writeFileSync( path.join( wordpressDir, 'static.txt' ), 'static' );
+	return wordpressDir;
+}
+
+function makeUnprotectedFixture() {
+	const wordpressDir = fs.mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-router-legacy-' )
+	);
+	fs.writeFileSync(
+		path.join( wordpressDir, 'router.php' ),
+		"<?php header( 'Content-Type: text/plain' ); echo 'legacy';"
+	);
+	fs.writeFileSync( path.join( wordpressDir, 'index.php' ), 'legacy' );
+	return wordpressDir;
+}
+
+async function findAvailablePort() {
+	const server = net.createServer();
+	server.unref();
+	server.listen( 0, '127.0.0.1' );
+	await once( server, 'listening' );
+	const address = server.address();
+	assert.notEqual( address, null );
+	assert.equal( typeof address, 'object' );
+	const { port } = address;
+	server.close();
+	await once( server, 'close' );
+	return port;
+}
+
+function request( port, requestPath, authToken ) {
+	return new Promise( ( resolve, reject ) => {
+		const headers = {};
+		if ( authToken !== undefined ) {
+			headers[ RUNTIME_AUTH_HEADER ] = authToken;
+		}
+
+		const req = http.get(
+			{
+				host: '127.0.0.1',
+				port,
+				path: requestPath,
+				headers,
+			},
+			( response ) => {
+				let body = '';
+				response.setEncoding( 'utf8' );
+				response.on( 'data', ( chunk ) => {
+					body += chunk;
+				} );
+				response.on( 'end', () => {
+					resolve( {
+						statusCode: response.statusCode,
+						headers: response.headers,
+						body,
+					} );
+				} );
+			}
+		);
+		req.on( 'error', reject );
+	} );
+}
+
+async function waitForServer( child, port, stderr ) {
+	for ( let attempt = 0; attempt < 100; attempt++ ) {
+		if ( child.exitCode !== null ) {
+			throw new Error(
+				`PHP server exited before becoming ready: ${ stderr() }`
+			);
+		}
+
+		try {
+			await request( port, '/', undefined );
+			return;
+		} catch ( error ) {
+			if ( error.code !== 'ECONNREFUSED' ) {
+				throw error;
+			}
+		}
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 25 ) );
+	}
+
+	throw new Error( `PHP server did not become ready: ${ stderr() }` );
+}
+
+async function startServer( wordpressDir, authToken ) {
+	const port = await findAvailablePort();
+	const env = { ...process.env };
+	if ( authToken === undefined ) {
+		delete env.CORTEXT_DESKTOP_AUTH_TOKEN;
+	} else {
+		env.CORTEXT_DESKTOP_AUTH_TOKEN = authToken;
+	}
+
+	const child = spawn(
+		'php',
+		[
+			'-S',
+			`127.0.0.1:${ port }`,
+			'-t',
+			wordpressDir,
+			path.join( wordpressDir, 'router.php' ),
+		],
+		{
+			cwd: wordpressDir,
+			env,
+			stdio: [ 'ignore', 'ignore', 'pipe' ],
+		}
+	);
+	let stderr = '';
+	child.stderr.setEncoding( 'utf8' );
+	child.stderr.on( 'data', ( chunk ) => {
+		stderr += chunk;
+	} );
+	try {
+		await waitForServer( child, port, () => stderr );
+	} catch ( error ) {
+		await stopServer( child );
+		fs.rmSync( wordpressDir, { recursive: true, force: true } );
+		throw error;
+	}
+	return { child, port };
+}
+
+async function stopServer( child ) {
+	if ( child.exitCode !== null || child.signalCode !== null ) {
+		return;
+	}
+	const exit = once( child, 'exit' );
+	child.kill( 'SIGTERM' );
+	await exit;
+}
+
+function registerCleanup( context, child, wordpressDir ) {
+	context.after( async () => {
+		await stopServer( child );
+		fs.rmSync( wordpressDir, { recursive: true, force: true } );
+	} );
+}
+
+test( 'startRuntime requires a non-empty auth token', () => {
+	const options = {
+		appDir: '/unused',
+		wordpressDir: '/unused',
+	};
+
+	assert.throws(
+		() => startRuntime( options ),
+		/startRuntime requires a non-empty authToken/
+	);
+	assert.throws(
+		() => startRuntime( { ...options, authToken: '   ' } ),
+		/startRuntime requires a non-empty authToken/
+	);
+} );
+
+test( 'startRuntime replaces an unprotected legacy router before listening', async ( context ) => {
+	const wordpressDir = makeUnprotectedFixture();
+	const port = await findAvailablePort();
+	const handle = startRuntime( {
+		appDir: DESKTOP_DIR,
+		authToken: AUTH_TOKEN,
+		port,
+		runtime: 'php',
+		runtimeStateDir: path.join( wordpressDir, 'runtime-state' ),
+		wordpressDir,
+	} );
+	context.after( () => {
+		stopRuntime( handle );
+		fs.rmSync( wordpressDir, { recursive: true, force: true } );
+	} );
+
+	assert.match(
+		fs.readFileSync( path.join( wordpressDir, 'router.php' ), 'utf8' ),
+		/hash_equals/
+	);
+	await handle.ready;
+	const unauthenticated = await request( port, '/', undefined );
+	assert.equal( unauthenticated.statusCode, 403 );
+	const authenticated = await request( port, '/', AUTH_TOKEN );
+	assert.equal( authenticated.statusCode, 200 );
+	assert.equal( authenticated.body, 'legacy' );
+} );
+
+test( 'startRuntime fails before listening without its authenticated router', async () => {
+	const wordpressDir = makeUnprotectedFixture();
+	const port = await findAvailablePort();
+	const appDir = fs.mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-router-missing-app-' )
+	);
+	try {
+		assert.throws(
+			() =>
+				startRuntime( {
+					appDir,
+					authToken: AUTH_TOKEN,
+					port,
+					runtime: 'php',
+					runtimeStateDir: path.join( wordpressDir, 'runtime-state' ),
+					wordpressDir,
+				} ),
+			/Authenticated desktop router not found/
+		);
+		await assert.rejects( request( port, '/', undefined ), /ECONNREFUSED/ );
+	} finally {
+		fs.rmSync( appDir, { recursive: true, force: true } );
+		fs.rmSync( wordpressDir, { recursive: true, force: true } );
+	}
+} );
+
+test( 'router authenticates static and dynamic requests', async ( context ) => {
+	const wordpressDir = makeFixture();
+	const { child, port } = await startServer( wordpressDir, AUTH_TOKEN );
+	registerCleanup( context, child, wordpressDir );
+
+	for ( const requestPath of [ '/static.txt', '/dynamic' ] ) {
+		const missing = await request( port, requestPath, undefined );
+		assert.equal( missing.statusCode, 403 );
+		assert.equal( missing.headers[ 'cache-control' ], 'no-store' );
+
+		const wrong = await request( port, requestPath, 'wrong-token' );
+		assert.equal( wrong.statusCode, 403 );
+
+		const authenticated = await request( port, requestPath, AUTH_TOKEN );
+		assert.equal( authenticated.statusCode, 200 );
+		assert.equal(
+			authenticated.body,
+			requestPath === '/static.txt' ? 'static' : 'dynamic'
+		);
+	}
+} );
+
+test( 'router fails closed when its auth token is not configured', async ( context ) => {
+	const wordpressDir = makeFixture();
+	const { child, port } = await startServer( wordpressDir, undefined );
+	registerCleanup( context, child, wordpressDir );
+
+	for ( const requestPath of [ '/static.txt', '/dynamic' ] ) {
+		const missing = await request( port, requestPath, undefined );
+		assert.equal( missing.statusCode, 403 );
+
+		const supplied = await request( port, requestPath, AUTH_TOKEN );
+		assert.equal( supplied.statusCode, 403 );
+	}
+} );

--- a/apps/desktop/scripts/runtime-session.test.mjs
+++ b/apps/desktop/scripts/runtime-session.test.mjs
@@ -7,6 +7,11 @@ const { installRuntimeAuthHeader } = runtimeSessionModule;
 const AUTH_HEADER = 'X-Cortext-Desktop-Token';
 const AUTH_TOKEN = 'private-runtime-token';
 const RUNTIME_ORIGIN = 'http://127.0.0.1:9402';
+const LOADING_URL = 'file:///Applications/Cortext.app/loading.html';
+const RUNTIME_FRAME = {
+	url: `${ RUNTIME_ORIGIN }/wp-admin/admin.php?page=cortext`,
+	origin: RUNTIME_ORIGIN,
+};
 
 function makeSession() {
 	const listeners = {};
@@ -34,10 +39,20 @@ function sendHeaders( listener, details ) {
 			{
 				id: 1,
 				requestHeaders: {},
+				frame: RUNTIME_FRAME,
 				...details,
 			},
 			resolve
 		);
+	} );
+}
+
+function install( session ) {
+	return installRuntimeAuthHeader( session, {
+		authHeader: AUTH_HEADER,
+		authToken: AUTH_TOKEN,
+		runtimeOrigin: RUNTIME_ORIGIN,
+		trustedDocumentUrls: [ LOADING_URL ],
 	} );
 }
 
@@ -66,11 +81,7 @@ test( 'requires a non-empty token and header name', () => {
 
 test( 'authenticates runtime requests and replaces spoofed headers', async () => {
 	const { listeners, session } = makeSession();
-	installRuntimeAuthHeader( session, {
-		authHeader: AUTH_HEADER,
-		authToken: AUTH_TOKEN,
-		runtimeOrigin: RUNTIME_ORIGIN,
-	} );
+	install( session );
 
 	const result = await sendHeaders( listeners.onBeforeSendHeaders, {
 		url: `${ RUNTIME_ORIGIN }/wp-admin/`,
@@ -89,11 +100,7 @@ test( 'authenticates runtime requests and replaces spoofed headers', async () =>
 
 test( 'never sends the runtime token to another origin', async () => {
 	const { listeners, session } = makeSession();
-	installRuntimeAuthHeader( session, {
-		authHeader: AUTH_HEADER,
-		authToken: AUTH_TOKEN,
-		runtimeOrigin: RUNTIME_ORIGIN,
-	} );
+	install( session );
 
 	const result = await sendHeaders( listeners.onBeforeSendHeaders, {
 		url: 'https://example.com/image.png',
@@ -108,11 +115,7 @@ test( 'never sends the runtime token to another origin', async () => {
 
 test( 'does not authenticate a redirect chain that leaves the runtime', async () => {
 	const { listeners, session } = makeSession();
-	installRuntimeAuthHeader( session, {
-		authHeader: AUTH_HEADER,
-		authToken: AUTH_TOKEN,
-		runtimeOrigin: RUNTIME_ORIGIN,
-	} );
+	install( session );
 
 	listeners.onBeforeRedirect( {
 		id: 42,
@@ -151,13 +154,76 @@ test( 'does not authenticate a redirect chain that leaves the runtime', async ()
 	);
 } );
 
+test( 'authenticates the shell page navigating to the runtime', async () => {
+	const { listeners, session } = makeSession();
+	install( session );
+
+	const result = await sendHeaders( listeners.onBeforeSendHeaders, {
+		url: `${ RUNTIME_ORIGIN }/wp-admin/admin.php?page=cortext`,
+		frame: { url: LOADING_URL, origin: 'file://' },
+	} );
+
+	assert.equal( result.requestHeaders[ AUTH_HEADER ], AUTH_TOKEN );
+} );
+
+test( 'never authenticates a request from embedded third-party content', async () => {
+	const { listeners, session } = makeSession();
+	install( session );
+
+	const embeddedFrames = [
+		{
+			url: 'https://www.youtube.com/embed/x',
+			origin: 'https://www.youtube.com',
+		},
+		// A frame nested inside the embed inherits the provider's origin.
+		{ url: 'about:blank', origin: 'https://www.youtube.com' },
+		// A popup an embed opened starts empty but keeps the opener's origin.
+		{ url: '', origin: 'https://www.youtube.com' },
+	];
+
+	for ( const frame of embeddedFrames ) {
+		const result = await sendHeaders( listeners.onBeforeSendHeaders, {
+			url: `${ RUNTIME_ORIGIN }/wp-admin/`,
+			frame,
+		} );
+		assert.equal( result.requestHeaders[ AUTH_HEADER ], undefined );
+	}
+} );
+
+test( 'never authenticates a request that arrives without a frame', async () => {
+	const { listeners, session } = makeSession();
+	install( session );
+
+	// Service workers and main-process fetches both land here, and embedded
+	// content can register a worker.
+	for ( const frame of [ undefined, null ] ) {
+		const result = await sendHeaders( listeners.onBeforeSendHeaders, {
+			url: `${ RUNTIME_ORIGIN }/wp-admin/`,
+			frame,
+		} );
+		assert.equal( result.requestHeaders[ AUTH_HEADER ], undefined );
+	}
+} );
+
+test( 'never authenticates a request whose frame was disposed', async () => {
+	const { listeners, session } = makeSession();
+	install( session );
+
+	const result = await sendHeaders( listeners.onBeforeSendHeaders, {
+		url: `${ RUNTIME_ORIGIN }/wp-admin/`,
+		frame: {
+			get origin() {
+				throw new Error( 'Render frame was disposed' );
+			},
+		},
+	} );
+
+	assert.equal( result.requestHeaders[ AUTH_HEADER ], undefined );
+} );
+
 test( 'cleans up all dedicated-session listeners idempotently', () => {
 	const { listeners, session } = makeSession();
-	const remove = installRuntimeAuthHeader( session, {
-		authHeader: AUTH_HEADER,
-		authToken: AUTH_TOKEN,
-		runtimeOrigin: RUNTIME_ORIGIN,
-	} );
+	const remove = install( session );
 
 	remove();
 	remove();

--- a/apps/desktop/scripts/runtime-session.test.mjs
+++ b/apps/desktop/scripts/runtime-session.test.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import runtimeSessionModule from '../lib/runtime-session.js';
+
+const { installRuntimeAuthHeader } = runtimeSessionModule;
+const AUTH_HEADER = 'X-Cortext-Desktop-Token';
+const AUTH_TOKEN = 'private-runtime-token';
+const RUNTIME_ORIGIN = 'http://127.0.0.1:9402';
+
+function makeSession() {
+	const listeners = {};
+	const webRequest = {};
+	for ( const eventName of [
+		'onBeforeRedirect',
+		'onBeforeSendHeaders',
+		'onCompleted',
+		'onErrorOccurred',
+	] ) {
+		webRequest[ eventName ] = ( filter, listener ) => {
+			if ( filter === null ) {
+				listeners[ eventName ] = null;
+				return;
+			}
+			listeners[ eventName ] = listener;
+		};
+	}
+	return { listeners, session: { webRequest } };
+}
+
+function sendHeaders( listener, details ) {
+	return new Promise( ( resolve ) => {
+		listener(
+			{
+				id: 1,
+				requestHeaders: {},
+				...details,
+			},
+			resolve
+		);
+	} );
+}
+
+test( 'requires a non-empty token and header name', () => {
+	const { session } = makeSession();
+
+	assert.throws(
+		() =>
+			installRuntimeAuthHeader( session, {
+				authHeader: AUTH_HEADER,
+				authToken: '',
+				runtimeOrigin: RUNTIME_ORIGIN,
+			} ),
+		/requires a non-empty authToken/
+	);
+	assert.throws(
+		() =>
+			installRuntimeAuthHeader( session, {
+				authHeader: ' ',
+				authToken: AUTH_TOKEN,
+				runtimeOrigin: RUNTIME_ORIGIN,
+			} ),
+		/requires a non-empty authHeader/
+	);
+} );
+
+test( 'authenticates runtime requests and replaces spoofed headers', async () => {
+	const { listeners, session } = makeSession();
+	installRuntimeAuthHeader( session, {
+		authHeader: AUTH_HEADER,
+		authToken: AUTH_TOKEN,
+		runtimeOrigin: RUNTIME_ORIGIN,
+	} );
+
+	const result = await sendHeaders( listeners.onBeforeSendHeaders, {
+		url: `${ RUNTIME_ORIGIN }/wp-admin/`,
+		requestHeaders: {
+			'User-Agent': 'Cortext test',
+			'x-cortext-desktop-token': 'spoofed-lowercase',
+			'X-CORTEXT-DESKTOP-TOKEN': 'spoofed-uppercase',
+		},
+	} );
+
+	assert.deepEqual( result.requestHeaders, {
+		'User-Agent': 'Cortext test',
+		[ AUTH_HEADER ]: AUTH_TOKEN,
+	} );
+} );
+
+test( 'never sends the runtime token to another origin', async () => {
+	const { listeners, session } = makeSession();
+	installRuntimeAuthHeader( session, {
+		authHeader: AUTH_HEADER,
+		authToken: AUTH_TOKEN,
+		runtimeOrigin: RUNTIME_ORIGIN,
+	} );
+
+	const result = await sendHeaders( listeners.onBeforeSendHeaders, {
+		url: 'https://example.com/image.png',
+		requestHeaders: {
+			[ AUTH_HEADER ]: 'spoofed',
+			Accept: 'image/*',
+		},
+	} );
+
+	assert.deepEqual( result.requestHeaders, { Accept: 'image/*' } );
+} );
+
+test( 'does not authenticate a redirect chain that leaves the runtime', async () => {
+	const { listeners, session } = makeSession();
+	installRuntimeAuthHeader( session, {
+		authHeader: AUTH_HEADER,
+		authToken: AUTH_TOKEN,
+		runtimeOrigin: RUNTIME_ORIGIN,
+	} );
+
+	listeners.onBeforeRedirect( {
+		id: 42,
+		url: 'https://example.com/redirect',
+		redirectURL: `${ RUNTIME_ORIGIN }/wp-json/`,
+	} );
+	const redirected = await sendHeaders( listeners.onBeforeSendHeaders, {
+		id: 42,
+		url: `${ RUNTIME_ORIGIN }/wp-json/`,
+	} );
+
+	assert.equal( redirected.requestHeaders[ AUTH_HEADER ], undefined );
+
+	listeners.onErrorOccurred( { id: 42 } );
+	const laterRequest = await sendHeaders( listeners.onBeforeSendHeaders, {
+		id: 42,
+		url: `${ RUNTIME_ORIGIN }/wp-json/`,
+	} );
+	assert.equal( laterRequest.requestHeaders[ AUTH_HEADER ], AUTH_TOKEN );
+
+	await sendHeaders( listeners.onBeforeSendHeaders, {
+		id: 43,
+		url: 'https://example.com/redirect',
+	} );
+	listeners.onCompleted( { id: 43 } );
+	const completedRequestId = await sendHeaders(
+		listeners.onBeforeSendHeaders,
+		{
+			id: 43,
+			url: `${ RUNTIME_ORIGIN }/wp-json/`,
+		}
+	);
+	assert.equal(
+		completedRequestId.requestHeaders[ AUTH_HEADER ],
+		AUTH_TOKEN
+	);
+} );
+
+test( 'cleans up all dedicated-session listeners idempotently', () => {
+	const { listeners, session } = makeSession();
+	const remove = installRuntimeAuthHeader( session, {
+		authHeader: AUTH_HEADER,
+		authToken: AUTH_TOKEN,
+		runtimeOrigin: RUNTIME_ORIGIN,
+	} );
+
+	remove();
+	remove();
+
+	assert.deepEqual( listeners, {
+		onBeforeRedirect: null,
+		onBeforeSendHeaders: null,
+		onCompleted: null,
+		onErrorOccurred: null,
+	} );
+} );

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -10,49 +10,114 @@
  * snapshot` first.
  */
 const { test, expect, _electron: electron } = require( '@playwright/test' );
+const http = require( 'node:http' );
 const path = require( 'node:path' );
-const { existsSync, rmSync } = require( 'node:fs' );
+const { existsSync, mkdtempSync, rmSync } = require( 'node:fs' );
 const os = require( 'node:os' );
 
 const APP_PATH = path.resolve( __dirname, '..' );
 const SNAPSHOT_PATH = path.join( APP_PATH, 'snapshot.zip' );
+let e2eTempRoot;
+let untrustedServer;
+let untrustedOrigin;
 
-// Electron's `app.getPath('userData')` uses the package name on macOS and
-// Linux. Start from a fresh userData dir so launch has to extract the
-// snapshot, same as a first run.
-function getUserDataPath() {
-	const home = os.homedir();
-	if ( process.platform === 'darwin' ) {
-		return path.join( home, 'Library/Application Support/cortext-desktop' );
-	}
-	if ( process.platform === 'win32' ) {
-		return path.join( process.env.APPDATA ?? home, 'cortext-desktop' );
-	}
-	return path.join(
-		process.env.XDG_CONFIG_HOME ?? path.join( home, '.config' ),
-		'cortext-desktop'
-	);
-}
-
-test.beforeAll( () => {
+test.beforeAll( async () => {
 	if ( ! existsSync( SNAPSHOT_PATH ) ) {
 		throw new Error(
 			`Missing ${ SNAPSHOT_PATH }. Run 'npm --prefix apps/desktop run snapshot' first.`
 		);
 	}
-	const userData = getUserDataPath();
-	if ( existsSync( userData ) ) {
-		rmSync( userData, { recursive: true, force: true } );
+	e2eTempRoot = mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-desktop-e2e-' )
+	);
+	untrustedServer = http.createServer( ( request, response ) => {
+		if ( request.url === '/redirect-runtime' ) {
+			response.writeHead( 302, {
+				'Cache-Control': 'no-store',
+				Location: 'http://127.0.0.1:9402/wp-includes/images/blank.gif',
+			} );
+			response.end();
+			return;
+		}
+
+		response.writeHead( 200, {
+			'Content-Type': 'text/html; charset=utf-8',
+			'Referrer-Policy': 'no-referrer',
+		} );
+		response.end(
+			`<!doctype html>
+			<body data-runtime-image="pending">
+				<img
+					src="http://127.0.0.1:9402/wp-includes/images/blank.gif"
+					onload="document.body.dataset.runtimeImage='loaded'"
+					onerror="document.body.dataset.runtimeImage='blocked'"
+				>
+				<a
+					id="runtime-link"
+					target="_top"
+					href="http://127.0.0.1:9402/wp-json/"
+					style="position:fixed;inset:0;display:block"
+				>Open runtime</a>
+			</body>`
+		);
+	} );
+	await new Promise( ( resolve, reject ) => {
+		untrustedServer.once( 'error', reject );
+		untrustedServer.listen( 0, '127.0.0.1', resolve );
+	} );
+	const address = untrustedServer.address();
+	if ( ! address || typeof address === 'string' ) {
+		throw new Error( 'Failed to start the untrusted E2E server.' );
+	}
+	untrustedOrigin = `http://127.0.0.1:${ address.port }/`;
+} );
+
+test.afterAll( async () => {
+	if ( untrustedServer ) {
+		await new Promise( ( resolve, reject ) => {
+			untrustedServer.close( ( error ) => {
+				if ( error ) {
+					reject( error );
+					return;
+				}
+				resolve();
+			} );
+		} );
+	}
+	if ( e2eTempRoot ) {
+		rmSync( e2eTempRoot, {
+			recursive: true,
+			force: true,
+			maxRetries: 3,
+		} );
 	}
 } );
 
 function launchDesktopApp() {
+	const userDataPath = mkdtempSync( path.join( e2eTempRoot, 'user-data-' ) );
 	return electron.launch( {
 		args: [ APP_PATH ],
 		env: {
 			...process.env,
 			CORTEXT_DEVTOOLS: '0',
+			CORTEXT_E2E: '1',
+			CORTEXT_E2E_USER_DATA_DIR: userDataPath,
 		},
+	} );
+}
+
+function requestWithoutRuntimeAuth( url ) {
+	return new Promise( ( resolve, reject ) => {
+		const request = http.get( url, ( response ) => {
+			response.resume();
+			response.once( 'end', () => resolve( response.statusCode ) );
+		} );
+		request.setTimeout( 10000, () => {
+			request.destroy(
+				new Error( `Unauthenticated request timed out: ${ url }` )
+			);
+		} );
+		request.once( 'error', reject );
 	} );
 }
 
@@ -104,12 +169,52 @@ function waitForProcessExit( app, timeoutMs = 10000 ) {
 	} );
 }
 
-test( 'opens the first Cortext document', async () => {
+test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 	const app = await launchDesktopApp();
 
 	try {
 		const window = await waitForCortextShell( app );
 		await expect.poll( () => window.title() ).toBe( 'Cortext' );
+		const staticAssetUrl = new URL(
+			'/wp-includes/css/dashicons.min.css',
+			window.url()
+		);
+		await expect(
+			requestWithoutRuntimeAuth( staticAssetUrl )
+		).resolves.toBe( 403 );
+		const redirectedImageStatus = await window.evaluate( ( origin ) => {
+			return new Promise( ( resolve ) => {
+				const image = new Image();
+				image.onload = () => resolve( 'loaded' );
+				image.onerror = () => resolve( 'blocked' );
+				image.src = new URL( '/redirect-runtime', origin ).href;
+				document.body.append( image );
+			} );
+		}, untrustedOrigin );
+		expect( redirectedImageStatus ).toBe( 'blocked' );
+
+		const untrustedFrameNavigation = window.waitForEvent(
+			'framenavigated',
+			( frame ) => frame.url() === untrustedOrigin
+		);
+		await window.evaluate( ( url ) => {
+			const frame = document.createElement( 'iframe' );
+			frame.src = url;
+			frame.style =
+				'position:fixed;z-index:2147483647;inset:0;width:100vw;height:100vh;pointer-events:auto';
+			document.body.append( frame );
+		}, untrustedOrigin );
+		const untrustedFrame = await untrustedFrameNavigation;
+		await expect
+			.poll( () =>
+				untrustedFrame
+					.locator( 'body' )
+					.getAttribute( 'data-runtime-image' )
+			)
+			.toBe( 'blocked' );
+		await untrustedFrame.locator( '#runtime-link' ).click();
+		await window.waitForURL( 'http://127.0.0.1:9402/wp-json/' );
+		await expect( window.locator( 'body' ) ).toHaveText( 'Forbidden' );
 	} finally {
 		await app.close();
 	}
@@ -121,6 +226,12 @@ test( 'exits after closing its only window', async () => {
 
 	try {
 		const window = await waitForCortextShell( app );
+		await window.reload();
+		await expect(
+			window.locator(
+				'.cortext-workspace__pane[data-active="true"] .cortext-canvas'
+			)
+		).toBeVisible( { timeout: 30 * 1000 } );
 		const exitPromise = waitForProcessExit( app );
 		await window.close();
 		await exitPromise;

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -12,7 +12,7 @@
 const { test, expect, _electron: electron } = require( '@playwright/test' );
 const http = require( 'node:http' );
 const path = require( 'node:path' );
-const { existsSync, mkdtempSync, rmSync } = require( 'node:fs' );
+const { existsSync, mkdtempSync, realpathSync, rmSync } = require( 'node:fs' );
 const os = require( 'node:os' );
 
 const APP_PATH = path.resolve( __dirname, '..' );
@@ -20,6 +20,7 @@ const SNAPSHOT_PATH = path.join( APP_PATH, 'snapshot.zip' );
 let e2eTempRoot;
 let untrustedServer;
 let untrustedOrigin;
+let untrustedRequests;
 
 test.beforeAll( async () => {
 	if ( ! existsSync( SNAPSHOT_PATH ) ) {
@@ -30,7 +31,12 @@ test.beforeAll( async () => {
 	e2eTempRoot = mkdtempSync(
 		path.join( os.tmpdir(), 'cortext-desktop-e2e-' )
 	);
+	untrustedRequests = [];
 	untrustedServer = http.createServer( ( request, response ) => {
+		untrustedRequests.push( {
+			url: request.url,
+			runtimeToken: request.headers[ 'x-cortext-desktop-token' ],
+		} );
 		if ( request.url === '/redirect-runtime' ) {
 			response.writeHead( 302, {
 				'Cache-Control': 'no-store',
@@ -93,17 +99,38 @@ test.afterAll( async () => {
 	}
 } );
 
-function launchDesktopApp() {
-	const userDataPath = mkdtempSync( path.join( e2eTempRoot, 'user-data-' ) );
-	return electron.launch( {
-		args: [ APP_PATH ],
+async function launchDesktopApp(
+	userDataPath = mkdtempSync( path.join( e2eTempRoot, 'user-data-' ) )
+) {
+	const app = await electron.launch( {
+		args: [ APP_PATH, `--user-data-dir=${ userDataPath }` ],
 		env: {
 			...process.env,
 			CORTEXT_DEVTOOLS: '0',
 			CORTEXT_E2E: '1',
-			CORTEXT_E2E_USER_DATA_DIR: userDataPath,
 		},
 	} );
+	return { app, userDataPath };
+}
+
+async function expectTemporaryUserData( app, userDataPath ) {
+	await expect
+		.poll(
+			async () => {
+				try {
+					const actualUserDataPath = await app.evaluate(
+						( { app } ) => app.getPath( 'userData' )
+					);
+					return realpathSync( actualUserDataPath );
+				} catch {
+					// Electron can replace its initial execution context while
+					// the first BrowserWindow is navigating.
+					return null;
+				}
+			},
+			{ timeout: 10 * 1000 }
+		)
+		.toBe( realpathSync( userDataPath ) );
 }
 
 function requestWithoutRuntimeAuth( url ) {
@@ -144,6 +171,149 @@ async function waitForCortextShell( app ) {
 	return window;
 }
 
+function reloadFirstRuntimeNavigationFromMenu( app ) {
+	return app.evaluate( ( { BrowserWindow, Menu } ) => {
+		return new Promise( ( resolve, reject ) => {
+			const win = BrowserWindow.getAllWindows()[ 0 ];
+			const webContents = win.webContents;
+			const findMenuItem = ( items, role ) => {
+				for ( const item of items ) {
+					if ( item.role === role ) {
+						return item;
+					}
+					if ( item.submenu ) {
+						const nested = findMenuItem( item.submenu.items, role );
+						if ( nested ) {
+							return nested;
+						}
+					}
+				}
+				return null;
+			};
+			const reloadItem = findMenuItem(
+				Menu.getApplicationMenu().items,
+				'reload'
+			);
+			if ( ! reloadItem ) {
+				reject( new Error( 'Reload menu item not found.' ) );
+				return;
+			}
+
+			let reloadStarted = false;
+			const timer = setTimeout( () => {
+				cleanup();
+				reject(
+					new Error(
+						'The first runtime navigation was not reloaded from the menu.'
+					)
+				);
+			}, 90 * 1000 );
+			const cleanup = () => {
+				clearTimeout( timer );
+				webContents.off( 'did-navigate', onNavigate );
+				webContents.off( 'did-start-navigation', onStart );
+				webContents.off( 'did-finish-load', onFinish );
+			};
+			const onStart = ( event ) => {
+				if (
+					event.isMainFrame &&
+					event.url.startsWith( 'http://127.0.0.1:9402/' )
+				) {
+					reloadStarted = true;
+				}
+			};
+			const onFinish = () => {
+				if ( ! reloadStarted ) {
+					return;
+				}
+				cleanup();
+				resolve( webContents.getURL() );
+			};
+			const onNavigate = ( _event, url ) => {
+				if (
+					! url.startsWith(
+						'http://127.0.0.1:9402/wp-admin/admin.php?page=cortext'
+					)
+				) {
+					return;
+				}
+				webContents.off( 'did-navigate', onNavigate );
+				webContents.on( 'did-start-navigation', onStart );
+				webContents.on( 'did-finish-load', onFinish );
+				reloadItem.click( {}, win, webContents );
+			};
+
+			webContents.on( 'did-navigate', onNavigate );
+		} );
+	} );
+}
+
+function openExternalFromRuntime(
+	app,
+	externalUrl,
+	target,
+	windowUrlSuffix = null
+) {
+	return app.evaluate(
+		( { BrowserWindow, shell }, options ) => {
+			return new Promise( ( resolve, reject ) => {
+				const originalOpenExternal = shell.openExternal;
+				let settled = false;
+				const finish = ( callback, value ) => {
+					if ( settled ) {
+						return;
+					}
+					settled = true;
+					clearTimeout( timer );
+					shell.openExternal = originalOpenExternal;
+					callback( value );
+				};
+				const timer = setTimeout( () => {
+					finish(
+						reject,
+						new Error(
+							'External navigation was not routed to the OS browser.'
+						)
+					);
+				}, 10 * 1000 );
+				shell.openExternal = ( openedUrl ) => {
+					finish( resolve, openedUrl );
+					return Promise.resolve();
+				};
+
+				const targetWindow = BrowserWindow.getAllWindows().find(
+					( candidate ) => {
+						const url = candidate.webContents.getURL();
+						return options.windowUrlSuffix
+							? url.endsWith( options.windowUrlSuffix )
+							: url.startsWith( 'http://127.0.0.1:9402/' );
+					}
+				);
+				if ( ! targetWindow ) {
+					finish(
+						reject,
+						new Error( 'Cortext runtime window not found.' )
+					);
+					return;
+				}
+
+				const script =
+					options.target === '_blank'
+						? `window.open(${ JSON.stringify(
+								options.externalUrl
+						  ) }, '_blank')`
+						: `window.location.assign(${ JSON.stringify(
+								options.externalUrl
+						  ) })`;
+				targetWindow.webContents
+					.executeJavaScript( script )
+					.catch( ( error ) => finish( reject, error ) );
+			} );
+		},
+		{ externalUrl, target, windowUrlSuffix }
+	);
+}
+
 function waitForProcessExit( app, timeoutMs = 10000 ) {
 	const child = app.process();
 	return new Promise( ( resolve, reject ) => {
@@ -170,18 +340,49 @@ function waitForProcessExit( app, timeoutMs = 10000 ) {
 }
 
 test( 'opens Cortext and rejects untrusted runtime requests', async () => {
-	const app = await launchDesktopApp();
+	const { app, userDataPath } = await launchDesktopApp();
+	untrustedRequests.length = 0;
 
 	try {
+		await expectTemporaryUserData( app, userDataPath );
 		const window = await waitForCortextShell( app );
 		await expect.poll( () => window.title() ).toBe( 'Cortext' );
 		const staticAssetUrl = new URL(
 			'/wp-includes/css/dashicons.min.css',
 			window.url()
 		);
+		const sessionSecurity = await app.evaluate(
+			async ( { BrowserWindow, session }, assetUrl ) => {
+				const mainWindow = BrowserWindow.getAllWindows()[ 0 ];
+				const runtimeSession =
+					session.fromPartition( 'persist:cortext' );
+				const trustedResponse = await runtimeSession.fetch( assetUrl );
+				await trustedResponse.arrayBuffer();
+				const untrustedResponse =
+					await session.defaultSession.fetch( assetUrl );
+				await untrustedResponse.arrayBuffer();
+				return {
+					mainUsesRuntimeSession:
+						mainWindow.webContents.session === runtimeSession,
+					cacheSize: await runtimeSession.getCacheSize(),
+					isPersistent: runtimeSession.isPersistent(),
+					trustedStatus: trustedResponse.status,
+					untrustedStatus: untrustedResponse.status,
+				};
+			},
+			staticAssetUrl.href
+		);
+		expect( sessionSecurity ).toEqual( {
+			mainUsesRuntimeSession: true,
+			cacheSize: 0,
+			isPersistent: true,
+			trustedStatus: 200,
+			untrustedStatus: 403,
+		} );
 		await expect(
 			requestWithoutRuntimeAuth( staticAssetUrl )
 		).resolves.toBe( 403 );
+
 		const redirectedImageStatus = await window.evaluate( ( origin ) => {
 			return new Promise( ( resolve ) => {
 				const image = new Image();
@@ -192,53 +393,214 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 			} );
 		}, untrustedOrigin );
 		expect( redirectedImageStatus ).toBe( 'blocked' );
+		expect(
+			untrustedRequests.find(
+				( request ) => request.url === '/redirect-runtime'
+			)?.runtimeToken
+		).toBeUndefined();
 
-		const untrustedFrameNavigation = window.waitForEvent(
-			'framenavigated',
-			( frame ) => frame.url() === untrustedOrigin
+		const blockedFrameAttempt = app.evaluate(
+			( { BrowserWindow }, targetUrl ) => {
+				return new Promise( ( resolve, reject ) => {
+					const webContents =
+						BrowserWindow.getAllWindows()[ 0 ].webContents;
+					const timer = setTimeout( () => {
+						webContents.off(
+							'will-frame-navigate',
+							onFrameNavigate
+						);
+						reject(
+							new Error(
+								'External iframe navigation was not observed.'
+							)
+						);
+					}, 10 * 1000 );
+					const onFrameNavigate = ( event ) => {
+						if ( event.url !== targetUrl ) {
+							return;
+						}
+						clearTimeout( timer );
+						webContents.off(
+							'will-frame-navigate',
+							onFrameNavigate
+						);
+						resolve( {
+							defaultPrevented: event.defaultPrevented,
+							isMainFrame: event.isMainFrame,
+						} );
+					};
+					webContents.on( 'will-frame-navigate', onFrameNavigate );
+				} );
+			},
+			untrustedOrigin
 		);
 		await window.evaluate( ( url ) => {
 			const frame = document.createElement( 'iframe' );
+			frame.id = 'untrusted-frame';
 			frame.src = url;
-			frame.style =
-				'position:fixed;z-index:2147483647;inset:0;width:100vw;height:100vh;pointer-events:auto';
 			document.body.append( frame );
 		}, untrustedOrigin );
-		const untrustedFrame = await untrustedFrameNavigation;
+		await expect( blockedFrameAttempt ).resolves.toEqual( {
+			defaultPrevented: true,
+			isMainFrame: false,
+		} );
+		expect(
+			window.frames().some( ( frame ) => frame.url() === untrustedOrigin )
+		).toBe( false );
+		await window
+			.locator( '#untrusted-frame' )
+			.evaluate( ( frame ) => frame.remove() );
+
+		const externalUrl = 'https://example.com/cortext-test';
+		await expect(
+			openExternalFromRuntime( app, externalUrl, '_blank' )
+		).resolves.toBe( externalUrl );
+		await expect(
+			openExternalFromRuntime( app, externalUrl, '_self' )
+		).resolves.toBe( externalUrl );
+		await expect.poll( () => window.url() ).not.toBe( externalUrl );
+
+		const popupPromise = app.waitForEvent( 'window' );
+		await window.evaluate( () => {
+			window.open(
+				'/wp-json/',
+				'_blank',
+				'nodeIntegration=yes,contextIsolation=no,sandbox=no,webSecurity=no'
+			);
+		} );
+		const popup = await popupPromise;
+		await popup.waitForURL( 'http://127.0.0.1:9402/wp-json/' );
+		await expect( popup.locator( 'body' ) ).not.toHaveText( 'Forbidden' );
+		const popupSecurity = await app.evaluate(
+			( { session, webContents } ) => {
+				const runtimeSession =
+					session.fromPartition( 'persist:cortext' );
+				const popupContents = webContents
+					.getAllWebContents()
+					.find( ( candidate ) =>
+						candidate.getURL().endsWith( '/wp-json/' )
+					);
+				if ( ! popupContents ) {
+					throw new Error(
+						'Internal runtime popup WebContents not found.'
+					);
+				}
+				const preferences = popupContents.getLastWebPreferences();
+				return {
+					contextIsolation: preferences.contextIsolation,
+					nodeIntegration: preferences.nodeIntegration,
+					sameSession: popupContents.session === runtimeSession,
+					sandbox: preferences.sandbox,
+					webSecurity: preferences.webSecurity,
+					isPersistent: popupContents.session.isPersistent(),
+				};
+			}
+		);
+		expect( popupSecurity ).toEqual( {
+			contextIsolation: true,
+			nodeIntegration: false,
+			sameSession: true,
+			sandbox: true,
+			webSecurity: true,
+			isPersistent: true,
+		} );
+		await expect(
+			openExternalFromRuntime( app, externalUrl, '_self', '/wp-json/' )
+		).resolves.toBe( externalUrl );
+		await expect
+			.poll( () => popup.url() )
+			.toBe( 'http://127.0.0.1:9402/wp-json/' );
+		await popup.close();
+
+		const untrustedWindowPromise = app.waitForEvent( 'window' );
+		await app.evaluate( async ( { BrowserWindow }, url ) => {
+			const untrustedWindow = new BrowserWindow( {
+				show: false,
+				webPreferences: {
+					contextIsolation: true,
+					sandbox: true,
+				},
+			} );
+			globalThis.__cortextE2EUntrustedWindow = untrustedWindow;
+			await untrustedWindow.loadURL( url );
+		}, untrustedOrigin );
+		const untrustedWindow = await untrustedWindowPromise;
 		await expect
 			.poll( () =>
-				untrustedFrame
+				untrustedWindow
 					.locator( 'body' )
 					.getAttribute( 'data-runtime-image' )
 			)
 			.toBe( 'blocked' );
-		await untrustedFrame.locator( '#runtime-link' ).click();
-		await window.waitForURL( 'http://127.0.0.1:9402/wp-json/' );
-		await expect( window.locator( 'body' ) ).toHaveText( 'Forbidden' );
+		await untrustedWindow.locator( '#runtime-link' ).click();
+		await untrustedWindow.waitForURL( 'http://127.0.0.1:9402/wp-json/' );
+		await expect( untrustedWindow.locator( 'body' ) ).toHaveText(
+			'Forbidden'
+		);
+		await untrustedWindow.close();
+		await app.evaluate( () => {
+			globalThis.__cortextE2EUntrustedWindow = null;
+		} );
+
+		expect( untrustedRequests.length ).toBeGreaterThan( 0 );
+		expect(
+			untrustedRequests.every(
+				( request ) => request.runtimeToken === undefined
+			)
+		).toBe( true );
 	} finally {
 		await app.close();
 	}
 } );
 
-test( 'exits after closing its only window', async () => {
-	const app = await launchDesktopApp();
+test( 'reloads, preserves preferences, and exits with its window', async () => {
+	const { app, userDataPath } = await launchDesktopApp();
 	let didExit = false;
+	let relaunchedApp = null;
 
 	try {
+		await app.firstWindow();
+		const menuReload = reloadFirstRuntimeNavigationFromMenu( app );
+		await expectTemporaryUserData( app, userDataPath );
 		const window = await waitForCortextShell( app );
-		await window.reload();
+		await expect( menuReload ).resolves.toMatch(
+			/^http:\/\/127\.0\.0\.1:9402\//
+		);
+		await expect( window.locator( 'body' ) ).not.toHaveText( 'Forbidden' );
 		await expect(
 			window.locator(
 				'.cortext-workspace__pane[data-active="true"] .cortext-canvas'
 			)
 		).toBeVisible( { timeout: 30 * 1000 } );
+		await window.evaluate( () => {
+			window.localStorage.setItem(
+				'cortext.e2ePersistentPreference',
+				'preserved'
+			);
+		} );
 		const exitPromise = waitForProcessExit( app );
 		await window.close();
 		await exitPromise;
 		didExit = true;
+
+		( { app: relaunchedApp } = await launchDesktopApp( userDataPath ) );
+		await expectTemporaryUserData( relaunchedApp, userDataPath );
+		const relaunchedWindow = await waitForCortextShell( relaunchedApp );
+		await expect
+			.poll( () =>
+				relaunchedWindow.evaluate( () =>
+					window.localStorage.getItem(
+						'cortext.e2ePersistentPreference'
+					)
+				)
+			)
+			.toBe( 'preserved' );
 	} finally {
 		if ( ! didExit ) {
 			await app.close();
+		}
+		if ( relaunchedApp ) {
+			await relaunchedApp.close();
 		}
 	}
 } );

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -356,8 +356,11 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 				const mainWindow = BrowserWindow.getAllWindows()[ 0 ];
 				const runtimeSession =
 					session.fromPartition( 'persist:cortext' );
-				const trustedResponse = await runtimeSession.fetch( assetUrl );
-				await trustedResponse.arrayBuffer();
+				// The token rides on Cortext frames, not on the session handle,
+				// so a fetch with no frame behind it is rejected even here.
+				const framelessResponse =
+					await runtimeSession.fetch( assetUrl );
+				await framelessResponse.arrayBuffer();
 				const untrustedResponse =
 					await session.defaultSession.fetch( assetUrl );
 				await untrustedResponse.arrayBuffer();
@@ -366,7 +369,7 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 						mainWindow.webContents.session === runtimeSession,
 					cacheSize: await runtimeSession.getCacheSize(),
 					isPersistent: runtimeSession.isPersistent(),
-					trustedStatus: trustedResponse.status,
+					framelessStatus: framelessResponse.status,
 					untrustedStatus: untrustedResponse.status,
 				};
 			},
@@ -376,7 +379,7 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 			mainUsesRuntimeSession: true,
 			cacheSize: 0,
 			isPersistent: true,
-			trustedStatus: 200,
+			framelessStatus: 403,
 			untrustedStatus: 403,
 		} );
 		await expect(
@@ -399,40 +402,11 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 			)?.runtimeToken
 		).toBeUndefined();
 
-		const blockedFrameAttempt = app.evaluate(
-			( { BrowserWindow }, targetUrl ) => {
-				return new Promise( ( resolve, reject ) => {
-					const webContents =
-						BrowserWindow.getAllWindows()[ 0 ].webContents;
-					const timer = setTimeout( () => {
-						webContents.off(
-							'will-frame-navigate',
-							onFrameNavigate
-						);
-						reject(
-							new Error(
-								'External iframe navigation was not observed.'
-							)
-						);
-					}, 10 * 1000 );
-					const onFrameNavigate = ( event ) => {
-						if ( event.url !== targetUrl ) {
-							return;
-						}
-						clearTimeout( timer );
-						webContents.off(
-							'will-frame-navigate',
-							onFrameNavigate
-						);
-						resolve( {
-							defaultPrevented: event.defaultPrevented,
-							isMainFrame: event.isMainFrame,
-						} );
-					};
-					webContents.on( 'will-frame-navigate', onFrameNavigate );
-				} );
-			},
-			untrustedOrigin
+		// Third-party frames render, because blocks such as Embed put a
+		// provider's iframe on the page. They still sit outside the boundary.
+		const untrustedFrameNavigation = window.waitForEvent(
+			'framenavigated',
+			( frame ) => frame.url() === untrustedOrigin
 		);
 		await window.evaluate( ( url ) => {
 			const frame = document.createElement( 'iframe' );
@@ -440,13 +414,15 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 			frame.src = url;
 			document.body.append( frame );
 		}, untrustedOrigin );
-		await expect( blockedFrameAttempt ).resolves.toEqual( {
-			defaultPrevented: true,
-			isMainFrame: false,
-		} );
-		expect(
-			window.frames().some( ( frame ) => frame.url() === untrustedOrigin )
-		).toBe( false );
+		const untrustedFrame = await untrustedFrameNavigation;
+		await expect
+			.poll( () =>
+				untrustedFrame
+					.locator( 'body' )
+					.getAttribute( 'data-runtime-image' )
+			)
+			.toBe( 'blocked' );
+
 		await window
 			.locator( '#untrusted-frame' )
 			.evaluate( ( frame ) => frame.remove() );
@@ -541,6 +517,31 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 		await app.evaluate( () => {
 			globalThis.__cortextE2EUntrustedWindow = null;
 		} );
+
+		// Last, because a cancelled top-level navigation leaves the page with a
+		// pending navigation that Playwright's auto-waiting never resolves.
+		// An embedded frame must not steer the app window, runtime URL or not.
+		const frameNavigation = window.waitForEvent(
+			'framenavigated',
+			( frame ) => frame.url() === untrustedOrigin
+		);
+		await window.evaluate( ( url ) => {
+			const frame = document.createElement( 'iframe' );
+			frame.src = url;
+			document.body.append( frame );
+		}, untrustedOrigin );
+		const steeringFrame = await frameNavigation;
+		const appUrlBeforeSteering = window.url();
+		await steeringFrame.evaluate( () =>
+			document.getElementById( 'runtime-link' ).click()
+		);
+		await expect
+			.poll( () =>
+				app.evaluate( ( { BrowserWindow } ) =>
+					BrowserWindow.getAllWindows()[ 0 ].webContents.getURL()
+				)
+			)
+			.toBe( appUrlBeforeSteering );
 
 		expect( untrustedRequests.length ).toBeGreaterThan( 0 );
 		expect(

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -2,6 +2,26 @@
 
 Running log for desktop-specific runtime and packaging decisions. Keep the detailed benchmark numbers in PR comments or artifacts unless they become stable product guidance.
 
+## 2026-07-24 — Authenticate every local runtime request
+
+**Decision.** Each Electron launch generates a new random 256-bit token, keeps
+it in memory, and passes it to the local runtime through its environment.
+Electron adds the token as an internal header only for requests to
+`http://127.0.0.1:9402/`. The PHP, FrankenPHP, and PHP-FPM runtime paths reject
+requests without the matching token before serving WordPress or static files.
+The benchmark follows the same contract with its own ephemeral token and never
+includes it in the recorded results. The loopback address and fixed port 9402
+remain unchanged.
+
+**Why.** The desktop-only autologin makes every accepted WordPress request an
+administrator request. Requiring a per-launch secret prevents web pages and
+accidental localhost clients from reaching that session just because they know
+the port. The secret is not persisted, logged, or placed in a URL.
+
+**Limit.** This is a boundary against browser-originated and accidental local
+requests, not against hostile native software running as the same macOS user.
+Such a process can already read the user's Cortext application data.
+
 ## 2026-06-19 — In-place auto-updates over GitHub Releases
 
 **Decision.** The signed desktop app now updates itself from GitHub Releases with `electron-updater`. The mac build ships both `dmg` and `zip`: users download the DMG for first install, while Squirrel.Mac installs the zip. The `github` publish config makes electron-builder write `latest-mac.yml` and `app-update.yml`, and Buildkite uploads the zip, blockmap, and `latest-mac.yml` to the same draft Release as the DMG. The plugin workflow still owns the Release; Buildkite only attaches desktop assets. Drafts remain hidden from the updater. Once a human publishes a Release, the installed app can pick it up. The app menu has one `autoInstallUpdates` checkbox plus a "Check for Updates..." / "Restart to Apply Update" item. On first launch after an app update, Cortext also refreshes the bundled WordPress and plugin code in the extracted site, preserving the SQLite database, uploads, and wp-config. WordPress handles any database upgrade on the next load.

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -6,12 +6,22 @@ Running log for desktop-specific runtime and packaging decisions. Keep the detai
 
 **Decision.** Each Electron launch generates a new random 256-bit token, keeps
 it in memory, and passes it to the local runtime through its environment.
-Electron adds the token as an internal header only for requests to
-`http://127.0.0.1:9402/`. The PHP, FrankenPHP, and PHP-FPM runtime paths reject
-requests without the matching token before serving WordPress or static files.
-The benchmark follows the same contract with its own ephemeral token and never
-includes it in the recorded results. The loopback address and fixed port 9402
-remain unchanged.
+Every app window uses a dedicated Electron session. Its browser storage remains
+persistent so theme, layout, and integration preferences survive restarts, but
+the token is never stored there. HTTP caching is disabled, and cookies, service
+workers, and Cache API data for the runtime are cleared at launch. The session
+adds the token as an internal header to requests for
+`http://127.0.0.1:9402/`, without trying to infer trust from `Sec-Fetch-Site` or
+the current window URL. External top-level links leave the app through the
+system browser; external frames and document redirects are blocked; internal
+popups use the same protected session. A request chain that leaves the runtime
+cannot regain the token by redirecting back.
+
+The PHP, FrankenPHP, and PHP-FPM runtime paths reject requests without the
+matching token before serving WordPress or static files. Caddy then removes the
+header before proxying to PHP and filters it from error logs. The benchmark
+follows the same contract with its own ephemeral token and never includes it in
+the recorded results. The loopback address and fixed port 9402 remain unchanged.
 
 **Why.** The desktop-only autologin makes every accepted WordPress request an
 administrator request. Requiring a per-launch secret prevents web pages and
@@ -21,6 +31,15 @@ the port. The secret is not persisted, logged, or placed in a URL.
 **Limit.** This is a boundary against browser-originated and accidental local
 requests, not against hostile native software running as the same macOS user.
 Such a process can already read the user's Cortext application data.
+
+**Product boundary.** Desktop hides publishing and copy-link affordances, and
+published localhost routes remain behind the same token. They are not shareable
+in Safari or another client. Public publishing remains a feature of Cortext on
+a WordPress web site.
+
+**Migration note.** Moving from Electron's default session to the dedicated
+partition resets existing browser-only desktop preferences once. The WordPress
+database, documents, uploads, and application settings are unaffected.
 
 ## 2026-06-19 — In-place auto-updates over GitHub Releases
 

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -10,12 +10,17 @@ Every app window uses a dedicated Electron session. Its browser storage remains
 persistent so theme, layout, and integration preferences survive restarts, but
 the token is never stored there. HTTP caching is disabled, and cookies, service
 workers, and Cache API data for the runtime are cleared at launch. The session
-adds the token as an internal header to requests for
-`http://127.0.0.1:9402/`, without trying to infer trust from `Sec-Fetch-Site` or
-the current window URL. External top-level links leave the app through the
-system browser; external frames and document redirects are blocked; internal
-popups use the same protected session. A request chain that leaves the runtime
-cannot regain the token by redirecting back.
+adds the token as an internal header to requests for `http://127.0.0.1:9402/`
+that come from a Cortext frame, reading the frame origin Chromium already
+resolved instead of inferring trust from `Sec-Fetch-Site` or the current window
+URL. Embedded third-party frames render, so the Embed block keeps working, but
+they stay outside the boundary: origin inheritance covers frames nested inside
+them and popups they open, and a request with no frame behind it, such as one
+from a service worker, is never authenticated. External top-level links leave
+the app through the system browser; an embedded frame cannot steer the app
+window; document redirects to another origin are blocked; internal popups use
+the same protected session. A request chain that leaves the runtime cannot
+regain the token by redirecting back.
 
 The PHP, FrankenPHP, and PHP-FPM runtime paths reject requests without the
 matching token before serving WordPress or static files. Caddy then removes the


### PR DESCRIPTION
## What

Require a new random token on every launch before the desktop app serves WordPress or static files. Direct requests to the fixed localhost port now get `403`; Cortext can still reload and open internal links in new windows.

External links open in the system browser. The app blocks external frames and document redirects from entering its private session. Desktop publishing and copy-link controls stay hidden, and published localhost URLs remain unavailable outside the app.

## Why

Desktop autologin makes every accepted WordPress request an administrator request. A web page or accidental localhost client should not gain that access just by knowing the port.

## How

All Cortext windows share a dedicated Electron session that keeps browser preferences between launches but never stores the token. Older desktop builds kept these preferences in Electron's default session, so this move resets them once. WordPress data and app settings are unchanged.

The PHP router and the experimental Caddy runtimes check the token before serving content. Caddy removes the header before PHP and redacts it from error logs.

## Testing Instructions

1. Build the desktop snapshot and start Cortext.
2. Confirm that the initial document opens, then use View > Reload or `Cmd+R` and confirm that Cortext returns instead of showing "Forbidden".
3. Change a browser-backed preference such as the color scheme, quit, reopen Cortext, and confirm that the preference remains.
4. While Cortext is open, run `curl -i http://127.0.0.1:9402/wp-includes/images/blank.gif` and confirm that it returns `403 Forbidden`.
5. Close Cortext and confirm that its local PHP process exits.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.
