### PR TITLE
Desktop: assign each profile a runtime origin

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -62,10 +62,15 @@ fresh machine. The binary is ignored by git.
 
 ## What it does
 
-Electron spawns `php -S 127.0.0.1:9402` against the unzipped site and
-uses `router.php` for the rewrite behavior WordPress normally gets from
-nginx or Apache. Once PHP reports that it is accepting connections, the
-window loads `http://127.0.0.1:9402/wp-admin/admin.php?page=cortext`.
+Electron asks the operating system for an available loopback port, spawns PHP
+against the unzipped site, and uses `router.php` for the rewrite behavior
+WordPress normally gets from nginx or Apache. The selected port is saved per
+desktop profile so origin-scoped preferences remain available after a restart.
+If that port is occupied, Cortext chooses and saves another one. Profiles
+created by an older build try their previous port once for the same migration
+reason. A collision-forced change creates a new browser origin, so browser-only
+preferences and the local Notion key must be entered again; WordPress documents
+and settings are unaffected.
 
 Each launch creates a new 256-bit authentication token in memory. Every Cortext
 window uses one dedicated Electron session, which adds the token to requests
@@ -82,12 +87,18 @@ top-level links open in the system browser, an embedded frame cannot steer the
 app window, and internal popups stay in the protected session.
 
 The runtime rejects requests without the matching token before serving
-WordPress or static files. The token is passed through the runtime environment
-and is never written to disk, included in a URL, logged, forwarded to PHP by
-Caddy, or added to benchmark results. This protects the local admin session
-from web pages and accidental localhost clients. It does not protect against
-native processes running as the same macOS user, which can already read that
-user's Cortext data. The loopback address and port remain `127.0.0.1:9402`.
+WordPress or static files. It also requires the request `Host` and any supplied
+`Origin` to match the selected runtime origin, and every server binds only to
+`127.0.0.1`. The token is passed through the runtime environment and is never
+written to disk, included in a URL, logged, forwarded to PHP by Caddy, or added
+to benchmark results. This protects the local admin session from web pages and
+accidental localhost clients. It does not protect against native processes
+running as the same macOS user, which can already read that user's Cortext
+data.
+
+Only one Cortext process may use a desktop profile at a time. Opening the app
+again focuses the existing window instead of starting another PHP process
+against the same SQLite database.
 
 Desktop hides the publishing and copy-link controls. Published localhost URLs
 are also protected by the token, so they are intentionally not shareable in
@@ -189,10 +200,11 @@ npm --prefix apps/desktop run bench:runtime -- --runtime=php --iterations=50 --w
 ```
 
 The benchmark extracts the snapshot into `apps/desktop/.runtime-bench/`,
-starts the selected runtime on port 9402, measures representative admin
-and REST endpoints, and writes `artifacts/desktop-runtime-<runtime-or-label>.json`.
-Pass `--label=<name>` when comparing multiple binaries behind the same
-runtime, such as `--label=php-system` and `--label=php-bundled`.
+starts the selected runtime on an available loopback port, measures
+representative admin and REST endpoints, and writes
+`artifacts/desktop-runtime-<runtime-or-label>.json`. Pass `--label=<name>`
+when comparing multiple binaries behind the same runtime, such as
+`--label=php-system` and `--label=php-bundled`.
 The desktop snapshot adds a `Server-Timing: cortext_wp` header, so the JSON
 has both total HTTP latency and WordPress request time.
 
@@ -218,6 +230,8 @@ profile.
 - `router.php`: gives PHP's built-in server the `.htaccess` behavior
   WordPress expects. Existing files are served from disk; everything else
   goes through `index.php`.
+- `bootstrap.php`: defines the selected runtime origin before WordPress or
+  an existing desktop `wp-config.php` loads.
 - `worker.php`: experimental FrankenPHP worker entrypoint used only when
   `CORTEXT_RUNTIME=franken`.
 - `mu-plugins/cortext-autologin.php`: bypasses `auth_redirect()` and

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -62,15 +62,19 @@ fresh machine. The binary is ignored by git.
 
 ## What it does
 
-Electron asks the operating system for an available loopback port, spawns PHP
+Electron takes the first free loopback port in the 9403-9498 band, spawns PHP
 against the unzipped site, and uses `router.php` for the rewrite behavior
 WordPress normally gets from nginx or Apache. The selected port is saved per
 desktop profile so origin-scoped preferences remain available after a restart.
-If that port is occupied, Cortext chooses and saves another one. Profiles
+The band sits below the ephemeral range the kernel hands out for outbound
+sockets, so a saved port is unlikely to be taken while Cortext is closed. If it
+is taken anyway, Cortext scans the band again and saves the new choice. Profiles
 created by an older build try their previous port once for the same migration
-reason. A collision-forced change creates a new browser origin, so browser-only
-preferences and the local Notion key must be entered again; WordPress documents
-and settings are unaffected.
+reason. A forced change creates a new browser origin, so browser-only
+preferences and the local Notion key must be entered again. WordPress settings
+and uploads survive; blocks that embed uploaded media keep the previous origin
+in their markup and need re-inserting, because content still stores absolute
+URLs.
 
 Each launch creates a new 256-bit authentication token in memory. Every Cortext
 window uses one dedicated Electron session, which adds the token to requests

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -1034,11 +1034,16 @@ function stopProcessEntries( entries, options = {} ) {
 	);
 }
 
-function isAddressInUseFailure( entries ) {
-	return entries.some( ( entry ) =>
-		/(?:address already in use|eaddrinuse|bind: address)/i.test(
-			entry.outputTail
-		)
+function isPortBindFailure( entries, port ) {
+	const phpListenFailure = new RegExp(
+		`failed to listen on 127\\.0\\.0\\.1:${ port }(?:\\s|$)`,
+		'i'
+	);
+	return entries.some(
+		( entry ) =>
+			/(?:address already in use|eaddrinuse|bind: address|only one usage of each socket address)/i.test(
+				entry.outputTail
+			) || phpListenFailure.test( entry.outputTail )
 	);
 }
 
@@ -1122,12 +1127,15 @@ async function launchRuntime( handle, options ) {
 			// The child `exit` event may precede the final stderr data. Wait for
 			// stdio to close before deciding whether this was a bind collision.
 			await waitForProcessOutputToClose( failedProcesses );
-			const addressInUse = isAddressInUseFailure( failedProcesses );
+			const portBindFailure = isPortBindFailure(
+				failedProcesses,
+				selectedPort
+			);
 			for ( const cleanupPath of failedCleanupPaths ) {
 				fs.rmSync( cleanupPath, { recursive: true, force: true } );
 			}
 
-			if ( ! addressInUse || attempt > 0 ) {
+			if ( ! portBindFailure || attempt > 0 ) {
 				throw error;
 			}
 
@@ -1246,6 +1254,7 @@ module.exports = {
 	childProcessOptions,
 	findRuntimeExecutable,
 	findAvailablePort,
+	isPortBindFailure,
 	isValidPort,
 	normalizeRuntime,
 	phpCliWorkerConfig,

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -111,7 +111,14 @@ function isEnabled( value ) {
 }
 
 function addPhpIni( args, key, value ) {
-	args.push( '-d', `${ key }=${ value }` );
+	// PHP parses -d values with php.ini grammar even when Node passes argv
+	// directly. Quote paths so Windows short names such as RUNNER~1 are not
+	// treated as expressions, and keep literal path characters literal.
+	const encodedValue = String( value )
+		.replaceAll( '\\', '\\\\' )
+		.replaceAll( '"', '\\"' )
+		.replaceAll( '$', '\\$' );
+	args.push( '-d', `${ key }="${ encodedValue }"` );
 }
 
 function ensureDir( dir ) {

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -1,15 +1,21 @@
 const { spawn } = require( 'child_process' );
 const fs = require( 'fs' );
 const http = require( 'http' );
+const net = require( 'net' );
 const os = require( 'os' );
 const path = require( 'path' );
 const { findExecutable } = require( './executable' );
 
-const DEFAULT_PORT = 9402;
+// Existing profiles used this origin before runtime ports became per-profile.
+// Keeping it as their first preference preserves origin-scoped browser state.
+const LEGACY_PORT = 9402;
 const DEFAULT_READY_PATH = '/wp-includes/images/blank.gif';
 const RUNTIME_AUTH_HEADER = 'X-Cortext-Desktop-Token';
 const RUNTIME_AUTH_ENV = 'CORTEXT_DESKTOP_AUTH_TOKEN';
 const WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS = [ '.COM', '.EXE' ];
+const RUNTIME_HOST_ENV = 'CORTEXT_DESKTOP_RUNTIME_HOST';
+const RUNTIME_ORIGIN_ENV = 'CORTEXT_DESKTOP_RUNTIME_ORIGIN';
+const RUNTIME_BOOTSTRAP_ENV = 'CORTEXT_DESKTOP_RUNTIME_BOOTSTRAP';
 const EXPLORATION_OBJECT_CACHE_MARKER =
 	'Cortext Desktop APCu object-cache exploration drop-in';
 
@@ -75,17 +81,19 @@ function resolveExecutable( envName, bundledPath, commandName, installHint ) {
 	);
 }
 
-function pipeProcessOutput( child ) {
-	if ( process.env.CORTEXT_RUNTIME_QUIET === '1' ) {
-		child.stdout.resume();
-		child.stderr.resume();
-		return;
-	}
+function pipeProcessOutput( child, onOutput ) {
+	const quiet = process.env.CORTEXT_RUNTIME_QUIET === '1';
 	child.stdout.on( 'data', ( chunk ) => {
-		process.stdout.write( chunk );
+		onOutput( chunk );
+		if ( ! quiet ) {
+			process.stdout.write( chunk );
+		}
 	} );
 	child.stderr.on( 'data', ( chunk ) => {
-		process.stderr.write( chunk );
+		onOutput( chunk );
+		if ( ! quiet ) {
+			process.stderr.write( chunk );
+		}
 	} );
 }
 
@@ -157,6 +165,22 @@ function configureRuntimeRouter( wordpressDir, appDir ) {
 	}
 
 	fs.copyFileSync( sourcePath, path.join( wordpressDir, 'router.php' ) );
+}
+
+function configureRuntimeBootstrap( wordpressDir, appDir ) {
+	const sourcePath = path.join( appDir, 'runtime/bootstrap.php' );
+	if ( ! fs.existsSync( sourcePath ) ) {
+		throw new Error(
+			`Desktop runtime bootstrap not found at ${ sourcePath }.`
+		);
+	}
+
+	const bootstrapPath = path.join(
+		wordpressDir,
+		'cortext-runtime-bootstrap.php'
+	);
+	fs.copyFileSync( sourcePath, bootstrapPath );
+	return bootstrapPath;
 }
 
 function configurePreloadFiles( wordpressDir, appDir ) {
@@ -241,12 +265,21 @@ function childProcessOptions( options = {} ) {
 
 function addProcess( handle, name, command, args, options = {} ) {
 	const child = spawn( command, args, childProcessOptions( options ) );
-	handle.processes.push( {
+	const entry = {
 		name,
 		child,
 		killProcessGroup: options.detached === true,
+		expectedExit: false,
+		outputClosed: false,
+		outputTail: '',
+	};
+	handle.processes.push( entry );
+	pipeProcessOutput( child, ( chunk ) => {
+		entry.outputTail = `${ entry.outputTail }${ chunk }`.slice( -8192 );
 	} );
-	pipeProcessOutput( child );
+	child.once( 'close', () => {
+		entry.outputClosed = true;
+	} );
 
 	child.on( 'exit', ( code, signal ) => {
 		console.log(
@@ -254,6 +287,8 @@ function addProcess( handle, name, command, args, options = {} ) {
 		);
 		if (
 			! handle.stopping &&
+			! handle.starting &&
+			! entry.expectedExit &&
 			typeof handle.onUnexpectedExit === 'function'
 		) {
 			handle.onUnexpectedExit( name, code, signal );
@@ -284,7 +319,13 @@ function phpCliWorkerConfig( env = process.env, platform = process.platform ) {
 	};
 }
 
-function waitForHttpReady( handle, port, authToken, timeoutMs = 30000 ) {
+function waitForHttpReady(
+	handle,
+	port,
+	authToken,
+	runtimeOrigin,
+	timeoutMs = 30000
+) {
 	return new Promise( ( resolve, reject ) => {
 		let settled = false;
 		let lastFailure = null;
@@ -411,7 +452,40 @@ function waitForHttpReady( handle, port, authToken, timeoutMs = 30000 ) {
 					return;
 				}
 
+				const invalidHostStatus = await requestStatus( {
+					Host: `localhost:${ port }`,
+					[ RUNTIME_AUTH_HEADER ]: authToken,
+				} );
+				if ( settled ) {
+					return;
+				}
+				if ( invalidHostStatus !== 403 ) {
+					fail(
+						new Error(
+							`Runtime security check failed: invalid Host request returned HTTP ${ invalidHostStatus }.`
+						)
+					);
+					return;
+				}
+
+				const invalidOriginStatus = await requestStatus( {
+					Origin: 'https://example.com',
+					[ RUNTIME_AUTH_HEADER ]: authToken,
+				} );
+				if ( settled ) {
+					return;
+				}
+				if ( invalidOriginStatus !== 403 ) {
+					fail(
+						new Error(
+							`Runtime security check failed: invalid Origin request returned HTTP ${ invalidOriginStatus }.`
+						)
+					);
+					return;
+				}
+
 				const authenticatedStatus = await requestStatus( {
+					Origin: runtimeOrigin,
 					[ RUNTIME_AUTH_HEADER ]: authToken,
 				} );
 				if ( settled ) {
@@ -448,7 +522,8 @@ function startPhpCli(
 	port,
 	appDir,
 	runtimeStateDir,
-	authToken
+	runtimeEnvironment,
+	bootstrapPath
 ) {
 	const phpBin = resolveExecutable(
 		'CORTEXT_PHP_BIN',
@@ -469,8 +544,10 @@ function startPhpCli(
 		`[cortext-desktop] starting php -S (127.0.0.1:${ port }) against ${ wordpressDir }`
 	);
 	const workerConfig = phpCliWorkerConfig();
+	const phpIniArgs = phpCliIniArgs( wordpressDir, appDir, runtimeStateDir );
+	addPhpIni( phpIniArgs, 'auto_prepend_file', bootstrapPath );
 	const phpArgs = [
-		...phpCliIniArgs( wordpressDir, appDir, runtimeStateDir ),
+		...phpIniArgs,
 		'-S',
 		`127.0.0.1:${ port }`,
 		'-t',
@@ -479,7 +556,7 @@ function startPhpCli(
 	];
 	const phpEnv = {
 		...process.env,
-		[ RUNTIME_AUTH_ENV ]: authToken,
+		...runtimeEnvironment,
 	};
 	if ( process.platform === 'win32' ) {
 		delete phpEnv.CORTEXT_PHP_CLI_SERVER_WORKERS;
@@ -499,7 +576,13 @@ function startPhpCli(
 	} );
 }
 
-function startFrankenPhp( handle, wordpressDir, port, appDir, authToken ) {
+function startFrankenPhp(
+	handle,
+	wordpressDir,
+	port,
+	appDir,
+	runtimeEnvironment
+) {
 	const frankenBin = resolveExecutable(
 		'CORTEXT_FRANKENPHP_BIN',
 		bundledRuntimeExecutable( appDir, 'frankenphp' ),
@@ -527,7 +610,7 @@ function startFrankenPhp( handle, wordpressDir, port, appDir, authToken ) {
 			cwd: wordpressDir,
 			env: {
 				...process.env,
-				[ RUNTIME_AUTH_ENV ]: authToken,
+				...runtimeEnvironment,
 				CORTEXT_PORT: String( port ),
 				CORTEXT_WORDPRESS_ROOT: wordpressDir,
 				CORTEXT_CADDY_STORAGE: path.join( handle.stateDir, 'caddy' ),
@@ -538,7 +621,7 @@ function startFrankenPhp( handle, wordpressDir, port, appDir, authToken ) {
 	);
 }
 
-function writePhpFpmConfig( runtimeStateDir, wordpressDir ) {
+function writePhpFpmConfig( runtimeStateDir, wordpressDir, bootstrapPath ) {
 	fs.mkdirSync( runtimeStateDir, { recursive: true } );
 	const socketDir = fs.mkdtempSync(
 		path.join( os.tmpdir(), 'cortext-fpm-' )
@@ -570,6 +653,7 @@ function writePhpFpmConfig( runtimeStateDir, wordpressDir ) {
 				'php-errors.log'
 			) }`,
 			'php_admin_flag[log_errors] = on',
+			`php_admin_value[auto_prepend_file] = ${ bootstrapPath }`,
 			'php_value[opcache.enable] = 1',
 			'php_value[opcache.validate_timestamps] = 0',
 			'',
@@ -585,7 +669,8 @@ function startPhpFpmCaddy(
 	port,
 	appDir,
 	runtimeStateDir,
-	authToken
+	runtimeEnvironment,
+	bootstrapPath
 ) {
 	const phpFpmBin = resolveExecutable(
 		'CORTEXT_PHP_FPM_BIN',
@@ -604,7 +689,11 @@ function startPhpFpmCaddy(
 		throw new Error( `PHP-FPM Caddyfile not found at ${ configPath }.` );
 	}
 
-	const fpm = writePhpFpmConfig( runtimeStateDir, wordpressDir );
+	const fpm = writePhpFpmConfig(
+		runtimeStateDir,
+		wordpressDir,
+		bootstrapPath
+	);
 	handle.cleanupPaths.push( fpm.socketDir );
 	console.log(
 		`[cortext-desktop] starting php-fpm + Caddy (127.0.0.1:${ port }) against ${ wordpressDir }`
@@ -618,7 +707,7 @@ function startPhpFpmCaddy(
 			cwd: wordpressDir,
 			env: {
 				...process.env,
-				[ RUNTIME_AUTH_ENV ]: authToken,
+				...runtimeEnvironment,
 			},
 		}
 	);
@@ -631,7 +720,7 @@ function startPhpFpmCaddy(
 			cwd: wordpressDir,
 			env: {
 				...process.env,
-				[ RUNTIME_AUTH_ENV ]: authToken,
+				...runtimeEnvironment,
 				CORTEXT_PORT: String( port ),
 				CORTEXT_WORDPRESS_ROOT: wordpressDir,
 				CORTEXT_PHP_FPM_SOCKET: fpm.socketPath,
@@ -641,59 +730,65 @@ function startPhpFpmCaddy(
 	);
 }
 
-function startRuntime( {
-	appDir,
-	wordpressDir,
-	port = DEFAULT_PORT,
-	runtime = process.env.CORTEXT_RUNTIME,
-	runtimeStateDir,
-	onUnexpectedExit,
-	authToken,
-} ) {
-	if ( typeof authToken !== 'string' || authToken.trim().length === 0 ) {
-		throw new TypeError( 'startRuntime requires a non-empty authToken.' );
-	}
+function isValidPort( port ) {
+	return Number.isInteger( port ) && port >= 1 && port <= 65535;
+}
 
-	const normalized = normalizeRuntime( runtime );
-	const handle = {
-		runtime: normalized,
-		processes: [],
-		cleanupPaths: [],
-		stopping: false,
-		onUnexpectedExit,
-	};
-	const stateDir =
-		runtimeStateDir ||
-		fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-desktop-runtime-' ) );
-	handle.stateDir = stateDir;
+function inspectAvailablePort( port ) {
+	return new Promise( ( resolve, reject ) => {
+		const server = net.createServer();
+		server.unref();
+		server.once( 'error', reject );
+		server.listen( port, '127.0.0.1', () => {
+			const address = server.address();
+			const selectedPort =
+				address && typeof address === 'object' ? address.port : null;
+			server.close( ( error ) => {
+				if ( error ) {
+					reject( error );
+					return;
+				}
+				resolve( selectedPort );
+			} );
+		} );
+	} );
+}
 
-	configureObjectCacheDropIn( wordpressDir, appDir );
-	configureRuntimeRouter( wordpressDir, appDir );
-	configureDesktopUpdateLock( wordpressDir, appDir );
-
-	if ( normalized === 'php' ) {
-		startPhpCli( handle, wordpressDir, port, appDir, stateDir, authToken );
-	} else if ( normalized === 'franken' ) {
-		startFrankenPhp( handle, wordpressDir, port, appDir, authToken );
-	} else if ( normalized === 'php-fpm' ) {
-		startPhpFpmCaddy(
-			handle,
-			wordpressDir,
-			port,
-			appDir,
-			stateDir,
-			authToken
-		);
-	}
-
-	handle.ready = waitForHttpReady( handle, port, authToken ).catch(
-		async ( error ) => {
-			// Report why startup failed, not why the cleanup afterwards did.
-			await stopRuntime( handle ).catch( () => {} );
-			throw error;
+async function findAvailablePort( preferredPort ) {
+	if ( preferredPort !== undefined && preferredPort !== null ) {
+		if ( ! isValidPort( preferredPort ) ) {
+			throw new TypeError(
+				'startRuntime port must be an integer between 1 and 65535.'
+			);
 		}
-	);
-	return handle;
+		try {
+			return await inspectAvailablePort( preferredPort );
+		} catch ( error ) {
+			if ( error.code !== 'EADDRINUSE' ) {
+				throw error;
+			}
+		}
+	}
+
+	return inspectAvailablePort( 0 );
+}
+
+function runtimeEndpoint( port ) {
+	const host = `127.0.0.1:${ port }`;
+	return {
+		host,
+		origin: `http://${ host }`,
+		port,
+	};
+}
+
+function makeRuntimeEnvironment( authToken, endpoint, bootstrapPath ) {
+	return {
+		[ RUNTIME_AUTH_ENV ]: authToken,
+		[ RUNTIME_HOST_ENV ]: endpoint.host,
+		[ RUNTIME_ORIGIN_ENV ]: endpoint.origin,
+		[ RUNTIME_BOOTSTRAP_ENV ]: bootstrapPath,
+	};
 }
 
 function isProcessRunning( child ) {
@@ -866,6 +961,222 @@ function waitForProcessExit(
 	} );
 }
 
+function waitForProcessOutputToClose( entries, timeoutMs = 5500 ) {
+	return Promise.all(
+		entries.map(
+			( entry ) =>
+				new Promise( ( resolve ) => {
+					if ( ! entry.child || entry.outputClosed ) {
+						resolve();
+						return;
+					}
+					const timer = setTimeout( () => {
+						entry.child.off( 'close', onClose );
+						resolve();
+					}, timeoutMs );
+					const onClose = () => {
+						clearTimeout( timer );
+						entry.child.off( 'close', onClose );
+						resolve();
+					};
+					entry.child.once( 'close', onClose );
+					if ( entry.outputClosed ) {
+						onClose();
+					}
+				} )
+		)
+	);
+}
+
+function stopProcessEntries( entries, options = {} ) {
+	const processes = [ ...entries ].reverse();
+	for ( const entry of processes ) {
+		entry.expectedExit = true;
+	}
+	return Promise.all(
+		processes.map( ( { child, killProcessGroup } ) =>
+			waitForProcessExit( child, {
+				killProcessGroup,
+				...options,
+			} )
+		)
+	);
+}
+
+function isAddressInUseFailure( entries ) {
+	return entries.some( ( entry ) =>
+		/(?:address already in use|eaddrinuse|bind: address)/i.test(
+			entry.outputTail
+		)
+	);
+}
+
+async function launchRuntime( handle, options ) {
+	const {
+		appDir,
+		wordpressDir,
+		port,
+		runtimeStateDir,
+		authToken,
+		bootstrapPath,
+		portAllocator,
+	} = options;
+	let selectedPort = await portAllocator( port );
+	if ( ! isValidPort( selectedPort ) ) {
+		throw new Error( 'Runtime port allocator returned an invalid port.' );
+	}
+
+	for ( let attempt = 0; attempt < 2; attempt++ ) {
+		if ( handle.stopping ) {
+			throw new Error( 'Runtime startup was cancelled.' );
+		}
+
+		const endpoint = runtimeEndpoint( selectedPort );
+		const runtimeEnvironment = makeRuntimeEnvironment(
+			authToken,
+			endpoint,
+			bootstrapPath
+		);
+		const processStart = handle.processes.length;
+		const cleanupStart = handle.cleanupPaths.length;
+
+		handle.port = endpoint.port;
+		handle.host = endpoint.host;
+		handle.origin = endpoint.origin;
+
+		if ( handle.runtime === 'php' ) {
+			startPhpCli(
+				handle,
+				wordpressDir,
+				endpoint.port,
+				appDir,
+				runtimeStateDir,
+				runtimeEnvironment,
+				bootstrapPath
+			);
+		} else if ( handle.runtime === 'franken' ) {
+			startFrankenPhp(
+				handle,
+				wordpressDir,
+				endpoint.port,
+				appDir,
+				runtimeEnvironment
+			);
+		} else if ( handle.runtime === 'php-fpm' ) {
+			startPhpFpmCaddy(
+				handle,
+				wordpressDir,
+				endpoint.port,
+				appDir,
+				runtimeStateDir,
+				runtimeEnvironment,
+				bootstrapPath
+			);
+		}
+
+		try {
+			await waitForHttpReady(
+				handle,
+				endpoint.port,
+				authToken,
+				endpoint.origin
+			);
+			handle.starting = false;
+			return handle;
+		} catch ( error ) {
+			const failedProcesses = handle.processes.splice( processStart );
+			const failedCleanupPaths =
+				handle.cleanupPaths.splice( cleanupStart );
+			await stopProcessEntries( failedProcesses );
+			// The child `exit` event may precede the final stderr data. Wait for
+			// stdio to close before deciding whether this was a bind collision.
+			await waitForProcessOutputToClose( failedProcesses );
+			const addressInUse = isAddressInUseFailure( failedProcesses );
+			for ( const cleanupPath of failedCleanupPaths ) {
+				fs.rmSync( cleanupPath, { recursive: true, force: true } );
+			}
+
+			if ( ! addressInUse || attempt > 0 ) {
+				throw error;
+			}
+
+			console.warn(
+				`[cortext-desktop] runtime port ${ selectedPort } was claimed during startup; choosing another`
+			);
+			selectedPort = await portAllocator();
+			if ( ! isValidPort( selectedPort ) ) {
+				throw new Error(
+					'Runtime port allocator returned an invalid port.'
+				);
+			}
+		}
+	}
+
+	throw new Error( 'Unable to start the desktop runtime.' );
+}
+
+function startRuntime( {
+	appDir,
+	wordpressDir,
+	port,
+	runtime = process.env.CORTEXT_RUNTIME,
+	runtimeStateDir,
+	onUnexpectedExit,
+	authToken,
+	portAllocator = findAvailablePort,
+} ) {
+	if ( typeof authToken !== 'string' || authToken.trim().length === 0 ) {
+		throw new TypeError( 'startRuntime requires a non-empty authToken.' );
+	}
+	if ( typeof portAllocator !== 'function' ) {
+		throw new TypeError( 'startRuntime portAllocator must be a function.' );
+	}
+	if ( port !== undefined && port !== null && ! isValidPort( port ) ) {
+		throw new TypeError(
+			'startRuntime port must be an integer between 1 and 65535.'
+		);
+	}
+
+	const normalized = normalizeRuntime( runtime );
+	const handle = {
+		runtime: normalized,
+		processes: [],
+		cleanupPaths: [],
+		starting: true,
+		stopping: false,
+		onUnexpectedExit,
+		port: null,
+		host: null,
+		origin: null,
+	};
+	const stateDir =
+		runtimeStateDir ||
+		fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-desktop-runtime-' ) );
+	handle.stateDir = stateDir;
+
+	configureObjectCacheDropIn( wordpressDir, appDir );
+	configureRuntimeRouter( wordpressDir, appDir );
+	const bootstrapPath = configureRuntimeBootstrap( wordpressDir, appDir );
+	configureDesktopUpdateLock( wordpressDir, appDir );
+
+	handle.ready = launchRuntime( handle, {
+		appDir,
+		wordpressDir,
+		port,
+		runtimeStateDir: stateDir,
+		authToken,
+		bootstrapPath,
+		portAllocator,
+	} ).catch( async ( error ) => {
+		if ( ! handle.stopping ) {
+			// Report why startup failed, not why the cleanup afterwards did.
+			await stopRuntime( handle ).catch( () => {} );
+		}
+		throw error;
+	} );
+	return handle;
+}
+
 function stopRuntime( handle, options = {} ) {
 	if ( ! handle ) {
 		return Promise.resolve();
@@ -876,16 +1187,8 @@ function stopRuntime( handle, options = {} ) {
 	handle.stopping = true;
 
 	const stopPromise = ( async () => {
-		const processes = [ ...( handle.processes || [] ) ].reverse();
 		try {
-			await Promise.all(
-				processes.map( ( { child, killProcessGroup } ) =>
-					waitForProcessExit( child, {
-						killProcessGroup,
-						...options,
-					} )
-				)
-			);
+			await stopProcessEntries( handle.processes || [], options );
 		} finally {
 			for ( const cleanupPath of handle.cleanupPaths || [] ) {
 				fs.rmSync( cleanupPath, { recursive: true, force: true } );
@@ -903,12 +1206,14 @@ function stopRuntime( handle, options = {} ) {
 }
 
 module.exports = {
-	DEFAULT_PORT,
+	LEGACY_PORT,
 	RUNTIME_AUTH_HEADER,
 	WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS,
 	bundledRuntimeExecutable,
 	childProcessOptions,
 	findRuntimeExecutable,
+	findAvailablePort,
+	isValidPort,
 	normalizeRuntime,
 	phpCliWorkerConfig,
 	runWindowsTaskkill,

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -9,6 +9,13 @@ const { findExecutable } = require( './executable' );
 // Existing profiles used this origin before runtime ports became per-profile.
 // Keeping it as their first preference preserves origin-scoped browser state.
 const LEGACY_PORT = 9402;
+// Ports offered to a profile that has no preference yet. The band starts just
+// past the legacy port so an upgrading profile keeps its claim on that one, and
+// sits below the ephemeral range the kernel hands out for outbound sockets
+// (49152+ on macOS, 32768+ on Linux). A port saved from that range would be
+// competing with the short-lived loopback traffic churning through it.
+const RUNTIME_PORT_FIRST = 9403;
+const RUNTIME_PORT_LAST = 9498;
 const DEFAULT_READY_PATH = '/wp-includes/images/blank.gif';
 const RUNTIME_AUTH_HEADER = 'X-Cortext-Desktop-Token';
 const RUNTIME_AUTH_ENV = 'CORTEXT_DESKTOP_AUTH_TOKEN';
@@ -754,6 +761,17 @@ function inspectAvailablePort( port ) {
 	} );
 }
 
+async function claimPort( port ) {
+	try {
+		return { port: await inspectAvailablePort( port ) };
+	} catch ( error ) {
+		if ( error.code !== 'EADDRINUSE' ) {
+			throw error;
+		}
+		return null;
+	}
+}
+
 async function findAvailablePort( preferredPort ) {
 	if ( preferredPort !== undefined && preferredPort !== null ) {
 		if ( ! isValidPort( preferredPort ) ) {
@@ -761,15 +779,21 @@ async function findAvailablePort( preferredPort ) {
 				'startRuntime port must be an integer between 1 and 65535.'
 			);
 		}
-		try {
-			return await inspectAvailablePort( preferredPort );
-		} catch ( error ) {
-			if ( error.code !== 'EADDRINUSE' ) {
-				throw error;
-			}
+		const preferred = await claimPort( preferredPort );
+		if ( preferred ) {
+			return preferred.port;
 		}
 	}
 
+	for ( let port = RUNTIME_PORT_FIRST; port <= RUNTIME_PORT_LAST; port++ ) {
+		const claimed = await claimPort( port );
+		if ( claimed ) {
+			return claimed.port;
+		}
+	}
+
+	// Every band port is taken. Start anyway on whatever the kernel offers; the
+	// profile loses origin stability, not the ability to run.
 	return inspectAvailablePort( 0 );
 }
 
@@ -1208,6 +1232,8 @@ function stopRuntime( handle, options = {} ) {
 module.exports = {
 	LEGACY_PORT,
 	RUNTIME_AUTH_HEADER,
+	RUNTIME_PORT_FIRST,
+	RUNTIME_PORT_LAST,
 	WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS,
 	bundledRuntimeExecutable,
 	childProcessOptions,

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -447,6 +447,9 @@ async function startDesktop() {
 			origin: runtimeOrigin,
 			storages: [ 'cookies', 'serviceworkers', 'cachestorage' ],
 		} );
+		if ( quitting ) {
+			return;
+		}
 		removeRuntimeAuthHeader = installRuntimeAuthHeader( runtimeSession, {
 			authHeader: RUNTIME_AUTH_HEADER,
 			authToken,
@@ -456,6 +459,9 @@ async function startDesktop() {
 		configureTrustedWindow( win, runtimeSession, runtimeOrigin );
 		await loadSite( win, runtimeOrigin );
 	} catch ( err ) {
+		if ( quitting ) {
+			return;
+		}
 		console.error( '[cortext-desktop]', err );
 		if ( win ) {
 			win.loadFile( ERROR_PAGE );

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -11,8 +11,9 @@ const path = require( 'path' );
 const fs = require( 'fs' );
 const { pathToFileURL } = require( 'url' );
 const {
-	DEFAULT_PORT: PORT,
+	LEGACY_PORT,
 	RUNTIME_AUTH_HEADER,
+	isValidPort,
 	startRuntime,
 	stopRuntime,
 } = require( './lib/runtime' );
@@ -44,7 +45,6 @@ const LOADING_PAGE = path.resolve( __dirname, 'loading.html' );
 const LOADING_URL = pathToFileURL( LOADING_PAGE ).href;
 const ERROR_PAGE = path.resolve( __dirname, 'error.html' );
 const ERROR_URL = pathToFileURL( ERROR_PAGE ).href;
-const RUNTIME_ORIGIN = `http://127.0.0.1:${ PORT }`;
 const RUNTIME_SESSION_PARTITION = 'persist:cortext';
 // The local shell pages Cortext loads itself, before and instead of the runtime.
 const TRUSTED_DOCUMENT_URLS = [ LOADING_URL, ERROR_URL ];
@@ -52,12 +52,14 @@ const TRUSTED_DOCUMENT_URLS = [ LOADING_URL, ERROR_URL ];
 // One instance owns the extracted site and the runtime port. A second launch
 // would extract on top of the first one's half-written files, so hand focus
 // back to the window already running and leave.
-if ( ! app.requestSingleInstanceLock() ) {
+const hasSingleInstanceLock = app.requestSingleInstanceLock();
+if ( ! hasSingleInstanceLock ) {
 	app.exit( 0 );
 }
 
 let runtimeHandle = null;
 let removeRuntimeAuthHeader = null;
+let mainWindow = null;
 let quitting = false;
 const childWindows = new Set();
 let allowQuit = false;
@@ -67,6 +69,13 @@ let appQuitPromise = null;
 
 function getSiteRoot() {
 	return path.join( app.getPath( 'userData' ), 'site' );
+}
+
+function preferredRuntimePort( storedPort, hadExistingSite ) {
+	if ( isValidPort( storedPort ) ) {
+		return storedPort;
+	}
+	return hadExistingSite ? LEGACY_PORT : undefined;
 }
 
 function stopRuntimeBeforeQuit() {
@@ -135,22 +144,21 @@ function refreshMenu() {
 	);
 }
 
-function isAllowedTopLevelUrl( url ) {
+function isAllowedTopLevelUrl( url, runtimeOrigin ) {
 	return (
-		hasOrigin( url, RUNTIME_ORIGIN ) ||
-		TRUSTED_DOCUMENT_URLS.includes( url )
+		hasOrigin( url, runtimeOrigin ) || TRUSTED_DOCUMENT_URLS.includes( url )
 	);
 }
 
 // Third-party frames may render so blocks such as Embed keep working. They
 // cannot reach the runtime: the token only rides on requests whose frame origin
 // is Cortext's own, and that origin is inherited, not claimed.
-function isAllowedFrameUrl( url ) {
+function isAllowedFrameUrl( url, runtimeOrigin ) {
 	if ( url === 'about:blank' || url === 'about:srcdoc' ) {
 		return true;
 	}
 	// The editor canvas is a blob: frame, which carries the runtime origin.
-	if ( hasOrigin( url, RUNTIME_ORIGIN ) ) {
+	if ( hasOrigin( url, runtimeOrigin ) ) {
 		return true;
 	}
 	try {
@@ -160,8 +168,10 @@ function isAllowedFrameUrl( url ) {
 	}
 }
 
-function isAllowedDocumentUrl( url, isMainFrame ) {
-	return isMainFrame ? isAllowedTopLevelUrl( url ) : isAllowedFrameUrl( url );
+function isAllowedDocumentUrl( url, isMainFrame, runtimeOrigin ) {
+	return isMainFrame
+		? isAllowedTopLevelUrl( url, runtimeOrigin )
+		: isAllowedFrameUrl( url, runtimeOrigin );
 }
 
 function openExternalUrl( url ) {
@@ -204,7 +214,7 @@ function secureWebPreferences( webPreferences, runtimeSession ) {
 	};
 }
 
-function configureTrustedWindow( win, runtimeSession ) {
+function configureTrustedWindow( win, runtimeSession, runtimeOrigin ) {
 	win.on( 'page-title-updated', ( event ) => {
 		event.preventDefault();
 		win.setTitle( 'Cortext' );
@@ -212,7 +222,7 @@ function configureTrustedWindow( win, runtimeSession ) {
 
 	const { webContents } = win;
 	webContents.on( 'will-navigate', ( event ) => {
-		if ( ! isAllowedTopLevelUrl( event.url ) ) {
+		if ( ! isAllowedTopLevelUrl( event.url, runtimeOrigin ) ) {
 			event.preventDefault();
 			openExternalUrl( event.url );
 			return;
@@ -222,7 +232,7 @@ function configureTrustedWindow( win, runtimeSession ) {
 		if (
 			! isTrustedRuntimeFrame(
 				event.initiator,
-				RUNTIME_ORIGIN,
+				runtimeOrigin,
 				TRUSTED_DOCUMENT_URLS
 			)
 		) {
@@ -230,19 +240,24 @@ function configureTrustedWindow( win, runtimeSession ) {
 		}
 	} );
 	webContents.on( 'will-frame-navigate', ( event ) => {
-		if ( event.isMainFrame || isAllowedDocumentUrl( event.url, false ) ) {
+		if (
+			event.isMainFrame ||
+			isAllowedDocumentUrl( event.url, false, runtimeOrigin )
+		) {
 			return;
 		}
 		event.preventDefault();
 	} );
 	webContents.on( 'will-redirect', ( event ) => {
-		if ( isAllowedDocumentUrl( event.url, event.isMainFrame ) ) {
+		if (
+			isAllowedDocumentUrl( event.url, event.isMainFrame, runtimeOrigin )
+		) {
 			return;
 		}
 		event.preventDefault();
 	} );
 	webContents.setWindowOpenHandler( ( { url } ) => {
-		if ( ! hasOrigin( url, RUNTIME_ORIGIN ) ) {
+		if ( ! hasOrigin( url, runtimeOrigin ) ) {
 			openExternalUrl( url );
 			return { action: 'deny' };
 		}
@@ -250,13 +265,22 @@ function configureTrustedWindow( win, runtimeSession ) {
 		return {
 			action: 'allow',
 			createWindow: ( options ) =>
-				createInternalWindow( options, runtimeSession, win )
-					.webContents,
+				createInternalWindow(
+					options,
+					runtimeSession,
+					runtimeOrigin,
+					win
+				).webContents,
 		};
 	} );
 }
 
-function createInternalWindow( options, runtimeSession, parent ) {
+function createInternalWindow(
+	options,
+	runtimeSession,
+	runtimeOrigin,
+	parent
+) {
 	const windowOptions = { ...options };
 	const { webPreferences } = windowOptions;
 	delete windowOptions.webPreferences;
@@ -287,7 +311,7 @@ function createInternalWindow( options, runtimeSession, parent ) {
 	child.once( 'closed', () => {
 		childWindows.delete( child );
 	} );
-	configureTrustedWindow( child, runtimeSession );
+	configureTrustedWindow( child, runtimeSession, runtimeOrigin );
 	return child;
 }
 
@@ -310,15 +334,13 @@ function createWindow( runtimeSession ) {
 		void quitAfterRuntimeStops();
 	} );
 
-	configureTrustedWindow( win, runtimeSession );
 	return win;
 }
 
-async function loadSite( win ) {
+async function loadSite( win, runtimeOrigin ) {
 	try {
-		await runtimeHandle.ready;
 		await win.loadURL(
-			`http://127.0.0.1:${ PORT }/wp-admin/admin.php?page=cortext`
+			`${ runtimeOrigin }/wp-admin/admin.php?page=cortext`
 		);
 		if ( ! app.isPackaged && process.env.CORTEXT_DEVTOOLS !== '0' ) {
 			win.webContents.openDevTools( { mode: 'detach' } );
@@ -338,7 +360,7 @@ async function loadSite( win ) {
 	}
 }
 
-app.whenReady().then( async () => {
+async function startDesktop() {
 	let win = null;
 	try {
 		const authToken = crypto.randomBytes( 32 ).toString( 'hex' );
@@ -346,16 +368,6 @@ app.whenReady().then( async () => {
 			RUNTIME_SESSION_PARTITION,
 			{ cache: false }
 		);
-		await runtimeSession.clearStorageData( {
-			origin: RUNTIME_ORIGIN,
-			storages: [ 'cookies', 'serviceworkers', 'cachestorage' ],
-		} );
-		removeRuntimeAuthHeader = installRuntimeAuthHeader( runtimeSession, {
-			authHeader: RUNTIME_AUTH_HEADER,
-			authToken,
-			runtimeOrigin: RUNTIME_ORIGIN,
-			trustedDocumentUrls: TRUSTED_DOCUMENT_URLS,
-		} );
 
 		if (
 			process.platform === 'darwin' &&
@@ -367,12 +379,21 @@ app.whenReady().then( async () => {
 
 		refreshMenu();
 		win = createWindow( runtimeSession );
+		mainWindow = win;
+		win.once( 'closed', () => {
+			if ( mainWindow === win ) {
+				mainWindow = null;
+			}
+		} );
 		// Load the loading screen before any site refresh so users never stare at
 		// a blank window.
 		await win.loadFile( LOADING_PAGE );
 
 		const siteRoot = getSiteRoot();
 		recoverInterruptedSwap( siteRoot );
+		const hadExistingSite = fs.existsSync(
+			path.join( siteRoot, 'wordpress' )
+		);
 		console.log( `[cortext-desktop] preparing site at ${ siteRoot }` );
 		await ensureSiteFromSnapshot( {
 			snapshotZip: SNAPSHOT_ZIP,
@@ -393,10 +414,15 @@ app.whenReady().then( async () => {
 			return;
 		}
 		const wordpressDir = path.join( siteRoot, 'wordpress' );
+		const runtimePort = preferredRuntimePort(
+			settings.get( 'runtimePort' ),
+			hadExistingSite
+		);
 
 		runtimeHandle = startRuntime( {
 			appDir: RESOURCES_DIR,
 			authToken,
+			port: runtimePort,
 			wordpressDir,
 			runtimeStateDir: path.join(
 				app.getPath( 'temp' ),
@@ -409,7 +435,26 @@ app.whenReady().then( async () => {
 			},
 		} );
 
-		await loadSite( win );
+		await runtimeHandle.ready;
+		if ( quitting ) {
+			return;
+		}
+		const runtimeOrigin = runtimeHandle.origin;
+		if ( settings.get( 'runtimePort' ) !== runtimeHandle.port ) {
+			settings.set( 'runtimePort', runtimeHandle.port );
+		}
+		await runtimeSession.clearStorageData( {
+			origin: runtimeOrigin,
+			storages: [ 'cookies', 'serviceworkers', 'cachestorage' ],
+		} );
+		removeRuntimeAuthHeader = installRuntimeAuthHeader( runtimeSession, {
+			authHeader: RUNTIME_AUTH_HEADER,
+			authToken,
+			runtimeOrigin,
+			trustedDocumentUrls: TRUSTED_DOCUMENT_URLS,
+		} );
+		configureTrustedWindow( win, runtimeSession, runtimeOrigin );
+		await loadSite( win, runtimeOrigin );
 	} catch ( err ) {
 		console.error( '[cortext-desktop]', err );
 		if ( win ) {
@@ -418,18 +463,22 @@ app.whenReady().then( async () => {
 			app.quit();
 		}
 	}
-} );
+}
 
-app.on( 'second-instance', () => {
-	const [ existing ] = BrowserWindow.getAllWindows();
-	if ( ! existing ) {
-		return;
-	}
-	if ( existing.isMinimized() ) {
-		existing.restore();
-	}
-	existing.focus();
-} );
+if ( hasSingleInstanceLock ) {
+	app.on( 'second-instance', () => {
+		if ( ! mainWindow || mainWindow.isDestroyed() ) {
+			return;
+		}
+		if ( mainWindow.isMinimized() ) {
+			mainWindow.restore();
+		}
+		mainWindow.show();
+		mainWindow.focus();
+	} );
+
+	app.whenReady().then( startDesktop );
+}
 
 app.on( 'window-all-closed', () => {
 	app.quit();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -47,6 +47,10 @@
 				"to": "runtime/router.php"
 			},
 			{
+				"from": "runtime/bootstrap.php",
+				"to": "runtime/bootstrap.php"
+			},
+			{
 				"from": "runtime/mu-plugins/cortext-update-lock.php",
 				"to": "runtime/mu-plugins/cortext-update-lock.php"
 			}

--- a/apps/desktop/runtime/Caddyfile.frankenphp
+++ b/apps/desktop/runtime/Caddyfile.frankenphp
@@ -4,6 +4,12 @@
 	persist_config off
 	storage file_system {$CORTEXT_CADDY_STORAGE}
 
+	frankenphp {
+		php_ini {
+			auto_prepend_file "{$CORTEXT_DESKTOP_RUNTIME_BOOTSTRAP}"
+		}
+	}
+
 	# Error events retain the original request, so redact the private header
 	# at the logger as well as removing it before PHP.
 	log default {
@@ -15,11 +21,13 @@
 	}
 }
 
-http://127.0.0.1:{$CORTEXT_PORT} {
+http://:{$CORTEXT_PORT} {
+	bind 127.0.0.1
+
 	# `route` preserves this literal order. Without it, Caddy sorts
 	# request_header ahead of respond and authentication always fails.
 	route {
-		@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN}`
+		@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {env.CORTEXT_DESKTOP_RUNTIME_HOST} == "" || {env.CORTEXT_DESKTOP_RUNTIME_ORIGIN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN} || {http.request.hostport} != {env.CORTEXT_DESKTOP_RUNTIME_HOST} || ({http.request.header.Origin} != "" && {http.request.header.Origin} != {env.CORTEXT_DESKTOP_RUNTIME_ORIGIN})`
 		respond @unauthorized "Forbidden" 403
 
 		request_header -X-Cortext-Desktop-Token

--- a/apps/desktop/runtime/Caddyfile.php-fpm
+++ b/apps/desktop/runtime/Caddyfile.php-fpm
@@ -15,11 +15,13 @@
 	}
 }
 
-http://127.0.0.1:{$CORTEXT_PORT} {
+http://:{$CORTEXT_PORT} {
+	bind 127.0.0.1
+
 	# `route` preserves this literal order. Without it, Caddy sorts
 	# request_header ahead of respond and authentication always fails.
 	route {
-		@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN}`
+		@unauthorized `{env.CORTEXT_DESKTOP_AUTH_TOKEN} == "" || {env.CORTEXT_DESKTOP_RUNTIME_HOST} == "" || {env.CORTEXT_DESKTOP_RUNTIME_ORIGIN} == "" || {http.request.header.X-Cortext-Desktop-Token} != {env.CORTEXT_DESKTOP_AUTH_TOKEN} || {http.request.hostport} != {env.CORTEXT_DESKTOP_RUNTIME_HOST} || ({http.request.header.Origin} != "" && {http.request.header.Origin} != {env.CORTEXT_DESKTOP_RUNTIME_ORIGIN})`
 		respond @unauthorized "Forbidden" 403
 
 		request_header -X-Cortext-Desktop-Token

--- a/apps/desktop/runtime/bootstrap.php
+++ b/apps/desktop/runtime/bootstrap.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Defines the per-profile desktop runtime origin before WordPress loads.
+ *
+ * Existing desktop sites keep their generated wp-config.php across app
+ * upgrades. Defining these guarded constants here lets those sites move away
+ * from the legacy fixed port without replacing salts or other user config.
+ */
+
+$cortext_desktop_runtime_origin = getenv( 'CORTEXT_DESKTOP_RUNTIME_ORIGIN' );
+
+if (
+	! is_string( $cortext_desktop_runtime_origin ) ||
+	! preg_match(
+		'/\Ahttp:\/\/127\.0\.0\.1:([1-9][0-9]{0,4})\z/D',
+		$cortext_desktop_runtime_origin,
+		$cortext_desktop_runtime_origin_match
+	) ||
+	(int) $cortext_desktop_runtime_origin_match[1] > 65535
+) {
+	throw new RuntimeException( 'Invalid Cortext desktop runtime origin.' );
+}
+
+if ( ! defined( 'WP_HOME' ) ) {
+	define( 'WP_HOME', $cortext_desktop_runtime_origin );
+}
+if ( ! defined( 'WP_SITEURL' ) ) {
+	define( 'WP_SITEURL', $cortext_desktop_runtime_origin );
+}
+
+unset(
+	$cortext_desktop_runtime_origin,
+	$cortext_desktop_runtime_origin_match
+);

--- a/apps/desktop/runtime/router.php
+++ b/apps/desktop/runtime/router.php
@@ -7,14 +7,29 @@
  * The desktop snapshot copies this file into the bundled site.
  */
 
-$expected_token = getenv( 'CORTEXT_DESKTOP_AUTH_TOKEN' );
-$provided_token = $_SERVER['HTTP_X_CORTEXT_DESKTOP_TOKEN'] ?? '';
+$expected_token  = getenv( 'CORTEXT_DESKTOP_AUTH_TOKEN' );
+$expected_host   = getenv( 'CORTEXT_DESKTOP_RUNTIME_HOST' );
+$expected_origin = getenv( 'CORTEXT_DESKTOP_RUNTIME_ORIGIN' );
+$provided_token  = $_SERVER['HTTP_X_CORTEXT_DESKTOP_TOKEN'] ?? '';
+$provided_host   = $_SERVER['HTTP_HOST'] ?? '';
+$provided_origin = $_SERVER['HTTP_ORIGIN'] ?? '';
 
 if (
 	! is_string( $expected_token ) ||
 	$expected_token === '' ||
+	! is_string( $expected_host ) ||
+	$expected_host === '' ||
+	! is_string( $expected_origin ) ||
+	$expected_origin === '' ||
 	! is_string( $provided_token ) ||
-	! hash_equals( $expected_token, $provided_token )
+	! hash_equals( $expected_token, $provided_token ) ||
+	! is_string( $provided_host ) ||
+	! hash_equals( $expected_host, $provided_host ) ||
+	! is_string( $provided_origin ) ||
+	(
+		$provided_origin !== '' &&
+		! hash_equals( $expected_origin, $provided_origin )
+	)
 ) {
 	http_response_code( 403 );
 	header( 'Cache-Control: no-store' );
@@ -22,6 +37,8 @@ if (
 	echo 'Forbidden';
 	exit;
 }
+
+require_once __DIR__ . '/cortext-runtime-bootstrap.php';
 
 $uri = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 if ( $uri !== '/' && file_exists( __DIR__ . $uri ) ) {

--- a/apps/desktop/runtime/worker.php
+++ b/apps/desktop/runtime/worker.php
@@ -7,6 +7,8 @@
  * for each request. It deliberately lives behind CORTEXT_RUNTIME=franken.
  */
 
+require_once __DIR__ . '/cortext-runtime-bootstrap.php';
+
 if ( ! function_exists( 'frankenphp_handle_request' ) ) {
 	require __DIR__ . '/index.php';
 	return;

--- a/apps/desktop/scripts/app-shell.test.mjs
+++ b/apps/desktop/scripts/app-shell.test.mjs
@@ -397,3 +397,93 @@ test( 'closing during site preparation never starts the runtime', async () => {
 	assert.equal( refreshCalls, 0 );
 	assert.equal( startCalls, 0 );
 } );
+
+test( 'closing while runtime storage is cleared never finishes startup', async () => {
+	let finishStorageClear;
+	let markStorageClearStarted;
+	let installHeaderCalls = 0;
+	let loadUrlCalls = 0;
+	let quitCalls = 0;
+	let stopCalls = 0;
+	const windows = [];
+	const storageClearFinished = new Promise( ( resolve ) => {
+		finishStorageClear = resolve;
+	} );
+	const storageClearStarted = new Promise( ( resolve ) => {
+		markStorageClearStarted = resolve;
+	} );
+
+	class FakeWindow extends EventEmitter {
+		constructor( options ) {
+			super();
+			this.webContents = new EventEmitter();
+			Object.assign( this.webContents, {
+				openDevTools: () => {},
+				session: options.webPreferences.session,
+				setWindowOpenHandler: () => {},
+			} );
+			windows.push( this );
+		}
+
+		loadFile() {
+			return Promise.resolve();
+		}
+
+		loadURL() {
+			loadUrlCalls += 1;
+			return Promise.resolve();
+		}
+
+		setTitle() {}
+	}
+
+	const app = new EventEmitter();
+	Object.assign( app, {
+		isPackaged: false,
+		name: 'Cortext',
+		getPath: ( name ) => `/tmp/cortext-${ name }`,
+		getVersion: () => '1.0.0',
+		quit: () => {
+			quitCalls += 1;
+		},
+		whenReady: () => Promise.resolve(),
+	} );
+
+	loadMain(
+		app,
+		async () => {
+			stopCalls += 1;
+		},
+		undefined,
+		{
+			BrowserWindow: FakeWindow,
+			installRuntimeAuthHeader: () => {
+				installHeaderCalls += 1;
+				return () => {};
+			},
+			Menu: { setApplicationMenu: () => {} },
+			runtimeSession: {
+				clearStorageData: () => {
+					markStorageClearStarted();
+					return storageClearFinished;
+				},
+			},
+			startRuntime: runtimeHandle,
+		}
+	);
+
+	await storageClearStarted;
+	assert.equal( windows.length, 1 );
+
+	const closeEvent = quitEvent();
+	windows[ 0 ].emit( 'close', closeEvent );
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+	assert.equal( closeEvent.preventDefaultCalled, true );
+	assert.equal( stopCalls, 1 );
+	assert.equal( quitCalls, 1 );
+
+	finishStorageClear();
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+	assert.equal( installHeaderCalls, 0 );
+	assert.equal( loadUrlCalls, 0 );
+} );

--- a/apps/desktop/scripts/app-shell.test.mjs
+++ b/apps/desktop/scripts/app-shell.test.mjs
@@ -25,6 +25,14 @@ function requireWithMocks( modulePath, mocks ) {
 	}
 }
 
+function runtimeHandle() {
+	return {
+		origin: 'http://127.0.0.1:9403',
+		port: 9403,
+		ready: Promise.resolve(),
+	};
+}
+
 function loadMain(
 	app,
 	stopRuntime,
@@ -39,7 +47,7 @@ function loadMain(
 			clearStorageData: async () => {},
 		},
 		scheduleUpdateCheck = () => {},
-		startRuntime = () => {},
+		startRuntime = runtimeHandle,
 	} = {}
 ) {
 	// Every test here runs as the instance that holds the lock.
@@ -58,8 +66,10 @@ function loadMain(
 			},
 		},
 		'./lib/runtime': {
-			DEFAULT_PORT: 9402,
+			LEGACY_PORT: 9402,
 			RUNTIME_AUTH_HEADER: 'X-Cortext-Desktop-Token',
+			isValidPort: ( port ) =>
+				Number.isInteger( port ) && port >= 1 && port <= 65535,
 			startRuntime,
 			stopRuntime,
 		},
@@ -87,7 +97,7 @@ function loadMain(
 		},
 		'./lib/menu': { buildAppMenu: () => [] },
 		'./lib/settings': {
-			get: () => true,
+			get: ( key ) => ( key === 'autoInstallUpdates' ? true : undefined ),
 			set: () => {},
 		},
 	} );
@@ -102,7 +112,7 @@ function quitEvent() {
 	};
 }
 
-test( 'a second instance leaves without touching the site', () => {
+test( 'a second instance leaves without touching the site', async () => {
 	let exitCalls = 0;
 	let ensureCalls = 0;
 
@@ -115,7 +125,7 @@ test( 'a second instance leaves without touching the site', () => {
 		},
 		quit: () => {},
 		requestSingleInstanceLock: () => false,
-		whenReady: () => new Promise( () => {} ),
+		whenReady: () => Promise.resolve(),
 	} );
 
 	loadMain(
@@ -128,6 +138,7 @@ test( 'a second instance leaves without touching the site', () => {
 			},
 		}
 	);
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
 
 	assert.equal( exitCalls, 1 );
 	assert.equal( ensureCalls, 0 );
@@ -274,7 +285,7 @@ test( 'updater closes the window, then waits for the runtime before quitting', a
 			scheduleUpdateCheck: ( options ) => {
 				updaterOptions = options;
 			},
-			startRuntime: () => ( { ready: Promise.resolve() } ),
+			startRuntime: runtimeHandle,
 		}
 	);
 
@@ -364,7 +375,7 @@ test( 'closing during site preparation never starts the runtime', async () => {
 			},
 			startRuntime: () => {
 				startCalls += 1;
-				return { ready: Promise.resolve() };
+				return runtimeHandle();
 			},
 		}
 	);

--- a/apps/desktop/scripts/bench-runtime.mjs
+++ b/apps/desktop/scripts/bench-runtime.mjs
@@ -10,7 +10,6 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire( import.meta.url );
 const {
-	DEFAULT_PORT,
 	normalizeRuntime,
 	RUNTIME_AUTH_HEADER,
 	startRuntime,
@@ -104,14 +103,15 @@ function parseServerTiming( header ) {
 	return match ? Number.parseFloat( match[ 1 ] ) : null;
 }
 
-function redirectedPath( location ) {
-	const url = new URL( location, `http://127.0.0.1:${ DEFAULT_PORT }` );
+function redirectedPath( location, runtimeOrigin ) {
+	const url = new URL( location, runtimeOrigin );
 	return `${ url.pathname }${ url.search }`;
 }
 
 function requestPath(
 	endpoint,
 	authToken,
+	runtimeEndpoint,
 	redirects = 0,
 	startedAt = performance.now()
 ) {
@@ -122,7 +122,7 @@ function requestPath(
 				headers: {
 					[ RUNTIME_AUTH_HEADER ]: authToken,
 				},
-				port: DEFAULT_PORT,
+				port: runtimeEndpoint.port,
 				path: endpoint.path,
 				timeout: 30000,
 			},
@@ -142,9 +142,13 @@ function requestPath(
 						requestPath(
 							{
 								...endpoint,
-								path: redirectedPath( location ),
+								path: redirectedPath(
+									location,
+									runtimeEndpoint.origin
+								),
 							},
 							authToken,
+							runtimeEndpoint,
 							redirects + 1,
 							startedAt
 						).then( resolveRequest, rejectRequest );
@@ -204,14 +208,22 @@ function summarize( samples ) {
 	};
 }
 
-async function runEndpoint( endpoint, warmup, iterations, authToken ) {
+async function runEndpoint(
+	endpoint,
+	warmup,
+	iterations,
+	authToken,
+	runtimeEndpoint
+) {
 	for ( let index = 0; index < warmup; index++ ) {
-		await requestPath( endpoint, authToken );
+		await requestPath( endpoint, authToken, runtimeEndpoint );
 	}
 
 	const samples = [];
 	for ( let index = 0; index < iterations; index++ ) {
-		samples.push( await requestPath( endpoint, authToken ) );
+		samples.push(
+			await requestPath( endpoint, authToken, runtimeEndpoint )
+		);
 	}
 
 	return summarize( samples );
@@ -322,13 +334,18 @@ async function main() {
 		if ( unexpectedExit ) {
 			throw unexpectedExit;
 		}
+		const runtimeEndpoint = {
+			origin: handle.origin,
+			port: handle.port,
+		};
 		const scenarios = {};
 		for ( const endpoint of ENDPOINTS ) {
 			scenarios[ endpoint.name ] = await runEndpoint(
 				endpoint,
 				options.warmup,
 				options.iterations,
-				authToken
+				authToken,
+				runtimeEndpoint
 			);
 		}
 
@@ -337,7 +354,7 @@ async function main() {
 			runtime: options.runtime,
 			iterations: options.iterations,
 			warmup: options.warmup,
-			port: DEFAULT_PORT,
+			port: runtimeEndpoint.port,
 			generated_at: new Date().toISOString(),
 			environment: environmentInfo( options.runtime ),
 			scenarios,

--- a/apps/desktop/scripts/build-snapshot.mjs
+++ b/apps/desktop/scripts/build-snapshot.mjs
@@ -185,11 +185,15 @@ console.log( '[snapshot] Installing Cortext plugin' );
 cpSync( STAGED_PLUGIN, resolve( pluginsDir, 'cortext' ), { recursive: true } );
 
 console.log(
-	'[snapshot] Adding runtime files (router + worker + preload + mu-plugins)'
+	'[snapshot] Adding runtime files (router + bootstrap + worker + preload + mu-plugins)'
 );
 cpSync(
 	resolve( RUNTIME_DIR, 'router.php' ),
 	resolve( SITE_DIR, 'router.php' )
+);
+cpSync(
+	resolve( RUNTIME_DIR, 'bootstrap.php' ),
+	resolve( SITE_DIR, 'cortext-runtime-bootstrap.php' )
 );
 cpSync(
 	resolve( RUNTIME_DIR, 'worker.php' ),
@@ -232,14 +236,19 @@ await ensureCachedDownload( WP_CLI_PHAR_URL, wpCliPhar );
 const PHP_BIN = resolvePhpBin();
 
 function wpCli( args ) {
-	run( PHP_BIN, [ wpCliPhar, `--path=${ SITE_DIR }`, ...args ] );
+	run( PHP_BIN, [ wpCliPhar, `--path=${ SITE_DIR }`, ...args ], {
+		env: {
+			...process.env,
+			CORTEXT_DESKTOP_RUNTIME_ORIGIN: 'http://127.0.0.1:1',
+		},
+	} );
 }
 
 console.log( '[snapshot] Installing WordPress' );
 wpCli( [
 	'core',
 	'install',
-	'--url=http://127.0.0.1:9402',
+	'--url=http://127.0.0.1:1',
 	'--title=Cortext',
 	'--admin_user=admin',
 	`--admin_password=${ randomSalt()

--- a/apps/desktop/scripts/caddy-auth.test.mjs
+++ b/apps/desktop/scripts/caddy-auth.test.mjs
@@ -33,6 +33,22 @@ for ( const config of CONFIGS ) {
 		assert.ok( removeHeaderAt < upstreamAt );
 	} );
 
+	test( `${ config.name } binds to loopback and validates Host and Origin`, () => {
+		const caddyfile = fs.readFileSync( config.path, 'utf8' );
+
+		assert.match( caddyfile, /http:\/\/:\{\$CORTEXT_PORT\} \{/ );
+		assert.match( caddyfile, /\bbind 127\.0\.0\.1\b/ );
+		assert.match(
+			caddyfile,
+			/http\.request\.hostport\} != \{env\.CORTEXT_DESKTOP_RUNTIME_HOST\}/
+		);
+		assert.match(
+			caddyfile,
+			/http\.request\.header\.Origin\} != \{env\.CORTEXT_DESKTOP_RUNTIME_ORIGIN\}/
+		);
+		assert.doesNotMatch( caddyfile, /127\.0\.0\.1:9402/ );
+	} );
+
 	test( `${ config.name } filters the private header from error logs`, () => {
 		const caddyfile = fs.readFileSync( config.path, 'utf8' );
 
@@ -42,3 +58,15 @@ for ( const config of CONFIGS ) {
 		);
 	} );
 }
+
+test( 'FrankenPHP prepends the dynamic WordPress origin bootstrap', () => {
+	const caddyfile = fs.readFileSync(
+		new URL( '../runtime/Caddyfile.frankenphp', import.meta.url ),
+		'utf8'
+	);
+
+	assert.match(
+		caddyfile,
+		/php_ini \{[\s\S]*auto_prepend_file "\{\$CORTEXT_DESKTOP_RUNTIME_BOOTSTRAP\}"/
+	);
+} );

--- a/apps/desktop/scripts/router-auth.test.mjs
+++ b/apps/desktop/scripts/router-auth.test.mjs
@@ -47,7 +47,9 @@ function makeFixture() {
 
 function makeUnprotectedFixture() {
 	const wordpressDir = fs.mkdtempSync(
-		path.join( os.tmpdir(), 'cortext-router-legacy-' )
+		// PHP's -d parser treats an unquoted tilde as INI syntax. Windows CI
+		// commonly places temp files below RUNNER~1, so keep that case covered.
+		path.join( os.tmpdir(), 'cortext-router-legacy-RUNNER~1-' )
 	);
 	fs.writeFileSync(
 		path.join( wordpressDir, 'router.php' ),

--- a/apps/desktop/scripts/router-auth.test.mjs
+++ b/apps/desktop/scripts/router-auth.test.mjs
@@ -26,6 +26,10 @@ function makeFixture() {
 		new URL( '../runtime/router.php', import.meta.url ),
 		path.join( wordpressDir, 'router.php' )
 	);
+	fs.copyFileSync(
+		new URL( '../runtime/bootstrap.php', import.meta.url ),
+		path.join( wordpressDir, 'cortext-runtime-bootstrap.php' )
+	);
 	fs.writeFileSync(
 		path.join( wordpressDir, 'index.php' ),
 		"<?php header( 'Content-Type: text/plain' ); echo 'dynamic';"
@@ -43,6 +47,14 @@ function makeUnprotectedFixture() {
 		"<?php header( 'Content-Type: text/plain' ); echo 'legacy';"
 	);
 	fs.writeFileSync( path.join( wordpressDir, 'index.php' ), 'legacy' );
+	fs.writeFileSync(
+		path.join( wordpressDir, 'wp-config.php' ),
+		"<?php if ( ! defined( 'WP_HOME' ) ) { define( 'WP_HOME', 'http://127.0.0.1:9402' ); } if ( ! defined( 'WP_SITEURL' ) ) { define( 'WP_SITEURL', 'http://127.0.0.1:9402' ); }"
+	);
+	fs.writeFileSync(
+		path.join( wordpressDir, 'origin.php' ),
+		"<?php require __DIR__ . '/wp-config.php'; header( 'Content-Type: text/plain' ); echo WP_HOME . \"\\n\" . WP_SITEURL;"
+	);
 	return wordpressDir;
 }
 
@@ -60,11 +72,17 @@ async function findAvailablePort() {
 	return port;
 }
 
-function request( port, requestPath, authToken ) {
+function request( port, requestPath, authToken, requestOptions = {} ) {
 	return new Promise( ( resolve, reject ) => {
 		const headers = {};
 		if ( authToken !== undefined ) {
 			headers[ RUNTIME_AUTH_HEADER ] = authToken;
+		}
+		if ( requestOptions.host !== undefined ) {
+			headers.Host = requestOptions.host;
+		}
+		if ( requestOptions.origin !== undefined ) {
+			headers.Origin = requestOptions.origin;
 		}
 
 		const req = http.get(
@@ -116,13 +134,24 @@ async function waitForServer( child, port, stderr ) {
 	throw new Error( `PHP server did not become ready: ${ stderr() }` );
 }
 
-async function startServer( wordpressDir, authToken ) {
+async function startServer(
+	wordpressDir,
+	authToken,
+	{ configureEndpoint = true } = {}
+) {
 	const port = await findAvailablePort();
 	const env = { ...process.env };
 	if ( authToken === undefined ) {
 		delete env.CORTEXT_DESKTOP_AUTH_TOKEN;
 	} else {
 		env.CORTEXT_DESKTOP_AUTH_TOKEN = authToken;
+	}
+	if ( configureEndpoint ) {
+		env.CORTEXT_DESKTOP_RUNTIME_HOST = `127.0.0.1:${ port }`;
+		env.CORTEXT_DESKTOP_RUNTIME_ORIGIN = `http://127.0.0.1:${ port }`;
+	} else {
+		delete env.CORTEXT_DESKTOP_RUNTIME_HOST;
+		delete env.CORTEXT_DESKTOP_RUNTIME_ORIGIN;
 	}
 
 	const child = spawn(
@@ -208,11 +237,95 @@ test( 'startRuntime replaces an unprotected legacy router before listening', asy
 		/hash_equals/
 	);
 	await handle.ready;
+	assert.equal( handle.port, port );
+	assert.equal( handle.host, `127.0.0.1:${ port }` );
+	assert.equal( handle.origin, `http://127.0.0.1:${ port }` );
 	const unauthenticated = await request( port, '/', undefined );
 	assert.equal( unauthenticated.statusCode, 403 );
 	const authenticated = await request( port, '/', AUTH_TOKEN );
 	assert.equal( authenticated.statusCode, 200 );
 	assert.equal( authenticated.body, 'legacy' );
+	const migratedOrigin = await request( port, '/origin.php', AUTH_TOKEN, {
+		origin: handle.origin,
+	} );
+	assert.equal( migratedOrigin.statusCode, 200 );
+	assert.equal(
+		migratedOrigin.body,
+		`${ handle.origin }\n${ handle.origin }`
+	);
+} );
+
+test( 'startRuntime chooses a dynamic port when its preference is occupied', async ( context ) => {
+	const wordpressDir = makeUnprotectedFixture();
+	const blocker = net.createServer();
+	blocker.listen( 0, '127.0.0.1' );
+	await once( blocker, 'listening' );
+	const address = blocker.address();
+	assert.notEqual( address, null );
+	assert.equal( typeof address, 'object' );
+
+	const handle = startRuntime( {
+		appDir: DESKTOP_DIR,
+		authToken: AUTH_TOKEN,
+		port: address.port,
+		runtime: 'php',
+		runtimeStateDir: path.join( wordpressDir, 'runtime-state' ),
+		wordpressDir,
+	} );
+	context.after( async () => {
+		stopRuntime( handle );
+		await new Promise( ( resolve ) => blocker.close( resolve ) );
+		fs.rmSync( wordpressDir, { recursive: true, force: true } );
+	} );
+
+	await handle.ready;
+	assert.notEqual( handle.port, address.port );
+	assert.equal( handle.origin, `http://127.0.0.1:${ handle.port }` );
+	const authenticated = await request( handle.port, '/', AUTH_TOKEN, {
+		origin: handle.origin,
+	} );
+	assert.equal( authenticated.statusCode, 200 );
+} );
+
+test( 'startRuntime retries when its selected port is claimed before spawn', async ( context ) => {
+	const wordpressDir = makeUnprotectedFixture();
+	const blocker = net.createServer( ( socket ) => socket.destroy() );
+	blocker.listen( 0, '127.0.0.1' );
+	await once( blocker, 'listening' );
+	const blockedAddress = blocker.address();
+	assert.notEqual( blockedAddress, null );
+	assert.equal( typeof blockedAddress, 'object' );
+	const retryPort = await findAvailablePort();
+	const preferredPort = await findAvailablePort();
+	const allocatorCalls = [];
+
+	const handle = startRuntime( {
+		appDir: DESKTOP_DIR,
+		authToken: AUTH_TOKEN,
+		port: preferredPort,
+		portAllocator: async ( requestedPort ) => {
+			allocatorCalls.push( requestedPort );
+			return allocatorCalls.length === 1
+				? blockedAddress.port
+				: retryPort;
+		},
+		runtime: 'php',
+		runtimeStateDir: path.join( wordpressDir, 'runtime-state' ),
+		wordpressDir,
+	} );
+	context.after( async () => {
+		stopRuntime( handle );
+		await new Promise( ( resolve ) => blocker.close( resolve ) );
+		fs.rmSync( wordpressDir, { recursive: true, force: true } );
+	} );
+
+	await handle.ready;
+	assert.deepEqual( allocatorCalls, [ preferredPort, undefined ] );
+	assert.equal( handle.port, retryPort );
+	const authenticated = await request( handle.port, '/', AUTH_TOKEN, {
+		origin: handle.origin,
+	} );
+	assert.equal( authenticated.statusCode, 200 );
 } );
 
 test( 'startRuntime fails before listening without its authenticated router', async () => {
@@ -260,6 +373,29 @@ test( 'router authenticates static and dynamic requests', async ( context ) => {
 			authenticated.body,
 			requestPath === '/static.txt' ? 'static' : 'dynamic'
 		);
+
+		const authenticatedWithOrigin = await request(
+			port,
+			requestPath,
+			AUTH_TOKEN,
+			{ origin: `http://127.0.0.1:${ port }` }
+		);
+		assert.equal( authenticatedWithOrigin.statusCode, 200 );
+
+		for ( const requestOptions of [
+			{ host: `localhost:${ port }` },
+			{ host: `127.0.0.1:${ port + 1 }` },
+			{ origin: 'null' },
+			{ origin: 'https://example.com' },
+		] ) {
+			const rejected = await request(
+				port,
+				requestPath,
+				AUTH_TOKEN,
+				requestOptions
+			);
+			assert.equal( rejected.statusCode, 403 );
+		}
 	}
 } );
 
@@ -275,4 +411,15 @@ test( 'router fails closed when its auth token is not configured', async ( conte
 		const supplied = await request( port, requestPath, AUTH_TOKEN );
 		assert.equal( supplied.statusCode, 403 );
 	}
+} );
+
+test( 'router fails closed without its expected runtime endpoint', async ( context ) => {
+	const wordpressDir = makeFixture();
+	const { child, port } = await startServer( wordpressDir, AUTH_TOKEN, {
+		configureEndpoint: false,
+	} );
+	registerCleanup( context, child, wordpressDir );
+
+	const response = await request( port, '/', AUTH_TOKEN );
+	assert.equal( response.statusCode, 403 );
 } );

--- a/apps/desktop/scripts/router-auth.test.mjs
+++ b/apps/desktop/scripts/router-auth.test.mjs
@@ -11,7 +11,14 @@ import { fileURLToPath } from 'node:url';
 
 import runtime from '../lib/runtime.js';
 
-const { RUNTIME_AUTH_HEADER, startRuntime, stopRuntime } = runtime;
+const {
+	RUNTIME_AUTH_HEADER,
+	RUNTIME_PORT_FIRST,
+	RUNTIME_PORT_LAST,
+	findAvailablePort,
+	startRuntime,
+	stopRuntime,
+} = runtime;
 const AUTH_TOKEN = 'test-runtime-auth-token';
 const DESKTOP_DIR = path.resolve(
 	path.dirname( fileURLToPath( import.meta.url ) ),
@@ -58,7 +65,9 @@ function makeUnprotectedFixture() {
 	return wordpressDir;
 }
 
-async function findAvailablePort() {
+// A throwaway port for fixture servers. Unlike the runtime allocator this is
+// free to use the ephemeral range, since nothing here outlives the test.
+async function reserveEphemeralPort() {
 	const server = net.createServer();
 	server.unref();
 	server.listen( 0, '127.0.0.1' );
@@ -139,7 +148,7 @@ async function startServer(
 	authToken,
 	{ configureEndpoint = true } = {}
 ) {
-	const port = await findAvailablePort();
+	const port = await reserveEphemeralPort();
 	const env = { ...process.env };
 	if ( authToken === undefined ) {
 		delete env.CORTEXT_DESKTOP_AUTH_TOKEN;
@@ -218,7 +227,7 @@ test( 'startRuntime requires a non-empty auth token', () => {
 
 test( 'startRuntime replaces an unprotected legacy router before listening', async ( context ) => {
 	const wordpressDir = makeUnprotectedFixture();
-	const port = await findAvailablePort();
+	const port = await reserveEphemeralPort();
 	const handle = startRuntime( {
 		appDir: DESKTOP_DIR,
 		authToken: AUTH_TOKEN,
@@ -255,6 +264,45 @@ test( 'startRuntime replaces an unprotected legacy router before listening', asy
 	);
 } );
 
+test( 'findAvailablePort picks from the fixed band, not the ephemeral range', async () => {
+	const selected = await findAvailablePort();
+
+	assert.ok(
+		selected >= RUNTIME_PORT_FIRST && selected <= RUNTIME_PORT_LAST,
+		`expected a band port, got ${ selected }`
+	);
+} );
+
+test( 'findAvailablePort scans past an occupied band port', async ( context ) => {
+	const first = await findAvailablePort();
+	const blocker = net.createServer();
+	blocker.listen( first, '127.0.0.1' );
+	await once( blocker, 'listening' );
+	context.after(
+		() => new Promise( ( resolve ) => blocker.close( resolve ) )
+	);
+
+	const second = await findAvailablePort();
+
+	assert.ok(
+		second > first && second <= RUNTIME_PORT_LAST,
+		`expected a later band port than ${ first }, got ${ second }`
+	);
+} );
+
+test( 'findAvailablePort keeps an available preference over the band', async () => {
+	const outsideBand = await new Promise( ( resolve, reject ) => {
+		const probe = net.createServer();
+		probe.once( 'error', reject );
+		probe.listen( 0, '127.0.0.1', () => {
+			const { port } = probe.address();
+			probe.close( () => resolve( port ) );
+		} );
+	} );
+
+	assert.equal( await findAvailablePort( outsideBand ), outsideBand );
+} );
+
 test( 'startRuntime chooses a dynamic port when its preference is occupied', async ( context ) => {
 	const wordpressDir = makeUnprotectedFixture();
 	const blocker = net.createServer();
@@ -273,13 +321,17 @@ test( 'startRuntime chooses a dynamic port when its preference is occupied', asy
 		wordpressDir,
 	} );
 	context.after( async () => {
-		stopRuntime( handle );
+		await stopRuntime( handle );
 		await new Promise( ( resolve ) => blocker.close( resolve ) );
 		fs.rmSync( wordpressDir, { recursive: true, force: true } );
 	} );
 
 	await handle.ready;
 	assert.notEqual( handle.port, address.port );
+	assert.ok(
+		handle.port >= RUNTIME_PORT_FIRST && handle.port <= RUNTIME_PORT_LAST,
+		`expected a band port, got ${ handle.port }`
+	);
 	assert.equal( handle.origin, `http://127.0.0.1:${ handle.port }` );
 	const authenticated = await request( handle.port, '/', AUTH_TOKEN, {
 		origin: handle.origin,
@@ -295,8 +347,8 @@ test( 'startRuntime retries when its selected port is claimed before spawn', asy
 	const blockedAddress = blocker.address();
 	assert.notEqual( blockedAddress, null );
 	assert.equal( typeof blockedAddress, 'object' );
-	const retryPort = await findAvailablePort();
-	const preferredPort = await findAvailablePort();
+	const retryPort = await reserveEphemeralPort();
+	const preferredPort = await reserveEphemeralPort();
 	const allocatorCalls = [];
 
 	const handle = startRuntime( {
@@ -314,7 +366,7 @@ test( 'startRuntime retries when its selected port is claimed before spawn', asy
 		wordpressDir,
 	} );
 	context.after( async () => {
-		stopRuntime( handle );
+		await stopRuntime( handle );
 		await new Promise( ( resolve ) => blocker.close( resolve ) );
 		fs.rmSync( wordpressDir, { recursive: true, force: true } );
 	} );
@@ -330,7 +382,7 @@ test( 'startRuntime retries when its selected port is claimed before spawn', asy
 
 test( 'startRuntime fails before listening without its authenticated router', async () => {
 	const wordpressDir = makeUnprotectedFixture();
-	const port = await findAvailablePort();
+	const port = await reserveEphemeralPort();
 	const appDir = fs.mkdtempSync(
 		path.join( os.tmpdir(), 'cortext-router-missing-app-' )
 	);

--- a/apps/desktop/scripts/runtime-session.test.mjs
+++ b/apps/desktop/scripts/runtime-session.test.mjs
@@ -6,7 +6,7 @@ import runtimeSessionModule from '../lib/runtime-session.js';
 const { installRuntimeAuthHeader } = runtimeSessionModule;
 const AUTH_HEADER = 'X-Cortext-Desktop-Token';
 const AUTH_TOKEN = 'private-runtime-token';
-const RUNTIME_ORIGIN = 'http://127.0.0.1:9402';
+const RUNTIME_ORIGIN = 'http://127.0.0.1:43123';
 const LOADING_URL = 'file:///Applications/Cortext.app/loading.html';
 const RUNTIME_FRAME = {
 	url: `${ RUNTIME_ORIGIN }/wp-admin/admin.php?page=cortext`,
@@ -111,6 +111,15 @@ test( 'never sends the runtime token to another origin', async () => {
 	} );
 
 	assert.deepEqual( result.requestHeaders, { Accept: 'image/*' } );
+
+	const otherLoopbackPort = await sendHeaders(
+		listeners.onBeforeSendHeaders,
+		{
+			url: 'http://127.0.0.1:43124/wp-admin/',
+			requestHeaders: {},
+		}
+	);
+	assert.equal( otherLoopbackPort.requestHeaders[ AUTH_HEADER ], undefined );
 } );
 
 test( 'does not authenticate a redirect chain that leaves the runtime', async () => {

--- a/apps/desktop/scripts/runtime.test.mjs
+++ b/apps/desktop/scripts/runtime.test.mjs
@@ -11,6 +11,7 @@ const {
 	bundledRuntimeExecutable,
 	childProcessOptions,
 	findRuntimeExecutable,
+	isPortBindFailure,
 	phpCliWorkerConfig,
 	runWindowsTaskkill,
 	stopRuntime,
@@ -74,6 +75,36 @@ test( 'child process options hide the Windows console', () => {
 		cwd: 'C:\\site',
 		windowsHide: true,
 	} );
+} );
+
+test( 'runtime startup recognizes cross-platform port bind failures', () => {
+	const cases = [
+		[
+			'Failed to listen on 127.0.0.1:9402 (reason: Address already in use)',
+			true,
+		],
+		[
+			'Failed to listen on 127.0.0.1:9402 (reason: An attempt was made to access a socket in a way forbidden by its access permissions)',
+			true,
+		],
+		[
+			'listen tcp 127.0.0.1:9402: bind: Only one usage of each socket address is normally permitted.',
+			true,
+		],
+		[ 'PHP Parse error: syntax error in bootstrap.php', false ],
+		[
+			'Failed to listen on 127.0.0.1:9403 (reason: An attempt was made to access a socket in a way forbidden by its access permissions)',
+			false,
+		],
+	];
+
+	for ( const [ outputTail, expected ] of cases ) {
+		assert.equal(
+			isPortBindFailure( [ { outputTail } ], 9402 ),
+			expected,
+			outputTail
+		);
+	}
 } );
 
 test( 'Windows ignores PHP CLI worker settings and does not detach', () => {

--- a/apps/desktop/scripts/wp-config.mjs
+++ b/apps/desktop/scripts/wp-config.mjs
@@ -32,9 +32,8 @@ export function buildWpConfig() {
 		lines.push( `define( '${ key }', '${ randomSalt() }' );` );
 	}
 	lines.push( "$table_prefix = 'wp_';" );
+	lines.push( "require_once __DIR__ . '/cortext-runtime-bootstrap.php';" );
 	const guardedConstants = [
-		[ 'WP_HOME', "'http://127.0.0.1:9402'" ],
-		[ 'WP_SITEURL', "'http://127.0.0.1:9402'" ],
 		[ 'CORTEXT_DESKTOP', 'true' ],
 		[ 'DISABLE_WP_CRON', 'true' ],
 		// The mu-plugin repeats these for desktop sites created by older builds.

--- a/apps/desktop/scripts/wp-config.test.mjs
+++ b/apps/desktop/scripts/wp-config.test.mjs
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { buildWpConfig } from './wp-config.mjs';
+
+const BOOTSTRAP_PATH = fileURLToPath(
+	new URL( '../runtime/bootstrap.php', import.meta.url )
+);
 
 test( 'desktop wp-config disables WordPress self-updates', () => {
 	const config = buildWpConfig();
@@ -10,4 +16,55 @@ test( 'desktop wp-config disables WordPress self-updates', () => {
 	assert.match( config, /define\( 'WP_AUTO_UPDATE_CORE', false \);/ );
 	assert.match( config, /define\( 'DISALLOW_FILE_MODS', true \);/ );
 	assert.match( config, /define\( 'DISALLOW_FILE_EDIT', true \);/ );
+} );
+
+test( 'desktop wp-config loads the runtime origin without a fixed port', () => {
+	const config = buildWpConfig();
+
+	assert.match(
+		config,
+		/require_once __DIR__ \. '\/cortext-runtime-bootstrap\.php';/
+	);
+	assert.doesNotMatch( config, /127\.0\.0\.1:9402/ );
+	assert.doesNotMatch( config, /define\( 'WP_(?:HOME|SITEURL)'/ );
+} );
+
+test( 'runtime bootstrap defines the current origin before legacy config', () => {
+	const origin = 'http://127.0.0.1:54321';
+	const result = spawnSync(
+		'php',
+		[
+			'-r',
+			`require ${ JSON.stringify(
+				BOOTSTRAP_PATH
+			) }; if ( ! defined( 'WP_HOME' ) ) { define( 'WP_HOME', 'http://127.0.0.1:9402' ); } echo WP_HOME . "\\n" . WP_SITEURL;`,
+		],
+		{
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				CORTEXT_DESKTOP_RUNTIME_ORIGIN: origin,
+			},
+		}
+	);
+
+	assert.equal( result.status, 0, result.stderr );
+	assert.equal( result.stdout, `${ origin }\n${ origin }` );
+} );
+
+test( 'runtime bootstrap fails closed for a non-loopback origin', () => {
+	const result = spawnSync(
+		'php',
+		[ '-r', `require ${ JSON.stringify( BOOTSTRAP_PATH ) };` ],
+		{
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				CORTEXT_DESKTOP_RUNTIME_ORIGIN: 'https://example.com',
+			},
+		}
+	);
+
+	assert.notEqual( result.status, 0 );
+	assert.match( result.stderr, /Invalid Cortext desktop runtime origin/ );
 } );

--- a/apps/desktop/scripts/wp-config.test.mjs
+++ b/apps/desktop/scripts/wp-config.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
@@ -27,6 +28,20 @@ test( 'desktop wp-config loads the runtime origin without a fixed port', () => {
 	);
 	assert.doesNotMatch( config, /127\.0\.0\.1:9402/ );
 	assert.doesNotMatch( config, /define\( 'WP_(?:HOME|SITEURL)'/ );
+} );
+
+test( 'desktop package includes the runtime origin bootstrap', () => {
+	const packageConfig = JSON.parse(
+		readFileSync( new URL( '../package.json', import.meta.url ), 'utf8' )
+	);
+
+	assert.ok(
+		packageConfig.build.extraResources.some(
+			( resource ) =>
+				resource.from === 'runtime/bootstrap.php' &&
+				resource.to === 'runtime/bootstrap.php'
+		)
+	);
 } );
 
 test( 'runtime bootstrap defines the current origin before legacy config', () => {

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -362,6 +362,12 @@ function waitForProcessExit( app, timeoutMs = 10000 ) {
 }
 
 async function expectSecondInstanceToExit( app, userDataPath ) {
+	await app.evaluate( ( { app } ) => {
+		globalThis.__cortextE2ESecondInstanceSeen = false;
+		app.once( 'second-instance', () => {
+			globalThis.__cortextE2ESecondInstanceSeen = true;
+		} );
+	} );
 	const secondInstance = spawn(
 		app.process().spawnfile,
 		[ APP_PATH, `--user-data-dir=${ userDataPath }` ],
@@ -382,12 +388,15 @@ async function expectSecondInstanceToExit( app, userDataPath ) {
 		}, 10 * 1000 );
 		timeoutId.unref?.();
 	} );
-	const [ exitCode ] = await Promise.race( [
-		once( secondInstance, 'exit' ),
-		timeout,
-	] );
+	await Promise.race( [ once( secondInstance, 'exit' ), timeout ] );
 	clearTimeout( timeoutId );
-	expect( exitCode ).toBe( 0 );
+	await expect
+		.poll(
+			() =>
+				app.evaluate( () => globalThis.__cortextE2ESecondInstanceSeen ),
+			{ timeout: 10 * 1000 }
+		)
+		.toBe( true );
 }
 
 test( 'opens Cortext and rejects untrusted runtime requests', async () => {

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -10,9 +10,18 @@
  * snapshot` first.
  */
 const { test, expect, _electron: electron } = require( '@playwright/test' );
+const { spawn } = require( 'node:child_process' );
+const { once } = require( 'node:events' );
 const http = require( 'node:http' );
 const path = require( 'node:path' );
-const { existsSync, mkdtempSync, realpathSync, rmSync } = require( 'node:fs' );
+const {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} = require( 'node:fs' );
 const os = require( 'node:os' );
 
 const APP_PATH = path.resolve( __dirname, '..' );
@@ -21,6 +30,7 @@ let e2eTempRoot;
 let untrustedServer;
 let untrustedOrigin;
 let untrustedRequests;
+let runtimeOrigin;
 
 test.beforeAll( async () => {
 	if ( ! existsSync( SNAPSHOT_PATH ) ) {
@@ -40,7 +50,7 @@ test.beforeAll( async () => {
 		if ( request.url === '/redirect-runtime' ) {
 			response.writeHead( 302, {
 				'Cache-Control': 'no-store',
-				Location: 'http://127.0.0.1:9402/wp-includes/images/blank.gif',
+				Location: `${ runtimeOrigin }/wp-includes/images/blank.gif`,
 			} );
 			response.end();
 			return;
@@ -54,14 +64,14 @@ test.beforeAll( async () => {
 			`<!doctype html>
 			<body data-runtime-image="pending">
 				<img
-					src="http://127.0.0.1:9402/wp-includes/images/blank.gif"
+					src="${ runtimeOrigin }/wp-includes/images/blank.gif"
 					onload="document.body.dataset.runtimeImage='loaded'"
 					onerror="document.body.dataset.runtimeImage='blocked'"
 				>
 				<a
 					id="runtime-link"
 					target="_top"
-					href="http://127.0.0.1:9402/wp-json/"
+					href="${ runtimeOrigin }/wp-json/"
 					style="position:fixed;inset:0;display:block"
 				>Open runtime</a>
 			</body>`
@@ -100,8 +110,16 @@ test.afterAll( async () => {
 } );
 
 async function launchDesktopApp(
-	userDataPath = mkdtempSync( path.join( e2eTempRoot, 'user-data-' ) )
+	userDataPath = mkdtempSync( path.join( e2eTempRoot, 'user-data-' ) ),
+	preferredRuntimePort = null
 ) {
+	if ( preferredRuntimePort !== null ) {
+		mkdirSync( userDataPath, { recursive: true } );
+		writeFileSync(
+			path.join( userDataPath, 'settings.json' ),
+			JSON.stringify( { runtimePort: preferredRuntimePort } )
+		);
+	}
 	const app = await electron.launch( {
 		args: [ APP_PATH, `--user-data-dir=${ userDataPath }` ],
 		env: {
@@ -176,6 +194,7 @@ function reloadFirstRuntimeNavigationFromMenu( app ) {
 		return new Promise( ( resolve, reject ) => {
 			const win = BrowserWindow.getAllWindows()[ 0 ];
 			const webContents = win.webContents;
+			let origin = null;
 			const findMenuItem = ( items, role ) => {
 				for ( const item of items ) {
 					if ( item.role === role ) {
@@ -217,7 +236,8 @@ function reloadFirstRuntimeNavigationFromMenu( app ) {
 			const onStart = ( event ) => {
 				if (
 					event.isMainFrame &&
-					event.url.startsWith( 'http://127.0.0.1:9402/' )
+					origin &&
+					event.url.startsWith( `${ origin }/` )
 				) {
 					reloadStarted = true;
 				}
@@ -230,13 +250,15 @@ function reloadFirstRuntimeNavigationFromMenu( app ) {
 				resolve( webContents.getURL() );
 			};
 			const onNavigate = ( _event, url ) => {
+				const navigatedUrl = new URL( url );
 				if (
-					! url.startsWith(
-						'http://127.0.0.1:9402/wp-admin/admin.php?page=cortext'
-					)
+					navigatedUrl.hostname !== '127.0.0.1' ||
+					navigatedUrl.pathname !== '/wp-admin/admin.php' ||
+					navigatedUrl.searchParams.get( 'page' ) !== 'cortext'
 				) {
 					return;
 				}
+				origin = navigatedUrl.origin;
 				webContents.off( 'did-navigate', onNavigate );
 				webContents.on( 'did-start-navigation', onStart );
 				webContents.on( 'did-finish-load', onFinish );
@@ -286,7 +308,7 @@ function openExternalFromRuntime(
 						const url = candidate.webContents.getURL();
 						return options.windowUrlSuffix
 							? url.endsWith( options.windowUrlSuffix )
-							: url.startsWith( 'http://127.0.0.1:9402/' );
+							: url.startsWith( `${ options.runtimeOrigin }/` );
 					}
 				);
 				if ( ! targetWindow ) {
@@ -310,7 +332,7 @@ function openExternalFromRuntime(
 					.catch( ( error ) => finish( reject, error ) );
 			} );
 		},
-		{ externalUrl, target, windowUrlSuffix }
+		{ externalUrl, target, windowUrlSuffix, runtimeOrigin }
 	);
 }
 
@@ -339,13 +361,61 @@ function waitForProcessExit( app, timeoutMs = 10000 ) {
 	} );
 }
 
+async function expectSecondInstanceToExit( app, userDataPath ) {
+	const secondInstance = spawn(
+		app.process().spawnfile,
+		[ APP_PATH, `--user-data-dir=${ userDataPath }` ],
+		{
+			env: {
+				...process.env,
+				CORTEXT_DEVTOOLS: '0',
+				CORTEXT_E2E: '1',
+			},
+			stdio: 'ignore',
+		}
+	);
+	let timeoutId;
+	const timeout = new Promise( ( _resolve, reject ) => {
+		timeoutId = setTimeout( () => {
+			secondInstance.kill( 'SIGKILL' );
+			reject( new Error( 'Second Cortext instance stayed open.' ) );
+		}, 10 * 1000 );
+		timeoutId.unref?.();
+	} );
+	const [ exitCode ] = await Promise.race( [
+		once( secondInstance, 'exit' ),
+		timeout,
+	] );
+	clearTimeout( timeoutId );
+	expect( exitCode ).toBe( 0 );
+}
+
 test( 'opens Cortext and rejects untrusted runtime requests', async () => {
-	const { app, userDataPath } = await launchDesktopApp();
+	const occupiedPortServer = http.createServer( ( _request, response ) => {
+		response.writeHead( 200 );
+		response.end( 'occupied' );
+	} );
+	await new Promise( ( resolve, reject ) => {
+		occupiedPortServer.once( 'error', reject );
+		occupiedPortServer.listen( 0, '127.0.0.1', resolve );
+	} );
+	const occupiedAddress = occupiedPortServer.address();
+	if ( ! occupiedAddress || typeof occupiedAddress === 'string' ) {
+		throw new Error( 'Failed to reserve the preferred E2E runtime port.' );
+	}
+	const { app, userDataPath } = await launchDesktopApp(
+		undefined,
+		occupiedAddress.port
+	);
 	untrustedRequests.length = 0;
 
 	try {
 		await expectTemporaryUserData( app, userDataPath );
 		const window = await waitForCortextShell( app );
+		runtimeOrigin = new URL( window.url() ).origin;
+		expect( new URL( runtimeOrigin ).port ).not.toBe(
+			String( occupiedAddress.port )
+		);
 		await expect.poll( () => window.title() ).toBe( 'Cortext' );
 		const staticAssetUrl = new URL(
 			'/wp-includes/css/dashicons.min.css',
@@ -385,6 +455,15 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 		await expect(
 			requestWithoutRuntimeAuth( staticAssetUrl )
 		).resolves.toBe( 403 );
+		const wordpressOrigins = await window.evaluate( async () => {
+			const response = await fetch( '/?rest_route=/' );
+			const body = await response.json();
+			return { home: body.home, url: body.url };
+		} );
+		expect( wordpressOrigins ).toEqual( {
+			home: runtimeOrigin,
+			url: runtimeOrigin,
+		} );
 
 		const redirectedImageStatus = await window.evaluate( ( origin ) => {
 			return new Promise( ( resolve ) => {
@@ -445,7 +524,7 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 			);
 		} );
 		const popup = await popupPromise;
-		await popup.waitForURL( 'http://127.0.0.1:9402/wp-json/' );
+		await popup.waitForURL( `${ runtimeOrigin }/wp-json/` );
 		await expect( popup.locator( 'body' ) ).not.toHaveText( 'Forbidden' );
 		const popupSecurity = await app.evaluate(
 			( { session, webContents } ) => {
@@ -485,7 +564,7 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 		).resolves.toBe( externalUrl );
 		await expect
 			.poll( () => popup.url() )
-			.toBe( 'http://127.0.0.1:9402/wp-json/' );
+			.toBe( `${ runtimeOrigin }/wp-json/` );
 		await popup.close();
 
 		const untrustedWindowPromise = app.waitForEvent( 'window' );
@@ -509,7 +588,7 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 			)
 			.toBe( 'blocked' );
 		await untrustedWindow.locator( '#runtime-link' ).click();
-		await untrustedWindow.waitForURL( 'http://127.0.0.1:9402/wp-json/' );
+		await untrustedWindow.waitForURL( `${ runtimeOrigin }/wp-json/` );
 		await expect( untrustedWindow.locator( 'body' ) ).toHaveText(
 			'Forbidden'
 		);
@@ -551,6 +630,15 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 		).toBe( true );
 	} finally {
 		await app.close();
+		await new Promise( ( resolve, reject ) => {
+			occupiedPortServer.close( ( error ) => {
+				if ( error ) {
+					reject( error );
+					return;
+				}
+				resolve();
+			} );
+		} );
 	}
 } );
 
@@ -564,9 +652,11 @@ test( 'reloads, preserves preferences, and exits with its window', async () => {
 		const menuReload = reloadFirstRuntimeNavigationFromMenu( app );
 		await expectTemporaryUserData( app, userDataPath );
 		const window = await waitForCortextShell( app );
-		await expect( menuReload ).resolves.toMatch(
-			/^http:\/\/127\.0\.0\.1:9402\//
-		);
+		runtimeOrigin = new URL( window.url() ).origin;
+		await expectSecondInstanceToExit( app, userDataPath );
+		await expect( window.locator( '#cortext-root' ) ).toBeVisible();
+		const reloadedUrl = await menuReload;
+		expect( new URL( reloadedUrl ).origin ).toBe( runtimeOrigin );
 		await expect( window.locator( 'body' ) ).not.toHaveText( 'Forbidden' );
 		await expect(
 			window.locator(
@@ -587,6 +677,9 @@ test( 'reloads, preserves preferences, and exits with its window', async () => {
 		( { app: relaunchedApp } = await launchDesktopApp( userDataPath ) );
 		await expectTemporaryUserData( relaunchedApp, userDataPath );
 		const relaunchedWindow = await waitForCortextShell( relaunchedApp );
+		expect( new URL( relaunchedWindow.url() ).origin ).toBe(
+			runtimeOrigin
+		);
 		await expect
 			.poll( () =>
 				relaunchedWindow.evaluate( () =>

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -368,18 +368,24 @@ async function expectSecondInstanceToExit( app, userDataPath ) {
 			globalThis.__cortextE2ESecondInstanceSeen = true;
 		} );
 	} );
-	const secondInstance = spawn(
-		app.process().spawnfile,
-		[ APP_PATH, `--user-data-dir=${ userDataPath }` ],
-		{
-			env: {
-				...process.env,
-				CORTEXT_DEVTOOLS: '0',
-				CORTEXT_E2E: '1',
-			},
-			stdio: 'ignore',
-		}
-	);
+	const secondInstanceArgs = [
+		APP_PATH,
+		`--user-data-dir=${ userDataPath }`,
+	];
+	// Playwright disables Chromium's sandbox for its Electron process on
+	// Linux. Match that test-only launch mode so the second process reaches
+	// Electron's single-instance lock instead of exiting during bootstrap.
+	if ( process.platform === 'linux' ) {
+		secondInstanceArgs.unshift( '--no-sandbox' );
+	}
+	const secondInstance = spawn( app.process().spawnfile, secondInstanceArgs, {
+		env: {
+			...process.env,
+			CORTEXT_DEVTOOLS: '0',
+			CORTEXT_E2E: '1',
+		},
+		stdio: 'ignore',
+	} );
 	let timeoutId;
 	const timeout = new Promise( ( _resolve, reject ) => {
 		timeoutId = setTimeout( () => {

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -4,12 +4,12 @@ Running log for desktop-specific runtime and packaging decisions. Keep the detai
 
 ## 2026-07-28 — Give each desktop profile its own runtime origin
 
-**Decision.** New desktop profiles ask the operating system for an available
-loopback port and save the selected port in that profile's settings. Later
-launches reuse it so browser-backed preferences and the local Notion key remain
-under a stable Chromium origin. If the preferred port is occupied, Cortext
-chooses and saves another one. Profiles upgraded from the fixed-port build try
-their legacy port first to preserve the same origin-scoped data.
+**Decision.** New desktop profiles take the first free loopback port in the
+9403-9498 band and save it in that profile's settings. Later launches reuse it
+so browser-backed preferences and the local Notion key remain under a stable
+Chromium origin. If the saved port is occupied, Cortext scans the band again and
+saves the new choice. Profiles upgraded from the fixed-port build try their
+legacy port first to preserve the same origin-scoped data.
 
 The PHP and experimental Caddy runtimes receive the selected origin through
 their environment. A bootstrap defines `WP_HOME` and `WP_SITEURL` before the
@@ -30,12 +30,24 @@ Notion key under old origins. The per-launch authentication token remains the
 security credential; the port is collision avoidance and origin scoping, not a
 secret.
 
+**Why a fixed band instead of asking the kernel.** Binding port 0 returns a port
+from the ephemeral range (49152+ on macOS, 32768+ on Linux), which is the range
+the kernel hands out for outbound sockets. That is the right answer for a port
+that lives seconds and the wrong one for a port saved across launches: loopback
+traffic from local servers, proxies and other apps churns through it constantly.
+The 9403-9498 band is never handed out spontaneously, so only software that
+explicitly binds there can take a saved port. When the whole band is occupied
+Cortext still falls back to port 0, trading origin stability for starting at all.
+
 **Collision trade-off.** If another process takes the saved port, moving the
 profile to a new origin strands browser-only preferences under the old origin.
 The user may need to re-enter those preferences and the local Notion key.
-WordPress documents, uploads, and settings are unaffected. Avoiding even this
-rare reset would require moving browser-only state to origin-independent
-storage.
+WordPress settings and uploads are unaffected, but documents are only partly so:
+blocks that embed uploaded media keep the previous origin in their markup, so
+those images need re-inserting. That is not specific to a port change. Content
+stores absolute URLs today, which also blocks syncing documents between a
+desktop profile and a remote site, and the fix belongs with that work: store the
+attachment identity and resolve the URL at render, the way mentions already do.
 
 ## 2026-07-24 — Authenticate every local runtime request
 

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -2,6 +2,41 @@
 
 Running log for desktop-specific runtime and packaging decisions. Keep the detailed benchmark numbers in PR comments or artifacts unless they become stable product guidance.
 
+## 2026-07-28 — Give each desktop profile its own runtime origin
+
+**Decision.** New desktop profiles ask the operating system for an available
+loopback port and save the selected port in that profile's settings. Later
+launches reuse it so browser-backed preferences and the local Notion key remain
+under a stable Chromium origin. If the preferred port is occupied, Cortext
+chooses and saves another one. Profiles upgraded from the fixed-port build try
+their legacy port first to preserve the same origin-scoped data.
+
+The PHP and experimental Caddy runtimes receive the selected origin through
+their environment. A bootstrap defines `WP_HOME` and `WP_SITEURL` before the
+preserved `wp-config.php` loads, so both new snapshots and existing sites
+generate URLs for the active origin without replacing salts or user config.
+Every runtime requires the exact loopback `Host`; an `Origin` header may be
+absent, but if present it must match exactly. Caddy also binds explicitly to
+`127.0.0.1`.
+
+Only one Electron process may use a profile at a time. A second launch focuses
+the existing window instead of starting another runtime against the same
+SQLite database.
+
+**Why the port is stable per profile, not per launch.** Chromium partitions
+local storage by the complete origin, including the port. Rotating it on every
+launch would make theme and layout preferences disappear and strand the local
+Notion key under old origins. The per-launch authentication token remains the
+security credential; the port is collision avoidance and origin scoping, not a
+secret.
+
+**Collision trade-off.** If another process takes the saved port, moving the
+profile to a new origin strands browser-only preferences under the old origin.
+The user may need to re-enter those preferences and the local Notion key.
+WordPress documents, uploads, and settings are unaffected. Avoiding even this
+rare reset would require moving browser-only state to origin-independent
+storage.
+
 ## 2026-07-24 — Authenticate every local runtime request
 
 **Decision.** Each Electron launch generates a new random 256-bit token, keeps

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -43,11 +43,9 @@ Cortext still falls back to port 0, trading origin stability for starting at all
 profile to a new origin strands browser-only preferences under the old origin.
 The user may need to re-enter those preferences and the local Notion key.
 WordPress settings and uploads are unaffected, but documents are only partly so:
-blocks that embed uploaded media keep the previous origin in their markup, so
-those images need re-inserting. That is not specific to a port change. Content
-stores absolute URLs today, which also blocks syncing documents between a
-desktop profile and a remote site, and the fix belongs with that work: store the
-attachment identity and resolve the URL at render, the way mentions already do.
+blocks that embed uploaded media keep the previous origin in their markup and
+nothing rewrites them, at save or at render, so those images need re-inserting.
+That is a property of how block content stores URLs, not of the port change.
 
 ## 2026-07-24 — Authenticate every local runtime request
 


### PR DESCRIPTION
## What

Cortext Desktop now gives each profile its own loopback port instead of assuming 9402. It takes the first free port in a fixed band, reuses it across launches, moves when that port is occupied, and rejects requests whose `Host` or supplied `Origin` does not match. Starting Cortext again focuses the existing window instead of opening a second runtime against the same SQLite database.

## Why

Changing the port on every launch would discard origin-scoped preferences and strand the local Notion key. A saved port per profile avoids fixed-port collisions without resetting that state on normal restarts. The band exists for the same reason. A port assigned by the operating system comes from the range the kernel recycles for outbound sockets, which is a poor place to park a port we intend to keep.

## How

- Selecting from 9403-9498, which the kernel never hands out on its own, and falling back to whatever the operating system offers only when the whole band is busy.
- Trying the legacy port once for existing profiles so upgrades keep their previous Chromium origin.
- Defining WordPress's home and site URLs from the active origin before the preserved config loads.
- Binding every runtime to `127.0.0.1` and retrying once if the selected port is claimed during startup.

A collision that forces a new origin leaves browser-only preferences and the local Notion key under the old one. WordPress settings and uploads are unaffected, but blocks with embedded media keep the previous origin in their markup, so those images need re-inserting. Content stores absolute URLs today, which is also a problem for syncing documents with a remote site. This PR does not change that.

## Testing Instructions

1. Build the desktop snapshot and launch Cortext with a fresh `--user-data-dir`. Confirm that the window opens on a port between 9403 and 9498.
2. Note the port in that profile's `settings.json`, change a browser-backed preference, quit, and relaunch the same profile. Confirm that the URL keeps the same port and the preference remains.
3. Quit Cortext, occupy the saved port with another local server, and relaunch. Confirm that Cortext opens on another port in the band and your documents still open.
4. Run `curl -i <runtime-origin>/wp-includes/images/blank.gif` without a token and confirm that it returns `403 Forbidden`.
5. Start Cortext a second time with the same profile and confirm that the second process exits while the existing window comes forward.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.
