### PR TITLE
Desktop: Remove POSIX dependencies from snapshots and runtime

### DIFF
--- a/apps/desktop/lib/archive.js
+++ b/apps/desktop/lib/archive.js
@@ -1,0 +1,102 @@
+const path = require( 'path' );
+const extract = require( 'extract-zip' );
+const yauzl = require( 'yauzl' );
+
+function assertSafeEntryName( entryName, destination ) {
+	const normalized = entryName.replace( /\\/g, '/' );
+	if (
+		! normalized ||
+		normalized.includes( '\0' ) ||
+		path.posix.isAbsolute( normalized ) ||
+		/^[A-Za-z]:/.test( normalized )
+	) {
+		throw new Error( `Unsafe ZIP entry path: ${ entryName }` );
+	}
+
+	const segments = normalized.split( '/' ).filter( Boolean );
+	if ( segments.includes( '..' ) ) {
+		throw new Error( `Unsafe ZIP entry path: ${ entryName }` );
+	}
+
+	const root = path.resolve( destination );
+	const target = path.resolve( root, ...segments );
+	if ( target !== root && ! target.startsWith( `${ root }${ path.sep }` ) ) {
+		throw new Error( `Unsafe ZIP entry path: ${ entryName }` );
+	}
+}
+
+function assertSafeEntry( entry, destination ) {
+	assertSafeEntryName( entry.fileName, destination );
+
+	const unixMode = entry.externalFileAttributes >>> 16;
+	const fileType = unixMode & 0xf000;
+	// Match extract-zip by checking symlink mode bits for every creator platform.
+	if ( fileType === 0xa000 ) {
+		throw new Error(
+			`ZIP entry is a symbolic link and cannot be extracted: ${ entry.fileName }`
+		);
+	}
+}
+
+// extract-zip creates parent directories before onEntry runs, so validate every
+// entry first to avoid creating directories outside the destination.
+function validateZipEntries( archivePath, destination ) {
+	return new Promise( ( resolve, reject ) => {
+		yauzl.open(
+			archivePath,
+			{ autoClose: true, lazyEntries: true },
+			( openError, zipFile ) => {
+				if ( openError ) {
+					reject( openError );
+					return;
+				}
+
+				let settled = false;
+				const fail = ( error ) => {
+					if ( settled ) {
+						return;
+					}
+					settled = true;
+					zipFile.close();
+					reject( error );
+				};
+
+				zipFile.on( 'error', fail );
+				zipFile.on( 'entry', ( entry ) => {
+					try {
+						assertSafeEntry( entry, destination );
+						zipFile.readEntry();
+					} catch ( error ) {
+						fail( error );
+					}
+				} );
+				zipFile.on( 'end', () => {
+					if ( settled ) {
+						return;
+					}
+					settled = true;
+					resolve();
+				} );
+				zipFile.readEntry();
+			}
+		);
+	} );
+}
+
+async function extractZip( archivePath, destination ) {
+	const absoluteDestination = path.resolve( destination );
+	await validateZipEntries( archivePath, absoluteDestination );
+	await extract( archivePath, {
+		dir: absoluteDestination,
+		onEntry: ( entry ) => {
+			assertSafeEntry( entry, absoluteDestination );
+		},
+	} );
+}
+
+module.exports = {
+	assertSafeEntry,
+	assertSafeEntryName,
+	extractZip,
+	validateZipEntries,
+};

--- a/apps/desktop/lib/executable.js
+++ b/apps/desktop/lib/executable.js
@@ -1,0 +1,138 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const DEFAULT_WINDOWS_PATHEXT = '.COM;.EXE;.BAT;.CMD';
+
+function envValue( env, name, platform = process.platform ) {
+	if ( platform !== 'win32' ) {
+		return env[ name ];
+	}
+
+	const key = Object.keys( env ).find(
+		( candidate ) => candidate.toLowerCase() === name.toLowerCase()
+	);
+	return key ? env[ key ] : undefined;
+}
+
+function defaultIsFile( candidate, platform ) {
+	try {
+		if ( ! fs.statSync( candidate ).isFile() ) {
+			return false;
+		}
+		if ( platform !== 'win32' ) {
+			fs.accessSync( candidate, fs.constants.X_OK );
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function windowsExtensions(
+	command,
+	env,
+	pathApi,
+	allowedWindowsExtensions = null
+) {
+	const allowed = allowedWindowsExtensions
+		? new Set(
+				allowedWindowsExtensions.map( ( extension ) =>
+					extension.toLowerCase()
+				)
+		  )
+		: null;
+	const configured =
+		envValue( env, 'PATHEXT', 'win32' ) || DEFAULT_WINDOWS_PATHEXT;
+	const extensions = configured
+		.split( ';' )
+		.map( ( extension ) => extension.trim() )
+		.filter( Boolean )
+		.map( ( extension ) =>
+			extension.startsWith( '.' ) ? extension : `.${ extension }`
+		)
+		.filter(
+			( extension ) => ! allowed || allowed.has( extension.toLowerCase() )
+		);
+	const commandExtension = pathApi.extname( command ).toLowerCase();
+
+	if ( commandExtension ) {
+		return extensions.some(
+			( extension ) => extension.toLowerCase() === commandExtension
+		)
+			? [ '' ]
+			: [];
+	}
+
+	return [ '', ...extensions ];
+}
+
+function findExecutable(
+	command,
+	{
+		env = process.env,
+		platform = process.platform,
+		cwd = process.cwd(),
+		isFile = ( candidate ) => defaultIsFile( candidate, platform ),
+		allowedWindowsExtensions = null,
+	} = {}
+) {
+	if ( typeof command !== 'string' || ! command.trim() ) {
+		return null;
+	}
+
+	const trimmed = command.trim().replace( /^"(.*)"$/, '$1' );
+	const pathApi = platform === 'win32' ? path.win32 : path;
+	const extensions =
+		platform === 'win32'
+			? windowsExtensions(
+					trimmed,
+					env,
+					pathApi,
+					allowedWindowsExtensions
+			  )
+			: [ '' ];
+	const check = ( base ) => {
+		for ( const extension of extensions ) {
+			const candidate = `${ base }${ extension }`;
+			if ( isFile( candidate ) ) {
+				return candidate;
+			}
+		}
+		return null;
+	};
+
+	const isPath =
+		pathApi.isAbsolute( trimmed ) ||
+		trimmed.includes( '/' ) ||
+		trimmed.includes( '\\' ) ||
+		( platform === 'win32' && /^[A-Za-z]:/.test( trimmed ) );
+
+	if ( isPath ) {
+		const candidate = pathApi.isAbsolute( trimmed )
+			? trimmed
+			: pathApi.resolve( cwd, trimmed );
+		return check( candidate );
+	}
+
+	const pathValue = envValue( env, 'PATH', platform );
+	if ( ! pathValue ) {
+		return null;
+	}
+
+	for ( const rawDir of pathValue.split( pathApi.delimiter ) ) {
+		const unquoted = rawDir.trim().replace( /^"(.*)"$/, '$1' );
+		const dir = unquoted || cwd;
+		const found = check( pathApi.join( dir, trimmed ) );
+		if ( found ) {
+			return found;
+		}
+	}
+
+	return null;
+}
+
+module.exports = {
+	DEFAULT_WINDOWS_PATHEXT,
+	envValue,
+	findExecutable,
+};

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -1,13 +1,15 @@
-const { spawn, spawnSync } = require( 'child_process' );
+const { spawn } = require( 'child_process' );
 const fs = require( 'fs' );
 const http = require( 'http' );
 const os = require( 'os' );
 const path = require( 'path' );
+const { findExecutable } = require( './executable' );
 
 const DEFAULT_PORT = 9402;
 const DEFAULT_READY_PATH = '/wp-includes/images/blank.gif';
 const RUNTIME_AUTH_HEADER = 'X-Cortext-Desktop-Token';
 const RUNTIME_AUTH_ENV = 'CORTEXT_DESKTOP_AUTH_TOKEN';
+const WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS = [ '.COM', '.EXE' ];
 const EXPLORATION_OBJECT_CACHE_MARKER =
 	'Cortext Desktop APCu object-cache exploration drop-in';
 
@@ -27,36 +29,49 @@ function normalizeRuntime( runtime ) {
 	);
 }
 
-function commandExists( command ) {
-	if ( command.includes( path.sep ) ) {
-		return fs.existsSync( command );
-	}
-	const result = spawnSync( 'which', [ command ], {
-		stdio: [ 'ignore', 'pipe', 'ignore' ],
-		encoding: 'utf8',
+function findRuntimeExecutable( command, options = {} ) {
+	const platform = options.platform ?? process.platform;
+	return findExecutable( command, {
+		...options,
+		platform,
+		allowedWindowsExtensions:
+			platform === 'win32' ? WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS : null,
 	} );
-	return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function bundledRuntimeExecutable(
+	appDir,
+	commandName,
+	platform = process.platform
+) {
+	const pathApi = platform === 'win32' ? path.win32 : path;
+	const executable =
+		platform === 'win32' && ! commandName.toLowerCase().endsWith( '.exe' )
+			? `${ commandName }.exe`
+			: commandName;
+	return pathApi.join( appDir, 'runtime/bin', executable );
 }
 
 function resolveExecutable( envName, bundledPath, commandName, installHint ) {
 	const configured = process.env[ envName ];
 	if ( configured ) {
-		if ( fs.existsSync( configured ) || commandExists( configured ) ) {
-			return configured;
+		const resolved = findRuntimeExecutable( configured );
+		if ( resolved ) {
+			return resolved;
 		}
 		throw new Error(
-			`${ envName } points to a missing executable: ${ configured }`
+			`${ envName } does not point to an executable: ${ configured }`
 		);
 	}
 	if ( bundledPath && fs.existsSync( bundledPath ) ) {
 		return bundledPath;
 	}
-	const fromPath = commandExists( commandName );
+	const fromPath = findRuntimeExecutable( commandName );
 	if ( fromPath ) {
 		return fromPath;
 	}
 	throw new Error(
-		`Missing ${ commandName }. ${ installHint } Set ${ envName } to an executable path to override.`
+		`${ commandName } was not found. ${ installHint } To use a different executable, set ${ envName } to its path.`
 	);
 }
 
@@ -216,11 +231,16 @@ function phpCliIniArgs( wordpressDir, appDir, runtimeStateDir ) {
 	return args;
 }
 
-function addProcess( handle, name, command, args, options = {} ) {
-	const child = spawn( command, args, {
+function childProcessOptions( options = {} ) {
+	return {
 		stdio: [ 'ignore', 'pipe', 'pipe' ],
 		...options,
-	} );
+		windowsHide: true,
+	};
+}
+
+function addProcess( handle, name, command, args, options = {} ) {
+	const child = spawn( command, args, childProcessOptions( options ) );
 	handle.processes.push( {
 		name,
 		child,
@@ -241,6 +261,27 @@ function addProcess( handle, name, command, args, options = {} ) {
 	} );
 
 	return child;
+}
+
+function phpCliWorkerConfig( env = process.env, platform = process.platform ) {
+	const configured =
+		env.CORTEXT_PHP_CLI_SERVER_WORKERS ||
+		env.PHP_CLI_SERVER_WORKERS ||
+		null;
+
+	if ( platform === 'win32' ) {
+		return {
+			workers: null,
+			detached: false,
+			ignoredWorkers: configured,
+		};
+	}
+
+	return {
+		workers: configured,
+		detached: Number.parseInt( configured || '1', 10 ) > 1,
+		ignoredWorkers: null,
+	};
 }
 
 function waitForHttpReady( handle, port, authToken, timeoutMs = 30000 ) {
@@ -411,9 +452,12 @@ function startPhpCli(
 ) {
 	const phpBin = resolveExecutable(
 		'CORTEXT_PHP_BIN',
-		path.join( appDir, 'runtime/bin/php' ),
+		bundledRuntimeExecutable( appDir, 'php' ),
 		'php',
-		'Install PHP 8.1+ or bundle apps/desktop/runtime/bin/php.'
+		`Install PHP 8.1+ or include ${ bundledRuntimeExecutable(
+			'apps/desktop',
+			'php'
+		) } in the app bundle.`
 	);
 	const routerPath = path.join( wordpressDir, 'router.php' );
 	if ( ! fs.existsSync( routerPath ) ) {
@@ -424,9 +468,7 @@ function startPhpCli(
 	console.log(
 		`[cortext-desktop] starting php -S (127.0.0.1:${ port }) against ${ wordpressDir }`
 	);
-	const workers =
-		process.env.CORTEXT_PHP_CLI_SERVER_WORKERS ||
-		process.env.PHP_CLI_SERVER_WORKERS;
+	const workerConfig = phpCliWorkerConfig();
 	const phpArgs = [
 		...phpCliIniArgs( wordpressDir, appDir, runtimeStateDir ),
 		'-S',
@@ -439,22 +481,30 @@ function startPhpCli(
 		...process.env,
 		[ RUNTIME_AUTH_ENV ]: authToken,
 	};
-	if ( workers ) {
-		phpEnv.PHP_CLI_SERVER_WORKERS = workers;
+	if ( process.platform === 'win32' ) {
+		delete phpEnv.CORTEXT_PHP_CLI_SERVER_WORKERS;
+		delete phpEnv.PHP_CLI_SERVER_WORKERS;
+		if ( workerConfig.ignoredWorkers ) {
+			console.warn(
+				'[cortext-desktop] Windows does not support multiple PHP CLI server workers; using one worker.'
+			);
+		}
+	} else if ( workerConfig.workers ) {
+		phpEnv.PHP_CLI_SERVER_WORKERS = workerConfig.workers;
 	}
 	addProcess( handle, 'php', phpBin, phpArgs, {
 		cwd: wordpressDir,
 		env: phpEnv,
-		detached: Number.parseInt( workers || '1', 10 ) > 1,
+		detached: workerConfig.detached,
 	} );
 }
 
 function startFrankenPhp( handle, wordpressDir, port, appDir, authToken ) {
 	const frankenBin = resolveExecutable(
 		'CORTEXT_FRANKENPHP_BIN',
-		path.join( appDir, 'runtime/bin/frankenphp' ),
+		bundledRuntimeExecutable( appDir, 'frankenphp' ),
 		'frankenphp',
-		'Download the FrankenPHP macOS binary into apps/desktop/runtime/bin/frankenphp.'
+		'Place the FrankenPHP binary in apps/desktop/runtime/bin.'
 	);
 	const configPath = path.join( appDir, 'runtime/Caddyfile.frankenphp' );
 	if ( ! fs.existsSync( configPath ) ) {
@@ -539,15 +589,15 @@ function startPhpFpmCaddy(
 ) {
 	const phpFpmBin = resolveExecutable(
 		'CORTEXT_PHP_FPM_BIN',
-		path.join( appDir, 'runtime/bin/php-fpm' ),
+		bundledRuntimeExecutable( appDir, 'php-fpm' ),
 		'php-fpm',
-		'Install php-fpm or bundle apps/desktop/runtime/bin/php-fpm.'
+		'Install php-fpm or include apps/desktop/runtime/bin/php-fpm in the app bundle.'
 	);
 	const caddyBin = resolveExecutable(
 		'CORTEXT_CADDY_BIN',
-		path.join( appDir, 'runtime/bin/caddy' ),
+		bundledRuntimeExecutable( appDir, 'caddy' ),
 		'caddy',
-		'Download Caddy into apps/desktop/runtime/bin/caddy.'
+		'Place the Caddy binary in apps/desktop/runtime/bin.'
 	);
 	const configPath = path.join( appDir, 'runtime/Caddyfile.php-fpm' );
 	if ( ! fs.existsSync( configPath ) ) {
@@ -637,53 +687,225 @@ function startRuntime( {
 	}
 
 	handle.ready = waitForHttpReady( handle, port, authToken ).catch(
-		( error ) => {
-			stopRuntime( handle );
+		async ( error ) => {
+			await stopRuntime( handle );
 			throw error;
 		}
 	);
 	return handle;
 }
 
-function stopRuntime( handle ) {
-	if ( ! handle ) {
+function isProcessRunning( child ) {
+	return child && child.exitCode === null && child.signalCode === null;
+}
+
+function signalProcess(
+	child,
+	killProcessGroup,
+	signal,
+	platform = process.platform
+) {
+	if ( platform === 'win32' ) {
+		child.kill();
 		return;
 	}
-	handle.stopping = true;
-	for ( const { child, killProcessGroup } of [
-		...handle.processes,
-	].reverse() ) {
-		if ( child && child.exitCode === null && child.signalCode === null ) {
-			try {
-				if ( killProcessGroup && child.pid ) {
-					process.kill( -child.pid, 'SIGTERM' );
-				} else {
-					child.kill( 'SIGTERM' );
-				}
-			} catch {}
-			const timer = setTimeout( () => {
-				if ( child.exitCode === null && child.signalCode === null ) {
-					try {
-						if ( killProcessGroup && child.pid ) {
-							process.kill( -child.pid, 'SIGKILL' );
-						} else {
-							child.kill( 'SIGKILL' );
-						}
-					} catch {}
-				}
-			}, 5000 );
-			timer.unref?.();
+	if ( killProcessGroup && child.pid ) {
+		process.kill( -child.pid, signal );
+		return;
+	}
+	child.kill( signal );
+}
+
+function runWindowsTaskkill( pid, spawnProcess = spawn, timeoutMs = 5000 ) {
+	return new Promise( ( resolve ) => {
+		let killer;
+		let settled = false;
+		let timeout = null;
+		const finish = ( succeeded ) => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			if ( timeout ) {
+				clearTimeout( timeout );
+			}
+			resolve( succeeded );
+		};
+
+		try {
+			killer = spawnProcess(
+				'taskkill',
+				[ '/PID', String( pid ), '/T', '/F' ],
+				childProcessOptions( {
+					stdio: [ 'ignore', 'ignore', 'ignore' ],
+				} )
+			);
+		} catch {
+			finish( false );
+			return;
 		}
+
+		killer.once( 'error', () => finish( false ) );
+		killer.once( 'exit', ( code ) => finish( code === 0 ) );
+		timeout = setTimeout( () => {
+			try {
+				killer.kill();
+			} catch {}
+			finish( false );
+		}, timeoutMs );
+	} );
+}
+
+function waitForProcessExit(
+	child,
+	{
+		killProcessGroup = false,
+		gracePeriodMs = 5000,
+		forcePeriodMs = 1000,
+		platform = process.platform,
+		runTaskkill = runWindowsTaskkill,
+		sendSignal = signalProcess,
+	} = {}
+) {
+	if ( ! isProcessRunning( child ) ) {
+		return Promise.resolve();
 	}
-	for ( const cleanupPath of handle.cleanupPaths || [] ) {
-		fs.rmSync( cleanupPath, { recursive: true, force: true } );
+
+	return new Promise( ( resolve, reject ) => {
+		let settled = false;
+		let forceTimer = null;
+		let finalTimer = null;
+		const cleanup = () => {
+			if ( forceTimer ) {
+				clearTimeout( forceTimer );
+			}
+			if ( finalTimer ) {
+				clearTimeout( finalTimer );
+			}
+			child.off( 'exit', finish );
+			child.off( 'close', finish );
+			child.off( 'error', onError );
+		};
+		const finish = () => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			cleanup();
+			resolve();
+		};
+		const fail = ( error ) => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			cleanup();
+			reject( error );
+		};
+		const onError = () => {
+			if ( ! child.pid || ! isProcessRunning( child ) ) {
+				finish();
+			}
+		};
+
+		child.once( 'exit', finish );
+		child.once( 'close', finish );
+		child.once( 'error', onError );
+
+		if ( ! isProcessRunning( child ) ) {
+			finish();
+			return;
+		}
+
+		try {
+			sendSignal( child, killProcessGroup, 'SIGTERM', platform );
+		} catch {
+			if ( ! isProcessRunning( child ) ) {
+				finish();
+				return;
+			}
+		}
+
+		if ( settled ) {
+			return;
+		}
+		forceTimer = setTimeout( async () => {
+			if ( ! isProcessRunning( child ) ) {
+				finish();
+				return;
+			}
+			try {
+				if ( platform === 'win32' && child.pid ) {
+					await runTaskkill( child.pid );
+				} else {
+					sendSignal( child, killProcessGroup, 'SIGKILL', platform );
+				}
+			} catch {
+				if ( ! isProcessRunning( child ) ) {
+					finish();
+				}
+			}
+			if ( settled ) {
+				return;
+			}
+			finalTimer = setTimeout( () => {
+				if ( ! isProcessRunning( child ) ) {
+					finish();
+					return;
+				}
+				fail(
+					new Error(
+						`Runtime process ${
+							child.pid || '<unknown>'
+						} is still running after forced termination.`
+					)
+				);
+			}, forcePeriodMs );
+		}, gracePeriodMs );
+	} );
+}
+
+function stopRuntime( handle ) {
+	if ( ! handle ) {
+		return Promise.resolve();
 	}
+	if ( handle.stopPromise ) {
+		return handle.stopPromise;
+	}
+	handle.stopping = true;
+
+	const stopPromise = ( async () => {
+		const processes = [ ...( handle.processes || [] ) ].reverse();
+		await Promise.all(
+			processes.map( ( { child, killProcessGroup } ) =>
+				waitForProcessExit( child, { killProcessGroup } )
+			)
+		);
+
+		for ( const cleanupPath of handle.cleanupPaths || [] ) {
+			fs.rmSync( cleanupPath, { recursive: true, force: true } );
+		}
+	} )();
+	handle.stopPromise = stopPromise.catch( ( error ) => {
+		handle.stopPromise = null;
+		handle.stopping = false;
+		throw error;
+	} );
+
+	return handle.stopPromise;
 }
 
 module.exports = {
 	DEFAULT_PORT,
 	RUNTIME_AUTH_HEADER,
+	WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS,
+	bundledRuntimeExecutable,
+	childProcessOptions,
+	findRuntimeExecutable,
 	normalizeRuntime,
+	phpCliWorkerConfig,
+	runWindowsTaskkill,
 	startRuntime,
 	stopRuntime,
+	waitForProcessExit,
 };

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -688,7 +688,8 @@ function startRuntime( {
 
 	handle.ready = waitForHttpReady( handle, port, authToken ).catch(
 		async ( error ) => {
-			await stopRuntime( handle );
+			// Report why startup failed, not why the cleanup afterwards did.
+			await stopRuntime( handle ).catch( () => {} );
 			throw error;
 		}
 	);
@@ -865,7 +866,7 @@ function waitForProcessExit(
 	} );
 }
 
-function stopRuntime( handle ) {
+function stopRuntime( handle, options = {} ) {
 	if ( ! handle ) {
 		return Promise.resolve();
 	}
@@ -876,19 +877,25 @@ function stopRuntime( handle ) {
 
 	const stopPromise = ( async () => {
 		const processes = [ ...( handle.processes || [] ) ].reverse();
-		await Promise.all(
-			processes.map( ( { child, killProcessGroup } ) =>
-				waitForProcessExit( child, { killProcessGroup } )
-			)
-		);
-
-		for ( const cleanupPath of handle.cleanupPaths || [] ) {
-			fs.rmSync( cleanupPath, { recursive: true, force: true } );
+		try {
+			await Promise.all(
+				processes.map( ( { child, killProcessGroup } ) =>
+					waitForProcessExit( child, {
+						killProcessGroup,
+						...options,
+					} )
+				)
+			);
+		} finally {
+			for ( const cleanupPath of handle.cleanupPaths || [] ) {
+				fs.rmSync( cleanupPath, { recursive: true, force: true } );
+			}
 		}
 	} )();
+	// A failed stop timed out; it did not call the shutdown off. The signals are
+	// still on their way, so leave `stopping` set and let the caller retry.
 	handle.stopPromise = stopPromise.catch( ( error ) => {
 		handle.stopPromise = null;
-		handle.stopping = false;
 		throw error;
 	} );
 

--- a/apps/desktop/lib/site-refresh.js
+++ b/apps/desktop/lib/site-refresh.js
@@ -1,6 +1,6 @@
-const { spawnSync } = require( 'child_process' );
 const fs = require( 'fs' );
 const path = require( 'path' );
+const { extractZip } = require( './archive' );
 const { parseVersion, isNewer } = require( './version' );
 
 // The extracted site stores the app version that created it. When a newer app
@@ -36,15 +36,13 @@ function writeMarker( siteRoot, version ) {
 	fs.writeFileSync( markerPath( siteRoot ), String( version ) );
 }
 
-function extractSnapshot( snapshotZip, dest ) {
+async function extractSnapshot( snapshotZip, dest ) {
 	fs.mkdirSync( dest, { recursive: true } );
-	// macOS `unzip` can exit 1 for warnings, such as stripped absolute paths.
-	// Check the extracted files instead.
-	spawnSync( 'unzip', [ '-q', '-o', snapshotZip, '-d', dest ], {
-		stdio: [ 'ignore', 'ignore', 'ignore' ],
-	} );
+	await extractZip( snapshotZip, dest );
 	if ( ! fs.existsSync( path.join( dest, 'wordpress/index.php' ) ) ) {
-		throw new Error( `Snapshot extraction failed under ${ dest }` );
+		throw new Error(
+			`Snapshot extraction failed: wordpress/index.php is missing from ${ dest }.`
+		);
 	}
 }
 
@@ -61,15 +59,39 @@ function carryOver( fromWordpress, toWordpress ) {
 	}
 }
 
-// If the app was killed after the old tree was stashed but before the new tree
-// landed, restore the user's site before first-run extraction can seed a fresh
-// one.
+function backupDirectories( siteRoot, prefix = BAK_PREFIX ) {
+	return fs
+		.readdirSync( siteRoot )
+		.filter( ( name ) => name.startsWith( prefix ) )
+		.sort();
+}
+
+// A previous process may have installed a complete tree and exited before
+// deleting its first-run backup. Copy the user data from each backup into the
+// live tree before deleting it. This also preserves the original data when two
+// app processes start at the same time.
+function reconcileBackupsIntoLiveSite( siteRoot ) {
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	if ( ! fs.existsSync( path.join( wordpressDir, 'index.php' ) ) ) {
+		return;
+	}
+	for ( const name of backupDirectories(
+		siteRoot,
+		`${ BAK_PREFIX }first-run-`
+	) ) {
+		const backupDir = path.join( siteRoot, name );
+		carryOver( backupDir, wordpressDir );
+		fs.rmSync( backupDir, { recursive: true, force: true } );
+	}
+}
+
+// If the app stopped after renaming the old tree but before installing the new
+// one, restore the backup before the next first-run extraction.
 function recoverInterruptedSwap( siteRoot ) {
 	if ( ! fs.existsSync( siteRoot ) ) {
 		return;
 	}
-	// Remove scratch extraction dirs left by a killed refresh so they do not
-	// pile up.
+	// Remove temporary extraction directories left by an interrupted refresh.
 	for ( const name of fs.readdirSync( siteRoot ) ) {
 		if ( name.startsWith( NEXT_PREFIX ) ) {
 			fs.rmSync( path.join( siteRoot, name ), {
@@ -80,12 +102,10 @@ function recoverInterruptedSwap( siteRoot ) {
 	}
 	const wordpressDir = path.join( siteRoot, 'wordpress' );
 	if ( fs.existsSync( wordpressDir ) ) {
+		reconcileBackupsIntoLiveSite( siteRoot );
 		return;
 	}
-	const baks = fs
-		.readdirSync( siteRoot )
-		.filter( ( name ) => name.startsWith( BAK_PREFIX ) )
-		.sort();
+	const baks = backupDirectories( siteRoot );
 	if ( baks.length ) {
 		fs.renameSync(
 			path.join( siteRoot, baks[ baks.length - 1 ] ),
@@ -94,10 +114,86 @@ function recoverInterruptedSwap( siteRoot ) {
 	}
 }
 
+// Extract a new site into a temporary directory. If Electron exits before
+// extraction finishes, the next launch deletes the temporary directory and
+// retries, so WordPress does not start from a partial tree.
+async function ensureSiteFromSnapshot( { snapshotZip, siteRoot, version } ) {
+	recoverInterruptedSwap( siteRoot );
+
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	const wordpressIndex = path.join( wordpressDir, 'index.php' );
+	if ( fs.existsSync( wordpressIndex ) ) {
+		return wordpressDir;
+	}
+	if ( ! fs.existsSync( snapshotZip ) ) {
+		throw new Error(
+			`No snapshot was found at ${ snapshotZip }. Run 'npm run snapshot' in apps/desktop.`
+		);
+	}
+
+	fs.mkdirSync( siteRoot, { recursive: true } );
+	const stamp = `${ Date.now() }-${ process.pid }`;
+	const nextSite = path.join( siteRoot, `.next-first-run-${ stamp }` );
+	fs.rmSync( nextSite, { recursive: true, force: true } );
+
+	try {
+		await extractSnapshot( snapshotZip, nextSite );
+
+		// Another launch may finish extraction first. Keep its valid WordPress
+		// tree instead of replacing it.
+		if ( ! fs.existsSync( wordpressIndex ) ) {
+			const nextWordpress = path.join( nextSite, 'wordpress' );
+			const liveTreeExists = fs.existsSync( wordpressDir );
+			const bakDir = path.join(
+				siteRoot,
+				`${ BAK_PREFIX }first-run-${ stamp }`
+			);
+
+			// An incomplete code tree may still contain the user's database,
+			// uploads, and wp-config. Copy them into the extracted tree before
+			// backing up the current directory.
+			if ( liveTreeExists ) {
+				carryOver( wordpressDir, nextWordpress );
+				fs.renameSync( wordpressDir, bakDir );
+			}
+			let promoted = false;
+			try {
+				fs.renameSync( nextWordpress, wordpressDir );
+				promoted = true;
+				writeMarker( siteRoot, version );
+			} catch ( swapError ) {
+				if (
+					! promoted &&
+					fs.existsSync( path.join( wordpressDir, 'index.php' ) )
+				) {
+					// Another process installed its tree first. Copy the user data
+					// from the first-run backup into that tree.
+					reconcileBackupsIntoLiveSite( siteRoot );
+					return wordpressDir;
+				}
+				if ( promoted ) {
+					fs.rmSync( wordpressDir, {
+						recursive: true,
+						force: true,
+					} );
+				}
+				if ( liveTreeExists && fs.existsSync( bakDir ) ) {
+					fs.renameSync( bakDir, wordpressDir );
+				}
+				throw swapError;
+			}
+			reconcileBackupsIntoLiveSite( siteRoot );
+		}
+		return wordpressDir;
+	} finally {
+		fs.rmSync( nextSite, { recursive: true, force: true } );
+	}
+}
+
 // Refresh the extracted site's code from the bundled snapshot when this app is
 // newer than the marker. Keep the user's database, uploads, and wp-config.
-// Returns true when it swapped files.
-function refreshSiteIfOutdated( { snapshotZip, siteRoot, version } ) {
+// Returns true when it replaces the code.
+async function refreshSiteIfOutdated( { snapshotZip, siteRoot, version } ) {
 	recoverInterruptedSwap( siteRoot );
 
 	const wordpressDir = path.join( siteRoot, 'wordpress' );
@@ -131,11 +227,11 @@ function refreshSiteIfOutdated( { snapshotZip, siteRoot, version } ) {
 
 	fs.rmSync( nextSite, { recursive: true, force: true } );
 	try {
-		extractSnapshot( snapshotZip, nextSite );
+		await extractSnapshot( snapshotZip, nextSite );
 		carryOver( wordpressDir, path.join( nextSite, 'wordpress' ) );
 
-		// Keep the swap on one volume. Each rename is atomic: stash the live
-		// tree, promote the new tree, restore the stash if promotion fails.
+		// Keep both directories on one volume so each rename is atomic. Back up
+		// the live tree, install the new one, and restore the backup if needed.
 		fs.renameSync( wordpressDir, bakDir );
 		try {
 			fs.renameSync( path.join( nextSite, 'wordpress' ), wordpressDir );
@@ -151,12 +247,13 @@ function refreshSiteIfOutdated( { snapshotZip, siteRoot, version } ) {
 		return true;
 	} catch ( err ) {
 		fs.rmSync( nextSite, { recursive: true, force: true } );
-		console.log( '[cortext-desktop] site refresh skipped:', err.message );
+		console.log( '[cortext-desktop] could not refresh site:', err.message );
 		return false;
 	}
 }
 
 module.exports = {
+	ensureSiteFromSnapshot,
 	refreshSiteIfOutdated,
 	recoverInterruptedSwap,
 	readMarker,

--- a/apps/desktop/lib/site-refresh.js
+++ b/apps/desktop/lib/site-refresh.js
@@ -62,26 +62,48 @@ function carryOver( fromWordpress, toWordpress ) {
 function backupDirectories( siteRoot, prefix = BAK_PREFIX ) {
 	return fs
 		.readdirSync( siteRoot )
-		.filter( ( name ) => name.startsWith( prefix ) )
-		.sort();
+		.filter( ( name ) => name.startsWith( prefix ) );
 }
 
-// A previous process may have installed a complete tree and exited before
-// deleting its first-run backup. Copy the user data from each backup into the
-// live tree before deleting it. This also preserves the original data when two
-// app processes start at the same time.
-function reconcileBackupsIntoLiveSite( siteRoot ) {
-	const wordpressDir = path.join( siteRoot, 'wordpress' );
-	if ( ! fs.existsSync( path.join( wordpressDir, 'index.php' ) ) ) {
+// Scratch and backup directory names end in `<milliseconds>-<pid>`.
+function backupTime( name ) {
+	const match = name.match( /(\d+)-\d+$/ );
+	return match ? Number( match[ 1 ] ) : 0;
+}
+
+// Prefer a backup holding a complete tree, then the most recent one. First-run
+// backups are incomplete by construction, so they are the last resort. Name
+// order will not do: `first-run-` sorts after every digit.
+function newestRestorableBackup( siteRoot ) {
+	const ranked = backupDirectories( siteRoot )
+		.map( ( name ) => ( {
+			name,
+			complete: fs.existsSync( path.join( siteRoot, name, 'index.php' ) ),
+			time: backupTime( name ),
+		} ) )
+		.sort(
+			( a, b ) =>
+				Number( a.complete ) - Number( b.complete ) || a.time - b.time
+		);
+	return ranked.length ? ranked[ ranked.length - 1 ].name : null;
+}
+
+// A launch may have installed a tree and exited before deleting its first-run
+// backup. Whoever made that backup copied the user data into the tree it
+// installed first, so the backup is scrap. Copying it back would overwrite
+// newer data with older data.
+function removeFirstRunBackups( siteRoot ) {
+	if ( ! fs.existsSync( path.join( siteRoot, 'wordpress/index.php' ) ) ) {
 		return;
 	}
 	for ( const name of backupDirectories(
 		siteRoot,
 		`${ BAK_PREFIX }first-run-`
 	) ) {
-		const backupDir = path.join( siteRoot, name );
-		carryOver( backupDir, wordpressDir );
-		fs.rmSync( backupDir, { recursive: true, force: true } );
+		fs.rmSync( path.join( siteRoot, name ), {
+			recursive: true,
+			force: true,
+		} );
 	}
 }
 
@@ -101,17 +123,13 @@ function recoverInterruptedSwap( siteRoot ) {
 		}
 	}
 	const wordpressDir = path.join( siteRoot, 'wordpress' );
-	if ( fs.existsSync( wordpressDir ) ) {
-		reconcileBackupsIntoLiveSite( siteRoot );
-		return;
+	if ( ! fs.existsSync( wordpressDir ) ) {
+		const backup = newestRestorableBackup( siteRoot );
+		if ( backup ) {
+			fs.renameSync( path.join( siteRoot, backup ), wordpressDir );
+		}
 	}
-	const baks = backupDirectories( siteRoot );
-	if ( baks.length ) {
-		fs.renameSync(
-			path.join( siteRoot, baks[ baks.length - 1 ] ),
-			wordpressDir
-		);
-	}
+	removeFirstRunBackups( siteRoot );
 }
 
 // Extract a new site into a temporary directory. If Electron exits before
@@ -166,9 +184,12 @@ async function ensureSiteFromSnapshot( { snapshotZip, siteRoot, version } ) {
 					! promoted &&
 					fs.existsSync( path.join( wordpressDir, 'index.php' ) )
 				) {
-					// Another process installed its tree first. Copy the user data
-					// from the first-run backup into that tree.
-					reconcileBackupsIntoLiveSite( siteRoot );
+					// Another launch installed its tree first. It extracted
+					// from the snapshot, so it holds seed data, not the user's.
+					if ( liveTreeExists && fs.existsSync( bakDir ) ) {
+						carryOver( bakDir, wordpressDir );
+					}
+					removeFirstRunBackups( siteRoot );
 					return wordpressDir;
 				}
 				if ( promoted ) {
@@ -182,7 +203,7 @@ async function ensureSiteFromSnapshot( { snapshotZip, siteRoot, version } ) {
 				}
 				throw swapError;
 			}
-			reconcileBackupsIntoLiveSite( siteRoot );
+			removeFirstRunBackups( siteRoot );
 		}
 		return wordpressDir;
 	} finally {

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -49,6 +49,13 @@ const RUNTIME_SESSION_PARTITION = 'persist:cortext';
 // The local shell pages Cortext loads itself, before and instead of the runtime.
 const TRUSTED_DOCUMENT_URLS = [ LOADING_URL, ERROR_URL ];
 
+// One instance owns the extracted site and the runtime port. A second launch
+// would extract on top of the first one's half-written files, so hand focus
+// back to the window already running and leave.
+if ( ! app.requestSingleInstanceLock() ) {
+	app.exit( 0 );
+}
+
 let runtimeHandle = null;
 let removeRuntimeAuthHeader = null;
 let quitting = false;
@@ -411,6 +418,17 @@ app.whenReady().then( async () => {
 			app.quit();
 		}
 	}
+} );
+
+app.on( 'second-instance', () => {
+	const [ existing ] = BrowserWindow.getAllWindows();
+	if ( ! existing ) {
+		return;
+	}
+	if ( existing.isMinimized() ) {
+		existing.restore();
+	}
+	existing.focus();
 } );
 
 app.on( 'window-all-closed', () => {

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -1,5 +1,4 @@
 const { app, BrowserWindow, Menu, session, shell } = require( 'electron' );
-const { spawnSync } = require( 'child_process' );
 const crypto = require( 'crypto' );
 const path = require( 'path' );
 const fs = require( 'fs' );
@@ -22,9 +21,9 @@ const {
 	setAutoDownload,
 } = require( './lib/auto-update' );
 const {
+	ensureSiteFromSnapshot,
 	refreshSiteIfOutdated,
 	recoverInterruptedSwap,
-	writeMarker,
 } = require( './lib/site-refresh' );
 const { buildAppMenu } = require( './lib/menu' );
 const settings = require( './lib/settings' );
@@ -50,33 +49,6 @@ const childWindows = new Set();
 
 function getSiteRoot() {
 	return path.join( app.getPath( 'userData' ), 'site' );
-}
-
-function ensureSiteFromSnapshot() {
-	const siteRoot = getSiteRoot();
-	const wordpressDir = path.join( siteRoot, 'wordpress' );
-	if ( fs.existsSync( wordpressDir ) ) {
-		return wordpressDir;
-	}
-	if ( ! fs.existsSync( SNAPSHOT_ZIP ) ) {
-		throw new Error(
-			`Snapshot not found at ${ SNAPSHOT_ZIP }. Run 'npm run snapshot' from apps/desktop/.`
-		);
-	}
-	console.log( `[cortext-desktop] extracting snapshot to ${ siteRoot }` );
-	fs.mkdirSync( siteRoot, { recursive: true } );
-	// macOS `unzip` can exit 1 for warnings such as "stripped absolute path".
-	// Treat extraction as successful only if the WordPress files appear below.
-	spawnSync( 'unzip', [ '-q', '-o', SNAPSHOT_ZIP, '-d', siteRoot ], {
-		stdio: [ 'ignore', 'ignore', 'ignore' ],
-	} );
-	if ( ! fs.existsSync( path.join( wordpressDir, 'index.php' ) ) ) {
-		throw new Error(
-			`Snapshot extraction failed: ${ wordpressDir } is empty.`
-		);
-	}
-	writeMarker( siteRoot, app.getVersion() );
-	return wordpressDir;
 }
 
 function refreshMenu() {
@@ -323,10 +295,15 @@ app.whenReady().then( async () => {
 
 		const siteRoot = getSiteRoot();
 		recoverInterruptedSwap( siteRoot );
-		ensureSiteFromSnapshot();
+		console.log( `[cortext-desktop] preparing site at ${ siteRoot }` );
+		await ensureSiteFromSnapshot( {
+			snapshotZip: SNAPSHOT_ZIP,
+			siteRoot,
+			version: app.getVersion(),
+		} );
 		// Update bundled WordPress/Cortext files before PHP starts. User data
 		// stays in place.
-		refreshSiteIfOutdated( {
+		await refreshSiteIfOutdated( {
 			snapshotZip: SNAPSHOT_ZIP,
 			siteRoot,
 			version: app.getVersion(),

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -1,4 +1,11 @@
-const { app, BrowserWindow, Menu, session, shell } = require( 'electron' );
+const {
+	app,
+	BrowserWindow,
+	dialog,
+	Menu,
+	session,
+	shell,
+} = require( 'electron' );
 const crypto = require( 'crypto' );
 const path = require( 'path' );
 const fs = require( 'fs' );
@@ -46,9 +53,63 @@ let runtimeHandle = null;
 let removeRuntimeAuthHeader = null;
 let quitting = false;
 const childWindows = new Set();
+let allowQuit = false;
+let updaterQuitRequested = false;
+let runtimeStopPromise = null;
+let appQuitPromise = null;
 
 function getSiteRoot() {
 	return path.join( app.getPath( 'userData' ), 'site' );
+}
+
+function stopRuntimeBeforeQuit() {
+	quitting = true;
+	if ( ! runtimeStopPromise ) {
+		runtimeStopPromise = Promise.resolve()
+			.then( () => stopRuntime( runtimeHandle ) )
+			.then( () => {
+				runtimeHandle = null;
+				if ( removeRuntimeAuthHeader ) {
+					removeRuntimeAuthHeader();
+					removeRuntimeAuthHeader = null;
+				}
+			} )
+			.catch( ( error ) => {
+				runtimeStopPromise = null;
+				quitting = false;
+				throw error;
+			} );
+	}
+	return runtimeStopPromise;
+}
+
+function quitAfterRuntimeStops() {
+	if ( appQuitPromise ) {
+		return appQuitPromise;
+	}
+	appQuitPromise = stopRuntimeBeforeQuit()
+		.then( () => {
+			allowQuit = true;
+			app.quit();
+			return true;
+		} )
+		.catch( ( err ) => {
+			console.error(
+				'[cortext-desktop] failed to stop PHP before quitting:',
+				err
+			);
+			runtimeStopPromise = null;
+			appQuitPromise = null;
+			quitting = false;
+			dialog.showErrorBox(
+				"Cortext couldn't quit",
+				`The local PHP process is still running. Try quitting Cortext again.\n\n${ String(
+					err?.message || err
+				) }`
+			);
+			return false;
+		} );
+	return appQuitPromise;
 }
 
 function refreshMenu() {
@@ -232,6 +293,15 @@ function createWindow( runtimeSession ) {
 		backgroundColor: '#1d1d1d',
 		webPreferences: secureWebPreferences( {}, runtimeSession ),
 	} );
+	win.on( 'close', ( event ) => {
+		// electron-updater closes all windows before it emits before-quit. Allow
+		// the windows to close; before-quit will wait for PHP.
+		if ( allowQuit || updaterQuitRequested ) {
+			return;
+		}
+		event.preventDefault();
+		void quitAfterRuntimeStops();
+	} );
 
 	configureTrustedWindow( win, runtimeSession );
 	return win;
@@ -250,6 +320,7 @@ async function loadSite( win ) {
 			window: win,
 			onState: refreshMenu,
 			prepareQuit: () => {
+				updaterQuitRequested = true;
 				quitting = true;
 			},
 			autoDownload: settings.get( 'autoInstallUpdates' ),
@@ -301,6 +372,9 @@ app.whenReady().then( async () => {
 			siteRoot,
 			version: app.getVersion(),
 		} );
+		if ( quitting ) {
+			return;
+		}
 		// Update bundled WordPress/Cortext files before PHP starts. User data
 		// stays in place.
 		await refreshSiteIfOutdated( {
@@ -308,6 +382,9 @@ app.whenReady().then( async () => {
 			siteRoot,
 			version: app.getVersion(),
 		} );
+		if ( quitting ) {
+			return;
+		}
 		const wordpressDir = path.join( siteRoot, 'wordpress' );
 
 		runtimeHandle = startRuntime( {
@@ -336,22 +413,15 @@ app.whenReady().then( async () => {
 	}
 } );
 
-function stopDesktopRuntime() {
-	stopRuntime( runtimeHandle );
-	runtimeHandle = null;
-	if ( removeRuntimeAuthHeader ) {
-		removeRuntimeAuthHeader();
-		removeRuntimeAuthHeader = null;
-	}
-}
-
 app.on( 'window-all-closed', () => {
-	quitting = true;
-	stopDesktopRuntime();
 	app.quit();
 } );
 
-app.on( 'before-quit', () => {
+app.on( 'before-quit', ( event ) => {
 	quitting = true;
-	stopDesktopRuntime();
+	if ( allowQuit ) {
+		return;
+	}
+	event.preventDefault();
+	void quitAfterRuntimeStops();
 } );

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -9,12 +9,15 @@
 			"version": "0.1.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"electron-updater": "^6.8.9"
+				"electron-updater": "^6.8.9",
+				"extract-zip": "^2.0.1",
+				"yauzl": "^2.10.0"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",
 				"electron": "^42.3.3",
-				"electron-builder": "^26.15.3"
+				"electron-builder": "^26.15.3",
+				"yazl": "^3.3.1"
 			}
 		},
 		"node_modules/@electron/asar": {
@@ -571,7 +574,7 @@
 			"version": "24.12.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
 			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -591,7 +594,6 @@
 			"version": "2.10.3",
 			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
 			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -950,7 +952,6 @@
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -1659,7 +1660,6 @@
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
 			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
@@ -1774,7 +1774,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
 			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"debug": "^4.1.1",
@@ -1819,7 +1818,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
 			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pend": "~1.2.0"
@@ -1999,7 +1997,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
@@ -2753,7 +2750,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
@@ -2824,7 +2820,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/picocolors": {
@@ -3012,7 +3007,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
 			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
@@ -3554,7 +3548,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {
@@ -3661,7 +3655,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/xmlbuilder": {
@@ -3724,11 +3717,30 @@
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
 			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/yazl": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+			"integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "^1.0.0"
+			}
+		},
+		"node_modules/yazl/node_modules/buffer-crc32": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,8 @@
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",
 		"electron": "^42.3.3",
-		"electron-builder": "^26.15.3"
+		"electron-builder": "^26.15.3",
+		"yazl": "^3.3.1"
 	},
 	"build": {
 		"appId": "com.automattic.cortext",
@@ -82,6 +83,8 @@
 		]
 	},
 	"dependencies": {
-		"electron-updater": "^6.8.9"
+		"electron-updater": "^6.8.9",
+		"extract-zip": "^2.0.1",
+		"yauzl": "^2.10.0"
 	}
 }

--- a/apps/desktop/scripts/app-shell.test.mjs
+++ b/apps/desktop/scripts/app-shell.test.mjs
@@ -42,6 +42,8 @@ function loadMain(
 		startRuntime = () => {},
 	} = {}
 ) {
+	// Every test here runs as the instance that holds the lock.
+	app.requestSingleInstanceLock ??= () => true;
 	requireWithMocks( '../main.js', {
 		electron: {
 			app,
@@ -99,6 +101,37 @@ function quitEvent() {
 		},
 	};
 }
+
+test( 'a second instance leaves without touching the site', () => {
+	let exitCalls = 0;
+	let ensureCalls = 0;
+
+	const app = new EventEmitter();
+	Object.assign( app, {
+		isPackaged: false,
+		name: 'Cortext',
+		exit: () => {
+			exitCalls += 1;
+		},
+		quit: () => {},
+		requestSingleInstanceLock: () => false,
+		whenReady: () => new Promise( () => {} ),
+	} );
+
+	loadMain(
+		app,
+		() => Promise.resolve(),
+		() => {},
+		{
+			ensureSiteFromSnapshot: async () => {
+				ensureCalls += 1;
+			},
+		}
+	);
+
+	assert.equal( exitCalls, 1 );
+	assert.equal( ensureCalls, 0 );
+} );
 
 test( 'repeated before-quit events stop the runtime only once', async () => {
 	let quitCalls = 0;

--- a/apps/desktop/scripts/app-shell.test.mjs
+++ b/apps/desktop/scripts/app-shell.test.mjs
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+
+const require = createRequire( import.meta.url );
+const Module = require( 'node:module' );
+
+function requireWithMocks( modulePath, mocks ) {
+	const resolved = require.resolve( modulePath );
+	delete require.cache[ resolved ];
+
+	const originalLoad = Module._load;
+	Module._load = function ( request, parent, isMain ) {
+		if ( Object.hasOwn( mocks, request ) ) {
+			return mocks[ request ];
+		}
+		return originalLoad.call( this, request, parent, isMain );
+	};
+
+	try {
+		return require( resolved );
+	} finally {
+		Module._load = originalLoad;
+	}
+}
+
+function loadMain(
+	app,
+	stopRuntime,
+	showErrorBox = () => {},
+	{
+		BrowserWindow = class {},
+		ensureSiteFromSnapshot = async () => {},
+		installRuntimeAuthHeader = () => () => {},
+		Menu = {},
+		refreshSiteIfOutdated = async () => {},
+		runtimeSession = {
+			clearStorageData: async () => {},
+		},
+		scheduleUpdateCheck = () => {},
+		startRuntime = () => {},
+	} = {}
+) {
+	requireWithMocks( '../main.js', {
+		electron: {
+			app,
+			BrowserWindow,
+			dialog: { showErrorBox },
+			Menu,
+			session: {
+				fromPartition: () => runtimeSession,
+			},
+			shell: {
+				openExternal: async () => {},
+			},
+		},
+		'./lib/runtime': {
+			DEFAULT_PORT: 9402,
+			RUNTIME_AUTH_HEADER: 'X-Cortext-Desktop-Token',
+			startRuntime,
+			stopRuntime,
+		},
+		'./lib/runtime-session': {
+			hasOrigin: ( value, origin ) => {
+				try {
+					return new URL( value ).origin === origin;
+				} catch {
+					return false;
+				}
+			},
+			installRuntimeAuthHeader,
+			isTrustedRuntimeFrame: () => true,
+		},
+		'./lib/auto-update': {
+			scheduleUpdateCheck,
+			checkForUpdatesInteractive: () => {},
+			isUpdateReadyToInstall: () => false,
+			setAutoDownload: () => {},
+		},
+		'./lib/site-refresh': {
+			ensureSiteFromSnapshot,
+			refreshSiteIfOutdated,
+			recoverInterruptedSwap: () => {},
+		},
+		'./lib/menu': { buildAppMenu: () => [] },
+		'./lib/settings': {
+			get: () => true,
+			set: () => {},
+		},
+	} );
+}
+
+function quitEvent() {
+	return {
+		preventDefaultCalled: false,
+		preventDefault() {
+			this.preventDefaultCalled = true;
+		},
+	};
+}
+
+test( 'repeated before-quit events stop the runtime only once', async () => {
+	let quitCalls = 0;
+	let stopCalls = 0;
+	let finishShutdown;
+	const shutdownFinished = new Promise( ( resolve ) => {
+		finishShutdown = resolve;
+	} );
+
+	const app = new EventEmitter();
+	Object.assign( app, {
+		isPackaged: false,
+		name: 'Cortext',
+		quit: () => {
+			quitCalls += 1;
+		},
+		whenReady: () => new Promise( () => {} ),
+	} );
+
+	loadMain( app, () => {
+		stopCalls += 1;
+		return shutdownFinished;
+	} );
+
+	const firstEvent = quitEvent();
+	const secondEvent = quitEvent();
+	app.emit( 'before-quit', firstEvent );
+	app.emit( 'before-quit', secondEvent );
+	await Promise.resolve();
+
+	assert.equal( firstEvent.preventDefaultCalled, true );
+	assert.equal( secondEvent.preventDefaultCalled, true );
+	assert.equal( stopCalls, 1 );
+	assert.equal( quitCalls, 0 );
+
+	finishShutdown();
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+	assert.equal( quitCalls, 1 );
+} );
+
+test( 'before-quit keeps the app open after a stop failure and retries on the next quit', async () => {
+	let quitCalls = 0;
+	let stopCalls = 0;
+	const errors = [];
+	const app = new EventEmitter();
+	Object.assign( app, {
+		isPackaged: false,
+		name: 'Cortext',
+		quit: () => {
+			quitCalls += 1;
+		},
+		whenReady: () => new Promise( () => {} ),
+	} );
+
+	loadMain(
+		app,
+		() => {
+			stopCalls += 1;
+			return Promise.reject( new Error( 'PHP is still running' ) );
+		},
+		( title, message ) => errors.push( { title, message } )
+	);
+
+	const event = quitEvent();
+	app.emit( 'before-quit', event );
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+
+	assert.equal( event.preventDefaultCalled, true );
+	assert.equal( quitCalls, 0 );
+	assert.equal( stopCalls, 1 );
+	assert.equal( errors.length, 1 );
+	assert.match( errors[ 0 ].message, /PHP is still running/ );
+
+	app.emit( 'before-quit', quitEvent() );
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+	assert.equal( stopCalls, 2 );
+	assert.equal( quitCalls, 0 );
+	assert.equal( errors.length, 2 );
+} );
+
+test( 'updater closes the window, then waits for the runtime before quitting', async () => {
+	let quitCalls = 0;
+	let stopCalls = 0;
+	let finishShutdown;
+	let updaterOptions = null;
+	let removeRuntimeAuthHeaderCalls = 0;
+	const windows = [];
+	const shutdownFinished = new Promise( ( resolve ) => {
+		finishShutdown = resolve;
+	} );
+
+	class FakeWindow extends EventEmitter {
+		constructor( options ) {
+			super();
+			this.webContents = new EventEmitter();
+			Object.assign( this.webContents, {
+				openDevTools: () => {},
+				session: options.webPreferences.session,
+				setWindowOpenHandler: () => {},
+			} );
+			windows.push( this );
+		}
+
+		loadFile() {
+			return Promise.resolve();
+		}
+
+		loadURL() {
+			return Promise.resolve();
+		}
+
+		setTitle() {}
+	}
+
+	const app = new EventEmitter();
+	Object.assign( app, {
+		isPackaged: false,
+		name: 'Cortext',
+		getPath: ( name ) => `/tmp/cortext-${ name }`,
+		getVersion: () => '1.0.0',
+		quit: () => {
+			quitCalls += 1;
+		},
+		whenReady: () => Promise.resolve(),
+	} );
+
+	loadMain(
+		app,
+		() => {
+			stopCalls += 1;
+			return shutdownFinished;
+		},
+		undefined,
+		{
+			BrowserWindow: FakeWindow,
+			installRuntimeAuthHeader: () => () => {
+				removeRuntimeAuthHeaderCalls += 1;
+			},
+			Menu: { setApplicationMenu: () => {} },
+			scheduleUpdateCheck: ( options ) => {
+				updaterOptions = options;
+			},
+			startRuntime: () => ( { ready: Promise.resolve() } ),
+		}
+	);
+
+	for ( let attempt = 0; attempt < 5 && ! updaterOptions; attempt++ ) {
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
+	}
+	assert.ok( updaterOptions );
+	assert.equal( windows.length, 1 );
+
+	updaterOptions.prepareQuit();
+	const closeEvent = quitEvent();
+	windows[ 0 ].emit( 'close', closeEvent );
+	assert.equal( closeEvent.preventDefaultCalled, false );
+
+	const beforeQuitEvent = quitEvent();
+	app.emit( 'before-quit', beforeQuitEvent );
+	await Promise.resolve();
+	assert.equal( beforeQuitEvent.preventDefaultCalled, true );
+	assert.equal( stopCalls, 1 );
+	assert.equal( quitCalls, 0 );
+	assert.equal( removeRuntimeAuthHeaderCalls, 0 );
+
+	finishShutdown();
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+	assert.equal( quitCalls, 1 );
+	assert.equal( removeRuntimeAuthHeaderCalls, 1 );
+} );
+
+test( 'closing during site preparation never starts the runtime', async () => {
+	let finishExtraction;
+	let quitCalls = 0;
+	let refreshCalls = 0;
+	let startCalls = 0;
+	let stopCalls = 0;
+	const windows = [];
+	const extractionFinished = new Promise( ( resolve ) => {
+		finishExtraction = resolve;
+	} );
+
+	class FakeWindow extends EventEmitter {
+		constructor( options ) {
+			super();
+			this.webContents = new EventEmitter();
+			Object.assign( this.webContents, {
+				openDevTools: () => {},
+				session: options.webPreferences.session,
+				setWindowOpenHandler: () => {},
+			} );
+			windows.push( this );
+		}
+
+		loadFile() {
+			return Promise.resolve();
+		}
+
+		loadURL() {
+			return Promise.resolve();
+		}
+
+		setTitle() {}
+	}
+
+	const app = new EventEmitter();
+	Object.assign( app, {
+		isPackaged: false,
+		name: 'Cortext',
+		getPath: ( name ) => `/tmp/cortext-${ name }`,
+		getVersion: () => '1.0.0',
+		quit: () => {
+			quitCalls += 1;
+		},
+		whenReady: () => Promise.resolve(),
+	} );
+
+	loadMain(
+		app,
+		async () => {
+			stopCalls += 1;
+		},
+		undefined,
+		{
+			BrowserWindow: FakeWindow,
+			ensureSiteFromSnapshot: () => extractionFinished,
+			Menu: { setApplicationMenu: () => {} },
+			refreshSiteIfOutdated: async () => {
+				refreshCalls += 1;
+			},
+			startRuntime: () => {
+				startCalls += 1;
+				return { ready: Promise.resolve() };
+			},
+		}
+	);
+
+	for ( let attempt = 0; attempt < 5 && windows.length === 0; attempt++ ) {
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
+	}
+	assert.equal( windows.length, 1 );
+
+	const closeEvent = quitEvent();
+	windows[ 0 ].emit( 'close', closeEvent );
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+	assert.equal( closeEvent.preventDefaultCalled, true );
+	assert.equal( stopCalls, 1 );
+	assert.equal( quitCalls, 1 );
+
+	finishExtraction();
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+	assert.equal( refreshCalls, 0 );
+	assert.equal( startCalls, 0 );
+} );

--- a/apps/desktop/scripts/archive.test.mjs
+++ b/apps/desktop/scripts/archive.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import archiveHelpers from '../lib/archive.js';
+import zipHelpers from './zip.js';
+
+const { assertSafeEntry, assertSafeEntryName, extractZip } = archiveHelpers;
+const { zipDirectory } = zipHelpers;
+
+function tmpDir() {
+	return fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-archive-' ) );
+}
+
+function writeFile( file, contents ) {
+	fs.mkdirSync( path.dirname( file ), { recursive: true } );
+	fs.writeFileSync( file, contents );
+}
+
+function replaceAllBytes( buffer, fromString, toString ) {
+	const from = Buffer.from( fromString );
+	const to = Buffer.from( toString );
+	assert.equal( from.length, to.length );
+
+	let count = 0;
+	let offset = 0;
+	while ( ( offset = buffer.indexOf( from, offset ) ) !== -1 ) {
+		to.copy( buffer, offset );
+		offset += to.length;
+		count += 1;
+	}
+	return count;
+}
+
+test( 'ZIP extraction rejects paths outside the destination', () => {
+	assert.throws(
+		() => assertSafeEntryName( '../outside.txt', tmpDir() ),
+		/Unsafe ZIP entry path/
+	);
+	assert.throws(
+		() => assertSafeEntryName( 'C:\\outside.txt', tmpDir() ),
+		/Unsafe ZIP entry path/
+	);
+} );
+
+test( 'ZIP extraction rejects unsafe entries before creating any directories', async () => {
+	const root = tmpDir();
+	const source = path.join( root, 'source' );
+	const archive = path.join( root, 'unsafe.zip' );
+	const destination = path.join( root, 'destination' );
+	const escapedDirectory = path.join( root, 'escaped-dir' );
+	writeFile(
+		path.join( source, 'aa/escaped-dir/file.txt' ),
+		'DO NOT EXTRACT'
+	);
+	await zipDirectory( source, archive, '' );
+
+	const bytes = fs.readFileSync( archive );
+	assert.equal(
+		replaceAllBytes(
+			bytes,
+			'aa/escaped-dir/file.txt',
+			'../escaped-dir/file.txt'
+		),
+		2
+	);
+	fs.writeFileSync( archive, bytes );
+
+	await assert.rejects(
+		extractZip( archive, destination ),
+		/invalid relative path|Unsafe ZIP entry path/
+	);
+	assert.equal( fs.existsSync( destination ), false );
+	assert.equal( fs.existsSync( escapedDirectory ), false );
+} );
+
+test( 'ZIP extraction rejects symbolic links', () => {
+	assert.throws(
+		() =>
+			assertSafeEntry(
+				{
+					fileName: 'wordpress/link',
+					versionMadeBy: 3 << 8,
+					externalFileAttributes: 0xa000 << 16,
+				},
+				tmpDir()
+			),
+		/ZIP entry is a symbolic link/
+	);
+} );
+
+test( 'ZIP extraction rejects symlink mode bits regardless of creator platform', () => {
+	assert.throws(
+		() =>
+			assertSafeEntry(
+				{
+					fileName: 'wordpress/link',
+					versionMadeBy: 0,
+					externalFileAttributes: 0xa000 << 16,
+				},
+				tmpDir()
+			),
+		/ZIP entry is a symbolic link/
+	);
+} );

--- a/apps/desktop/scripts/archive.test.mjs
+++ b/apps/desktop/scripts/archive.test.mjs
@@ -76,6 +76,25 @@ test( 'ZIP extraction rejects unsafe entries before creating any directories', a
 	assert.equal( fs.existsSync( escapedDirectory ), false );
 } );
 
+test( 'zipDirectory reports a file it cannot read and removes the archive', async () => {
+	const root = tmpDir();
+	const source = path.join( root, 'source' );
+	const archive = path.join( root, 'partial.zip' );
+	for ( const name of [ 'a', 'b', 'c', 'd' ] ) {
+		writeFile(
+			path.join( source, `${ name }.txt` ),
+			name.repeat( 200000 )
+		);
+	}
+
+	const pending = zipDirectory( source, archive, 'wordpress' );
+	// yazl opens each file lazily, after zipDirectory has walked the tree.
+	fs.rmSync( path.join( source, 'c.txt' ) );
+
+	await assert.rejects( pending, /ENOENT|not a file/ );
+	assert.equal( fs.existsSync( archive ), false );
+} );
+
 test( 'ZIP extraction rejects symbolic links', () => {
 	assert.throws(
 		() =>

--- a/apps/desktop/scripts/bench-runtime.mjs
+++ b/apps/desktop/scripts/bench-runtime.mjs
@@ -2,12 +2,7 @@
 import { spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { createRequire } from 'node:module';
-import {
-	existsSync,
-	mkdirSync,
-	rmSync,
-	writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import http from 'node:http';
 import { dirname, resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
@@ -21,6 +16,7 @@ const {
 	startRuntime,
 	stopRuntime,
 } = require( '../lib/runtime' );
+const { extractZip } = require( '../lib/archive' );
 
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const DESKTOP_DIR = resolve( __dirname, '..' );
@@ -75,27 +71,24 @@ function readOptions() {
 
 	options.runtime = normalizeRuntime( options.runtime );
 	if ( options.label && ! /^[a-z0-9._-]+$/i.test( options.label ) ) {
-		throw new Error( '--label may only contain letters, numbers, dots, underscores, and dashes.' );
+		throw new Error(
+			'--label can only contain letters, numbers, dots, underscores, and dashes.'
+		);
 	}
 	return options;
 }
 
-function unzipSnapshot( workDir ) {
+async function extractSnapshot( workDir ) {
 	const siteRoot = resolve( workDir, 'site' );
 	const wordpressDir = resolve( siteRoot, 'wordpress' );
 	rmSync( workDir, { recursive: true, force: true } );
 	mkdirSync( siteRoot, { recursive: true } );
 
-	const result = spawnSync(
-		'unzip',
-		[ '-q', '-o', SNAPSHOT_ZIP, '-d', siteRoot ],
-		{ stdio: [ 'ignore', 'ignore', 'ignore' ] }
-	);
-	if (
-		result.status !== 0 &&
-		! existsSync( resolve( wordpressDir, 'index.php' ) )
-	) {
-		throw new Error( `Snapshot extraction failed from ${ SNAPSHOT_ZIP }.` );
+	await extractZip( SNAPSHOT_ZIP, siteRoot );
+	if ( ! existsSync( resolve( wordpressDir, 'index.php' ) ) ) {
+		throw new Error(
+			`Snapshot extraction failed: wordpress/index.php is missing from ${ SNAPSHOT_ZIP }.`
+		);
 	}
 	return wordpressDir;
 }
@@ -104,9 +97,11 @@ function parseServerTiming( header ) {
 	if ( ! header ) {
 		return null;
 	}
-	const value = Array.isArray( header ) ? header.join( ',' ) : String( header );
+	const value = Array.isArray( header )
+		? header.join( ',' )
+		: String( header );
 	const match = value.match( /(?:^|,\s*)cortext_wp;dur=([0-9.]+)/ );
-	return match ? Number.parseFloat( match[1] ) : null;
+	return match ? Number.parseFloat( match[ 1 ] ) : null;
 }
 
 function redirectedPath( location ) {
@@ -138,7 +133,9 @@ function requestPath(
 					const location = res.headers.location;
 					if (
 						res.statusCode &&
-						[ 301, 302, 303, 307, 308 ].includes( res.statusCode ) &&
+						[ 301, 302, 303, 307, 308 ].includes(
+							res.statusCode
+						) &&
 						location &&
 						redirects < 5
 					) {
@@ -164,7 +161,7 @@ function requestPath(
 					resolveRequest( {
 						totalMs: duration,
 						serverMs: parseServerTiming(
-							res.headers['server-timing']
+							res.headers[ 'server-timing' ]
 						),
 						status: res.statusCode,
 					} );
@@ -194,7 +191,9 @@ function summarize( samples ) {
 	const total = samples.map( ( sample ) => sample.totalMs );
 	const server = samples
 		.map( ( sample ) => sample.serverMs )
-		.filter( ( value ) => typeof value === 'number' && ! Number.isNaN( value ) );
+		.filter(
+			( value ) => typeof value === 'number' && ! Number.isNaN( value )
+		);
 	return {
 		status: samples[ samples.length - 1 ]?.status ?? null,
 		requests: samples.length,
@@ -219,19 +218,7 @@ async function runEndpoint( endpoint, warmup, iterations, authToken ) {
 }
 
 async function stopAndWait( handle ) {
-	stopRuntime( handle );
-	await Promise.all(
-		handle.processes.map(
-			( { child } ) =>
-				new Promise( ( resolveStop ) => {
-					if ( child.exitCode !== null || child.signalCode !== null ) {
-						resolveStop();
-						return;
-					}
-					child.once( 'exit', resolveStop );
-				} )
-		)
-	);
+	await stopRuntime( handle );
 }
 
 function commandVersion( command, args ) {
@@ -242,7 +229,7 @@ function commandVersion( command, args ) {
 	if ( result.status !== 0 ) {
 		return null;
 	}
-	return ( result.stdout || result.stderr ).split( '\n' )[0].trim();
+	return ( result.stdout || result.stderr ).split( '\n' )[ 0 ].trim();
 }
 
 function phpRuntimeBin() {
@@ -307,14 +294,15 @@ async function main() {
 	const options = readOptions();
 	if ( ! existsSync( SNAPSHOT_ZIP ) ) {
 		throw new Error(
-			`Missing ${ SNAPSHOT_ZIP }. Run 'npm --prefix apps/desktop run snapshot' first.`
+			`No snapshot was found at ${ SNAPSHOT_ZIP }. Run 'npm --prefix apps/desktop run snapshot' first.`
 		);
 	}
 
 	const workDir = resolve( DESKTOP_DIR, '.runtime-bench', options.runtime );
-	const wordpressDir = unzipSnapshot( workDir );
+	const wordpressDir = await extractSnapshot( workDir );
 	const authToken = randomBytes( 32 ).toString( 'hex' );
-	process.env.CORTEXT_RUNTIME_QUIET = process.env.CORTEXT_RUNTIME_QUIET || '1';
+	process.env.CORTEXT_RUNTIME_QUIET =
+		process.env.CORTEXT_RUNTIME_QUIET || '1';
 	let unexpectedExit = null;
 	const handle = startRuntime( {
 		appDir: DESKTOP_DIR,

--- a/apps/desktop/scripts/build-snapshot.mjs
+++ b/apps/desktop/scripts/build-snapshot.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync, spawnSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import {
 	cpSync,
 	createWriteStream,
@@ -11,8 +11,14 @@ import {
 import https from 'node:https';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import archiveHelpers from '../lib/archive.js';
+import executableHelpers from '../lib/executable.js';
 import { buildWpConfig, randomSalt } from './wp-config.mjs';
+import zipHelpers from './zip.js';
 
+const { extractZip } = archiveHelpers;
+const { findExecutable } = executableHelpers;
+const { zipDirectory } = zipHelpers;
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const DESKTOP_DIR = resolve( __dirname, '..' );
 const REPO_ROOT = resolve( DESKTOP_DIR, '..', '..' );
@@ -51,46 +57,27 @@ function shellQuote( value ) {
 	return `'${ String( value ).replace( /'/g, "'\\''" ) }'`;
 }
 
-function commandExists( command ) {
-	if ( command.includes( '/' ) ) {
-		return existsSync( command ) ? command : null;
-	}
-	const result = spawnSync( 'which', [ command ], {
-		stdio: [ 'ignore', 'pipe', 'ignore' ],
-		encoding: 'utf8',
-	} );
-	return result.status === 0 ? result.stdout.trim() : null;
-}
-
 function resolvePhpBin() {
 	const configured = process.env.CORTEXT_PHP_BIN;
 	if ( configured ) {
-		const resolved = commandExists( configured );
+		const resolved = findExecutable( configured );
 		if ( resolved ) {
 			return resolved;
 		}
-		throw new Error( `CORTEXT_PHP_BIN points to a missing executable: ${ configured }` );
+		throw new Error(
+			`CORTEXT_PHP_BIN does not point to an executable: ${ configured }`
+		);
 	}
 	const bundled = resolve( RUNTIME_DIR, 'bin/php' );
 	if ( existsSync( bundled ) ) {
 		return bundled;
 	}
-	const fromPath = commandExists( 'php' );
+	const fromPath = findExecutable( 'php' );
 	if ( fromPath ) {
 		return fromPath;
 	}
 	throw new Error(
-		'Missing php. Install PHP 8.1+, set CORTEXT_PHP_BIN, or bundle apps/desktop/runtime/bin/php.'
-	);
-}
-
-// macOS `unzip` can exit 1 for warnings, including archives with stored
-// absolute paths. Callers verify the files they need after extraction.
-function unzipQuiet( zipPath, dest ) {
-	spawnSync(
-		'unzip',
-		[ '-q', '-o', zipPath, '-d', dest ],
-		{ stdio: [ 'ignore', 'ignore', 'ignore' ] }
+		'PHP was not found. Install PHP 8.1+, set CORTEXT_PHP_BIN, or include apps/desktop/runtime/bin/php in the app bundle.'
 	);
 }
 
@@ -154,23 +141,23 @@ for ( const entry of PLUGIN_INCLUDES ) {
 console.log( `[snapshot] Fetching WordPress ${ WP_VERSION }` );
 const wpZipPath = resolve( CACHE_DIR, `wordpress-${ WP_VERSION }.zip` );
 await ensureCachedDownload( WP_DOWNLOAD_URL, wpZipPath );
-unzipQuiet( wpZipPath, WORK_DIR );
+await extractZip( wpZipPath, WORK_DIR );
 if ( ! existsSync( resolve( SITE_DIR, 'index.php' ) ) ) {
-	throw new Error( `WordPress extraction failed: ${ SITE_DIR } missing index.php` );
+	throw new Error(
+		`WordPress extraction failed: index.php is missing from ${ SITE_DIR }.`
+	);
 }
 
 console.log( '[snapshot] Installing sqlite-database-integration plugin' );
 const sqliteZipPath = resolve( CACHE_DIR, 'sqlite-database-integration.zip' );
 await ensureCachedDownload( SQLITE_PLUGIN_URL, sqliteZipPath );
 const pluginsDir = resolve( SITE_DIR, 'wp-content/plugins' );
-unzipQuiet( sqliteZipPath, pluginsDir );
+await extractZip( sqliteZipPath, pluginsDir );
 if (
-	! existsSync(
-		resolve( pluginsDir, 'sqlite-database-integration/db.copy' )
-	)
+	! existsSync( resolve( pluginsDir, 'sqlite-database-integration/db.copy' ) )
 ) {
 	throw new Error(
-		'sqlite-database-integration plugin extraction failed: db.copy not found'
+		'sqlite-database-integration plugin extraction failed: db.copy is missing.'
 	);
 }
 cpSync(
@@ -230,9 +217,9 @@ const PHP_BIN = resolvePhpBin();
 
 function wpCli( args ) {
 	run(
-		`${ shellQuote( PHP_BIN ) } ${ shellQuote( wpCliPhar ) } --path=${ shellQuote(
-			SITE_DIR
-		) } ${ args }`
+		`${ shellQuote( PHP_BIN ) } ${ shellQuote(
+			wpCliPhar
+		) } --path=${ shellQuote( SITE_DIR ) } ${ args }`
 	);
 }
 
@@ -266,7 +253,9 @@ wpCli(
 		'--url=http://127.0.0.1:9402 ' +
 		'--title=Cortext ' +
 		'--admin_user=admin ' +
-		`--admin_password=${ randomSalt().replace( /[^A-Za-z0-9]/g, '' ).slice( 0, 24 ) } ` +
+		`--admin_password=${ randomSalt()
+			.replace( /[^A-Za-z0-9]/g, '' )
+			.slice( 0, 24 ) } ` +
 		'--admin_email=admin@example.com ' +
 		'--skip-email'
 );
@@ -282,9 +271,9 @@ for ( const seedCommand of snapshotSeedCommands() ) {
 
 console.log( '[snapshot] Zipping site' );
 rmSync( OUTFILE, { force: true } );
-run( `cd "${ WORK_DIR }" && zip -q -r "${ OUTFILE }" wordpress` );
+await zipDirectory( SITE_DIR, OUTFILE, 'wordpress' );
 if ( ! existsSync( OUTFILE ) ) {
-	throw new Error( `Snapshot zip was not written: ${ OUTFILE }` );
+	throw new Error( `Snapshot file was not created at ${ OUTFILE }.` );
 }
 
 console.log( '[snapshot] Cleaning staging dir' );

--- a/apps/desktop/scripts/executable.test.mjs
+++ b/apps/desktop/scripts/executable.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import executableHelpers from '../lib/executable.js';
+
+const { DEFAULT_WINDOWS_PATHEXT, envValue, findExecutable } = executableHelpers;
+
+function windowsFiles( files ) {
+	const normalized = new Set( files.map( ( file ) => file.toLowerCase() ) );
+	return ( candidate ) => normalized.has( candidate.toLowerCase() );
+}
+
+test( 'Windows environment lookup is case-insensitive', () => {
+	assert.equal( envValue( { Path: 'C:\\bin' }, 'PATH', 'win32' ), 'C:\\bin' );
+	assert.equal( envValue( { pathext: '.EXE' }, 'PATHEXT', 'win32' ), '.EXE' );
+} );
+
+test( 'findExecutable searches quoted Windows PATH entries with PATHEXT', () => {
+	const isFile = windowsFiles( [ 'C:\\Program Files\\PHP ñ\\php.EXE' ] );
+	assert.equal(
+		findExecutable( 'php', {
+			platform: 'win32',
+			env: {
+				Path: '"C:\\Program Files\\PHP ñ";C:\\other',
+				Pathext: '.EXE;.CMD',
+			},
+			cwd: 'C:\\workspace',
+			isFile,
+		} ),
+		'C:\\Program Files\\PHP ñ\\php.EXE'
+	);
+} );
+
+test( 'findExecutable uses custom PATHEXT entries', () => {
+	const isFile = windowsFiles( [ 'C:\\tools\\runner.CMD' ] );
+	assert.equal(
+		findExecutable( 'runner', {
+			platform: 'win32',
+			env: { PATH: 'C:\\tools', PATHEXT: '.CMD;.EXE' },
+			cwd: 'C:\\workspace',
+			isFile,
+		} ),
+		'C:\\tools\\runner.CMD'
+	);
+} );
+
+test( 'findExecutable skips .cmd files when only .com and .exe are allowed', () => {
+	const isFile = windowsFiles( [
+		'C:\\batch-only\\php.CMD',
+		'C:\\native\\php.EXE',
+	] );
+	assert.equal(
+		findExecutable( 'php', {
+			platform: 'win32',
+			env: {
+				PATH: 'C:\\batch-only;C:\\native',
+				PATHEXT: '.CMD;.EXE',
+			},
+			cwd: 'C:\\workspace',
+			isFile,
+			allowedWindowsExtensions: [ '.COM', '.EXE' ],
+		} ),
+		'C:\\native\\php.EXE'
+	);
+	assert.equal(
+		findExecutable( 'C:\\batch-only\\php.cmd', {
+			platform: 'win32',
+			env: { PATHEXT: '.CMD;.EXE' },
+			isFile,
+			allowedWindowsExtensions: [ '.COM', '.EXE' ],
+		} ),
+		null
+	);
+} );
+
+test( 'findExecutable uses the standard Windows extensions when PATHEXT is missing', () => {
+	const isFile = windowsFiles( [ 'C:\\tools\\php.EXE' ] );
+	assert.match( DEFAULT_WINDOWS_PATHEXT, /\.EXE/ );
+	assert.equal(
+		findExecutable( 'php', {
+			platform: 'win32',
+			env: { Path: 'C:\\tools' },
+			cwd: 'C:\\workspace',
+			isFile,
+		} ),
+		'C:\\tools\\php.EXE'
+	);
+} );
+
+test( 'findExecutable accepts an explicit quoted Windows path', () => {
+	const isFile = windowsFiles( [ 'C:\\PHP Runtime\\php.exe' ] );
+	assert.equal(
+		findExecutable( '"C:\\PHP Runtime\\php.exe"', {
+			platform: 'win32',
+			env: {},
+			cwd: 'C:\\workspace',
+			isFile,
+		} ),
+		'C:\\PHP Runtime\\php.exe'
+	);
+} );
+
+test( 'findExecutable returns null when no PATH candidate exists', () => {
+	assert.equal(
+		findExecutable( 'php', {
+			platform: 'win32',
+			env: { Path: 'C:\\missing' },
+			cwd: 'C:\\workspace',
+			isFile: () => false,
+		} ),
+		null
+	);
+} );

--- a/apps/desktop/scripts/router-auth.test.mjs
+++ b/apps/desktop/scripts/router-auth.test.mjs
@@ -198,8 +198,8 @@ test( 'startRuntime replaces an unprotected legacy router before listening', asy
 		runtimeStateDir: path.join( wordpressDir, 'runtime-state' ),
 		wordpressDir,
 	} );
-	context.after( () => {
-		stopRuntime( handle );
+	context.after( async () => {
+		await stopRuntime( handle );
 		fs.rmSync( wordpressDir, { recursive: true, force: true } );
 	} );
 

--- a/apps/desktop/scripts/runtime.test.mjs
+++ b/apps/desktop/scripts/runtime.test.mjs
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import runtimeHelpers from '../lib/runtime.js';
+
+const {
+	bundledRuntimeExecutable,
+	childProcessOptions,
+	findRuntimeExecutable,
+	phpCliWorkerConfig,
+	runWindowsTaskkill,
+	stopRuntime,
+	waitForProcessExit,
+} = runtimeHelpers;
+
+class FakeChild extends EventEmitter {
+	constructor( pid = 1234 ) {
+		super();
+		this.pid = pid;
+		this.exitCode = null;
+		this.signalCode = null;
+		this.killCalls = [];
+	}
+
+	kill( signal ) {
+		this.killCalls.push( signal );
+		return true;
+	}
+
+	exit( code = 0 ) {
+		this.exitCode = code;
+		this.emit( 'exit', code, null );
+		this.emit( 'close', code, null );
+	}
+}
+
+test( 'runtime lookup skips Windows batch wrappers', () => {
+	const files = new Set(
+		[ 'C:\\wrappers\\php.cmd', 'C:\\native\\php.exe' ].map( ( file ) =>
+			file.toLowerCase()
+		)
+	);
+	assert.equal(
+		findRuntimeExecutable( 'php', {
+			platform: 'win32',
+			env: {
+				PATH: 'C:\\wrappers;C:\\native',
+				PATHEXT: '.CMD;.EXE',
+			},
+			isFile: ( candidate ) => files.has( candidate.toLowerCase() ),
+		} ),
+		'C:\\native\\php.EXE'
+	);
+} );
+
+test( 'bundled PHP resolves to php.exe on Windows and php elsewhere', () => {
+	assert.equal(
+		bundledRuntimeExecutable( 'C:\\Cortext', 'php', 'win32' ),
+		path.win32.join( 'C:\\Cortext', 'runtime/bin', 'php.exe' )
+	);
+	assert.equal(
+		bundledRuntimeExecutable( '/Applications/Cortext', 'php', 'darwin' ),
+		path.join( '/Applications/Cortext', 'runtime/bin', 'php' )
+	);
+} );
+
+test( 'child process options hide the Windows console', () => {
+	assert.deepEqual( childProcessOptions( { cwd: 'C:\\site' } ), {
+		stdio: [ 'ignore', 'pipe', 'pipe' ],
+		cwd: 'C:\\site',
+		windowsHide: true,
+	} );
+} );
+
+test( 'Windows ignores PHP CLI worker settings and does not detach', () => {
+	assert.deepEqual(
+		phpCliWorkerConfig(
+			{
+				CORTEXT_PHP_CLI_SERVER_WORKERS: '4',
+				PHP_CLI_SERVER_WORKERS: '8',
+			},
+			'win32'
+		),
+		{
+			workers: null,
+			detached: false,
+			ignoredWorkers: '4',
+		}
+	);
+} );
+
+test( 'POSIX keeps the configured PHP worker count and uses a process group', () => {
+	assert.deepEqual(
+		phpCliWorkerConfig( { PHP_CLI_SERVER_WORKERS: '3' }, 'darwin' ),
+		{
+			workers: '3',
+			detached: true,
+			ignoredWorkers: null,
+		}
+	);
+} );
+
+test( 'Windows stops processes without POSIX signals', async () => {
+	const child = new FakeChild();
+	const stopped = waitForProcessExit( child, {
+		platform: 'win32',
+		gracePeriodMs: 100,
+		forcePeriodMs: 100,
+	} );
+	assert.deepEqual( child.killCalls, [ undefined ] );
+	child.exit();
+	await stopped;
+} );
+
+test( 'Windows uses taskkill for the process tree after graceful shutdown times out', async () => {
+	const calls = [];
+	const killer = new EventEmitter();
+	killer.kill = () => {};
+	const completed = runWindowsTaskkill( 4321, ( command, args, options ) => {
+		calls.push( { command, args, options } );
+		queueMicrotask( () => killer.emit( 'exit', 0 ) );
+		return killer;
+	} );
+
+	assert.equal( await completed, true );
+	assert.deepEqual( calls, [
+		{
+			command: 'taskkill',
+			args: [ '/PID', '4321', '/T', '/F' ],
+			options: {
+				stdio: [ 'ignore', 'ignore', 'ignore' ],
+				windowsHide: true,
+			},
+		},
+	] );
+} );
+
+test( 'POSIX shutdown signals the process group with SIGTERM first', async () => {
+	const child = new FakeChild();
+	const signals = [];
+	const stopped = waitForProcessExit( child, {
+		killProcessGroup: true,
+		gracePeriodMs: 100,
+		forcePeriodMs: 100,
+		sendSignal: ( target, killProcessGroup, signal ) => {
+			signals.push( { target, killProcessGroup, signal } );
+		},
+	} );
+
+	assert.deepEqual( signals, [
+		{ target: child, killProcessGroup: true, signal: 'SIGTERM' },
+	] );
+	child.exit();
+	await stopped;
+} );
+
+test( 'stopRuntime reuses its promise and cleans up after exit', async () => {
+	const cleanupPath = fs.mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-runtime-stop-' )
+	);
+	const child = new FakeChild();
+	const handle = {
+		processes: [ { child, killProcessGroup: false } ],
+		cleanupPaths: [ cleanupPath ],
+		stopping: false,
+	};
+
+	const first = stopRuntime( handle );
+	const second = stopRuntime( handle );
+	assert.equal( first, second );
+	assert.equal( handle.stopping, true );
+	assert.equal( fs.existsSync( cleanupPath ), true );
+
+	let settled = false;
+	first.finally( () => {
+		settled = true;
+	} );
+	await new Promise( ( resolve ) => setImmediate( resolve ) );
+	assert.equal( settled, false );
+
+	child.exit();
+	await first;
+	assert.equal( settled, true );
+	assert.equal( fs.existsSync( cleanupPath ), false );
+} );
+
+test( 'waitForProcessExit sends SIGKILL, then rejects if the process stays alive', async () => {
+	const child = new FakeChild( 5678 );
+	const signals = [];
+	await assert.rejects(
+		waitForProcessExit( child, {
+			gracePeriodMs: 5,
+			forcePeriodMs: 5,
+			sendSignal: ( target, killProcessGroup, signal ) => {
+				signals.push( { target, killProcessGroup, signal } );
+			},
+		} ),
+		/is still running after forced termination/
+	);
+	assert.deepEqual( signals, [
+		{ target: child, killProcessGroup: false, signal: 'SIGTERM' },
+		{ target: child, killProcessGroup: false, signal: 'SIGKILL' },
+	] );
+} );
+
+test( 'Windows shutdown rejects when the process stays alive after taskkill', async () => {
+	const child = new FakeChild( 5678 );
+	const taskkillPids = [];
+	await assert.rejects(
+		waitForProcessExit( child, {
+			platform: 'win32',
+			gracePeriodMs: 5,
+			forcePeriodMs: 5,
+			runTaskkill: async ( pid ) => {
+				taskkillPids.push( pid );
+				return true;
+			},
+		} ),
+		/is still running after forced termination/
+	);
+	assert.deepEqual( child.killCalls, [ undefined ] );
+	assert.deepEqual( taskkillPids, [ 5678 ] );
+} );

--- a/apps/desktop/scripts/runtime.test.mjs
+++ b/apps/desktop/scripts/runtime.test.mjs
@@ -188,6 +188,36 @@ test( 'stopRuntime reuses its promise and cleans up after exit', async () => {
 	assert.equal( fs.existsSync( cleanupPath ), false );
 } );
 
+test( 'a stop that times out still cleans up and stays marked as stopping', async () => {
+	const cleanupPath = fs.mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-runtime-wedged-' )
+	);
+	const wedged = new FakeChild( 4321 );
+	const crashes = [];
+	const handle = {
+		processes: [ { child: wedged, killProcessGroup: false } ],
+		cleanupPaths: [ cleanupPath ],
+		stopping: false,
+		onUnexpectedExit: ( name ) => crashes.push( name ),
+	};
+	wedged.on( 'exit', () => {
+		if ( ! handle.stopping ) {
+			handle.onUnexpectedExit( 'php' );
+		}
+	} );
+
+	await assert.rejects(
+		stopRuntime( handle, { gracePeriodMs: 5, forcePeriodMs: 5 } ),
+		/is still running after forced termination/
+	);
+	assert.equal( fs.existsSync( cleanupPath ), false );
+	assert.equal( handle.stopping, true );
+
+	// The kill was still on its way, so the exit that follows is not a crash.
+	wedged.exit();
+	assert.deepEqual( crashes, [] );
+} );
+
 test( 'waitForProcessExit sends SIGKILL, then rejects if the process stays alive', async () => {
 	const child = new FakeChild( 5678 );
 	const signals = [];

--- a/apps/desktop/scripts/runtime.test.mjs
+++ b/apps/desktop/scripts/runtime.test.mjs
@@ -207,7 +207,13 @@ test( 'a stop that times out still cleans up and stays marked as stopping', asyn
 	} );
 
 	await assert.rejects(
-		stopRuntime( handle, { gracePeriodMs: 5, forcePeriodMs: 5 } ),
+		// Pin the platform so this never reaches a real taskkill on Windows.
+		stopRuntime( handle, {
+			gracePeriodMs: 5,
+			forcePeriodMs: 5,
+			platform: 'linux',
+			sendSignal: () => {},
+		} ),
 		/is still running after forced termination/
 	);
 	assert.equal( fs.existsSync( cleanupPath ), false );

--- a/apps/desktop/scripts/site-refresh.test.mjs
+++ b/apps/desktop/scripts/site-refresh.test.mjs
@@ -1,17 +1,20 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import {
+	ensureSiteFromSnapshot,
 	refreshSiteIfOutdated,
 	recoverInterruptedSwap,
 	readMarker,
 	writeMarker,
 	BAK_PREFIX,
 } from '../lib/site-refresh.js';
+import zipHelpers from './zip.js';
+
+const { zipDirectory } = zipHelpers;
 
 function tmpDir() {
 	return fs.mkdtempSync( path.join( os.tmpdir(), 'cortext-site-refresh-' ) );
@@ -22,8 +25,8 @@ function writeFile( file, contents ) {
 	fs.writeFileSync( file, contents );
 }
 
-// A tiny WordPress-shaped tree: index.php satisfies the extraction check, and
-// the rest separates code from user data.
+// Create the minimum WordPress tree needed for extraction checks, with separate
+// code and user data.
 function writeSite( wordpressDir, { code, wpConfig, db, upload } ) {
 	writeFile( path.join( wordpressDir, 'index.php' ), code );
 	writeFile(
@@ -48,15 +51,11 @@ function writeSite( wordpressDir, { code, wpConfig, db, upload } ) {
 }
 
 // Build a snapshot.zip with a top-level `wordpress/` dir, like build-snapshot.
-function makeSnapshotZip( contents ) {
+async function makeSnapshotZip( contents ) {
 	const src = tmpDir();
 	writeSite( path.join( src, 'wordpress' ), contents );
 	const zipPath = path.join( src, 'snapshot.zip' );
-	const result = spawnSync( 'zip', [ '-q', '-r', zipPath, 'wordpress' ], {
-		cwd: src,
-		stdio: [ 'ignore', 'ignore', 'ignore' ],
-	} );
-	assert.equal( result.status, 0, 'zip fixture built' );
+	await zipDirectory( path.join( src, 'wordpress' ), zipPath, 'wordpress' );
 	return zipPath;
 }
 
@@ -64,7 +63,7 @@ function read( file ) {
 	return fs.readFileSync( file, 'utf8' );
 }
 
-test( 'refresh updates code and preserves the database, uploads, and wp-config', () => {
+test( 'refresh updates code and preserves the database, uploads, and wp-config', async () => {
 	const siteRoot = tmpDir();
 	const wordpressDir = path.join( siteRoot, 'wordpress' );
 	writeSite( wordpressDir, {
@@ -75,20 +74,20 @@ test( 'refresh updates code and preserves the database, uploads, and wp-config',
 	} );
 	writeMarker( siteRoot, '1.0.0' );
 
-	const snapshotZip = makeSnapshotZip( {
+	const snapshotZip = await makeSnapshotZip( {
 		code: 'CODE v2',
 		wpConfig: 'WPCONFIG v2 FRESH',
 		db: 'SEED DATA',
 	} );
 
-	const refreshed = refreshSiteIfOutdated( {
+	const refreshed = await refreshSiteIfOutdated( {
 		snapshotZip,
 		siteRoot,
 		version: '2.0.0',
 	} );
 
 	assert.equal( refreshed, true );
-		// Snapshot code replaced the old code.
+	// The refresh replaced the old code with the snapshot.
 	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'CODE v2' );
 	assert.equal(
 		read(
@@ -96,7 +95,7 @@ test( 'refresh updates code and preserves the database, uploads, and wp-config',
 		),
 		'CODE v2'
 	);
-		// User data and wp-config survived the swap.
+	// The refresh kept the user's data and wp-config.
 	assert.equal(
 		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
 		'USER DATA'
@@ -109,7 +108,7 @@ test( 'refresh updates code and preserves the database, uploads, and wp-config',
 		read( path.join( wordpressDir, 'wp-config.php' ) ),
 		'WPCONFIG v1 SALT'
 	);
-		// Marker moved forward, and no scratch dirs were left.
+	// The refresh updated the marker and removed its temporary directories.
 	assert.equal( readMarker( siteRoot ), '2.0.0' );
 	const leftovers = fs
 		.readdirSync( siteRoot )
@@ -119,37 +118,277 @@ test( 'refresh updates code and preserves the database, uploads, and wp-config',
 	assert.deepEqual( leftovers, [] );
 } );
 
-test( 'refresh is a no-op on the same version and never downgrades', () => {
+test( 'refresh does nothing for the same version and never downgrades', async () => {
 	const siteRoot = tmpDir();
 	const wordpressDir = path.join( siteRoot, 'wordpress' );
 	writeSite( wordpressDir, { code: 'CODE v2', db: 'USER DATA' } );
 	writeMarker( siteRoot, '2.0.0' );
-	const snapshotZip = makeSnapshotZip( { code: 'CODE other', db: 'SEED' } );
+	const snapshotZip = await makeSnapshotZip( {
+		code: 'CODE other',
+		db: 'SEED',
+	} );
 
 	assert.equal(
-		refreshSiteIfOutdated( { snapshotZip, siteRoot, version: '2.0.0' } ),
+		await refreshSiteIfOutdated( {
+			snapshotZip,
+			siteRoot,
+			version: '2.0.0',
+		} ),
 		false
 	);
 	assert.equal(
-		refreshSiteIfOutdated( { snapshotZip, siteRoot, version: '1.5.0' } ),
+		await refreshSiteIfOutdated( {
+			snapshotZip,
+			siteRoot,
+			version: '1.5.0',
+		} ),
 		false
 	);
-		// Still untouched.
+	// The existing site is unchanged.
 	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'CODE v2' );
 	assert.equal( readMarker( siteRoot ), '2.0.0' );
 } );
 
-test( 'refresh without an extracted site defers to first-run extraction', () => {
+test( 'refresh waits for first-run extraction when no site exists', async () => {
 	const siteRoot = tmpDir();
-	const snapshotZip = makeSnapshotZip( { code: 'CODE v2', db: 'SEED' } );
+	const snapshotZip = await makeSnapshotZip( {
+		code: 'CODE v2',
+		db: 'SEED',
+	} );
 	assert.equal(
-		refreshSiteIfOutdated( { snapshotZip, siteRoot, version: '2.0.0' } ),
+		await refreshSiteIfOutdated( {
+			snapshotZip,
+			siteRoot,
+			version: '2.0.0',
+		} ),
 		false
 	);
 	assert.equal( fs.existsSync( path.join( siteRoot, 'wordpress' ) ), false );
 } );
 
-test( 'recoverInterruptedSwap restores a stashed tree when wordpress is missing', () => {
+test( 'first-run extraction replaces an incomplete site without losing user data', async () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeFile( path.join( wordpressDir, 'partial.txt' ), 'INCOMPLETE' );
+	writeFile(
+		path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ),
+		'USER DATABASE'
+	);
+	writeFile(
+		path.join( wordpressDir, 'wp-content/uploads/photo.txt' ),
+		'USER UPLOAD'
+	);
+	writeFile( path.join( wordpressDir, 'wp-config.php' ), 'USER CONFIG' );
+	const snapshotZip = await makeSnapshotZip( {
+		code: 'COMPLETE',
+		db: 'SEED',
+	} );
+
+	assert.equal(
+		await ensureSiteFromSnapshot( {
+			snapshotZip,
+			siteRoot,
+			version: '2.0.0',
+		} ),
+		wordpressDir
+	);
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'COMPLETE' );
+	assert.equal(
+		fs.existsSync( path.join( wordpressDir, 'partial.txt' ) ),
+		false
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'USER DATABASE'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/uploads/photo.txt' ) ),
+		'USER UPLOAD'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-config.php' ) ),
+		'USER CONFIG'
+	);
+	assert.equal( readMarker( siteRoot ), '2.0.0' );
+	assert.deepEqual(
+		fs
+			.readdirSync( siteRoot )
+			.filter( ( name ) => name.startsWith( '.next-' ) ),
+		[]
+	);
+} );
+
+test( 'first-run extraction restores the original tree when the final rename fails', async () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeFile(
+		path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ),
+		'USER DATABASE'
+	);
+	writeFile(
+		path.join( wordpressDir, 'wp-content/uploads/photo.txt' ),
+		'USER UPLOAD'
+	);
+	writeFile( path.join( wordpressDir, 'wp-config.php' ), 'USER CONFIG' );
+	const snapshotZip = await makeSnapshotZip( {
+		code: 'COMPLETE',
+		db: 'SEED',
+	} );
+	const renameSync = fs.renameSync;
+	let renameCount = 0;
+	fs.renameSync = ( from, to ) => {
+		renameCount += 1;
+		if ( renameCount === 2 ) {
+			throw new Error( 'simulated first-run rename failure' );
+		}
+		return renameSync( from, to );
+	};
+
+	try {
+		await assert.rejects(
+			ensureSiteFromSnapshot( {
+				snapshotZip,
+				siteRoot,
+				version: '2.0.0',
+			} ),
+			/simulated first-run rename failure/
+		);
+	} finally {
+		fs.renameSync = renameSync;
+	}
+
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'USER DATABASE'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/uploads/photo.txt' ) ),
+		'USER UPLOAD'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-config.php' ) ),
+		'USER CONFIG'
+	);
+	assert.equal(
+		fs.existsSync( path.join( wordpressDir, 'index.php' ) ),
+		false
+	);
+	assert.deepEqual(
+		fs
+			.readdirSync( siteRoot )
+			.filter(
+				( name ) =>
+					name.startsWith( '.next-' ) || name.startsWith( BAK_PREFIX )
+			),
+		[]
+	);
+} );
+
+test( 'first-run extraction preserves user data when another process installs the live tree first', async () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeFile(
+		path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ),
+		'USER DATABASE'
+	);
+	writeFile(
+		path.join( wordpressDir, 'wp-content/uploads/photo.txt' ),
+		'USER UPLOAD'
+	);
+	writeFile( path.join( wordpressDir, 'wp-config.php' ), 'USER CONFIG' );
+	const snapshotZip = await makeSnapshotZip( {
+		code: 'OUR SNAPSHOT',
+		db: 'OUR SEED',
+	} );
+	const renameSync = fs.renameSync;
+	let renameCount = 0;
+	fs.renameSync = ( from, to ) => {
+		renameCount += 1;
+		if ( renameCount === 2 ) {
+			writeSite( wordpressDir, {
+				code: 'CONCURRENT SNAPSHOT',
+				wpConfig: 'CONCURRENT CONFIG',
+				db: 'CONCURRENT SEED',
+				upload: 'CONCURRENT UPLOAD',
+			} );
+			const error = new Error( 'destination already exists' );
+			error.code = 'EEXIST';
+			throw error;
+		}
+		return renameSync( from, to );
+	};
+
+	try {
+		assert.equal(
+			await ensureSiteFromSnapshot( {
+				snapshotZip,
+				siteRoot,
+				version: '2.0.0',
+			} ),
+			wordpressDir
+		);
+	} finally {
+		fs.renameSync = renameSync;
+	}
+
+	assert.equal(
+		read( path.join( wordpressDir, 'index.php' ) ),
+		'CONCURRENT SNAPSHOT'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'USER DATABASE'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/uploads/photo.txt' ) ),
+		'USER UPLOAD'
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-config.php' ) ),
+		'USER CONFIG'
+	);
+	assert.deepEqual(
+		fs
+			.readdirSync( siteRoot )
+			.filter(
+				( name ) =>
+					name.startsWith( '.next-' ) || name.startsWith( BAK_PREFIX )
+			),
+		[]
+	);
+} );
+
+test( 'a failed first-run extraction leaves the incomplete site untouched', async () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeFile( path.join( wordpressDir, 'partial.txt' ), 'KEEP UNTIL RETRY' );
+	const snapshotZip = path.join( tmpDir(), 'broken snapshot.zip' );
+	fs.writeFileSync( snapshotZip, 'not a zip archive' );
+
+	await assert.rejects(
+		ensureSiteFromSnapshot( {
+			snapshotZip,
+			siteRoot,
+			version: '2.0.0',
+		} )
+	);
+	assert.equal(
+		read( path.join( wordpressDir, 'partial.txt' ) ),
+		'KEEP UNTIL RETRY'
+	);
+	assert.equal(
+		fs.existsSync( path.join( wordpressDir, 'index.php' ) ),
+		false
+	);
+	assert.deepEqual(
+		fs
+			.readdirSync( siteRoot )
+			.filter( ( name ) => name.startsWith( '.next-' ) ),
+		[]
+	);
+} );
+
+test( 'recoverInterruptedSwap restores a backup when the live tree is missing', () => {
 	const siteRoot = tmpDir();
 	fs.mkdirSync( siteRoot, { recursive: true } );
 	const bak = path.join( siteRoot, `${ BAK_PREFIX }123-456` );
@@ -164,15 +403,18 @@ test( 'recoverInterruptedSwap restores a stashed tree when wordpress is missing'
 	assert.equal( fs.existsSync( bak ), false );
 } );
 
-test( 'refresh runs between same-core prereleases', () => {
+test( 'refresh runs when prerelease versions share the same numeric core', async () => {
 	const siteRoot = tmpDir();
 	const wordpressDir = path.join( siteRoot, 'wordpress' );
 	writeSite( wordpressDir, { code: 'CODE rc1', db: 'USER DATA' } );
 	writeMarker( siteRoot, '0.2.0-rc.1' );
-	const snapshotZip = makeSnapshotZip( { code: 'CODE rc2', db: 'SEED' } );
+	const snapshotZip = await makeSnapshotZip( {
+		code: 'CODE rc2',
+		db: 'SEED',
+	} );
 
 	assert.equal(
-		refreshSiteIfOutdated( {
+		await refreshSiteIfOutdated( {
 			snapshotZip,
 			siteRoot,
 			version: '0.2.0-rc.2',
@@ -187,7 +429,7 @@ test( 'refresh runs between same-core prereleases', () => {
 	assert.equal( readMarker( siteRoot ), '0.2.0-rc.2' );
 } );
 
-test( 'recoverInterruptedSwap clears orphaned scratch dirs and leaves the live tree', () => {
+test( 'recoverInterruptedSwap removes leftover temporary directories without changing the live tree', () => {
 	const siteRoot = tmpDir();
 	const wordpressDir = path.join( siteRoot, 'wordpress' );
 	writeFile( path.join( wordpressDir, 'index.php' ), 'LIVE' );
@@ -198,4 +440,112 @@ test( 'recoverInterruptedSwap clears orphaned scratch dirs and leaves the live t
 
 	assert.equal( fs.existsSync( scratch ), false );
 	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'LIVE' );
+} );
+
+test( 'recovery leaves the live database unchanged when a normal refresh backup remains', () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	const refreshBackup = path.join( siteRoot, `${ BAK_PREFIX }123-456` );
+	writeSite( wordpressDir, {
+		code: 'LIVE',
+		db: 'NEW USER DATABASE',
+	} );
+	writeSite( refreshBackup, {
+		code: 'OLD',
+		db: 'OLD USER DATABASE',
+	} );
+
+	recoverInterruptedSwap( siteRoot );
+
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'NEW USER DATABASE'
+	);
+	assert.equal( fs.existsSync( refreshBackup ), true );
+} );
+
+test( 'refresh handles paths with spaces and non-ASCII characters', async () => {
+	const parent = tmpDir();
+	const siteRoot = path.join( parent, 'Cortext site ñ' );
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeSite( wordpressDir, { code: 'OLD', db: 'USER DATA' } );
+	writeMarker( siteRoot, '1.0.0' );
+	const snapshotZip = await makeSnapshotZip( {
+		code: 'NUEVO',
+		db: 'SEED',
+	} );
+
+	assert.equal(
+		await refreshSiteIfOutdated( {
+			snapshotZip,
+			siteRoot,
+			version: '2.0.0',
+		} ),
+		true
+	);
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'NUEVO' );
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'USER DATA'
+	);
+} );
+
+test( 'refresh leaves the live site intact when the snapshot is corrupt', async () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeSite( wordpressDir, { code: 'LIVE', db: 'USER DATA' } );
+	writeMarker( siteRoot, '1.0.0' );
+	const snapshotZip = path.join( tmpDir(), 'broken snapshot.zip' );
+	fs.writeFileSync( snapshotZip, 'not a zip archive' );
+
+	assert.equal(
+		await refreshSiteIfOutdated( {
+			snapshotZip,
+			siteRoot,
+			version: '2.0.0',
+		} ),
+		false
+	);
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'LIVE' );
+	assert.equal( readMarker( siteRoot ), '1.0.0' );
+} );
+
+test( 'refresh restores the live tree when the final rename fails', async () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeSite( wordpressDir, { code: 'LIVE', db: 'USER DATA' } );
+	writeMarker( siteRoot, '1.0.0' );
+	const snapshotZip = await makeSnapshotZip( {
+		code: 'NEW',
+		db: 'SEED',
+	} );
+	const renameSync = fs.renameSync;
+	let renameCount = 0;
+	fs.renameSync = ( from, to ) => {
+		renameCount += 1;
+		if ( renameCount === 2 ) {
+			throw new Error( 'simulated rename failure' );
+		}
+		return renameSync( from, to );
+	};
+
+	try {
+		assert.equal(
+			await refreshSiteIfOutdated( {
+				snapshotZip,
+				siteRoot,
+				version: '2.0.0',
+			} ),
+			false
+		);
+	} finally {
+		fs.renameSync = renameSync;
+	}
+
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'LIVE' );
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'USER DATA'
+	);
+	assert.equal( readMarker( siteRoot ), '1.0.0' );
 } );

--- a/apps/desktop/scripts/site-refresh.test.mjs
+++ b/apps/desktop/scripts/site-refresh.test.mjs
@@ -442,6 +442,63 @@ test( 'recoverInterruptedSwap removes leftover temporary directories without cha
 	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'LIVE' );
 } );
 
+test( 'recovery restores the complete backup, not an older first-run one', () => {
+	const siteRoot = tmpDir();
+	writeSite( path.join( siteRoot, `${ BAK_PREFIX }2000-1` ), {
+		code: 'COMPLETE',
+		db: 'CURRENT DATABASE',
+	} );
+	// Older, and incomplete by construction, but its name sorts last.
+	writeFile(
+		path.join(
+			siteRoot,
+			`${ BAK_PREFIX }first-run-1000-2/wp-content/database/.ht.sqlite`
+		),
+		'OLD DATABASE'
+	);
+
+	recoverInterruptedSwap( siteRoot );
+
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	assert.equal( read( path.join( wordpressDir, 'index.php' ) ), 'COMPLETE' );
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'CURRENT DATABASE'
+	);
+	assert.deepEqual(
+		fs
+			.readdirSync( siteRoot )
+			.filter( ( name ) => name.startsWith( BAK_PREFIX ) ),
+		[]
+	);
+} );
+
+test( 'recovery never copies a stale first-run backup over newer user data', () => {
+	const siteRoot = tmpDir();
+	const wordpressDir = path.join( siteRoot, 'wordpress' );
+	writeSite( wordpressDir, { code: 'LIVE', db: 'NEW USER DATABASE' } );
+	writeFile(
+		path.join(
+			siteRoot,
+			`${ BAK_PREFIX }first-run-1000-2/wp-content/database/.ht.sqlite`
+		),
+		'OLD DATABASE'
+	);
+
+	recoverInterruptedSwap( siteRoot );
+
+	assert.equal(
+		read( path.join( wordpressDir, 'wp-content/database/.ht.sqlite' ) ),
+		'NEW USER DATABASE'
+	);
+	assert.deepEqual(
+		fs
+			.readdirSync( siteRoot )
+			.filter( ( name ) => name.startsWith( BAK_PREFIX ) ),
+		[]
+	);
+} );
+
 test( 'recovery leaves the live database unchanged when a normal refresh backup remains', () => {
 	const siteRoot = tmpDir();
 	const wordpressDir = path.join( siteRoot, 'wordpress' );

--- a/apps/desktop/scripts/zip.js
+++ b/apps/desktop/scripts/zip.js
@@ -54,10 +54,30 @@ function zipDirectory(
 	fs.mkdirSync( path.dirname( archivePath ), { recursive: true } );
 	return new Promise( ( resolve, reject ) => {
 		const output = fs.createWriteStream( archivePath );
-		const fail = ( error ) => reject( error );
+		let failure = null;
+		// yazl reports a file it cannot stat or read on the ZipFile itself, not
+		// on its output stream.
+		const fail = ( error ) => {
+			if ( failure ) {
+				return;
+			}
+			failure = error;
+			output.destroy();
+		};
+		const finish = () => {
+			if ( ! failure ) {
+				resolve();
+				return;
+			}
+			// Never leave a half-written archive where a caller can mistake it
+			// for a finished one.
+			fs.rmSync( archivePath, { force: true } );
+			reject( failure );
+		};
+		archive.once( 'error', fail );
 		archive.outputStream.once( 'error', fail );
 		output.once( 'error', fail );
-		output.once( 'close', resolve );
+		output.once( 'close', finish );
 		archive.outputStream.pipe( output );
 		archive.end();
 	} );

--- a/apps/desktop/scripts/zip.js
+++ b/apps/desktop/scripts/zip.js
@@ -1,0 +1,66 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+const yazl = require( 'yazl' );
+
+function walkDirectory( dir, relativeDir = '' ) {
+	const entries = [];
+	for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
+		const relativePath = path.posix.join(
+			relativeDir,
+			entry.name.replace( /\\/g, '/' )
+		);
+		const absolutePath = path.join( dir, entry.name );
+		if ( entry.isSymbolicLink() ) {
+			throw new Error(
+				`Symbolic links cannot be added to ZIP files: ${ absolutePath }`
+			);
+		}
+		if ( entry.isDirectory() ) {
+			entries.push( {
+				type: 'directory',
+				relativePath: `${ relativePath }/`,
+			} );
+			entries.push( ...walkDirectory( absolutePath, relativePath ) );
+		} else if ( entry.isFile() ) {
+			entries.push( {
+				type: 'file',
+				absolutePath,
+				relativePath,
+			} );
+		}
+	}
+	return entries;
+}
+
+function zipDirectory(
+	sourceDir,
+	archivePath,
+	rootName = path.basename( sourceDir )
+) {
+	const archive = new yazl.ZipFile();
+	const normalizedRoot = rootName.replace( /\\/g, '/' ).replace( /\/+$/, '' );
+	for ( const entry of walkDirectory( sourceDir ) ) {
+		const archiveEntry = path.posix.join(
+			normalizedRoot,
+			entry.relativePath
+		);
+		if ( entry.type === 'directory' ) {
+			archive.addEmptyDirectory( archiveEntry );
+		} else {
+			archive.addFile( entry.absolutePath, archiveEntry );
+		}
+	}
+
+	fs.mkdirSync( path.dirname( archivePath ), { recursive: true } );
+	return new Promise( ( resolve, reject ) => {
+		const output = fs.createWriteStream( archivePath );
+		const fail = ( error ) => reject( error );
+		archive.outputStream.once( 'error', fail );
+		output.once( 'error', fail );
+		output.once( 'close', resolve );
+		archive.outputStream.pipe( output );
+		archive.end();
+	} );
+}
+
+module.exports = { zipDirectory };


### PR DESCRIPTION
## What

This is the first app-side PR for Windows support. It replaces `zip`, `unzip`, and `which` with JavaScript helpers, adds Windows-aware executable lookup, and makes site extraction and runtime shutdown asynchronous.

The site refresh keeps the existing database, uploads, and `wp-config.php`. There's no Windows runtime or installer here yet, and this PR doesn't touch Buildkite or signing.

## Why

Most of the desktop app still assumes macOS or Linux paths, tools, and process signals. We need to remove those assumptions before the Windows build can start and shut down cleanly.

## How

Cortext now checks ZIP entries before extraction and only moves a site into place once the extraction has finished. On Windows, PHP uses `php.exe`, runs as one hidden worker without POSIX process groups, and falls back to `taskkill` if it doesn't exit normally.

The app also waits for PHP to stop before quitting or applying an update.

Only one copy runs at a time. Opening Cortext again brings the existing window to the front instead of starting a second app against the same site folder.

## Testing Instructions

1. Rebuild `snapshot.zip` from `apps/desktop`.
2. Launch Cortext and confirm that an existing workspace opens normally.
3. Make a change, quit Cortext, and reopen it to confirm the change is still there.
4. Close Cortext once while it is loading and once after it has loaded. Wait for it to quit fully, then reopen it and confirm it starts both times without a port 9402 error.
5. With Cortext already open, launch it again from Finder or the dock. Confirm that no second window opens and the existing one comes to the front.
