### PR TITLE
Desktop: Build the snapshot on Windows

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -124,3 +124,48 @@ jobs:
                       apps/desktop/test-results/
                       apps/desktop/playwright-report/
                   retention-days: 7
+
+    # Unit tests cover the Windows-specific branches with a mocked platform.
+    # This job runs those tests on Windows and builds the snapshot there too.
+    # It cannot launch the app until we bundle the Windows PHP runtime.
+    windows:
+        name: Desktop tests and snapshot (Windows)
+        runs-on: windows-latest
+        needs: changes
+        if: needs.changes.outputs.desktop_changed == 'true'
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@v7.0.0
+
+            - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+              with:
+                  php-version: '8.3'
+                  extensions: pdo_sqlite, sqlite3, mbstring, json, curl, openssl
+                  tools: composer:v2
+                  coverage: none
+
+            - run: composer install --no-interaction --prefer-dist --no-dev
+
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+              with:
+                  version: 11.0.8
+                  standalone: true
+
+            - uses: actions/setup-node@v7
+              with:
+                  node-version: '24.15'
+                  cache: 'pnpm'
+
+            - run: pnpm install --frozen-lockfile
+
+            - name: Install desktop dependencies
+              working-directory: apps/desktop
+              run: npm ci
+
+            - name: Run desktop unit tests
+              working-directory: apps/desktop
+              run: npm run test:unit
+
+            - name: Build snapshot
+              working-directory: apps/desktop
+              run: npm run snapshot

--- a/apps/desktop/scripts/build-snapshot.mjs
+++ b/apps/desktop/scripts/build-snapshot.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import {
 	cpSync,
 	createWriteStream,
@@ -13,6 +13,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import archiveHelpers from '../lib/archive.js';
 import executableHelpers from '../lib/executable.js';
+import { snapshotSeedCommands } from './seed-commands.mjs';
 import { buildWpConfig, randomSalt } from './wp-config.mjs';
 import zipHelpers from './zip.js';
 
@@ -49,12 +50,25 @@ const PLUGIN_INCLUDES = [
 	'vendor',
 ];
 
-function run( cmd, opts = {} ) {
-	execSync( cmd, { stdio: 'inherit', ...opts } );
-}
-
-function shellQuote( value ) {
-	return `'${ String( value ).replace( /'/g, "'\\''" ) }'`;
+// Pass arguments directly so paths with spaces behave consistently on macOS
+// and Windows.
+function run( command, args, options = {} ) {
+	const result = spawnSync( command, args, {
+		stdio: 'inherit',
+		...options,
+	} );
+	if ( result.error ) {
+		throw result.error;
+	}
+	if ( result.status !== 0 ) {
+		throw new Error(
+			`${ command } ${ args.join( ' ' ) } failed with ${
+				result.signal
+					? `signal ${ result.signal }`
+					: `exit code ${ result.status }`
+			}.`
+		);
+	}
 }
 
 function resolvePhpBin() {
@@ -123,7 +137,9 @@ async function ensureCachedDownload( url, cachePath ) {
 }
 
 console.log( '[snapshot] Building plugin assets' );
-run( 'npm run build', { cwd: REPO_ROOT } );
+// npm is a shell script on POSIX and npm.cmd on Windows, so this command still
+// needs a shell.
+run( 'npm', [ 'run', 'build' ], { cwd: REPO_ROOT, shell: true } );
 
 console.log( '[snapshot] Staging plugin files' );
 rmSync( WORK_DIR, { recursive: true, force: true } );
@@ -216,56 +232,31 @@ await ensureCachedDownload( WP_CLI_PHAR_URL, wpCliPhar );
 const PHP_BIN = resolvePhpBin();
 
 function wpCli( args ) {
-	run(
-		`${ shellQuote( PHP_BIN ) } ${ shellQuote(
-			wpCliPhar
-		) } --path=${ shellQuote( SITE_DIR ) } ${ args }`
-	);
-}
-
-function snapshotSeedCommands() {
-	const override = process.env.CORTEXT_DESKTOP_SEED_COMMANDS;
-	if ( override?.trim() ) {
-		return override
-			.split( /\r?\n/ )
-			.map( ( command ) => command.trim() )
-			.filter( Boolean );
-	}
-
-	const seedArgs = process.env.CORTEXT_DESKTOP_SEED_ARGS?.trim();
-	const commands = [ `cortext seed${ seedArgs ? ` ${ seedArgs }` : '' }` ];
-	const extra = process.env.CORTEXT_DESKTOP_EXTRA_SEED_COMMANDS;
-	if ( extra?.trim() ) {
-		commands.push(
-			...extra
-				.split( /\r?\n/ )
-				.map( ( command ) => command.trim() )
-				.filter( Boolean )
-		);
-	}
-
-	return commands;
+	run( PHP_BIN, [ wpCliPhar, `--path=${ SITE_DIR }`, ...args ] );
 }
 
 console.log( '[snapshot] Installing WordPress' );
-wpCli(
-	'core install ' +
-		'--url=http://127.0.0.1:9402 ' +
-		'--title=Cortext ' +
-		'--admin_user=admin ' +
-		`--admin_password=${ randomSalt()
-			.replace( /[^A-Za-z0-9]/g, '' )
-			.slice( 0, 24 ) } ` +
-		'--admin_email=admin@example.com ' +
-		'--skip-email'
-);
+wpCli( [
+	'core',
+	'install',
+	'--url=http://127.0.0.1:9402',
+	'--title=Cortext',
+	'--admin_user=admin',
+	`--admin_password=${ randomSalt()
+		.replace( /[^A-Za-z0-9]/g, '' )
+		.slice( 0, 24 ) }`,
+	'--admin_email=admin@example.com',
+	'--skip-email',
+] );
 
 console.log( '[snapshot] Activating Cortext' );
-wpCli( 'plugin activate cortext' );
+wpCli( [ 'plugin', 'activate', 'cortext' ] );
 
 console.log( '[snapshot] Seeding sample content' );
 for ( const seedCommand of snapshotSeedCommands() ) {
-	console.log( `[snapshot] Running seed command: wp ${ seedCommand }` );
+	console.log(
+		`[snapshot] Running seed command: wp ${ seedCommand.join( ' ' ) }`
+	);
 	wpCli( seedCommand );
 }
 

--- a/apps/desktop/scripts/runtime.test.mjs
+++ b/apps/desktop/scripts/runtime.test.mjs
@@ -231,6 +231,9 @@ test( 'waitForProcessExit sends SIGKILL, then rejects if the process stays alive
 		waitForProcessExit( child, {
 			gracePeriodMs: 5,
 			forcePeriodMs: 5,
+			// Pin the platform: on Windows the escalation is taskkill, not
+			// SIGKILL, and it would reach a real process on the host.
+			platform: 'linux',
 			sendSignal: ( target, killProcessGroup, signal ) => {
 				signals.push( { target, killProcessGroup, signal } );
 			},

--- a/apps/desktop/scripts/seed-commands.mjs
+++ b/apps/desktop/scripts/seed-commands.mjs
@@ -1,0 +1,74 @@
+// Seed commands are supplied one per line. Parse each line into an argument
+// list so wp-cli can run without sh or cmd.exe.
+
+// Keep quoted values, such as `--post_title="Hello world"`, in one argument.
+export function splitArguments( line ) {
+	const args = [];
+	let current = '';
+	let quote = null;
+	let started = false;
+
+	for ( const char of line ) {
+		if ( quote ) {
+			if ( char === quote ) {
+				quote = null;
+			} else {
+				current += char;
+			}
+			continue;
+		}
+		if ( char === '"' || char === "'" ) {
+			quote = char;
+			started = true;
+			continue;
+		}
+		if ( /\s/.test( char ) ) {
+			if ( started ) {
+				args.push( current );
+				current = '';
+				started = false;
+			}
+			continue;
+		}
+		current += char;
+		started = true;
+	}
+
+	if ( quote ) {
+		throw new Error(
+			`Unclosed ${
+				quote === '"' ? 'double' : 'single'
+			} quote in seed command: ${ line }`
+		);
+	}
+	if ( started ) {
+		args.push( current );
+	}
+	return args;
+}
+
+function commandLines( value ) {
+	return String( value )
+		.split( /\r?\n/ )
+		.map( ( line ) => line.trim() )
+		.filter( Boolean );
+}
+
+// Return each wp-cli seed command as an argument list.
+export function snapshotSeedCommands( env = process.env ) {
+	const override = env.CORTEXT_DESKTOP_SEED_COMMANDS;
+	if ( override?.trim() ) {
+		return commandLines( override ).map( splitArguments );
+	}
+
+	const seedArgs = env.CORTEXT_DESKTOP_SEED_ARGS?.trim();
+	const commands = [
+		[ 'cortext', 'seed', ...splitArguments( seedArgs || '' ) ],
+	];
+	const extra = env.CORTEXT_DESKTOP_EXTRA_SEED_COMMANDS;
+	if ( extra?.trim() ) {
+		commands.push( ...commandLines( extra ).map( splitArguments ) );
+	}
+
+	return commands;
+}

--- a/apps/desktop/scripts/seed-commands.test.mjs
+++ b/apps/desktop/scripts/seed-commands.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { snapshotSeedCommands, splitArguments } from './seed-commands.mjs';
+
+test( 'splitArguments separates unquoted arguments at whitespace', () => {
+	assert.deepEqual( splitArguments( 'plugin activate cortext' ), [
+		'plugin',
+		'activate',
+		'cortext',
+	] );
+	assert.deepEqual( splitArguments( '   spaced   out  ' ), [
+		'spaced',
+		'out',
+	] );
+	assert.deepEqual( splitArguments( '' ), [] );
+} );
+
+test( 'splitArguments keeps quoted text in one argument', () => {
+	assert.deepEqual(
+		splitArguments( 'post create --post_title="Hello world"' ),
+		[ 'post', 'create', '--post_title=Hello world' ]
+	);
+	assert.deepEqual( splitArguments( "eval 'echo 1;'" ), [
+		'eval',
+		'echo 1;',
+	] );
+	// Empty quotes produce an empty argument.
+	assert.deepEqual( splitArguments( 'option update blogname ""' ), [
+		'option',
+		'update',
+		'blogname',
+		'',
+	] );
+} );
+
+test( 'splitArguments rejects unclosed quotes', () => {
+	assert.throws(
+		() => splitArguments( 'post create --post_title="Hello' ),
+		/Unclosed double quote/
+	);
+} );
+
+test( 'snapshotSeedCommands uses cortext seed by default', () => {
+	assert.deepEqual( snapshotSeedCommands( {} ), [ [ 'cortext', 'seed' ] ] );
+} );
+
+test( 'snapshotSeedCommands appends arguments to the default command', () => {
+	assert.deepEqual(
+		snapshotSeedCommands( { CORTEXT_DESKTOP_SEED_ARGS: '--full' } ),
+		[ [ 'cortext', 'seed', '--full' ] ]
+	);
+} );
+
+test( 'snapshotSeedCommands runs extra commands after the default', () => {
+	assert.deepEqual(
+		snapshotSeedCommands( {
+			CORTEXT_DESKTOP_EXTRA_SEED_COMMANDS:
+				'plugin activate cortext\n\noption update blogname "My site"',
+		} ),
+		[
+			[ 'cortext', 'seed' ],
+			[ 'plugin', 'activate', 'cortext' ],
+			[ 'option', 'update', 'blogname', 'My site' ],
+		]
+	);
+} );
+
+test( 'snapshotSeedCommands uses the override instead of the default', () => {
+	assert.deepEqual(
+		snapshotSeedCommands( {
+			CORTEXT_DESKTOP_SEED_COMMANDS: 'cortext seed --minimal',
+			CORTEXT_DESKTOP_SEED_ARGS: '--full',
+		} ),
+		[ [ 'cortext', 'seed', '--minimal' ] ]
+	);
+} );


### PR DESCRIPTION
## What

Follow-up to #404.

This gets the desktop snapshot building on Windows. The builder no longer assembles `wp-cli` commands as shell strings, so paths with spaces and quoted seed values are not mangled. A Windows CI job now runs the desktop unit tests and builds `snapshot.zip`.

The Windows job also caught a POSIX-only assumption in one runtime test, which now explicitly exercises the Linux process path.

Cortext still does not launch on Windows. That needs the bundled PHP runtime.

## Why

#404 made the app itself portable, but the snapshot builder still relied on a POSIX shell. This needs to work before we can package Cortext for Windows.

## Testing Instructions

1. On Windows, with Node.js, PHP 8.1+, Composer and pnpm installed, check out the repo in a path containing spaces and build the snapshot from `apps/desktop`. Confirm that `snapshot.zip` is created.
2. On macOS, set `CORTEXT_DESKTOP_EXTRA_SEED_COMMANDS` to `post create --post_type=page --post_title="Hello there" --post_status=publish`, build the snapshot, then launch Cortext with a fresh `--user-data-dir`. Open the new page and confirm that its title is "Hello there", not "Hello".