### PR TITLE
Desktop: lock down and test the packaged app

### DIFF
--- a/.buildkite/commands/release-desktop.sh
+++ b/.buildkite/commands/release-desktop.sh
@@ -66,10 +66,16 @@ dmg=(apps/desktop/dist/*.dmg)
 dmg="${dmg[0]}"
 # electron-builder signs, notarizes and staples the .app, then wraps it in an
 # unsigned .dmg — so the notarized artifact to verify is the app, not the dmg.
-app="apps/desktop/dist/mac-arm64/Cortext.app"
+app="$PWD/apps/desktop/dist/mac-arm64/Cortext.app"
 codesign --verify --strict --deep --verbose=2 "$app"
 spctl --assess --type exec --verbose=2 "$app"
 xcrun stapler validate "$app"
+
+echo "--- :mag: verify packaged app"
+npm --prefix apps/desktop run verify:app -- --app "$app"
+
+echo "--- :test_tube: smoke-test packaged app"
+node apps/desktop/scripts/packaged-app-smoke.mjs --app "$app"
 
 if ! "$publish"; then
   echo "--- :information_source: no release tag; signed DMG stashed as a Buildkite artifact"

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -90,6 +90,14 @@ nor a service worker or popup it opens can reach the runtime. External
 top-level links open in the system browser, an embedded frame cannot steer the
 app window, and internal popups stay in the protected session.
 
+The dedicated session denies Electron permissions by default. HTTP and HTTPS
+frames may use fullscreen, so video embeds keep working. Only the exact Cortext
+runtime origin may write sanitized clipboard data. That origin and HTTPS embeds
+may use DRM and third-party storage. Cortext blocks camera and microphone
+access, screen capture, location, notifications, clipboard reads, filesystem
+and device access, input locks, requests to open external apps, and any
+permission it does not recognize.
+
 The runtime rejects requests without the matching token before serving
 WordPress or static files. It also requires the request `Host` and any supplied
 `Origin` to match the selected runtime origin, and every server binds only to
@@ -110,8 +118,12 @@ Safari or another client; publishing remains available when Cortext runs as a
 WordPress plugin on a web site.
 
 In a dev run, DevTools open by default; set `CORTEXT_DEVTOOLS=0` to turn them
-off. The packaged build never opens them. Closing the window kills the PHP
-process.
+off. Packaged builds disable DevTools and remove "Toggle Developer Tools" from
+the View menu. Electron fuses also disable Node modes and inspector arguments,
+prevent application code from loading outside `app.asar`, and remove extra
+`file://` privileges. Cortext serves its loading and error pages through the
+private `cortext-shell://` scheme under a restrictive content security policy.
+Closing the window kills the PHP process.
 
 For runtime experiments, set `CORTEXT_RUNTIME` before launch:
 
@@ -180,6 +192,18 @@ load.
 Release builds are arm64-only, signed, and notarized on Buildkite. Local builds
 remain unsigned unless you provide a signing environment.
 
+Inspect an already built `.app` with:
+
+```sh
+npm --prefix apps/desktop run verify:app -- \
+  --app "$PWD/apps/desktop/dist/mac-arm64/Cortext.app"
+```
+
+The verifier reads the fuse settings directly from the packaged Electron
+executable. It requires `app.asar`, rejects an unpacked app directory or
+`app.asar.unpacked` payload, checks the bundled snapshot and runtime files, and
+confirms that the PHP binary is executable and arm64.
+
 ## Releasing
 
 `.github/workflows/release.yml` is the entry point; run it from the Actions tab.
@@ -187,7 +211,12 @@ It builds the plugin ZIP, validates the milestone, writes release notes, and
 creates or updates the draft GitHub Release. Buildkite owns the macOS desktop
 DMG: the release tag build builds the arm64 PHP runtime, builds the distribution
 snapshot, runs electron-builder, signs and notarizes the app, and uploads the
-DMG to the same Release.
+DMG to the same Release. Before uploading, Buildkite verifies the signature,
+notarization, fuses, bundled files, and PHP binary, then starts the same `.app`
+with a temporary profile. The packaged-app smoke test connects only to
+Chromium's renderer through CDP on loopback. It waits for the Cortext canvas,
+confirms that a request without the token gets `403` and a second launch exits,
+then quits the app and checks that Electron, PHP, and the runtime port are gone.
 
 ## Performance
 
@@ -221,11 +250,12 @@ npm --prefix apps/desktop run snapshot
 npm --prefix apps/desktop run test:e2e
 ```
 
-The test passes a temporary `--user-data-dir` to Electron, starts the app, and
-checks the protected session, external navigation boundary, embedded
-third-party frames, internal popups, real menu Reload behavior, direct
-unauthenticated requests, and the rendered Cortext canvas. It does not read or remove the developer's normal desktop
-profile.
+The test starts Electron with a temporary `--user-data-dir`, so it never reads
+or removes the developer's normal desktop profile. It exercises session
+authentication, external navigation, embedded third-party frames, and internal
+popups. It also checks the app menu's Reload command, blocked sensitive
+permissions, working embed fullscreen, rejection of unauthenticated requests,
+and canvas rendering.
 
 ## Runtime files
 

--- a/apps/desktop/lib/auto-update.js
+++ b/apps/desktop/lib/auto-update.js
@@ -181,7 +181,7 @@ function initAutoUpdates( {
 		mainWindow = window ?? mainWindow;
 		return true;
 	}
-	if ( ! app.isPackaged || process.env.CORTEXT_E2E === '1' ) {
+	if ( ! app.isPackaged ) {
 		return false;
 	}
 	try {

--- a/apps/desktop/lib/auto-update.js
+++ b/apps/desktop/lib/auto-update.js
@@ -228,6 +228,10 @@ function runCheck( { manual } ) {
 // cannot load in a packaged build, use the old notify-only checker so users
 // still hear about updates.
 function scheduleUpdateCheck( options = {} ) {
+	// Keep packaged smoke tests offline and suppress update dialogs.
+	if ( process.env.CORTEXT_E2E === '1' ) {
+		return;
+	}
 	const ready = initAutoUpdates( options );
 	if ( ! ready ) {
 		if ( app.isPackaged ) {

--- a/apps/desktop/lib/menu.js
+++ b/apps/desktop/lib/menu.js
@@ -63,4 +63,4 @@ function buildAppMenu( {
 	return Menu.buildFromTemplate( template );
 }
 
-module.exports = { buildAppMenu, productionViewMenu };
+module.exports = { buildAppMenu };

--- a/apps/desktop/lib/menu.js
+++ b/apps/desktop/lib/menu.js
@@ -2,6 +2,22 @@ const { app, Menu } = require( 'electron' );
 
 const isMac = process.platform === 'darwin';
 
+function productionViewMenu() {
+	return {
+		label: 'View',
+		submenu: [
+			{ role: 'reload' },
+			{ role: 'forceReload' },
+			{ type: 'separator' },
+			{ role: 'resetZoom' },
+			{ role: 'zoomIn' },
+			{ role: 'zoomOut' },
+			{ type: 'separator' },
+			{ role: 'togglefullscreen' },
+		],
+	};
+}
+
 // Once we replace the default menu, add the standard roles back by hand. The
 // whole-submenu roles keep copy/paste/select-all/window shortcuts working, and
 // the app menu gets the update controls.
@@ -10,6 +26,7 @@ function buildAppMenu( {
 	onUpdateItem,
 	autoInstallUpdates,
 	onToggleAutoInstall,
+	enableDevTools = false,
 } ) {
 	const template = [
 		...( isMac
@@ -40,10 +57,10 @@ function buildAppMenu( {
 			  ]
 			: [] ),
 		{ role: 'editMenu' },
-		{ role: 'viewMenu' },
+		enableDevTools ? { role: 'viewMenu' } : productionViewMenu(),
 		{ role: 'windowMenu' },
 	];
 	return Menu.buildFromTemplate( template );
 }
 
-module.exports = { buildAppMenu };
+module.exports = { buildAppMenu, productionViewMenu };

--- a/apps/desktop/lib/session-permissions.js
+++ b/apps/desktop/lib/session-permissions.js
@@ -1,0 +1,141 @@
+const HTTPS_PERMISSION_NAMES = new Set( [
+	'mediaKeySystem',
+	'storage-access',
+	'top-level-storage-access',
+] );
+
+function webOrigin( value ) {
+	if ( typeof value !== 'string' || ! value.trim() ) {
+		return null;
+	}
+
+	try {
+		const url = new URL( value );
+		if (
+			! [ 'http:', 'https:' ].includes( url.protocol ) ||
+			url.username ||
+			url.password
+		) {
+			return null;
+		}
+		return url.origin;
+	} catch {
+		return null;
+	}
+}
+
+function isPermissionAllowed( { permission, requestingUrl, runtimeOrigin } ) {
+	const requestingOrigin = webOrigin( requestingUrl );
+	const normalizedRuntimeOrigin = webOrigin( runtimeOrigin );
+	if ( ! requestingOrigin || ! normalizedRuntimeOrigin ) {
+		return false;
+	}
+
+	if ( permission === 'fullscreen' ) {
+		return true;
+	}
+
+	if ( permission === 'clipboard-sanitized-write' ) {
+		return requestingOrigin === normalizedRuntimeOrigin;
+	}
+
+	if ( HTTPS_PERMISSION_NAMES.has( permission ) ) {
+		return (
+			requestingOrigin === normalizedRuntimeOrigin ||
+			requestingOrigin.startsWith( 'https://' )
+		);
+	}
+
+	return false;
+}
+
+function permissionCheckUrl( requestingOrigin, details ) {
+	if ( ! details || typeof details !== 'object' ) {
+		return null;
+	}
+
+	const normalizedRequestingOrigin = webOrigin( requestingOrigin );
+	if ( ! normalizedRequestingOrigin ) {
+		return null;
+	}
+
+	for ( const field of [ 'requestingUrl', 'securityOrigin' ] ) {
+		if ( details[ field ] === undefined ) {
+			continue;
+		}
+		if ( webOrigin( details[ field ] ) !== normalizedRequestingOrigin ) {
+			return null;
+		}
+	}
+
+	return requestingOrigin;
+}
+
+function permissionRequestUrl( details ) {
+	if ( ! details || typeof details !== 'object' ) {
+		return null;
+	}
+
+	const normalizedRequestingOrigin = webOrigin( details.requestingUrl );
+	if ( ! normalizedRequestingOrigin ) {
+		return null;
+	}
+
+	if (
+		details.securityOrigin !== undefined &&
+		webOrigin( details.securityOrigin ) !== normalizedRequestingOrigin
+	) {
+		return null;
+	}
+
+	return details.requestingUrl;
+}
+
+function installSessionPermissions( runtimeSession, runtimeOrigin ) {
+	const normalizedRuntimeOrigin = webOrigin( runtimeOrigin );
+	if ( ! normalizedRuntimeOrigin ) {
+		throw new Error( 'runtimeOrigin must be a valid HTTP(S) URL.' );
+	}
+
+	runtimeSession.setPermissionCheckHandler(
+		( _webContents, permission, requestingOrigin, details ) =>
+			isPermissionAllowed( {
+				permission,
+				requestingUrl: permissionCheckUrl( requestingOrigin, details ),
+				runtimeOrigin: normalizedRuntimeOrigin,
+			} )
+	);
+	runtimeSession.setPermissionRequestHandler(
+		( _webContents, permission, callback, details ) => {
+			callback(
+				isPermissionAllowed( {
+					permission,
+					requestingUrl: permissionRequestUrl( details ),
+					runtimeOrigin: normalizedRuntimeOrigin,
+				} )
+			);
+		}
+	);
+	runtimeSession.setDevicePermissionHandler( () => false );
+	runtimeSession.setDisplayMediaRequestHandler( ( _request, callback ) =>
+		callback( {} )
+	);
+
+	let installed = true;
+	return () => {
+		if ( ! installed ) {
+			return;
+		}
+		installed = false;
+
+		runtimeSession.setPermissionCheckHandler( null );
+		runtimeSession.setPermissionRequestHandler( null );
+		runtimeSession.setDevicePermissionHandler( null );
+		runtimeSession.setDisplayMediaRequestHandler( null );
+	};
+}
+
+module.exports = {
+	installSessionPermissions,
+	isPermissionAllowed,
+};

--- a/apps/desktop/lib/shell-protocol.js
+++ b/apps/desktop/lib/shell-protocol.js
@@ -1,0 +1,54 @@
+const fs = require( 'fs' );
+
+const SHELL_SCHEME = 'cortext-shell';
+const LOADING_URL = `${ SHELL_SCHEME }://app/loading`;
+const ERROR_URL = `${ SHELL_SCHEME }://app/error`;
+const RESPONSE_HEADERS = {
+	'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
+	'Content-Type': 'text/html; charset=utf-8',
+	'X-Content-Type-Options': 'nosniff',
+};
+
+function registerShellScheme( protocol ) {
+	protocol.registerSchemesAsPrivileged( [
+		{
+			scheme: SHELL_SCHEME,
+			privileges: {
+				secure: true,
+				standard: true,
+			},
+		},
+	] );
+}
+
+function installShellProtocol( runtimeSession, { loadingPage, errorPage } ) {
+	const pages = new Map( [
+		[ LOADING_URL, fs.readFileSync( loadingPage ) ],
+		[ ERROR_URL, fs.readFileSync( errorPage ) ],
+	] );
+
+	runtimeSession.protocol.handle( SHELL_SCHEME, ( request ) => {
+		const body = pages.get( request.url );
+		if ( ! body ) {
+			return new Response( 'Not found', {
+				status: 404,
+				headers: {
+					'Content-Type': 'text/plain; charset=utf-8',
+					'X-Content-Type-Options': 'nosniff',
+				},
+			} );
+		}
+		return new Response( body, {
+			status: 200,
+			headers: RESPONSE_HEADERS,
+		} );
+	} );
+}
+
+module.exports = {
+	ERROR_URL,
+	LOADING_URL,
+	SHELL_SCHEME,
+	installShellProtocol,
+	registerShellScheme,
+};

--- a/apps/desktop/lib/web-preferences.js
+++ b/apps/desktop/lib/web-preferences.js
@@ -1,0 +1,25 @@
+function secureWebPreferences(
+	webPreferences,
+	runtimeSession,
+	enableDevTools
+) {
+	const inheritedPreferences = { ...( webPreferences || {} ) };
+	delete inheritedPreferences.partition;
+	delete inheritedPreferences.preload;
+	delete inheritedPreferences.session;
+	return {
+		...inheritedPreferences,
+		session: runtimeSession,
+		contextIsolation: true,
+		nodeIntegration: false,
+		nodeIntegrationInWorker: false,
+		nodeIntegrationInSubFrames: false,
+		sandbox: true,
+		webviewTag: false,
+		webSecurity: true,
+		allowRunningInsecureContent: false,
+		devTools: enableDevTools,
+	};
+}
+
+module.exports = { secureWebPreferences };

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -3,13 +3,13 @@ const {
 	BrowserWindow,
 	dialog,
 	Menu,
+	protocol,
 	session,
 	shell,
 } = require( 'electron' );
 const crypto = require( 'crypto' );
 const path = require( 'path' );
 const fs = require( 'fs' );
-const { pathToFileURL } = require( 'url' );
 const {
 	LEGACY_PORT,
 	RUNTIME_AUTH_HEADER,
@@ -23,6 +23,12 @@ const {
 	isTrustedRuntimeFrame,
 } = require( './lib/runtime-session' );
 const { installSessionPermissions } = require( './lib/session-permissions' );
+const {
+	ERROR_URL,
+	LOADING_URL,
+	installShellProtocol,
+	registerShellScheme,
+} = require( './lib/shell-protocol' );
 const { secureWebPreferences } = require( './lib/web-preferences' );
 const {
 	scheduleUpdateCheck,
@@ -44,12 +50,14 @@ const RESOURCES_DIR = app.isPackaged ? process.resourcesPath : __dirname;
 const SNAPSHOT_ZIP = path.join( RESOURCES_DIR, 'snapshot.zip' );
 const APP_ICON = path.join( __dirname, 'assets/icon.png' );
 const LOADING_PAGE = path.resolve( __dirname, 'loading.html' );
-const LOADING_URL = pathToFileURL( LOADING_PAGE ).href;
 const ERROR_PAGE = path.resolve( __dirname, 'error.html' );
-const ERROR_URL = pathToFileURL( ERROR_PAGE ).href;
 const RUNTIME_SESSION_PARTITION = 'persist:cortext';
 // The local shell pages Cortext loads itself, before and instead of the runtime.
 const TRUSTED_DOCUMENT_URLS = [ LOADING_URL, ERROR_URL ];
+
+// Electron requires scheme registration before app.ready. Install the handler
+// on the runtime session once it exists.
+registerShellScheme( protocol );
 
 // One instance owns the extracted site and the runtime port. A second launch
 // would extract on top of the first one's half-written files, so hand focus
@@ -348,7 +356,7 @@ async function loadSite( win, runtimeOrigin ) {
 		} );
 	} catch ( err ) {
 		console.error( '[cortext-desktop] failed to reach PHP server:', err );
-		await win.loadFile( ERROR_PAGE );
+		await win.loadURL( ERROR_URL );
 	}
 }
 
@@ -360,6 +368,10 @@ async function startDesktop() {
 			RUNTIME_SESSION_PARTITION,
 			{ cache: false }
 		);
+		installShellProtocol( runtimeSession, {
+			loadingPage: LOADING_PAGE,
+			errorPage: ERROR_PAGE,
+		} );
 
 		if (
 			process.platform === 'darwin' &&
@@ -379,7 +391,7 @@ async function startDesktop() {
 		} );
 		// Load the loading screen before any site refresh so users never stare at
 		// a blank window.
-		await win.loadFile( LOADING_PAGE );
+		await win.loadURL( LOADING_URL );
 
 		const siteRoot = getSiteRoot();
 		recoverInterruptedSwap( siteRoot );
@@ -457,7 +469,7 @@ async function startDesktop() {
 		}
 		console.error( '[cortext-desktop]', err );
 		if ( win ) {
-			win.loadFile( ERROR_PAGE );
+			win.loadURL( ERROR_URL );
 		} else {
 			app.quit();
 		}

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -22,6 +22,7 @@ const {
 	installRuntimeAuthHeader,
 	isTrustedRuntimeFrame,
 } = require( './lib/runtime-session' );
+const { installSessionPermissions } = require( './lib/session-permissions' );
 const {
 	scheduleUpdateCheck,
 	checkForUpdatesInteractive,
@@ -443,6 +444,7 @@ async function startDesktop() {
 		if ( settings.get( 'runtimePort' ) !== runtimeHandle.port ) {
 			settings.set( 'runtimePort', runtimeHandle.port );
 		}
+		installSessionPermissions( runtimeSession, runtimeOrigin );
 		await runtimeSession.clearStorageData( {
 			origin: runtimeOrigin,
 			storages: [ 'cookies', 'serviceworkers', 'cachestorage' ],

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -23,6 +23,7 @@ const {
 	isTrustedRuntimeFrame,
 } = require( './lib/runtime-session' );
 const { installSessionPermissions } = require( './lib/session-permissions' );
+const { secureWebPreferences } = require( './lib/web-preferences' );
 const {
 	scheduleUpdateCheck,
 	checkForUpdatesInteractive,
@@ -141,6 +142,7 @@ function refreshMenu() {
 				settings.set( 'autoInstallUpdates', enabled );
 				setAutoDownload( enabled );
 			},
+			enableDevTools: ! app.isPackaged,
 		} )
 	);
 }
@@ -194,25 +196,6 @@ function openExternalUrl( url ) {
 			);
 		} );
 	} );
-}
-
-function secureWebPreferences( webPreferences, runtimeSession ) {
-	const inheritedPreferences = { ...( webPreferences || {} ) };
-	delete inheritedPreferences.partition;
-	delete inheritedPreferences.preload;
-	delete inheritedPreferences.session;
-	return {
-		...inheritedPreferences,
-		session: runtimeSession,
-		contextIsolation: true,
-		nodeIntegration: false,
-		nodeIntegrationInWorker: false,
-		nodeIntegrationInSubFrames: false,
-		sandbox: true,
-		webviewTag: false,
-		webSecurity: true,
-		allowRunningInsecureContent: false,
-	};
 }
 
 function configureTrustedWindow( win, runtimeSession, runtimeOrigin ) {
@@ -300,7 +283,11 @@ function createInternalWindow(
 		title: 'Cortext',
 		icon: APP_ICON,
 		backgroundColor: '#1d1d1d',
-		webPreferences: secureWebPreferences( webPreferences, runtimeSession ),
+		webPreferences: secureWebPreferences(
+			webPreferences,
+			runtimeSession,
+			! app.isPackaged
+		),
 	} );
 	if ( child.webContents.session !== runtimeSession ) {
 		child.destroy();
@@ -323,7 +310,11 @@ function createWindow( runtimeSession ) {
 		title: 'Cortext',
 		icon: APP_ICON,
 		backgroundColor: '#1d1d1d',
-		webPreferences: secureWebPreferences( {}, runtimeSession ),
+		webPreferences: secureWebPreferences(
+			{},
+			runtimeSession,
+			! app.isPackaged
+		),
 	} );
 	win.on( 'close', ( event ) => {
 		// electron-updater closes all windows before it emits before-quit. Allow

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -14,6 +14,7 @@
 				"yauzl": "^2.10.0"
 			},
 			"devDependencies": {
+				"@electron/fuses": "1.8.0",
 				"@playwright/test": "^1.60.0",
 				"electron": "^42.3.3",
 				"electron-builder": "^26.15.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,9 +15,11 @@
 		"test": "npm run test:e2e",
 		"test:unit": "node --test scripts/*.test.mjs",
 		"test:e2e": "playwright test",
+		"verify:app": "node scripts/verify-packaged-app.mjs",
 		"dist": "electron-builder"
 	},
 	"devDependencies": {
+		"@electron/fuses": "1.8.0",
 		"@playwright/test": "^1.60.0",
 		"electron": "^42.3.3",
 		"electron-builder": "^26.15.3",
@@ -26,6 +28,17 @@
 	"build": {
 		"appId": "com.automattic.cortext",
 		"productName": "Cortext",
+		"asar": true,
+		"electronFuses": {
+			"runAsNode": false,
+			"enableCookieEncryption": false,
+			"enableNodeOptionsEnvironmentVariable": false,
+			"enableNodeCliInspectArguments": false,
+			"enableEmbeddedAsarIntegrityValidation": true,
+			"onlyLoadAppFromAsar": true,
+			"loadBrowserProcessSpecificV8Snapshot": false,
+			"grantFileProtocolExtraPrivileges": false
+		},
 		"directories": {
 			"output": "dist"
 		},

--- a/apps/desktop/scripts/app-shell.test.mjs
+++ b/apps/desktop/scripts/app-shell.test.mjs
@@ -84,6 +84,9 @@ function loadMain(
 			installRuntimeAuthHeader,
 			isTrustedRuntimeFrame: () => true,
 		},
+		'./lib/session-permissions': {
+			installSessionPermissions: () => {},
+		},
 		'./lib/auto-update': {
 			scheduleUpdateCheck,
 			checkForUpdatesInteractive: () => {},

--- a/apps/desktop/scripts/app-shell.test.mjs
+++ b/apps/desktop/scripts/app-shell.test.mjs
@@ -58,6 +58,9 @@ function loadMain(
 			BrowserWindow,
 			dialog: { showErrorBox },
 			Menu,
+			protocol: {
+				registerSchemesAsPrivileged: () => {},
+			},
 			session: {
 				fromPartition: () => runtimeSession,
 			},
@@ -86,6 +89,12 @@ function loadMain(
 		},
 		'./lib/session-permissions': {
 			installSessionPermissions: () => {},
+		},
+		'./lib/shell-protocol': {
+			ERROR_URL: 'cortext-shell://app/error',
+			LOADING_URL: 'cortext-shell://app/loading',
+			installShellProtocol: () => {},
+			registerShellScheme: () => {},
 		},
 		'./lib/auto-update': {
 			scheduleUpdateCheck,
@@ -405,7 +414,7 @@ test( 'closing while runtime storage is cleared never finishes startup', async (
 	let finishStorageClear;
 	let markStorageClearStarted;
 	let installHeaderCalls = 0;
-	let loadUrlCalls = 0;
+	let runtimeLoadCalls = 0;
 	let quitCalls = 0;
 	let stopCalls = 0;
 	const windows = [];
@@ -432,8 +441,10 @@ test( 'closing while runtime storage is cleared never finishes startup', async (
 			return Promise.resolve();
 		}
 
-		loadURL() {
-			loadUrlCalls += 1;
+		loadURL( url ) {
+			if ( url.startsWith( 'http://127.0.0.1:' ) ) {
+				runtimeLoadCalls += 1;
+			}
 			return Promise.resolve();
 		}
 
@@ -488,5 +499,5 @@ test( 'closing while runtime storage is cleared never finishes startup', async (
 	finishStorageClear();
 	await new Promise( ( resolve ) => setImmediate( resolve ) );
 	assert.equal( installHeaderCalls, 0 );
-	assert.equal( loadUrlCalls, 0 );
+	assert.equal( runtimeLoadCalls, 0 );
 } );

--- a/apps/desktop/scripts/auto-update.test.mjs
+++ b/apps/desktop/scripts/auto-update.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire( import.meta.url );
+const Module = require( 'node:module' );
+
+function requireWithMocks( modulePath, mocks ) {
+	const resolved = require.resolve( modulePath );
+	delete require.cache[ resolved ];
+	const originalLoad = Module._load;
+	Module._load = function ( request, parent, isMain ) {
+		if ( Object.hasOwn( mocks, request ) ) {
+			return mocks[ request ];
+		}
+		return originalLoad.call( this, request, parent, isMain );
+	};
+
+	try {
+		return require( resolved );
+	} finally {
+		Module._load = originalLoad;
+	}
+}
+
+test( 'E2E mode skips both update checkers', () => {
+	const previousE2E = process.env.CORTEXT_E2E;
+	let legacyChecks = 0;
+	process.env.CORTEXT_E2E = '1';
+
+	try {
+		const { scheduleUpdateCheck } = requireWithMocks(
+			'../lib/auto-update',
+			{
+				electron: {
+					app: { isPackaged: true },
+					dialog: {},
+				},
+				'./update-check': {
+					scheduleUpdateCheck: () => {
+						legacyChecks += 1;
+					},
+				},
+			}
+		);
+
+		scheduleUpdateCheck();
+		assert.equal( legacyChecks, 0 );
+	} finally {
+		if ( previousE2E === undefined ) {
+			delete process.env.CORTEXT_E2E;
+		} else {
+			process.env.CORTEXT_E2E = previousE2E;
+		}
+	}
+} );

--- a/apps/desktop/scripts/menu.test.mjs
+++ b/apps/desktop/scripts/menu.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire( import.meta.url );
+const Module = require( 'node:module' );
+
+function loadMenu( platform = 'darwin' ) {
+	const resolved = require.resolve( '../lib/menu.js' );
+	delete require.cache[ resolved ];
+
+	const originalLoad = Module._load;
+	const originalPlatform = Object.getOwnPropertyDescriptor(
+		process,
+		'platform'
+	);
+	Object.defineProperty( process, 'platform', { value: platform } );
+	Module._load = function ( request, parent, isMain ) {
+		if ( request === 'electron' ) {
+			return {
+				app: { name: 'Cortext' },
+				Menu: {
+					buildFromTemplate: ( template ) => template,
+				},
+			};
+		}
+		return originalLoad.call( this, request, parent, isMain );
+	};
+
+	try {
+		return require( resolved );
+	} finally {
+		Module._load = originalLoad;
+		Object.defineProperty( process, 'platform', originalPlatform );
+	}
+}
+
+function menuOptions( enableDevTools ) {
+	return {
+		updateLabel: 'Check for Updates…',
+		onUpdateItem: () => {},
+		autoInstallUpdates: true,
+		onToggleAutoInstall: () => {},
+		enableDevTools,
+	};
+}
+
+test( 'production View menu keeps reload and zoom but omits DevTools', () => {
+	const { buildAppMenu } = loadMenu();
+	const template = buildAppMenu( menuOptions( false ) );
+	const viewMenu = template.find( ( item ) => item.label === 'View' );
+
+	assert.ok( viewMenu );
+	assert.deepEqual(
+		viewMenu.submenu
+			.filter( ( item ) => item.role )
+			.map( ( item ) => item.role ),
+		[
+			'reload',
+			'forceReload',
+			'resetZoom',
+			'zoomIn',
+			'zoomOut',
+			'togglefullscreen',
+		]
+	);
+	assert.equal(
+		viewMenu.submenu.some( ( item ) => item.role === 'toggleDevTools' ),
+		false
+	);
+} );
+
+test( "development uses Electron's standard View menu", () => {
+	const { buildAppMenu } = loadMenu( 'linux' );
+	const template = buildAppMenu( menuOptions( true ) );
+
+	assert.equal(
+		template.some( ( item ) => item.role === 'viewMenu' ),
+		true
+	);
+} );

--- a/apps/desktop/scripts/packaged-app-smoke.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.mjs
@@ -56,6 +56,14 @@ function assert( condition, message ) {
 	}
 }
 
+export function appendErrorDetails( error, details ) {
+	const suffix = `\n\n${ details }`;
+	error.message = `${ error.message }${ suffix }`;
+	if ( typeof error.stack === 'string' ) {
+		error.stack = `${ error.stack }${ suffix }`;
+	}
+}
+
 function delay( milliseconds ) {
 	return new Promise( ( resolve ) => setTimeout( resolve, milliseconds ) );
 }
@@ -434,9 +442,10 @@ async function runSmoke( appPath ) {
 		console.log( 'Cortext exited with code 0 and PHP stopped.' );
 	} catch ( error ) {
 		if ( first?.output ) {
-			error.message = `${
-				error.message
-			}\n\nPackaged app output:\n${ first.output() }`;
+			appendErrorDetails(
+				error,
+				`Packaged app output:\n${ first.output() }`
+			);
 		}
 		throw error;
 	} finally {

--- a/apps/desktop/scripts/packaged-app-smoke.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+
+import { chromium } from '@playwright/test';
+import { spawn } from 'node:child_process';
+import {
+	accessSync,
+	constants as fsConstants,
+	mkdtempSync,
+	rmSync,
+} from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CORTEXT_URL_PATTERN = /\/wp-admin\/admin\.php\?page=cortext(?:&|$)/;
+const CORTEXT_ROOT_SELECTOR = '#cortext-root';
+const ACTIVE_CANVAS_SELECTOR =
+	'.cortext-workspace__pane[data-active="true"] .cortext-canvas';
+const ACTIVE_CANVAS_LOADING_SELECTOR =
+	'.cortext-workspace__pane[data-active="true"] .cortext-canvas__loading';
+const START_TIMEOUT_MS = 120_000;
+const EXIT_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 250;
+
+function usage() {
+	return 'Usage: node apps/desktop/scripts/packaged-app-smoke.mjs --app <path-to-Cortext.app>';
+}
+
+function parseArguments( argv ) {
+	let appPath = null;
+
+	for ( let index = 0; index < argv.length; index++ ) {
+		if ( argv[ index ] === '--app' ) {
+			appPath = argv[ ++index ] ?? null;
+			continue;
+		}
+		if ( argv[ index ] === '--help' || argv[ index ] === '-h' ) {
+			console.log( usage() );
+			process.exit( 0 );
+		}
+		throw new Error( `Unknown argument: ${ argv[ index ] }\n${ usage() }` );
+	}
+
+	if ( ! appPath ) {
+		throw new Error( `Missing --app.\n${ usage() }` );
+	}
+
+	return path.resolve( appPath );
+}
+
+function assert( condition, message ) {
+	if ( ! condition ) {
+		throw new Error( message );
+	}
+}
+
+function delay( milliseconds ) {
+	return new Promise( ( resolve ) => setTimeout( resolve, milliseconds ) );
+}
+
+async function reserveLoopbackPort() {
+	const server = net.createServer();
+	await new Promise( ( resolve, reject ) => {
+		server.once( 'error', reject );
+		server.listen( 0, '127.0.0.1', resolve );
+	} );
+	const address = server.address();
+	assert(
+		address && typeof address !== 'string',
+		'Could not reserve a loopback port for Chromium CDP.'
+	);
+	await new Promise( ( resolve, reject ) => {
+		server.close( ( error ) => ( error ? reject( error ) : resolve() ) );
+	} );
+	return address.port;
+}
+
+function executableForApp( appPath ) {
+	const executable = path.join( appPath, 'Contents/MacOS/Cortext' );
+	accessSync( executable, fsConstants.X_OK );
+	return executable;
+}
+
+function captureProcessOutput( child, label ) {
+	let output = '';
+	const capture = ( stream, destination ) => {
+		stream?.on( 'data', ( chunk ) => {
+			const text = chunk.toString();
+			output = `${ output }${ text }`.slice( -64 * 1024 );
+			destination.write( `[${ label }] ${ text }` );
+		} );
+	};
+	capture( child.stdout, process.stdout );
+	capture( child.stderr, process.stderr );
+	return () => output;
+}
+
+function spawnApp( executable, args, label ) {
+	const child = spawn( executable, args, {
+		detached: true,
+		env: {
+			...process.env,
+			CORTEXT_E2E: '1',
+			CORTEXT_RUNTIME_QUIET: '1',
+		},
+		stdio: [ 'ignore', 'pipe', 'pipe' ],
+	} );
+	const output = captureProcessOutput( child, label );
+	child.once( 'error', ( error ) => {
+		console.error( `[${ label }] failed to launch:`, error );
+	} );
+	return { child, output };
+}
+
+function processHasExited( child ) {
+	return child.exitCode !== null || child.signalCode !== null;
+}
+
+function waitForProcessExit( child, timeoutMs, label ) {
+	if ( processHasExited( child ) ) {
+		return Promise.resolve( {
+			code: child.exitCode,
+			signal: child.signalCode,
+		} );
+	}
+
+	return new Promise( ( resolve, reject ) => {
+		const cleanup = () => {
+			clearTimeout( timeout );
+			child.off( 'error', onError );
+			child.off( 'exit', onExit );
+		};
+		const onError = ( error ) => {
+			cleanup();
+			reject( error );
+		};
+		const onExit = ( code, signal ) => {
+			cleanup();
+			resolve( { code, signal } );
+		};
+		const timeout = setTimeout( () => {
+			cleanup();
+			reject(
+				new Error(
+					`${ label } stayed open for more than ${ timeoutMs }ms.`
+				)
+			);
+		}, timeoutMs );
+		child.once( 'error', onError );
+		child.once( 'exit', onExit );
+	} );
+}
+
+function signalProcessGroup( child, signal ) {
+	if ( ! child?.pid ) {
+		return false;
+	}
+	try {
+		process.kill( -child.pid, signal );
+		return true;
+	} catch ( error ) {
+		if ( error.code === 'ESRCH' ) {
+			return false;
+		}
+		throw error;
+	}
+}
+
+async function terminateProcessGroup( child ) {
+	if ( ! child?.pid || ! signalProcessGroup( child, 'SIGTERM' ) ) {
+		return;
+	}
+
+	const deadline = Date.now() + 5_000;
+	while ( Date.now() < deadline ) {
+		await delay( 100 );
+		try {
+			process.kill( -child.pid, 0 );
+		} catch ( error ) {
+			if ( error.code === 'ESRCH' ) {
+				return;
+			}
+			throw error;
+		}
+	}
+	signalProcessGroup( child, 'SIGKILL' );
+}
+
+async function assertProcessGroupIsClosed( child, label ) {
+	const deadline = Date.now() + EXIT_TIMEOUT_MS;
+
+	while ( Date.now() < deadline ) {
+		try {
+			process.kill( -child.pid, 0 );
+		} catch ( error ) {
+			if ( error.code === 'ESRCH' ) {
+				return;
+			}
+			throw error;
+		}
+		await delay( POLL_INTERVAL_MS );
+	}
+
+	throw new Error(
+		`${ label } left one or more processes running after shutdown.`
+	);
+}
+
+export function request( url, timeoutMs = 2_000 ) {
+	return new Promise( ( resolve, reject ) => {
+		let response = null;
+		let settled = false;
+		let timeout = null;
+		const finish = ( callback, value ) => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			clearTimeout( timeout );
+			callback( value );
+		};
+		const fail = ( error ) => finish( reject, error );
+		const onAborted = () =>
+			fail( new Error( `Response aborted: ${ url }` ) );
+		const onResponseClose = () => {
+			if ( ! response.complete ) {
+				onAborted();
+			}
+		};
+		const outgoing = http.get( url, ( incoming ) => {
+			response = incoming;
+			const chunks = [];
+			response.on( 'data', ( chunk ) => chunks.push( chunk ) );
+			response.once( 'aborted', onAborted );
+			response.once( 'close', onResponseClose );
+			response.once( 'error', fail );
+			response.once( 'end', () => {
+				finish( resolve, {
+					body: Buffer.concat( chunks ).toString( 'utf8' ),
+					statusCode: response.statusCode,
+				} );
+			} );
+		} );
+		outgoing.once( 'error', fail );
+		timeout = setTimeout( () => {
+			const error = new Error( `Request timed out: ${ url }` );
+			fail( error );
+			outgoing.destroy();
+		}, timeoutMs );
+	} );
+}
+
+async function waitForCdp( port, child, output ) {
+	const endpoint = `http://127.0.0.1:${ port }`;
+	const deadline = Date.now() + START_TIMEOUT_MS;
+	let lastError = null;
+
+	while ( Date.now() < deadline ) {
+		if ( processHasExited( child ) ) {
+			throw new Error(
+				`Cortext exited before CDP became ready (code=${
+					child.exitCode
+				}, signal=${ child.signalCode }).\n${ output() }`
+			);
+		}
+		try {
+			const response = await request( `${ endpoint }/json/version` );
+			if ( response.statusCode === 200 ) {
+				return endpoint;
+			}
+		} catch ( error ) {
+			lastError = error;
+		}
+		await delay( POLL_INTERVAL_MS );
+	}
+
+	throw new Error(
+		`Chromium CDP did not become ready at ${ endpoint }: ${
+			lastError?.message ?? 'timed out'
+		}`
+	);
+}
+
+async function firstRendererPage( browser ) {
+	const deadline = Date.now() + START_TIMEOUT_MS;
+
+	while ( Date.now() < deadline ) {
+		for ( const context of browser.contexts() ) {
+			const [ page ] = context.pages();
+			if ( page ) {
+				return page;
+			}
+		}
+		await delay( POLL_INTERVAL_MS );
+	}
+	throw new Error( 'Cortext did not open a renderer page.' );
+}
+
+async function waitForCortextShell( page ) {
+	await page.waitForURL( CORTEXT_URL_PATTERN, {
+		timeout: START_TIMEOUT_MS,
+		waitUntil: 'domcontentloaded',
+	} );
+	await page.locator( CORTEXT_ROOT_SELECTOR ).waitFor( {
+		state: 'visible',
+		timeout: 30_000,
+	} );
+	await page.locator( ACTIVE_CANVAS_LOADING_SELECTOR ).waitFor( {
+		state: 'hidden',
+		timeout: 30_000,
+	} );
+	await page.locator( ACTIVE_CANVAS_SELECTOR ).waitFor( {
+		state: 'visible',
+		timeout: 30_000,
+	} );
+}
+
+async function assertRuntimeIsClosed( runtimeOrigin ) {
+	const deadline = Date.now() + EXIT_TIMEOUT_MS;
+	let lastError = null;
+
+	while ( Date.now() < deadline ) {
+		try {
+			await request( runtimeOrigin, 1_000 );
+		} catch ( error ) {
+			lastError = error;
+			if (
+				[ 'ECONNREFUSED', 'ECONNRESET', 'EPIPE' ].includes( error.code )
+			) {
+				return;
+			}
+		}
+		await delay( POLL_INTERVAL_MS );
+	}
+
+	throw new Error(
+		`PHP is still listening at ${ runtimeOrigin } after Electron exited (${
+			lastError?.message ?? 'no connection error'
+		}).`
+	);
+}
+
+async function runSmoke( appPath ) {
+	assert(
+		process.platform === 'darwin',
+		'This smoke test only runs on macOS.'
+	);
+	const executable = executableForApp( appPath );
+	const cdpPort = await reserveLoopbackPort();
+	const tempRoot = mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-packaged-smoke-' )
+	);
+	const userDataPath = path.join( tempRoot, 'user-data' );
+	const firstArgs = [
+		`--user-data-dir=${ userDataPath }`,
+		'--remote-debugging-address=127.0.0.1',
+		`--remote-debugging-port=${ cdpPort }`,
+	];
+	let first = null;
+	let second = null;
+	let browser = null;
+	let completed = false;
+
+	try {
+		console.log( `Launching packaged app: ${ appPath }` );
+		first = spawnApp( executable, firstArgs, 'cortext' );
+		const cdpEndpoint = await waitForCdp(
+			cdpPort,
+			first.child,
+			first.output
+		);
+		browser = await chromium.connectOverCDP( cdpEndpoint );
+		const page = await firstRendererPage( browser );
+		await waitForCortextShell( page );
+
+		const runtimeUrl = new URL( page.url() );
+		assert(
+			CORTEXT_URL_PATTERN.test(
+				`${ runtimeUrl.pathname }${ runtimeUrl.search }`
+			),
+			`Unexpected Cortext renderer URL: ${ runtimeUrl.href }`
+		);
+		assert(
+			runtimeUrl.protocol === 'http:' &&
+				runtimeUrl.hostname === '127.0.0.1' &&
+				runtimeUrl.port,
+			`Cortext renderer did not use a loopback runtime origin: ${ runtimeUrl.origin }`
+		);
+		const runtimeOrigin = runtimeUrl.origin;
+		console.log( `Cortext loaded at ${ runtimeOrigin }.` );
+
+		const unauthenticated = await request( `${ runtimeOrigin }/wp-json/` );
+		assert(
+			unauthenticated.statusCode === 403,
+			`Expected an unauthenticated runtime request to return 403, got ${ unauthenticated.statusCode }.`
+		);
+		console.log( 'Unauthenticated runtime request returned 403.' );
+
+		second = spawnApp(
+			executable,
+			[ `--user-data-dir=${ userDataPath }` ],
+			'second-instance'
+		);
+		const secondExit = await waitForProcessExit(
+			second.child,
+			15_000,
+			'Second Cortext instance'
+		);
+		assert(
+			secondExit.code === 0 && secondExit.signal === null,
+			`Second Cortext instance exited unexpectedly (code=${ secondExit.code }, signal=${ secondExit.signal }).`
+		);
+		assert(
+			! processHasExited( first.child ),
+			'The first Cortext instance exited when the second instance launched.'
+		);
+		console.log( 'Second instance exited; the first is still running.' );
+
+		await page.close();
+		const firstExit = await waitForProcessExit(
+			first.child,
+			EXIT_TIMEOUT_MS,
+			'Cortext'
+		);
+		assert(
+			firstExit.code === 0 && firstExit.signal === null,
+			`Cortext exited unexpectedly (code=${ firstExit.code }, signal=${ firstExit.signal }).`
+		);
+		await assertRuntimeIsClosed( runtimeOrigin );
+		await assertProcessGroupIsClosed( first.child, 'Cortext' );
+		completed = true;
+		console.log( 'Cortext exited with code 0 and PHP stopped.' );
+	} catch ( error ) {
+		if ( first?.output ) {
+			error.message = `${
+				error.message
+			}\n\nPackaged app output:\n${ first.output() }`;
+		}
+		throw error;
+	} finally {
+		if ( browser ) {
+			await browser.close().catch( () => {} );
+		}
+		await terminateProcessGroup( second?.child );
+		await terminateProcessGroup( first?.child );
+		rmSync( tempRoot, {
+			force: true,
+			maxRetries: 3,
+			recursive: true,
+		} );
+		if ( ! completed ) {
+			console.error( 'Cleaned up after failed smoke test.' );
+		}
+	}
+}
+
+const invokedPath = process.argv[ 1 ] && path.resolve( process.argv[ 1 ] );
+if ( invokedPath === fileURLToPath( import.meta.url ) ) {
+	try {
+		await runSmoke( parseArguments( process.argv.slice( 2 ) ) );
+	} catch ( error ) {
+		console.error( error.stack || error );
+		process.exitCode = 1;
+	}
+}

--- a/apps/desktop/scripts/packaged-app-smoke.test.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.test.mjs
@@ -3,7 +3,17 @@ import http from 'node:http';
 import { once } from 'node:events';
 import test from 'node:test';
 
-import { request } from './packaged-app-smoke.mjs';
+import { appendErrorDetails, request } from './packaged-app-smoke.mjs';
+
+test( 'keeps packaged output in an already rendered error stack', () => {
+	const error = new Error( 'Canvas did not load.' );
+	error.stack = `Error: ${ error.message }\n    at waitForCanvas`;
+
+	appendErrorDetails( error, 'Packaged app output:\nPHP failed.' );
+
+	assert.match( error.message, /Packaged app output:\nPHP failed\./ );
+	assert.match( error.stack, /Packaged app output:\nPHP failed\./ );
+} );
 
 async function listen( handler ) {
 	const server = http.createServer( handler );

--- a/apps/desktop/scripts/packaged-app-smoke.test.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import test from 'node:test';
+
+import { request } from './packaged-app-smoke.mjs';
+
+async function listen( handler ) {
+	const server = http.createServer( handler );
+	server.listen( 0, '127.0.0.1' );
+	await once( server, 'listening' );
+	const address = server.address();
+	assert.notEqual( address, null );
+	assert.equal( typeof address, 'object' );
+	return {
+		server,
+		url: `http://127.0.0.1:${ address.port }`,
+	};
+}
+
+test( 'HTTP helper rejects an aborted response', async ( t ) => {
+	const { server, url } = await listen( ( _incoming, response ) => {
+		response.writeHead( 200 );
+		response.flushHeaders();
+		response.write( 'partial' );
+		setImmediate( () => response.destroy() );
+	} );
+	t.after(
+		() =>
+			new Promise( ( resolve, reject ) => {
+				server.close( ( error ) =>
+					error ? reject( error ) : resolve()
+				);
+			} )
+	);
+
+	await assert.rejects( request( url, 1_000 ), /aborted|socket hang up/i );
+} );
+
+test( 'HTTP helper times out even while data is arriving', async ( t ) => {
+	const { server, url } = await listen( ( _incoming, response ) => {
+		response.writeHead( 200 );
+		const interval = setInterval( () => response.write( '.' ), 5 );
+		response.once( 'close', () => clearInterval( interval ) );
+	} );
+	t.after(
+		() =>
+			new Promise( ( resolve, reject ) => {
+				server.close( ( error ) =>
+					error ? reject( error ) : resolve()
+				);
+			} )
+	);
+
+	await assert.rejects( request( url, 50 ), /Request timed out/ );
+} );

--- a/apps/desktop/scripts/session-permissions.test.mjs
+++ b/apps/desktop/scripts/session-permissions.test.mjs
@@ -1,0 +1,272 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import sessionPermissionsModule from '../lib/session-permissions.js';
+
+const { installSessionPermissions, isPermissionAllowed } =
+	sessionPermissionsModule;
+const RUNTIME_ORIGIN = 'http://127.0.0.1:43123';
+
+function allowed( permission, requestingUrl, runtimeOrigin = RUNTIME_ORIGIN ) {
+	return isPermissionAllowed( {
+		permission,
+		requestingUrl,
+		runtimeOrigin,
+	} );
+}
+
+function makeSession() {
+	const handlers = {};
+	const session = {
+		setDevicePermissionHandler( handler ) {
+			handlers.device = handler;
+		},
+		setDisplayMediaRequestHandler( handler ) {
+			handlers.displayMedia = handler;
+		},
+		setPermissionCheckHandler( handler ) {
+			handlers.check = handler;
+		},
+		setPermissionRequestHandler( handler ) {
+			handlers.request = handler;
+		},
+	};
+	return { handlers, session };
+}
+
+function requestPermission( handler, permission, details ) {
+	let decision;
+	handler(
+		{},
+		permission,
+		( allowedDecision ) => {
+			decision = allowedDecision;
+		},
+		details
+	);
+	return decision;
+}
+
+test( 'allows only listed permissions', () => {
+	for ( const requestingUrl of [
+		`${ RUNTIME_ORIGIN }/wp-admin/`,
+		'http://embed.example/video',
+		'https://embed.example/video',
+	] ) {
+		assert.equal( allowed( 'fullscreen', requestingUrl ), true );
+	}
+
+	assert.equal(
+		allowed( 'clipboard-sanitized-write', `${ RUNTIME_ORIGIN }/wp-admin/` ),
+		true
+	);
+
+	for ( const permission of [
+		'mediaKeySystem',
+		'storage-access',
+		'top-level-storage-access',
+	] ) {
+		assert.equal(
+			allowed( permission, `${ RUNTIME_ORIGIN }/document/` ),
+			true
+		);
+		assert.equal(
+			allowed( permission, 'https://embed.example/content' ),
+			true
+		);
+	}
+} );
+
+test( 'requires the exact runtime origin and HTTPS for embeds', () => {
+	assert.equal(
+		allowed( 'clipboard-sanitized-write', 'http://127.0.0.1:43124/' ),
+		false
+	);
+	assert.equal(
+		allowed(
+			'clipboard-sanitized-write',
+			'http://127.0.0.1:43123.example/'
+		),
+		false
+	);
+
+	for ( const permission of [
+		'mediaKeySystem',
+		'storage-access',
+		'top-level-storage-access',
+	] ) {
+		assert.equal(
+			allowed( permission, 'http://embed.example/content' ),
+			false
+		);
+		assert.equal(
+			allowed( permission, 'https://embed.example:443/content' ),
+			true
+		);
+	}
+} );
+
+test( 'denies unlisted permissions and invalid URLs', () => {
+	for ( const permission of [
+		'clipboard-read',
+		'deprecated-sync-clipboard-read',
+		'display-capture',
+		'fileSystem',
+		'geolocation',
+		'hid',
+		'idle-detection',
+		'keyboardLock',
+		'media',
+		'midi',
+		'midiSysex',
+		'notifications',
+		'openExternal',
+		'pointerLock',
+		'serial',
+		'speaker-selection',
+		'usb',
+		'window-management',
+		'unknown',
+		'future-electron-permission',
+		undefined,
+	] ) {
+		assert.equal(
+			allowed( permission, `${ RUNTIME_ORIGIN }/wp-admin/` ),
+			false
+		);
+	}
+
+	for ( const requestingUrl of [
+		undefined,
+		null,
+		'',
+		'not a URL',
+		'about:blank',
+		'data:text/html,test',
+		'file:///tmp/test.html',
+		'ftp://example.com/',
+		'https://user:password@example.com/',
+	] ) {
+		assert.equal( allowed( 'fullscreen', requestingUrl ), false );
+	}
+
+	assert.equal(
+		allowed( 'fullscreen', 'https://example.com/', 'not a URL' ),
+		false
+	);
+} );
+
+test( 'rejects missing or conflicting permission request URLs', () => {
+	const { handlers, session } = makeSession();
+	installSessionPermissions( session, `${ RUNTIME_ORIGIN }/ignored/path` );
+
+	assert.equal(
+		handlers.check( null, 'fullscreen', 'https://video.example', {
+			isMainFrame: false,
+		} ),
+		true
+	);
+	assert.equal(
+		handlers.check( null, 'fullscreen', 'https://video.example', {
+			isMainFrame: false,
+			requestingUrl: 'https://video.example/watch',
+		} ),
+		true
+	);
+
+	for ( const [ requestingOrigin, details ] of [
+		[ 'not a URL', { isMainFrame: false } ],
+		[ 'https://video.example', null ],
+		[
+			'https://video.example',
+			{ isMainFrame: false, requestingUrl: 'not a URL' },
+		],
+		[
+			'https://video.example',
+			{
+				isMainFrame: false,
+				requestingUrl: 'https://other.example/watch',
+			},
+		],
+		[
+			'https://video.example',
+			{
+				isMainFrame: false,
+				securityOrigin: 'https://other.example',
+			},
+		],
+	] ) {
+		assert.equal(
+			handlers.check( null, 'fullscreen', requestingOrigin, details ),
+			false
+		);
+	}
+
+	assert.equal(
+		requestPermission( handlers.request, 'fullscreen', {
+			isMainFrame: false,
+			requestingUrl: 'https://video.example/watch',
+		} ),
+		true
+	);
+
+	for ( const details of [
+		undefined,
+		{},
+		{ requestingUrl: 'not a URL' },
+		{
+			requestingUrl: 'https://video.example/watch',
+			securityOrigin: 'https://other.example',
+		},
+	] ) {
+		assert.equal(
+			requestPermission( handlers.request, 'fullscreen', details ),
+			false
+		);
+	}
+} );
+
+test( 'denies device and screen capture', () => {
+	const { handlers, session } = makeSession();
+	installSessionPermissions( session, RUNTIME_ORIGIN );
+
+	assert.equal(
+		handlers.device( {
+			deviceType: 'usb',
+			origin: RUNTIME_ORIGIN,
+			device: {},
+		} ),
+		false
+	);
+
+	let displayDecision;
+	handlers.displayMedia(
+		{
+			securityOrigin: RUNTIME_ORIGIN,
+			videoRequested: true,
+		},
+		( streams ) => {
+			displayDecision = streams;
+		}
+	);
+	assert.deepEqual( displayDecision, {} );
+} );
+
+test( 'rejects an invalid origin and allows cleanup to run twice', () => {
+	const { handlers, session } = makeSession();
+	assert.throws(
+		() => installSessionPermissions( session, 'file:///tmp/runtime' ),
+		/runtimeOrigin must be a valid HTTP\(S\) URL/
+	);
+
+	const remove = installSessionPermissions( session, RUNTIME_ORIGIN );
+	remove();
+	remove();
+
+	assert.deepEqual( handlers, {
+		check: null,
+		request: null,
+		device: null,
+		displayMedia: null,
+	} );
+} );

--- a/apps/desktop/scripts/shell-protocol.test.mjs
+++ b/apps/desktop/scripts/shell-protocol.test.mjs
@@ -75,7 +75,7 @@ test( 'serves only the loading and error pages with the shell CSP', async () => 
 
 		for ( const url of [
 			`${ LOADING_URL }?unexpected=1`,
-			`${ SHELL_SCHEME }://app/../loading`,
+			`${ SHELL_SCHEME }://app/not-found`,
 			`${ SHELL_SCHEME }://other/loading`,
 		] ) {
 			const response = await handler( { url } );

--- a/apps/desktop/scripts/shell-protocol.test.mjs
+++ b/apps/desktop/scripts/shell-protocol.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire( import.meta.url );
+const {
+	ERROR_URL,
+	LOADING_URL,
+	SHELL_SCHEME,
+	installShellProtocol,
+	registerShellScheme,
+} = require( '../lib/shell-protocol' );
+
+test( 'registers only the required shell scheme privileges', () => {
+	let schemes;
+	registerShellScheme( {
+		registerSchemesAsPrivileged( value ) {
+			schemes = value;
+		},
+	} );
+
+	assert.deepEqual( schemes, [
+		{
+			scheme: SHELL_SCHEME,
+			privileges: {
+				secure: true,
+				standard: true,
+			},
+		},
+	] );
+} );
+
+test( 'serves only the loading and error pages with the shell CSP', async () => {
+	const tempRoot = mkdtempSync(
+		path.join( os.tmpdir(), 'cortext-shell-protocol-' )
+	);
+	const loadingPage = path.join( tempRoot, 'loading.html' );
+	const errorPage = path.join( tempRoot, 'error.html' );
+	writeFileSync( loadingPage, '<h1>Loading</h1>' );
+	writeFileSync( errorPage, '<h1>Error</h1>' );
+	let handler;
+
+	try {
+		installShellProtocol(
+			{
+				protocol: {
+					handle( scheme, installedHandler ) {
+						assert.equal( scheme, SHELL_SCHEME );
+						handler = installedHandler;
+					},
+				},
+			},
+			{ loadingPage, errorPage }
+		);
+
+		for ( const [ url, expected ] of [
+			[ LOADING_URL, '<h1>Loading</h1>' ],
+			[ ERROR_URL, '<h1>Error</h1>' ],
+		] ) {
+			const response = await handler( { url } );
+			assert.equal( response.status, 200 );
+			assert.equal( await response.text(), expected );
+			assert.equal(
+				response.headers.get( 'content-security-policy' ),
+				"default-src 'none'; style-src 'unsafe-inline'"
+			);
+			assert.equal(
+				response.headers.get( 'x-content-type-options' ),
+				'nosniff'
+			);
+		}
+
+		for ( const url of [
+			`${ LOADING_URL }?unexpected=1`,
+			`${ SHELL_SCHEME }://app/../loading`,
+			`${ SHELL_SCHEME }://other/loading`,
+		] ) {
+			const response = await handler( { url } );
+			assert.equal( response.status, 404 );
+		}
+	} finally {
+		rmSync( tempRoot, { recursive: true, force: true } );
+	}
+} );

--- a/apps/desktop/scripts/verify-packaged-app.mjs
+++ b/apps/desktop/scripts/verify-packaged-app.mjs
@@ -1,0 +1,318 @@
+import { constants as fsConstants } from 'node:fs';
+import { access, lstat, stat } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import electronFuses from '@electron/fuses';
+
+const { FuseV1Options, FuseVersion, getCurrentFuseWire } = electronFuses;
+
+const ENABLED_FUSE_STATE = '1'.charCodeAt( 0 );
+const DISABLED_FUSE_STATE = '0'.charCodeAt( 0 );
+
+export const EXPECTED_FUSES = Object.freeze( [
+	{
+		index: FuseV1Options.RunAsNode,
+		name: 'RunAsNode',
+		enabled: false,
+	},
+	{
+		index: FuseV1Options.EnableCookieEncryption,
+		name: 'EnableCookieEncryption',
+		enabled: false,
+	},
+	{
+		index: FuseV1Options.EnableNodeOptionsEnvironmentVariable,
+		name: 'EnableNodeOptionsEnvironmentVariable',
+		enabled: false,
+	},
+	{
+		index: FuseV1Options.EnableNodeCliInspectArguments,
+		name: 'EnableNodeCliInspectArguments',
+		enabled: false,
+	},
+	{
+		index: FuseV1Options.EnableEmbeddedAsarIntegrityValidation,
+		name: 'EnableEmbeddedAsarIntegrityValidation',
+		enabled: true,
+	},
+	{
+		index: FuseV1Options.OnlyLoadAppFromAsar,
+		name: 'OnlyLoadAppFromAsar',
+		enabled: true,
+	},
+	{
+		index: FuseV1Options.LoadBrowserProcessSpecificV8Snapshot,
+		name: 'LoadBrowserProcessSpecificV8Snapshot',
+		enabled: false,
+	},
+	{
+		index: FuseV1Options.GrantFileProtocolExtraPrivileges,
+		name: 'GrantFileProtocolExtraPrivileges',
+		enabled: false,
+	},
+] );
+
+export const REQUIRED_RESOURCES = Object.freeze( [
+	'snapshot.zip',
+	'runtime/bin/php',
+	'runtime/router.php',
+	'runtime/bootstrap.php',
+	'runtime/mu-plugins/cortext-update-lock.php',
+] );
+
+async function requireDirectory( directoryPath, label ) {
+	let details;
+	try {
+		details = await stat( directoryPath );
+	} catch ( error ) {
+		if ( error.code === 'ENOENT' ) {
+			throw new Error( `${ label } is missing: ${ directoryPath }` );
+		}
+		throw error;
+	}
+
+	if ( ! details.isDirectory() ) {
+		throw new Error( `${ label } is not a directory: ${ directoryPath }` );
+	}
+}
+
+async function requireFile( filePath, label ) {
+	let details;
+	try {
+		details = await stat( filePath );
+	} catch ( error ) {
+		if ( error.code === 'ENOENT' ) {
+			throw new Error( `${ label } is missing: ${ filePath }` );
+		}
+		throw error;
+	}
+
+	if ( ! details.isFile() ) {
+		throw new Error( `${ label } is not a file: ${ filePath }` );
+	}
+}
+
+async function requireAbsent( candidatePath, label ) {
+	try {
+		await lstat( candidatePath );
+	} catch ( error ) {
+		if ( error.code === 'ENOENT' ) {
+			return;
+		}
+		throw error;
+	}
+
+	throw new Error( `${ label } must not exist: ${ candidatePath }` );
+}
+
+export function inspectMachOArchitectures(
+	executablePath,
+	runCommand = spawnSync
+) {
+	const result = runCommand( '/usr/bin/lipo', [ '-archs', executablePath ], {
+		encoding: 'utf8',
+	} );
+
+	if ( result.error ) {
+		throw new Error(
+			`Could not inspect ${ executablePath }: ${ result.error.message }`
+		);
+	}
+	if ( result.status !== 0 ) {
+		throw new Error(
+			`Could not inspect ${ executablePath } with lipo: ${ (
+				result.stderr || ''
+			).trim() }`
+		);
+	}
+
+	const architectures = result.stdout.trim().split( /\s+/ ).filter( Boolean );
+	if ( architectures.length === 0 ) {
+		throw new Error(
+			`lipo returned no architectures for ${ executablePath }`
+		);
+	}
+
+	return architectures;
+}
+
+export async function verifyFuseStates(
+	appPath,
+	readFuseWire = getCurrentFuseWire
+) {
+	const wire = await readFuseWire( appPath );
+	if ( wire.version !== FuseVersion.V1 ) {
+		throw new Error(
+			`Unsupported Electron fuse wire version: ${ wire.version }`
+		);
+	}
+
+	for ( const expected of EXPECTED_FUSES ) {
+		const expectedState = expected.enabled
+			? ENABLED_FUSE_STATE
+			: DISABLED_FUSE_STATE;
+		const actualState = wire[ expected.index ];
+
+		if ( actualState !== expectedState ) {
+			throw new Error(
+				`Electron fuse ${ expected.name } must be ${
+					expected.enabled ? 'enabled' : 'disabled'
+				}; found state ${ actualState ?? 'missing' }`
+			);
+		}
+	}
+
+	return Object.keys( wire ).filter( ( key ) => /^\d+$/.test( key ) ).length;
+}
+
+export async function verifyPackagedApp(
+	appPath,
+	{
+		platform = process.platform,
+		readFuseWire = getCurrentFuseWire,
+		readArchitectures = inspectMachOArchitectures,
+	} = {}
+) {
+	const resolvedAppPath = path.resolve( appPath );
+	if ( path.extname( resolvedAppPath ) !== '.app' ) {
+		throw new Error( `Expected a macOS .app bundle: ${ resolvedAppPath }` );
+	}
+
+	await requireDirectory( resolvedAppPath, 'Application bundle' );
+
+	const resourcesPath = path.join( resolvedAppPath, 'Contents', 'Resources' );
+	await requireDirectory( resourcesPath, 'Resources directory' );
+
+	const appAsarPath = path.join( resourcesPath, 'app.asar' );
+	await requireFile( appAsarPath, 'app.asar' );
+	await requireAbsent(
+		path.join( resourcesPath, 'app' ),
+		'unpacked app directory'
+	);
+	await requireAbsent(
+		path.join( resourcesPath, 'app.asar.unpacked' ),
+		'app.asar.unpacked'
+	);
+	await requireAbsent(
+		path.join( resourcesPath, 'default_app.asar' ),
+		'default_app.asar'
+	);
+
+	for ( const relativePath of REQUIRED_RESOURCES ) {
+		await requireFile(
+			path.join( resourcesPath, relativePath ),
+			`Required resource ${ relativePath }`
+		);
+	}
+
+	const phpPath = path.join( resourcesPath, 'runtime', 'bin', 'php' );
+	try {
+		await access( phpPath, fsConstants.X_OK );
+	} catch {
+		throw new Error( `Bundled PHP is not executable: ${ phpPath }` );
+	}
+
+	let phpArchitectures = [];
+	if ( platform === 'darwin' ) {
+		phpArchitectures = await readArchitectures( phpPath );
+		if (
+			phpArchitectures.length !== 1 ||
+			phpArchitectures[ 0 ] !== 'arm64'
+		) {
+			throw new Error(
+				`Bundled PHP must contain only arm64; found: ${ phpArchitectures.join(
+					', '
+				) }`
+			);
+		}
+	}
+
+	const fuseCount = await verifyFuseStates( resolvedAppPath, readFuseWire );
+
+	return {
+		appPath: resolvedAppPath,
+		fuseCount,
+		phpArchitectures,
+		resources: REQUIRED_RESOURCES.map( ( relativePath ) =>
+			path.join( resourcesPath, relativePath )
+		),
+	};
+}
+
+export function parseArguments( args ) {
+	let appPath;
+	let help = false;
+
+	for ( let index = 0; index < args.length; index += 1 ) {
+		const argument = args[ index ];
+		if ( argument === '--help' || argument === '-h' ) {
+			help = true;
+			continue;
+		}
+
+		if ( argument === '--app' ) {
+			if ( appPath !== undefined ) {
+				throw new Error( '--app may only be provided once' );
+			}
+			appPath = args[ index + 1 ];
+			if ( ! appPath || appPath.startsWith( '--' ) ) {
+				throw new Error( '--app requires a path to a .app bundle' );
+			}
+			index += 1;
+			continue;
+		}
+
+		if ( argument.startsWith( '--app=' ) ) {
+			if ( appPath !== undefined ) {
+				throw new Error( '--app may only be provided once' );
+			}
+			appPath = argument.slice( '--app='.length );
+			if ( ! appPath ) {
+				throw new Error( '--app requires a path to a .app bundle' );
+			}
+			continue;
+		}
+
+		throw new Error( `Unknown argument: ${ argument }` );
+	}
+
+	if ( ! help && ! appPath ) {
+		throw new Error( '--app requires a path to a .app bundle' );
+	}
+
+	return { appPath, help };
+}
+
+function usage() {
+	return 'Usage: npm run verify:app -- --app <path-to-Cortext.app>';
+}
+
+async function main() {
+	const { appPath, help } = parseArguments( process.argv.slice( 2 ) );
+	if ( help ) {
+		console.log( usage() );
+		return;
+	}
+
+	const result = await verifyPackagedApp( appPath );
+	console.log( `Verified: ${ result.appPath }` );
+	console.log(
+		`Fuses: ${ EXPECTED_FUSES.length } required, ${ result.fuseCount } present`
+	);
+	console.log( `Resources: ${ result.resources.length } required, all present` );
+	if ( result.phpArchitectures.length > 0 ) {
+		console.log(
+			`PHP architecture: ${ result.phpArchitectures.join( ', ' ) }`
+		);
+	}
+}
+
+const invokedPath = process.argv[ 1 ] && path.resolve( process.argv[ 1 ] );
+if ( invokedPath === fileURLToPath( import.meta.url ) ) {
+	main().catch( ( error ) => {
+		console.error( `Packaged app verification failed: ${ error.message }` );
+		process.exitCode = 1;
+	} );
+}

--- a/apps/desktop/scripts/verify-packaged-app.test.mjs
+++ b/apps/desktop/scripts/verify-packaged-app.test.mjs
@@ -146,19 +146,27 @@ test( 'verifier rejects an unpacked ASAR payload', async ( t ) => {
 	);
 } );
 
-test( 'verifier requires executable arm64 PHP', async ( t ) => {
-	const { appPath, phpPath } = await createFixture( t );
-	await chmod( phpPath, 0o644 );
+// Windows treats X_OK as an existence check, so exercise the executable bit on
+// the POSIX runners and keep the architecture check below portable.
+test(
+	'verifier requires executable PHP',
+	{ skip: process.platform === 'win32' },
+	async ( t ) => {
+		const { appPath, phpPath } = await createFixture( t );
+		await chmod( phpPath, 0o644 );
 
-	await assert.rejects(
-		verifyPackagedApp( appPath, {
-			platform: 'darwin',
-			readArchitectures: () => [ 'arm64' ],
-		} ),
-		/Bundled PHP is not executable/
-	);
+		await assert.rejects(
+			verifyPackagedApp( appPath, {
+				platform: 'darwin',
+				readArchitectures: () => [ 'arm64' ],
+			} ),
+			/Bundled PHP is not executable/
+		);
+	}
+);
 
-	await chmod( phpPath, 0o755 );
+test( 'verifier requires arm64 PHP', async ( t ) => {
+	const { appPath } = await createFixture( t );
 	await assert.rejects(
 		verifyPackagedApp( appPath, {
 			platform: 'darwin',

--- a/apps/desktop/scripts/verify-packaged-app.test.mjs
+++ b/apps/desktop/scripts/verify-packaged-app.test.mjs
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import {
+	chmod,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	writeFile,
+} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+	EXPECTED_FUSES,
+	REQUIRED_RESOURCES,
+	inspectMachOArchitectures,
+	parseArguments,
+	verifyPackagedApp,
+} from './verify-packaged-app.mjs';
+
+const FUSE_SENTINEL = Buffer.from(
+	'dL7pKGdnNz796PbbjQWNKmHXBZaB9tsX',
+	'ascii'
+);
+const ENABLED_FUSE_STATE = '1'.charCodeAt( 0 );
+const DISABLED_FUSE_STATE = '0'.charCodeAt( 0 );
+
+function configuredFuseStates() {
+	return EXPECTED_FUSES.map( ( fuse ) =>
+		fuse.enabled ? ENABLED_FUSE_STATE : DISABLED_FUSE_STATE
+	);
+}
+
+async function createFixture( t, fuseStates = configuredFuseStates() ) {
+	const tempPath = await mkdtemp(
+		path.join( os.tmpdir(), 'cortext-packaged-app-' )
+	);
+	t.after( () => rm( tempPath, { recursive: true, force: true } ) );
+
+	const appPath = path.join( tempPath, 'Cortext.app' );
+	const resourcesPath = path.join( appPath, 'Contents', 'Resources' );
+	const frameworkPath = path.join(
+		appPath,
+		'Contents',
+		'Frameworks',
+		'Electron Framework.framework'
+	);
+
+	await mkdir( resourcesPath, { recursive: true } );
+	await mkdir( frameworkPath, { recursive: true } );
+	await writeFile( path.join( resourcesPath, 'app.asar' ), 'archive' );
+
+	for ( const relativePath of REQUIRED_RESOURCES ) {
+		const resourcePath = path.join( resourcesPath, relativePath );
+		await mkdir( path.dirname( resourcePath ), { recursive: true } );
+		await writeFile( resourcePath, relativePath );
+	}
+
+	const phpPath = path.join( resourcesPath, 'runtime', 'bin', 'php' );
+	await chmod( phpPath, 0o755 );
+
+	await writeFile(
+		path.join( frameworkPath, 'Electron Framework' ),
+		Buffer.concat( [
+			Buffer.from( 'electron-fixture', 'ascii' ),
+			FUSE_SENTINEL,
+			Buffer.from( [ 1, fuseStates.length, ...fuseStates ] ),
+		] )
+	);
+
+	return { appPath, phpPath, resourcesPath };
+}
+
+test( 'package.json sets every required fuse', async () => {
+	const packageConfig = JSON.parse(
+		await readFile( new URL( '../package.json', import.meta.url ), 'utf8' )
+	);
+
+	assert.equal( packageConfig.devDependencies[ '@electron/fuses' ], '1.8.0' );
+	assert.equal( packageConfig.build.asar, true );
+	assert.deepEqual( packageConfig.build.electronFuses, {
+		runAsNode: false,
+		enableCookieEncryption: false,
+		enableNodeOptionsEnvironmentVariable: false,
+		enableNodeCliInspectArguments: false,
+		enableEmbeddedAsarIntegrityValidation: true,
+		onlyLoadAppFromAsar: true,
+		loadBrowserProcessSpecificV8Snapshot: false,
+		grantFileProtocolExtraPrivileges: false,
+	} );
+} );
+
+test( 'verifier accepts an arm64 bundle with the required files and fuses', async ( t ) => {
+	const fuseStates = [ ...configuredFuseStates(), ENABLED_FUSE_STATE ];
+	const { appPath } = await createFixture( t, fuseStates );
+
+	const result = await verifyPackagedApp( appPath, {
+		platform: 'darwin',
+		readArchitectures: () => [ 'arm64' ],
+	} );
+
+	assert.equal( result.appPath, appPath );
+	assert.equal( result.fuseCount, fuseStates.length );
+	assert.deepEqual( result.phpArchitectures, [ 'arm64' ] );
+	assert.equal( result.resources.length, REQUIRED_RESOURCES.length );
+} );
+
+test( 'verifier rejects a changed required fuse', async ( t ) => {
+	const fuseStates = configuredFuseStates();
+	fuseStates[ 0 ] = ENABLED_FUSE_STATE;
+	const { appPath } = await createFixture( t, fuseStates );
+
+	await assert.rejects(
+		verifyPackagedApp( appPath, {
+			platform: 'darwin',
+			readArchitectures: () => [ 'arm64' ],
+		} ),
+		/RunAsNode must be disabled/
+	);
+} );
+
+test( 'verifier rejects fallback app code', async ( t ) => {
+	const { appPath, resourcesPath } = await createFixture( t );
+	await mkdir( path.join( resourcesPath, 'app' ) );
+
+	await assert.rejects(
+		verifyPackagedApp( appPath, {
+			platform: 'darwin',
+			readArchitectures: () => [ 'arm64' ],
+		} ),
+		/unpacked app directory must not exist/
+	);
+} );
+
+test( 'verifier rejects an unpacked ASAR payload', async ( t ) => {
+	const { appPath, resourcesPath } = await createFixture( t );
+	await mkdir( path.join( resourcesPath, 'app.asar.unpacked' ) );
+
+	await assert.rejects(
+		verifyPackagedApp( appPath, {
+			platform: 'darwin',
+			readArchitectures: () => [ 'arm64' ],
+		} ),
+		/app\.asar\.unpacked must not exist/
+	);
+} );
+
+test( 'verifier requires executable arm64 PHP', async ( t ) => {
+	const { appPath, phpPath } = await createFixture( t );
+	await chmod( phpPath, 0o644 );
+
+	await assert.rejects(
+		verifyPackagedApp( appPath, {
+			platform: 'darwin',
+			readArchitectures: () => [ 'arm64' ],
+		} ),
+		/Bundled PHP is not executable/
+	);
+
+	await chmod( phpPath, 0o755 );
+	await assert.rejects(
+		verifyPackagedApp( appPath, {
+			platform: 'darwin',
+			readArchitectures: () => [ 'x86_64' ],
+		} ),
+		/Bundled PHP must contain only arm64/
+	);
+} );
+
+test( 'lipo architecture inspection handles success and failure', () => {
+	assert.deepEqual(
+		inspectMachOArchitectures( '/tmp/php', () => ( {
+			status: 0,
+			stdout: 'arm64\n',
+			stderr: '',
+		} ) ),
+		[ 'arm64' ]
+	);
+
+	assert.throws(
+		() =>
+			inspectMachOArchitectures( '/tmp/php', () => ( {
+				status: 1,
+				stdout: '',
+				stderr: 'not a Mach-O file',
+			} ) ),
+		/not a Mach-O file/
+	);
+} );
+
+test( 'CLI accepts both --app forms', () => {
+	assert.deepEqual( parseArguments( [ '--app', '/tmp/Cortext.app' ] ), {
+		appPath: '/tmp/Cortext.app',
+		help: false,
+	} );
+	assert.deepEqual( parseArguments( [ '--app=/tmp/Cortext.app' ] ), {
+		appPath: '/tmp/Cortext.app',
+		help: false,
+	} );
+	assert.throws( () => parseArguments( [] ), /--app requires/ );
+} );

--- a/apps/desktop/scripts/web-preferences.test.mjs
+++ b/apps/desktop/scripts/web-preferences.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire( import.meta.url );
+const { secureWebPreferences } = require( '../lib/web-preferences' );
+
+test( 'production disables DevTools and uses the runtime session', () => {
+	const runtimeSession = {};
+	const preferences = secureWebPreferences(
+		{
+			allowRunningInsecureContent: true,
+			devTools: true,
+			nodeIntegration: true,
+			partition: 'attacker',
+			preload: '/tmp/attacker.js',
+			session: {},
+			webSecurity: false,
+		},
+		runtimeSession,
+		false
+	);
+
+	assert.equal( preferences.devTools, false );
+	assert.equal( preferences.session, runtimeSession );
+	assert.equal( preferences.contextIsolation, true );
+	assert.equal( preferences.nodeIntegration, false );
+	assert.equal( preferences.sandbox, true );
+	assert.equal( preferences.webSecurity, true );
+	assert.equal( preferences.allowRunningInsecureContent, false );
+	assert.equal( 'partition' in preferences, false );
+	assert.equal( 'preload' in preferences, false );
+} );
+
+test( 'development enables DevTools without changing isolation', () => {
+	const preferences = secureWebPreferences( {}, {}, true );
+
+	assert.equal( preferences.devTools, true );
+	assert.equal( preferences.contextIsolation, true );
+	assert.equal( preferences.nodeIntegration, false );
+	assert.equal( preferences.sandbox, true );
+} );

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -68,12 +68,67 @@ test.beforeAll( async () => {
 					onload="document.body.dataset.runtimeImage='loaded'"
 					onerror="document.body.dataset.runtimeImage='blocked'"
 				>
+				<button id="request-camera">Camera</button>
+				<button id="request-microphone">Microphone</button>
+				<button id="request-geolocation">Location</button>
+				<button id="request-notifications">Notifications</button>
+				<button id="request-clipboard-read">Clipboard</button>
+				<button id="request-fullscreen">Fullscreen</button>
 				<a
 					id="runtime-link"
 					target="_top"
 					href="${ runtimeOrigin }/wp-json/"
-					style="position:fixed;inset:0;display:block"
 				>Open runtime</a>
+				<script>
+					const recordMediaPermission = async ( name, constraints ) => {
+						try {
+							const stream = await navigator.mediaDevices.getUserMedia(
+								constraints
+							);
+							stream.getTracks().forEach( ( track ) => track.stop() );
+							document.body.dataset[ name ] = 'granted';
+						} catch {
+							document.body.dataset[ name ] = 'denied';
+						}
+					};
+					document.querySelector( '#request-camera' ).onclick = () =>
+						recordMediaPermission( 'camera', { video: true } );
+					document.querySelector( '#request-microphone' ).onclick = () =>
+						recordMediaPermission( 'microphone', { audio: true } );
+					document.querySelector( '#request-geolocation' ).onclick = () => {
+						navigator.geolocation.getCurrentPosition(
+							() => {
+								document.body.dataset.geolocation = 'granted';
+							},
+							() => {
+								document.body.dataset.geolocation = 'denied';
+							}
+						);
+					};
+					document.querySelector( '#request-notifications' ).onclick =
+						async () => {
+							document.body.dataset.notifications =
+								await Notification.requestPermission();
+						};
+					document.querySelector( '#request-clipboard-read' ).onclick =
+						async () => {
+							try {
+								await navigator.clipboard.readText();
+								document.body.dataset.clipboardRead = 'granted';
+							} catch {
+								document.body.dataset.clipboardRead = 'denied';
+							}
+						};
+					document.querySelector( '#request-fullscreen' ).onclick =
+						async () => {
+							try {
+								await document.documentElement.requestFullscreen();
+								document.body.dataset.fullscreen = 'entered';
+							} catch {
+								document.body.dataset.fullscreen = 'denied';
+							}
+						};
+				</script>
 			</body>`
 		);
 	} );
@@ -479,6 +534,12 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 			home: runtimeOrigin,
 			url: runtimeOrigin,
 		} );
+		const betaNoticeButton = window.getByRole( 'button', {
+			name: 'Got it',
+		} );
+		if ( await betaNoticeButton.isVisible() ) {
+			await betaNoticeButton.click();
+		}
 
 		const redirectedImageStatus = await window.evaluate( ( origin ) => {
 			return new Promise( ( resolve ) => {
@@ -505,6 +566,10 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 		await window.evaluate( ( url ) => {
 			const frame = document.createElement( 'iframe' );
 			frame.id = 'untrusted-frame';
+			frame.allow =
+				'camera; microphone; geolocation; clipboard-read; fullscreen';
+			frame.style.cssText =
+				'position:fixed;inset:0;width:640px;height:480px;z-index:2147483647;background:white';
 			frame.src = url;
 			document.body.append( frame );
 		}, untrustedOrigin );
@@ -516,6 +581,43 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 					.getAttribute( 'data-runtime-image' )
 			)
 			.toBe( 'blocked' );
+
+		for ( const permission of [
+			'camera',
+			'microphone',
+			'geolocation',
+			'notifications',
+			'clipboard-read',
+		] ) {
+			await untrustedFrame.locator( `#request-${ permission }` ).click();
+		}
+		await expect
+			.poll( async () => {
+				return untrustedFrame
+					.locator( 'body' )
+					.evaluate( ( body ) => ( {
+						camera: body.dataset.camera,
+						clipboardRead: body.dataset.clipboardRead,
+						geolocation: body.dataset.geolocation,
+						microphone: body.dataset.microphone,
+						notifications: body.dataset.notifications,
+					} ) );
+			} )
+			.toEqual( {
+				camera: 'denied',
+				clipboardRead: 'denied',
+				geolocation: 'denied',
+				microphone: 'denied',
+				notifications: 'denied',
+			} );
+		await untrustedFrame.locator( '#request-fullscreen' ).click();
+		await expect
+			.poll( () =>
+				untrustedFrame
+					.locator( 'body' )
+					.getAttribute( 'data-fullscreen' )
+			)
+			.toBe( 'entered' );
 
 		await window
 			.locator( '#untrusted-frame' )

--- a/docs/desktop-decisions.md
+++ b/docs/desktop-decisions.md
@@ -2,6 +2,49 @@
 
 Running log for desktop-specific runtime and packaging decisions. Keep the detailed benchmark numbers in PR comments or artifacts unless they become stable product guidance.
 
+## 2026-07-30 — Harden and test the packaged Electron app
+
+**Decision.** The dedicated `persist:cortext` session denies permissions by
+default. HTTP and HTTPS frames may use fullscreen. Only the exact runtime origin
+may write sanitized clipboard data. That origin and HTTPS embeds may use DRM
+and third-party storage. Cortext blocks camera and microphone access, display
+capture, location, notifications, clipboard reads, filesystem and device
+access, input locks, requests to open external apps, and any permission it does
+not recognize. The existing window-open and navigation handlers still control
+external links.
+
+Packaged builds turn off DevTools and remove "Toggle Developer Tools" from the
+View menu. Application code lives in `app.asar`. Electron fuses disable Node
+execution modes, Node environment and CLI inspector options, browser-process V8
+snapshot loading, code outside `app.asar`, and extra `file://` privileges. They
+also enable ASAR integrity checks. During packaged validation, `loadFile()`
+failed with these ASAR and fuse settings. Cortext now serves loading and error
+pages through an exact-match `cortext-shell://` handler in the dedicated
+session, under a restrictive CSP.
+
+After signing and notarizing the app, Buildkite reads the fuse settings from the
+executable and checks the ASAR layout, bundled runtime files, and arm64 PHP
+binary. It then starts the same `.app` with a temporary profile and update
+checks disabled. The smoke test attaches only to Chromium's renderer through
+CDP on loopback. It loads the canvas, confirms that a request without the token
+gets `403`, checks that a second instance exits, and waits for Electron, PHP,
+and the runtime port to shut down. Buildkite runs all of this before it uploads
+the artifact.
+
+**Why.** Tests launched from source skip `app.isPackaged`, ASAR paths, copied
+resources, fuse bits, and the signed executable. Code signing and Gatekeeper can
+accept an app that crashes on launch. The smoke test has already caught this
+once: with extra file-protocol privileges disabled, the old `loadFile()` startup
+path no longer worked.
+
+**Deferred.** Cookie encryption remains disabled because enabling its fuse
+migrates profiles in a way older builds cannot reverse. It needs a separate
+rollout. This change leaves entitlements alone. HTTP and HTTPS embeds may still
+render and use fullscreen; the Cortext origin and HTTPS embeds may also use DRM
+and third-party storage. Only the smoke command enables loopback CDP, and the
+test attaches to the renderer. Normal app launches do not open a debugging
+port.
+
 ## 2026-07-28 — Give each desktop profile its own runtime origin
 
 **Decision.** New desktop profiles take the first free loopback port in the
@@ -55,7 +98,7 @@ Every app window uses a dedicated Electron session. Its browser storage remains
 persistent so theme, layout, and integration preferences survive restarts, but
 the token is never stored there. HTTP caching is disabled, and cookies, service
 workers, and Cache API data for the runtime are cleared at launch. The session
-adds the token as an internal header to requests for `http://127.0.0.1:9402/`
+adds the token as an internal header to requests for the selected runtime origin
 that come from a Cortext frame, reading the frame origin Chromium already
 resolved instead of inferring trust from `Sec-Fetch-Site` or the current window
 URL. Embedded third-party frames render, so the Embed block keeps working, but
@@ -71,7 +114,8 @@ The PHP, FrankenPHP, and PHP-FPM runtime paths reject requests without the
 matching token before serving WordPress or static files. Caddy then removes the
 header before proxying to PHP and filters it from error logs. The benchmark
 follows the same contract with its own ephemeral token and never includes it in
-the recorded results. The loopback address and fixed port 9402 remain unchanged.
+the recorded results. The loopback address remains unchanged; the runtime port
+is selected per profile as documented above.
 
 **Why.** The desktop-only autologin makes every accepted WordPress request an
 administrator request. Requiring a per-launch secret prevents web pages and


### PR DESCRIPTION
## What

Follow-up to #397 and #403.

Embedded web content now gets only the Electron permissions Cortext needs. Fullscreen still works for HTTPS embeds, while access to the camera, microphone, screen capture, location, clipboard reads, and connected devices is blocked. Packaged builds also hide DevTools and disable unused Node and inspector entry points.

Buildkite now checks and opens the signed and notarized `.app` before uploading it. This verifies its security fuses and bundled runtime files, then checks startup, local runtime authentication, second-instance handling, and clean shutdown.

## Why

Cortext loads web embeds inside Electron, so the app should grant only the permissions they need.

Our current E2E tests run Electron from source and cannot catch failures that only affect the packaged app. Signing and notarization do not prove that the `.app` starts, so CI should open it before uploading it.

## How

- Serving loading and error pages through a private scheme so packaged builds do not need privileged `file://` access.
- Connecting the packaged smoke test only to the renderer over loopback CDP, without enabling the Node inspector.

## Testing Instructions

1. Install the macOS artifact from CI and open Cortext with a fresh profile. Confirm that the workspace and editor canvas load.
2. Open the View menu. Confirm that reload, zoom, and fullscreen are available, but "Toggle Developer Tools" is not.
3. Open an HTTPS video embed and enter fullscreen. Quit Cortext, reopen it, and confirm that it starts normally.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.
