### PR TITLE
Desktop: Build the bundled PHP runtime on Windows

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -174,16 +174,6 @@ jobs:
               working-directory: apps/desktop
               run: npm run test:unit
 
-            - name: Add Git's build tools to PATH
-              shell: pwsh
-              run: |
-                  $gitTools = Join-Path $env:ProgramFiles 'Git\usr\bin'
-                  $patch = Join-Path $gitTools 'patch.exe'
-                  if (-not (Test-Path $patch)) {
-                    throw "Git's patch.exe was not found at $patch"
-                  }
-                  $gitTools | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
             - name: Restore bundled PHP runtime
               id: php-runtime-cache
               uses: actions/cache/restore@v6.1.0
@@ -195,9 +185,17 @@ jobs:
             - name: Build bundled PHP
               id: build-php
               working-directory: apps/desktop
+              shell: pwsh
               env:
                   GITHUB_TOKEN: ${{ github.token }}
-              run: npm run runtime:php
+              run: |
+                  $gitTools = Join-Path $env:ProgramFiles 'Git\usr\bin'
+                  $patch = Join-Path $gitTools 'patch.exe'
+                  if (-not (Test-Path $patch)) {
+                    throw "Git's patch.exe was not found at $patch"
+                  }
+                  $env:PATH = "$env:PATH;$gitTools"
+                  npm run runtime:php
 
             - name: Save bundled PHP runtime
               if: ${{ success() && steps.build-php.outcome == 'success' && steps.php-runtime-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -125,21 +125,23 @@ jobs:
                       apps/desktop/playwright-report/
                   retention-days: 7
 
-    # Unit tests cover the Windows-specific branches with a mocked platform.
-    # This job runs those tests on Windows and builds the snapshot there too.
-    # It cannot launch the app until we bundle the Windows PHP runtime.
+    # Build the bundled PHP runtime before exercising the same launch path a
+    # Windows checkout uses.
     windows:
-        name: Desktop tests and snapshot (Windows)
-        runs-on: windows-latest
+        name: Playwright (Electron, Windows)
+        runs-on: windows-2022
         needs: changes
         if: needs.changes.outputs.desktop_changed == 'true'
-        timeout-minutes: 30
+        timeout-minutes: 90
+        env:
+            CORTEXT_STATIC_PHP_VERSION: '8.5'
+            CORTEXT_SPC_VERSION: '2.8.5'
         steps:
             - uses: actions/checkout@v7.0.0
 
             - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: '8.3'
+                  php-version: ${{ env.CORTEXT_STATIC_PHP_VERSION }}
                   extensions: pdo_sqlite, sqlite3, mbstring, json, curl, openssl
                   tools: composer:v2
                   coverage: none
@@ -162,10 +164,55 @@ jobs:
               working-directory: apps/desktop
               run: npm ci
 
+            # Electron 42 skips the binary download during npm ci. Fetch it here
+            # so Playwright has something to launch.
+            - name: Install Electron binary
+              working-directory: apps/desktop
+              run: npx install-electron
+
             - name: Run desktop unit tests
               working-directory: apps/desktop
               run: npm run test:unit
 
+            - name: Add Git build tools to PATH
+              shell: pwsh
+              run: |
+                  $gitTools = Join-Path $env:ProgramFiles 'Git\usr\bin'
+                  $patch = Join-Path $gitTools 'patch.exe'
+                  if (-not (Test-Path $patch)) {
+                    throw "Git's patch.exe was not found at $patch"
+                  }
+                  $gitTools | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+            - name: Cache bundled PHP runtime
+              uses: actions/cache@v6.1.0
+              with:
+                  path: apps/desktop/runtime/bin/php.exe
+                  key: desktop-runtime-php-${{ runner.os }}-${{ runner.arch }}-${{ env.CORTEXT_STATIC_PHP_VERSION }}-${{ env.CORTEXT_SPC_VERSION }}-${{ hashFiles('apps/desktop/scripts/install-runtime.mjs') }}
+
+            # The installer compiles on a cache miss and verifies the restored
+            # executable on a cache hit.
+            - name: Build bundled PHP runtime
+              working-directory: apps/desktop
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: npm run runtime:php
+
             - name: Build snapshot
               working-directory: apps/desktop
+              env:
+                  CORTEXT_PHP_BIN: ${{ github.workspace }}/apps/desktop/runtime/bin/php.exe
               run: npm run snapshot
+
+            - name: Run desktop smoke test
+              working-directory: apps/desktop
+              run: npm run test:e2e
+
+            - if: failure()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: desktop-playwright-artifacts-windows
+                  path: |
+                      apps/desktop/test-results/
+                      apps/desktop/playwright-report/
+                  retention-days: 7

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -47,7 +47,7 @@ jobs:
                     echo "desktop_changed=false" >> "$GITHUB_OUTPUT"
                   fi
 
-    playwright:
+    linux:
         name: Playwright (Electron, Linux)
         runs-on: ubuntu-latest
         needs: changes
@@ -86,8 +86,8 @@ jobs:
               working-directory: apps/desktop
               run: npm ci
 
-            # Electron 42 skips the binary download during npm ci. Fetch it here
-            # so Playwright has something to launch.
+            # npm ci does not download Electron 42's binary, so install it
+            # separately for Playwright.
             - name: Install Electron binary
               working-directory: apps/desktop
               run: npx install-electron
@@ -112,14 +112,14 @@ jobs:
 
             # Electron needs an X server on Linux runners; xvfb-run provides
             # one for the test process and tears it down after.
-            - name: Run desktop smoke test
+            - name: Run desktop E2E tests
               working-directory: apps/desktop
               run: xvfb-run --auto-servernum npm run test:e2e
 
             - if: failure()
               uses: actions/upload-artifact@v7
               with:
-                  name: desktop-playwright-artifacts
+                  name: desktop-playwright-artifacts-linux
                   path: |
                       apps/desktop/test-results/
                       apps/desktop/playwright-report/

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -125,8 +125,8 @@ jobs:
                       apps/desktop/playwright-report/
                   retention-days: 7
 
-    # Build the bundled PHP runtime before exercising the same launch path a
-    # Windows checkout uses.
+    # Build the bundled PHP runtime, then launch Cortext the same way it runs
+    # from a Windows checkout.
     windows:
         name: Playwright (Electron, Windows)
         runs-on: windows-2022
@@ -164,8 +164,8 @@ jobs:
               working-directory: apps/desktop
               run: npm ci
 
-            # Electron 42 skips the binary download during npm ci. Fetch it here
-            # so Playwright has something to launch.
+            # npm ci does not download Electron 42's binary, so install it
+            # separately for Playwright.
             - name: Install Electron binary
               working-directory: apps/desktop
               run: npx install-electron
@@ -174,7 +174,7 @@ jobs:
               working-directory: apps/desktop
               run: npm run test:unit
 
-            - name: Add Git build tools to PATH
+            - name: Add Git's build tools to PATH
               shell: pwsh
               run: |
                   $gitTools = Join-Path $env:ProgramFiles 'Git\usr\bin'
@@ -190,9 +190,8 @@ jobs:
                   path: apps/desktop/runtime/bin/php.exe
                   key: desktop-runtime-php-${{ runner.os }}-${{ runner.arch }}-${{ env.CORTEXT_STATIC_PHP_VERSION }}-${{ env.CORTEXT_SPC_VERSION }}-${{ hashFiles('apps/desktop/scripts/install-runtime.mjs') }}
 
-            # The installer compiles on a cache miss and verifies the restored
-            # executable on a cache hit.
-            - name: Build bundled PHP runtime
+            # Build PHP on a cache miss. The installer still checks cached binaries.
+            - name: Build bundled PHP
               working-directory: apps/desktop
               env:
                   GITHUB_TOKEN: ${{ github.token }}
@@ -204,7 +203,7 @@ jobs:
                   CORTEXT_PHP_BIN: ${{ github.workspace }}/apps/desktop/runtime/bin/php.exe
               run: npm run snapshot
 
-            - name: Run desktop smoke test
+            - name: Run desktop E2E tests
               working-directory: apps/desktop
               run: npm run test:e2e
 

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -48,7 +48,7 @@ jobs:
                   fi
 
     playwright:
-        name: Playwright (Electron)
+        name: Playwright (Electron, Linux)
         runs-on: ubuntu-latest
         needs: changes
         if: needs.changes.outputs.desktop_changed == 'true'

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -184,18 +184,27 @@ jobs:
                   }
                   $gitTools | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-            - name: Cache bundled PHP runtime
-              uses: actions/cache@v6.1.0
+            - name: Restore bundled PHP runtime
+              id: php-runtime-cache
+              uses: actions/cache/restore@v6.1.0
               with:
                   path: apps/desktop/runtime/bin/php.exe
                   key: desktop-runtime-php-${{ runner.os }}-${{ runner.arch }}-${{ env.CORTEXT_STATIC_PHP_VERSION }}-${{ env.CORTEXT_SPC_VERSION }}-${{ hashFiles('apps/desktop/scripts/install-runtime.mjs') }}
 
             # Build PHP on a cache miss. The installer still checks cached binaries.
             - name: Build bundled PHP
+              id: build-php
               working-directory: apps/desktop
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: npm run runtime:php
+
+            - name: Save bundled PHP runtime
+              if: ${{ success() && steps.build-php.outcome == 'success' && steps.php-runtime-cache.outputs.cache-hit != 'true' }}
+              uses: actions/cache/save@v6.1.0
+              with:
+                  path: apps/desktop/runtime/bin/php.exe
+                  key: ${{ steps.php-runtime-cache.outputs.cache-primary-key }}
 
             - name: Build snapshot
               working-directory: apps/desktop

--- a/apps/desktop/lib/executable.js
+++ b/apps/desktop/lib/executable.js
@@ -28,6 +28,19 @@ function defaultIsFile( candidate, platform ) {
 	}
 }
 
+function bundledRuntimeExecutable(
+	appDir,
+	commandName,
+	platform = process.platform
+) {
+	const pathApi = platform === 'win32' ? path.win32 : path;
+	const executable =
+		platform === 'win32' && ! commandName.toLowerCase().endsWith( '.exe' )
+			? `${ commandName }.exe`
+			: commandName;
+	return pathApi.join( appDir, 'runtime/bin', executable );
+}
+
 function windowsExtensions(
 	command,
 	env,
@@ -133,6 +146,7 @@ function findExecutable(
 
 module.exports = {
 	DEFAULT_WINDOWS_PATHEXT,
+	bundledRuntimeExecutable,
 	envValue,
 	findExecutable,
 };

--- a/apps/desktop/lib/executable.js
+++ b/apps/desktop/lib/executable.js
@@ -33,7 +33,7 @@ function bundledRuntimeExecutable(
 	commandName,
 	platform = process.platform
 ) {
-	const pathApi = platform === 'win32' ? path.win32 : path;
+	const pathApi = platform === 'win32' ? path.win32 : path.posix;
 	const executable =
 		platform === 'win32' && ! commandName.toLowerCase().endsWith( '.exe' )
 			? `${ commandName }.exe`
@@ -94,7 +94,7 @@ function findExecutable(
 	}
 
 	const trimmed = command.trim().replace( /^"(.*)"$/, '$1' );
-	const pathApi = platform === 'win32' ? path.win32 : path;
+	const pathApi = platform === 'win32' ? path.win32 : path.posix;
 	const extensions =
 		platform === 'win32'
 			? windowsExtensions(

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -4,7 +4,7 @@ const http = require( 'http' );
 const net = require( 'net' );
 const os = require( 'os' );
 const path = require( 'path' );
-const { findExecutable } = require( './executable' );
+const { bundledRuntimeExecutable, findExecutable } = require( './executable' );
 
 // Existing profiles used this origin before runtime ports became per-profile.
 // Keeping it as their first preference preserves origin-scoped browser state.
@@ -50,19 +50,6 @@ function findRuntimeExecutable( command, options = {} ) {
 		allowedWindowsExtensions:
 			platform === 'win32' ? WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS : null,
 	} );
-}
-
-function bundledRuntimeExecutable(
-	appDir,
-	commandName,
-	platform = process.platform
-) {
-	const pathApi = platform === 'win32' ? path.win32 : path;
-	const executable =
-		platform === 'win32' && ! commandName.toLowerCase().endsWith( '.exe' )
-			? `${ commandName }.exe`
-			: commandName;
-	return pathApi.join( appDir, 'runtime/bin', executable );
 }
 
 function resolveExecutable( envName, bundledPath, commandName, installHint ) {
@@ -1250,7 +1237,6 @@ module.exports = {
 	RUNTIME_PORT_FIRST,
 	RUNTIME_PORT_LAST,
 	WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS,
-	bundledRuntimeExecutable,
 	childProcessOptions,
 	findRuntimeExecutable,
 	findAvailablePort,

--- a/apps/desktop/scripts/build-snapshot.mjs
+++ b/apps/desktop/scripts/build-snapshot.mjs
@@ -18,7 +18,7 @@ import { buildWpConfig, randomSalt } from './wp-config.mjs';
 import zipHelpers from './zip.js';
 
 const { extractZip } = archiveHelpers;
-const { findExecutable } = executableHelpers;
+const { bundledRuntimeExecutable, findExecutable } = executableHelpers;
 const { zipDirectory } = zipHelpers;
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const DESKTOP_DIR = resolve( __dirname, '..' );
@@ -82,7 +82,7 @@ function resolvePhpBin() {
 			`CORTEXT_PHP_BIN does not point to an executable: ${ configured }`
 		);
 	}
-	const bundled = resolve( RUNTIME_DIR, 'bin/php' );
+	const bundled = bundledRuntimeExecutable( DESKTOP_DIR, 'php' );
 	if ( existsSync( bundled ) ) {
 		return bundled;
 	}
@@ -90,8 +90,9 @@ function resolvePhpBin() {
 	if ( fromPath ) {
 		return fromPath;
 	}
+	const bundledHint = bundledRuntimeExecutable( 'apps/desktop', 'php' );
 	throw new Error(
-		'PHP was not found. Install PHP 8.1+, set CORTEXT_PHP_BIN, or include apps/desktop/runtime/bin/php in the app bundle.'
+		`PHP was not found. Install PHP 8.1+, set CORTEXT_PHP_BIN, or include ${ bundledHint } in the app bundle.`
 	);
 }
 

--- a/apps/desktop/scripts/executable.test.mjs
+++ b/apps/desktop/scripts/executable.test.mjs
@@ -116,6 +116,18 @@ test( 'findExecutable accepts an explicit quoted Windows path', () => {
 	);
 } );
 
+test( 'findExecutable uses POSIX paths for non-Windows targets', () => {
+	assert.equal(
+		findExecutable( 'php', {
+			platform: 'darwin',
+			env: { PATH: '/usr/local/bin:/usr/bin' },
+			cwd: '/workspace',
+			isFile: ( candidate ) => candidate === '/usr/local/bin/php',
+		} ),
+		'/usr/local/bin/php'
+	);
+} );
+
 test( 'findExecutable returns null when no PATH candidate exists', () => {
 	assert.equal(
 		findExecutable( 'php', {

--- a/apps/desktop/scripts/executable.test.mjs
+++ b/apps/desktop/scripts/executable.test.mjs
@@ -3,7 +3,12 @@ import test from 'node:test';
 
 import executableHelpers from '../lib/executable.js';
 
-const { DEFAULT_WINDOWS_PATHEXT, envValue, findExecutable } = executableHelpers;
+const {
+	DEFAULT_WINDOWS_PATHEXT,
+	bundledRuntimeExecutable,
+	envValue,
+	findExecutable,
+} = executableHelpers;
 
 function windowsFiles( files ) {
 	const normalized = new Set( files.map( ( file ) => file.toLowerCase() ) );
@@ -13,6 +18,17 @@ function windowsFiles( files ) {
 test( 'Windows environment lookup is case-insensitive', () => {
 	assert.equal( envValue( { Path: 'C:\\bin' }, 'PATH', 'win32' ), 'C:\\bin' );
 	assert.equal( envValue( { pathext: '.EXE' }, 'PATHEXT', 'win32' ), '.EXE' );
+} );
+
+test( 'bundled runtime executables use the platform filename', () => {
+	assert.equal(
+		bundledRuntimeExecutable( 'C:\\Cortext', 'php', 'win32' ),
+		'C:\\Cortext\\runtime\\bin\\php.exe'
+	);
+	assert.equal(
+		bundledRuntimeExecutable( '/Applications/Cortext', 'php', 'darwin' ),
+		'/Applications/Cortext/runtime/bin/php'
+	);
 } );
 
 test( 'findExecutable searches quoted Windows PATH entries with PATHEXT', () => {

--- a/apps/desktop/scripts/executable.test.mjs
+++ b/apps/desktop/scripts/executable.test.mjs
@@ -20,7 +20,7 @@ test( 'Windows environment lookup is case-insensitive', () => {
 	assert.equal( envValue( { pathext: '.EXE' }, 'PATHEXT', 'win32' ), '.EXE' );
 } );
 
-test( 'bundled runtime executables use the platform filename', () => {
+test( 'bundled runtime paths use .exe on Windows', () => {
 	assert.equal(
 		bundledRuntimeExecutable( 'C:\\Cortext', 'php', 'win32' ),
 		'C:\\Cortext\\runtime\\bin\\php.exe'

--- a/apps/desktop/scripts/install-runtime.mjs
+++ b/apps/desktop/scripts/install-runtime.mjs
@@ -17,10 +17,9 @@ const DESKTOP_DIR = resolve( __dirname, '..' );
 const BIN_DIR = resolve( DESKTOP_DIR, 'runtime/bin' );
 const CACHE_DIR = resolve( DESKTOP_DIR, '.runtime-cache' );
 
-const PHP_VERSION = process.env.CORTEXT_STATIC_PHP_VERSION || '8.5';
-const SPC_VERSION = process.env.CORTEXT_SPC_VERSION || '2.8.5';
-const FRANKENPHP_VERSION =
-	process.env.CORTEXT_FRANKENPHP_VERSION || 'v1.12.2';
+export const PHP_VERSION = process.env.CORTEXT_STATIC_PHP_VERSION || '8.5';
+export const SPC_VERSION = process.env.CORTEXT_SPC_VERSION || '2.8.5';
+const FRANKENPHP_VERSION = process.env.CORTEXT_FRANKENPHP_VERSION || 'v1.12.2';
 const CADDY_VERSION = process.env.CORTEXT_CADDY_VERSION || '2.11.3';
 
 function isEnabled( value ) {
@@ -37,7 +36,7 @@ const PHP_WITH_APCU =
 const PHP_WITH_JIT =
 	PHP_EXPERIMENTAL || isEnabled( process.env.CORTEXT_STATIC_PHP_JIT );
 
-const BASE_PHP_EXTENSIONS = [
+export const BASE_PHP_EXTENSIONS = [
 	'opcache',
 	'pdo',
 	'pdo_sqlite',
@@ -66,9 +65,9 @@ const BASE_PHP_EXTENSIONS = [
 	'exif',
 ];
 
-function phpExtensions() {
+export function phpExtensions( withApcu = PHP_WITH_APCU ) {
 	const extensions = [ ...BASE_PHP_EXTENSIONS ];
-	if ( PHP_WITH_APCU ) {
+	if ( withApcu ) {
 		extensions.push( 'apcu' );
 	}
 	return extensions;
@@ -101,59 +100,113 @@ function readOptions() {
 	return options;
 }
 
-function platformKey() {
-	if ( process.platform !== 'darwin' ) {
+export function phpRuntimeDescriptor(
+	platform = process.platform,
+	arch = process.arch
+) {
+	if ( platform === 'darwin' ) {
+		if ( arch === 'arm64' ) {
+			return {
+				key: 'macos-aarch64',
+				spcAsset: 'spc-macos-aarch64.tar.gz',
+				spcExecutable: 'spc',
+				builtPhp: 'buildroot/bin/php',
+				runtimePhp: 'php',
+				spcPackageRoot: 'aarch64-darwin',
+				archive: true,
+			};
+		}
+		if ( arch === 'x64' ) {
+			return {
+				key: 'macos-x86_64',
+				spcAsset: 'spc-macos-x86_64.tar.gz',
+				spcExecutable: 'spc',
+				builtPhp: 'buildroot/bin/php',
+				runtimePhp: 'php',
+				spcPackageRoot: 'x86_64-darwin',
+				archive: true,
+			};
+		}
+		throw new Error( `Unsupported macOS architecture: ${ arch }.` );
+	}
+
+	if ( platform === 'win32' ) {
+		if ( arch === 'x64' ) {
+			return {
+				key: 'windows-x64',
+				spcAsset: 'spc-windows-x64.exe',
+				spcExecutable: 'spc.exe',
+				builtPhp: 'buildroot/bin/php.exe',
+				runtimePhp: 'php.exe',
+				spcPackageRoot: null,
+				archive: false,
+			};
+		}
+		throw new Error( `Unsupported Windows architecture: ${ arch }.` );
+	}
+
+	throw new Error(
+		`Bundled PHP is only supported on macOS and Windows. Current platform: ${ platform }.`
+	);
+}
+
+function macPlatformKey( platform = process.platform, arch = process.arch ) {
+	if ( platform !== 'darwin' ) {
 		throw new Error(
-			`Only macOS runtime artifacts are supported by this exploration script. Current platform: ${ process.platform }.`
+			`This runtime is only available on macOS. Current platform: ${ platform }.`
 		);
 	}
-	if ( process.arch === 'arm64' ) {
-		return 'macos-aarch64';
-	}
-	if ( process.arch === 'x64' ) {
-		return 'macos-x86_64';
-	}
-	throw new Error( `Unsupported macOS architecture: ${ process.arch }.` );
+	return phpRuntimeDescriptor( platform, arch ).key;
 }
 
-function spcPackageRoot() {
-	if ( process.arch === 'arm64' ) {
-		return 'aarch64-darwin';
-	}
-	if ( process.arch === 'x64' ) {
-		return 'x86_64-darwin';
-	}
-	throw new Error( `Unsupported macOS architecture: ${ process.arch }.` );
+export function frankenPlatformName(
+	platform = process.platform,
+	arch = process.arch
+) {
+	return macPlatformKey( platform, arch ) === 'macos-aarch64'
+		? 'mac-arm64'
+		: 'mac-x86_64';
 }
 
-function frankenPlatformName() {
-	return platformKey() === 'macos-aarch64' ? 'mac-arm64' : 'mac-x86_64';
+export function caddyPlatformName(
+	platform = process.platform,
+	arch = process.arch
+) {
+	return macPlatformKey( platform, arch ) === 'macos-aarch64'
+		? 'mac_arm64'
+		: 'mac_amd64';
 }
 
-function caddyPlatformName() {
-	return platformKey() === 'macos-aarch64' ? 'mac_arm64' : 'mac_amd64';
-}
-
-function run( command, args, options = {} ) {
-	const result = spawnSync( command, args, {
+export function run( command, args, options = {}, spawn = spawnSync ) {
+	const result = spawn( command, args, {
 		stdio: 'inherit',
 		...options,
 	} );
+	if ( result.error ) {
+		throw result.error;
+	}
 	if ( result.status !== 0 ) {
 		throw new Error(
-			`${ command } ${ args.join( ' ' ) } failed with exit code ${ result.status }`
+			`${ command } ${ args.join( ' ' ) } failed with exit code ${
+				result.status
+			}`
 		);
 	}
 }
 
-function output( command, args ) {
-	const result = spawnSync( command, args, {
+export function output( command, args, spawn = spawnSync ) {
+	const result = spawn( command, args, {
 		encoding: 'utf8',
 		stdio: [ 'ignore', 'pipe', 'pipe' ],
 	} );
+	if ( result.error ) {
+		throw result.error;
+	}
 	if ( result.status !== 0 ) {
 		throw new Error(
-			`${ command } ${ args.join( ' ' ) } failed: ${ result.stderr || result.stdout }`
+			`${ command } ${ args.join( ' ' ) } failed: ${
+				result.stderr || result.stdout
+			}`
 		);
 	}
 	return ( result.stdout || result.stderr ).trim();
@@ -183,7 +236,9 @@ function download( url, dest, redirects = 0 ) {
 			if ( ! response.statusCode || response.statusCode >= 400 ) {
 				response.resume();
 				rejectDownload(
-					new Error( `Download failed (${ response.statusCode }) for ${ url }` )
+					new Error(
+						`Download failed (${ response.statusCode }) for ${ url }`
+					)
 				);
 				return;
 			}
@@ -207,47 +262,71 @@ async function ensureDownload( url, dest ) {
 	return dest;
 }
 
-function installExecutable( src, dest, force ) {
-	if ( existsSync( dest ) && ! force ) {
-		console.log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
+function installExecutable(
+	src,
+	dest,
+	force,
+	{ makeExecutable = true, dependencies = {} } = {}
+) {
+	const {
+		exists = existsSync,
+		mkdir = mkdirSync,
+		copyFile = copyFileSync,
+		chmod = chmodSync,
+		log = console.log,
+	} = dependencies;
+
+	if ( exists( dest ) && ! force ) {
+		log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
 		return false;
 	}
-	mkdirSync( dirname( dest ), { recursive: true } );
-	copyFileSync( src, dest );
-	chmodSync( dest, 0o755 );
-	console.log( `[runtime] Installed ${ dest }` );
+	mkdir( dirname( dest ), { recursive: true } );
+	copyFile( src, dest );
+	if ( makeExecutable ) {
+		chmod( dest, 0o755 );
+	}
+	log( `[runtime] Installed ${ dest }` );
 	return true;
 }
 
 async function installFranken( options ) {
+	const platformName = frankenPlatformName();
 	const dest = resolve( BIN_DIR, 'frankenphp' );
 	if ( existsSync( dest ) && ! options.force ) {
-		console.log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
-		console.log( output( dest, [ 'version' ] ).split( '\n' )[0] );
+		console.log(
+			`[runtime] ${ dest } already exists. Use --force to replace it.`
+		);
+		console.log( output( dest, [ 'version' ] ).split( '\n' )[ 0 ] );
 		return;
 	}
 
-	const asset = `frankenphp-${ frankenPlatformName() }`;
+	const asset = `frankenphp-${ platformName }`;
 	const url = `https://github.com/php/frankenphp/releases/download/${ FRANKENPHP_VERSION }/${ asset }`;
 	const cachePath = resolve( CACHE_DIR, asset );
 
 	await ensureDownload( url, cachePath );
 	installExecutable( cachePath, dest, options.force );
-	console.log( output( dest, [ 'version' ] ).split( '\n' )[0] );
+	console.log( output( dest, [ 'version' ] ).split( '\n' )[ 0 ] );
 }
 
 async function installCaddy( options ) {
+	const platformName = caddyPlatformName();
 	const dest = resolve( BIN_DIR, 'caddy' );
 	if ( existsSync( dest ) && ! options.force ) {
-		console.log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
-		console.log( output( dest, [ 'version' ] ).split( '\n' )[0] );
+		console.log(
+			`[runtime] ${ dest } already exists. Use --force to replace it.`
+		);
+		console.log( output( dest, [ 'version' ] ).split( '\n' )[ 0 ] );
 		return;
 	}
 
-	const asset = `caddy_${ CADDY_VERSION }_${ caddyPlatformName() }.tar.gz`;
+	const asset = `caddy_${ CADDY_VERSION }_${ platformName }.tar.gz`;
 	const url = `https://github.com/caddyserver/caddy/releases/download/v${ CADDY_VERSION }/${ asset }`;
 	const archive = resolve( CACHE_DIR, asset );
-	const extractDir = resolve( CACHE_DIR, `caddy-${ CADDY_VERSION }-${ caddyPlatformName() }` );
+	const extractDir = resolve(
+		CACHE_DIR,
+		`caddy-${ CADDY_VERSION }-${ platformName }`
+	);
 	const extracted = resolve( extractDir, 'caddy' );
 
 	await ensureDownload( url, archive );
@@ -257,49 +336,58 @@ async function installCaddy( options ) {
 		run( 'tar', [ '-xzf', archive, '-C', extractDir ] );
 	}
 	installExecutable( extracted, dest, options.force );
-	console.log( output( dest, [ 'version' ] ).split( '\n' )[0] );
+	console.log( output( dest, [ 'version' ] ).split( '\n' )[ 0 ] );
 }
 
-function verifyPhp( phpBin ) {
-	const modules = output( phpBin, [ '-m' ] )
-		.split( '\n' )
-		.map( ( module ) => module.trim().toLowerCase() );
-	const requiredModules = [
-		'pdo',
-		'pdo_sqlite',
-		'sqlite3',
-		'mbstring',
-		'curl',
-		'openssl',
-		'zip',
-		'gd',
-		'xml',
-		'dom',
-		'simplexml',
-		'xmlreader',
-		'xmlwriter',
-		'phar',
-		'session',
-		'tokenizer',
-		'fileinfo',
-		'filter',
-		'ctype',
-		'iconv',
-		'zend opcache',
-	];
+export function requiredPhpModules( extensions = phpExtensions() ) {
+	return extensions.map( ( extension ) =>
+		extension === 'opcache' ? 'zend opcache' : extension.toLowerCase()
+	);
+}
 
-	if ( PHP_WITH_APCU ) {
-		requiredModules.push( 'apcu' );
+function phpMajorMinor( version ) {
+	const match = String( version ).match( /^(\d+)\.(\d+)/ );
+	if ( ! match ) {
+		throw new Error( `Invalid PHP version: ${ version }` );
+	}
+	return `${ match[ 1 ] }.${ match[ 2 ] }`;
+}
+
+export function verifyPhp(
+	phpBin,
+	{
+		phpVersion = PHP_VERSION,
+		extensions = phpExtensions(),
+		withJit = PHP_WITH_JIT,
+		getOutput = output,
+		log = console.log,
+	} = {}
+) {
+	const expectedVersion = phpMajorMinor( phpVersion );
+	const actualVersion = getOutput( phpBin, [
+		'-r',
+		"echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;",
+	] );
+	if ( actualVersion !== expectedVersion ) {
+		throw new Error(
+			`Bundled PHP ${ actualVersion } does not match requested PHP ${ expectedVersion }.`
+		);
 	}
 
-	for ( const required of requiredModules ) {
+	const modules = getOutput( phpBin, [ '-m' ] )
+		.split( '\n' )
+		.map( ( module ) => module.trim().toLowerCase() );
+
+	for ( const required of requiredPhpModules( extensions ) ) {
 		if ( ! modules.includes( required ) ) {
-			throw new Error( `Bundled PHP is missing required module: ${ required }` );
+			throw new Error(
+				`Bundled PHP is missing required module: ${ required }`
+			);
 		}
 	}
 
-	if ( PHP_WITH_JIT ) {
-		const jit = output( phpBin, [
+	if ( withJit ) {
+		const jit = getOutput( phpBin, [
 			'-d',
 			'opcache.enable_cli=1',
 			'-d',
@@ -311,50 +399,96 @@ function verifyPhp( phpBin ) {
 		] );
 		const parsed = JSON.parse( jit || 'null' );
 		if ( ! parsed || parsed.enabled !== true ) {
-			throw new Error( 'Bundled PHP did not report enabled OPcache JIT.' );
+			throw new Error(
+				'Bundled PHP did not report enabled OPcache JIT.'
+			);
 		}
 	}
 
-	console.log( output( phpBin, [ '-v' ] ).split( '\n' )[0] );
+	log( getOutput( phpBin, [ '-v' ] ).split( '\n' )[ 0 ] );
 }
 
-async function installPhp( options ) {
-	const dest = resolve( BIN_DIR, 'php' );
-	if ( existsSync( dest ) && ! options.force ) {
-		console.log( `[runtime] ${ dest } already exists. Use --force to replace it.` );
-		verifyPhp( dest );
+export async function installPhp(
+	options,
+	{
+		platform = process.platform,
+		arch = process.arch,
+		phpVersion = PHP_VERSION,
+		spcVersion = SPC_VERSION,
+		withApcu = PHP_WITH_APCU,
+		withJit = PHP_WITH_JIT,
+		binDir = BIN_DIR,
+		cacheDir = CACHE_DIR,
+		dependencies = {},
+	} = {}
+) {
+	const descriptor = phpRuntimeDescriptor( platform, arch );
+	const deps = {
+		exists: existsSync,
+		mkdir: mkdirSync,
+		copyFile: copyFileSync,
+		chmod: chmodSync,
+		ensureDownload,
+		run,
+		output,
+		log: console.log,
+		...dependencies,
+	};
+	const extensions = phpExtensions( withApcu );
+	const dest = resolve( binDir, descriptor.runtimePhp );
+
+	if ( deps.exists( dest ) && ! options.force ) {
+		deps.log(
+			`[runtime] ${ dest } already exists. Use --force to replace it.`
+		);
+		verifyPhp( dest, {
+			phpVersion,
+			extensions,
+			withJit,
+			getOutput: deps.output,
+			log: deps.log,
+		} );
 		return;
 	}
 
-	const spcAsset = `spc-${ platformKey() }.tar.gz`;
-	const spcUrl = `https://github.com/crazywhalecc/static-php-cli/releases/download/${ SPC_VERSION }/${ spcAsset }`;
-	const spcArchive = resolve( CACHE_DIR, spcAsset );
-	const spcDir = resolve( CACHE_DIR, `spc-build-${ SPC_VERSION }` );
-	const spcBin = resolve( spcDir, 'spc' );
-	const builtPhp = resolve( spcDir, 'buildroot/bin/php' );
+	const spcUrl = `https://github.com/crazywhalecc/static-php-cli/releases/download/${ spcVersion }/${ descriptor.spcAsset }`;
+	const spcDownload = resolve( cacheDir, descriptor.spcAsset );
+	const spcDir = resolve( cacheDir, `spc-build-${ spcVersion }` );
+	const spcBin = resolve( spcDir, descriptor.spcExecutable );
+	const builtPhp = resolve( spcDir, descriptor.builtPhp );
 
-	await ensureDownload( spcUrl, spcArchive );
-	if ( ! existsSync( spcBin ) ) {
-		mkdirSync( spcDir, { recursive: true } );
-		run( 'tar', [ '-xzf', spcArchive, '-C', spcDir ] );
-		chmodSync( spcBin, 0o755 );
+	await deps.ensureDownload( spcUrl, spcDownload );
+	if ( ! deps.exists( spcBin ) ) {
+		deps.mkdir( spcDir, { recursive: true } );
+		if ( descriptor.archive ) {
+			deps.run( 'tar', [ '-xzf', spcDownload, '-C', spcDir ] );
+			deps.chmod( spcBin, 0o755 );
+		} else {
+			deps.copyFile( spcDownload, spcBin );
+		}
 	}
 
-	if ( ! existsSync( builtPhp ) || options.rebuild ) {
-		const pkgConfig = resolve(
-			spcDir,
-			'pkgroot',
-			spcPackageRoot(),
-			'bin/pkg-config'
-		);
-		if ( ! existsSync( pkgConfig ) ) {
-			run( spcBin, [ 'install-pkg', 'pkg-config' ], { cwd: spcDir } );
+	if ( ! deps.exists( builtPhp ) || options.rebuild ) {
+		if ( descriptor.archive ) {
+			const pkgConfig = resolve(
+				spcDir,
+				'pkgroot',
+				descriptor.spcPackageRoot,
+				'bin/pkg-config'
+			);
+			if ( ! deps.exists( pkgConfig ) ) {
+				deps.run( spcBin, [ 'install-pkg', 'pkg-config' ], {
+					cwd: spcDir,
+				} );
+			}
+		} else {
+			deps.run( spcBin, [ 'doctor', '--auto-fix' ], { cwd: spcDir } );
 		}
 
-		const extensionList = phpExtensions().join( ',' );
+		const extensionList = extensions.join( ',' );
 		const buildArgs = [ 'build', extensionList, '--build-cli' ];
 
-		if ( ! PHP_WITH_JIT ) {
+		if ( ! withJit ) {
 			buildArgs.push( '--disable-opcache-jit' );
 		}
 
@@ -367,26 +501,37 @@ async function installPhp( options ) {
 			'pcre.jit=1'
 		);
 
-		run(
+		deps.run(
 			spcBin,
 			[
 				'download',
 				`--for-extensions=${ extensionList }`,
-				`--with-php=${ PHP_VERSION }`,
+				`--with-php=${ phpVersion }`,
 				'--prefer-pre-built',
 				'--retry=2',
 			],
 			{ cwd: spcDir }
 		);
-		run( spcBin, [ 'switch-php-version', PHP_VERSION ], { cwd: spcDir } );
-		run( spcBin, buildArgs, { cwd: spcDir } );
+		deps.run( spcBin, [ 'switch-php-version', phpVersion ], {
+			cwd: spcDir,
+		} );
+		deps.run( spcBin, buildArgs, { cwd: spcDir } );
 	}
 
-	installExecutable( builtPhp, dest, true );
-	verifyPhp( dest );
+	installExecutable( builtPhp, dest, true, {
+		makeExecutable: descriptor.archive,
+		dependencies: deps,
+	} );
+	verifyPhp( dest, {
+		phpVersion,
+		extensions,
+		withJit,
+		getOutput: deps.output,
+		log: deps.log,
+	} );
 }
 
-async function main() {
+export async function main() {
 	const options = readOptions();
 	if ( options.runtime === 'php' ) {
 		await installPhp( options );
@@ -401,7 +546,12 @@ async function main() {
 	}
 }
 
-main().catch( ( err ) => {
-	console.error( `[runtime] ${ err.message }` );
-	process.exitCode = 1;
-} );
+if (
+	process.argv[ 1 ] &&
+	resolve( process.argv[ 1 ] ) === fileURLToPath( import.meta.url )
+) {
+	main().catch( ( err ) => {
+		console.error( `[runtime] ${ err.message }` );
+		process.exitCode = 1;
+	} );
+}

--- a/apps/desktop/scripts/install-runtime.mjs
+++ b/apps/desktop/scripts/install-runtime.mjs
@@ -146,14 +146,14 @@ export function phpRuntimeDescriptor(
 	}
 
 	throw new Error(
-		`Bundled PHP is only supported on macOS and Windows. Current platform: ${ platform }.`
+		`Bundled PHP only supports macOS and Windows, not ${ platform }.`
 	);
 }
 
 function macPlatformKey( platform = process.platform, arch = process.arch ) {
 	if ( platform !== 'darwin' ) {
 		throw new Error(
-			`This runtime is only available on macOS. Current platform: ${ platform }.`
+			`This runtime only supports macOS, not ${ platform }.`
 		);
 	}
 	return phpRuntimeDescriptor( platform, arch ).key;
@@ -370,7 +370,7 @@ export function verifyPhp(
 	] );
 	if ( actualVersion !== expectedVersion ) {
 		throw new Error(
-			`Bundled PHP ${ actualVersion } does not match requested PHP ${ expectedVersion }.`
+			`Bundled PHP is ${ actualVersion }, but this build needs PHP ${ expectedVersion }.`
 		);
 	}
 
@@ -381,7 +381,7 @@ export function verifyPhp(
 	for ( const required of requiredPhpModules( extensions ) ) {
 		if ( ! modules.includes( required ) ) {
 			throw new Error(
-				`Bundled PHP is missing required module: ${ required }`
+				`Bundled PHP is missing the ${ required } module.`
 			);
 		}
 	}
@@ -400,7 +400,7 @@ export function verifyPhp(
 		const parsed = JSON.parse( jit || 'null' );
 		if ( ! parsed || parsed.enabled !== true ) {
 			throw new Error(
-				'Bundled PHP did not report enabled OPcache JIT.'
+				'OPcache JIT is not enabled in the bundled PHP runtime.'
 			);
 		}
 	}

--- a/apps/desktop/scripts/install-runtime.test.mjs
+++ b/apps/desktop/scripts/install-runtime.test.mjs
@@ -1,0 +1,382 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+import {
+	BASE_PHP_EXTENSIONS,
+	caddyPlatformName,
+	frankenPlatformName,
+	installPhp,
+	output,
+	phpExtensions,
+	phpRuntimeDescriptor,
+	requiredPhpModules,
+	run,
+	verifyPhp,
+} from './install-runtime.mjs';
+
+function phpOutput( { version = '8.5', extensions = phpExtensions() } = {} ) {
+	const modules = requiredPhpModules( extensions ).join( '\n' );
+
+	return ( command, args ) => {
+		assert.match( command, /php(?:\.exe)?$/ );
+		if ( args[ 0 ] === '-r' && args[ 1 ].includes( 'PHP_MAJOR_VERSION' ) ) {
+			return version;
+		}
+		if ( args[ 0 ] === '-m' ) {
+			return modules;
+		}
+		if ( args[ 0 ] === '-v' ) {
+			return `PHP ${ version }.0`;
+		}
+		if (
+			args.some( ( argument ) =>
+				argument.includes( 'opcache_get_status' )
+			)
+		) {
+			return JSON.stringify( { enabled: true } );
+		}
+		throw new Error( `Unexpected PHP arguments: ${ args.join( ' ' ) }` );
+	};
+}
+
+function fakeDependencies( { files = [], getOutput = phpOutput() } = {} ) {
+	const existing = new Set( files );
+	const calls = {
+		chmod: [],
+		copyFile: [],
+		downloads: [],
+		logs: [],
+		mkdir: [],
+		output: [],
+		run: [],
+	};
+
+	return {
+		calls,
+		dependencies: {
+			exists: ( path ) => existing.has( path ),
+			mkdir: ( path, options ) => calls.mkdir.push( { path, options } ),
+			copyFile: ( source, destination ) => {
+				calls.copyFile.push( { source, destination } );
+				existing.add( destination );
+			},
+			chmod: ( path, mode ) => calls.chmod.push( { path, mode } ),
+			ensureDownload: async ( url, destination ) => {
+				calls.downloads.push( { url, destination } );
+				existing.add( destination );
+				return destination;
+			},
+			run: ( command, args, options ) =>
+				calls.run.push( { command, args, options } ),
+			output: ( command, args ) => {
+				calls.output.push( { command, args } );
+				return getOutput( command, args );
+			},
+			log: ( message ) => calls.logs.push( message ),
+		},
+	};
+}
+
+test( 'PHP runtime descriptors preserve macOS artifacts and paths', () => {
+	assert.deepEqual( phpRuntimeDescriptor( 'darwin', 'arm64' ), {
+		key: 'macos-aarch64',
+		spcAsset: 'spc-macos-aarch64.tar.gz',
+		spcExecutable: 'spc',
+		builtPhp: 'buildroot/bin/php',
+		runtimePhp: 'php',
+		spcPackageRoot: 'aarch64-darwin',
+		archive: true,
+	} );
+	assert.deepEqual( phpRuntimeDescriptor( 'darwin', 'x64' ), {
+		key: 'macos-x86_64',
+		spcAsset: 'spc-macos-x86_64.tar.gz',
+		spcExecutable: 'spc',
+		builtPhp: 'buildroot/bin/php',
+		runtimePhp: 'php',
+		spcPackageRoot: 'x86_64-darwin',
+		archive: true,
+	} );
+} );
+
+test( 'the Windows descriptor uses native executable names', () => {
+	assert.deepEqual( phpRuntimeDescriptor( 'win32', 'x64' ), {
+		key: 'windows-x64',
+		spcAsset: 'spc-windows-x64.exe',
+		spcExecutable: 'spc.exe',
+		builtPhp: 'buildroot/bin/php.exe',
+		runtimePhp: 'php.exe',
+		spcPackageRoot: null,
+		archive: false,
+	} );
+} );
+
+test( 'unsupported platforms and Windows architectures fail early', () => {
+	assert.throws(
+		() => phpRuntimeDescriptor( 'win32', 'arm64' ),
+		/Unsupported Windows architecture: arm64/
+	);
+	assert.throws(
+		() => phpRuntimeDescriptor( 'linux', 'x64' ),
+		/only supported on macOS and Windows/
+	);
+} );
+
+test( 'FrankenPHP and Caddy remain macOS-only', () => {
+	assert.equal( frankenPlatformName( 'darwin', 'arm64' ), 'mac-arm64' );
+	assert.equal( caddyPlatformName( 'darwin', 'x64' ), 'mac_amd64' );
+	assert.throws(
+		() => frankenPlatformName( 'win32', 'x64' ),
+		/only available on macOS/
+	);
+	assert.throws(
+		() => caddyPlatformName( 'win32', 'x64' ),
+		/only available on macOS/
+	);
+} );
+
+test( 'run and output preserve spawn errors', () => {
+	const spawnError = Object.assign( new Error( 'spawn missing ENOENT' ), {
+		code: 'ENOENT',
+	} );
+	const spawn = () => ( { error: spawnError, status: null } );
+
+	assert.throws(
+		() => run( 'missing', [], {}, spawn ),
+		( error ) => {
+			assert.equal( error, spawnError );
+			return true;
+		}
+	);
+	assert.throws(
+		() => output( 'missing', [], spawn ),
+		( error ) => {
+			assert.equal( error, spawnError );
+			return true;
+		}
+	);
+} );
+
+test( 'required modules stay in sync with compiled extensions', () => {
+	const extensions = phpExtensions( true );
+	const modules = requiredPhpModules( extensions );
+
+	assert.equal( extensions.length, BASE_PHP_EXTENSIONS.length + 1 );
+	assert.equal( modules.length, extensions.length );
+	assert.equal( modules[ extensions.indexOf( 'opcache' ) ], 'zend opcache' );
+	assert.ok( modules.includes( 'zlib' ) );
+	assert.ok( modules.includes( 'bcmath' ) );
+	assert.ok( modules.includes( 'bz2' ) );
+	assert.ok( modules.includes( 'calendar' ) );
+	assert.ok( modules.includes( 'exif' ) );
+	assert.ok( modules.includes( 'apcu' ) );
+} );
+
+test( 'PHP verification checks the requested major and minor version', () => {
+	assert.throws(
+		() =>
+			verifyPhp( '/runtime/php', {
+				phpVersion: '8.5.4',
+				getOutput: phpOutput( { version: '8.4' } ),
+				log: () => {},
+			} ),
+		/Bundled PHP 8\.4 does not match requested PHP 8\.5/
+	);
+} );
+
+test( 'PHP verification checks every compiled module', () => {
+	const extensions = phpExtensions( true );
+	const withoutBcmath = extensions.filter(
+		( extension ) => extension !== 'bcmath'
+	);
+
+	assert.throws(
+		() =>
+			verifyPhp( '/runtime/php', {
+				extensions,
+				getOutput: phpOutput( { extensions: withoutBcmath } ),
+				log: () => {},
+			} ),
+		/missing required module: bcmath/
+	);
+	assert.doesNotThrow( () =>
+		verifyPhp( '/runtime/php', {
+			extensions,
+			withJit: true,
+			getOutput: phpOutput( { extensions } ),
+			log: () => {},
+		} )
+	);
+} );
+
+test( 'Windows installs SPC directly and compiles PHP without Unix tools', async () => {
+	const root = resolve( 'test-runtime-windows' );
+	const binDir = resolve( root, 'runtime/bin' );
+	const cacheDir = resolve( root, '.runtime-cache' );
+	const spcDir = resolve( cacheDir, 'spc-build-2.8.5' );
+	const spcDownload = resolve( cacheDir, 'spc-windows-x64.exe' );
+	const spcBin = resolve( spcDir, 'spc.exe' );
+	const builtPhp = resolve( spcDir, 'buildroot/bin/php.exe' );
+	const dest = resolve( binDir, 'php.exe' );
+	const { calls, dependencies } = fakeDependencies();
+
+	await installPhp(
+		{ force: false, rebuild: false },
+		{
+			platform: 'win32',
+			arch: 'x64',
+			binDir,
+			cacheDir,
+			dependencies,
+		}
+	);
+
+	assert.deepEqual( calls.downloads, [
+		{
+			url: 'https://github.com/crazywhalecc/static-php-cli/releases/download/2.8.5/spc-windows-x64.exe',
+			destination: spcDownload,
+		},
+	] );
+	assert.deepEqual( calls.copyFile, [
+		{ source: spcDownload, destination: spcBin },
+		{ source: builtPhp, destination: dest },
+	] );
+	assert.deepEqual( calls.chmod, [] );
+	assert.deepEqual(
+		calls.run.map( ( call ) => [ call.command, ...call.args ] ),
+		[
+			[ spcBin, 'doctor', '--auto-fix' ],
+			[
+				spcBin,
+				'download',
+				`--for-extensions=${ phpExtensions().join( ',' ) }`,
+				'--with-php=8.5',
+				'--prefer-pre-built',
+				'--retry=2',
+			],
+			[ spcBin, 'switch-php-version', '8.5' ],
+			[
+				spcBin,
+				'build',
+				phpExtensions().join( ',' ),
+				'--build-cli',
+				'--disable-opcache-jit',
+				'-I',
+				'opcache.enable_cli=1',
+				'-I',
+				'opcache.validate_timestamps=0',
+				'-I',
+				'pcre.jit=1',
+			],
+		]
+	);
+	assert.ok( calls.run.every( ( call ) => call.options.cwd === spcDir ) );
+	assert.equal(
+		calls.run.some(
+			( call ) =>
+				call.command === 'tar' || call.args[ 0 ] === 'install-pkg'
+		),
+		false
+	);
+	assert.equal( calls.output[ 0 ].command, dest );
+} );
+
+test( 'Windows only runs doctor when it needs to compile PHP', async () => {
+	const root = resolve( 'test-runtime-windows-built' );
+	const binDir = resolve( root, 'runtime/bin' );
+	const cacheDir = resolve( root, '.runtime-cache' );
+	const spcDir = resolve( cacheDir, 'spc-build-2.8.5' );
+	const spcBin = resolve( spcDir, 'spc.exe' );
+	const builtPhp = resolve( spcDir, 'buildroot/bin/php.exe' );
+	const dest = resolve( binDir, 'php.exe' );
+	const { calls, dependencies } = fakeDependencies( {
+		files: [ spcBin, builtPhp ],
+	} );
+
+	await installPhp(
+		{ force: false, rebuild: false },
+		{
+			platform: 'win32',
+			arch: 'x64',
+			binDir,
+			cacheDir,
+			dependencies,
+		}
+	);
+
+	assert.deepEqual( calls.run, [] );
+	assert.deepEqual( calls.copyFile, [
+		{ source: builtPhp, destination: dest },
+	] );
+} );
+
+test( 'a cached Windows PHP binary is always verified', async () => {
+	const root = resolve( 'test-runtime-windows-cached' );
+	const binDir = resolve( root, 'runtime/bin' );
+	const cacheDir = resolve( root, '.runtime-cache' );
+	const dest = resolve( binDir, 'php.exe' );
+	const { calls, dependencies } = fakeDependencies( { files: [ dest ] } );
+
+	await installPhp(
+		{ force: false, rebuild: false },
+		{
+			platform: 'win32',
+			arch: 'x64',
+			binDir,
+			cacheDir,
+			dependencies,
+		}
+	);
+
+	assert.deepEqual( calls.downloads, [] );
+	assert.deepEqual( calls.copyFile, [] );
+	assert.deepEqual( calls.run, [] );
+	assert.deepEqual(
+		calls.output.map( ( call ) => call.args[ 0 ] ),
+		[ '-r', '-m', '-v' ]
+	);
+} );
+
+test( 'macOS keeps tar extraction, pkg-config and executable modes', async () => {
+	const root = resolve( 'test-runtime-macos' );
+	const binDir = resolve( root, 'runtime/bin' );
+	const cacheDir = resolve( root, '.runtime-cache' );
+	const spcDir = resolve( cacheDir, 'spc-build-2.8.5' );
+	const spcDownload = resolve( cacheDir, 'spc-macos-aarch64.tar.gz' );
+	const spcBin = resolve( spcDir, 'spc' );
+	const dest = resolve( binDir, 'php' );
+	const { calls, dependencies } = fakeDependencies();
+
+	await installPhp(
+		{ force: false, rebuild: false },
+		{
+			platform: 'darwin',
+			arch: 'arm64',
+			binDir,
+			cacheDir,
+			dependencies,
+		}
+	);
+
+	assert.deepEqual( calls.downloads[ 0 ], {
+		url: 'https://github.com/crazywhalecc/static-php-cli/releases/download/2.8.5/spc-macos-aarch64.tar.gz',
+		destination: spcDownload,
+	} );
+	assert.deepEqual( calls.run[ 0 ], {
+		command: 'tar',
+		args: [ '-xzf', spcDownload, '-C', spcDir ],
+		options: undefined,
+	} );
+	assert.equal(
+		calls.run.some( ( call ) => call.args[ 0 ] === 'install-pkg' ),
+		true
+	);
+	assert.equal(
+		calls.run.some( ( call ) => call.args[ 0 ] === 'doctor' ),
+		false
+	);
+	assert.deepEqual( calls.chmod, [
+		{ path: spcBin, mode: 0o755 },
+		{ path: dest, mode: 0o755 },
+	] );
+} );

--- a/apps/desktop/scripts/install-runtime.test.mjs
+++ b/apps/desktop/scripts/install-runtime.test.mjs
@@ -15,7 +15,20 @@ import {
 	verifyPhp,
 } from './install-runtime.mjs';
 
-function phpOutput( { version = '8.5', extensions = phpExtensions() } = {} ) {
+const TEST_PHP_VERSION = '8.5';
+const TEST_SPC_VERSION = '2.8.5';
+const TEST_EXTENSIONS = phpExtensions( false );
+const TEST_RUNTIME_OPTIONS = {
+	phpVersion: TEST_PHP_VERSION,
+	spcVersion: TEST_SPC_VERSION,
+	withApcu: false,
+	withJit: false,
+};
+
+function phpOutput( {
+	version = TEST_PHP_VERSION,
+	extensions = TEST_EXTENSIONS,
+} = {} ) {
 	const modules = requiredPhpModules( extensions ).join( '\n' );
 
 	return ( command, args ) => {
@@ -176,7 +189,7 @@ test( 'PHP rejects the wrong major or minor version', () => {
 	assert.throws(
 		() =>
 			verifyPhp( '/runtime/php', {
-				phpVersion: '8.5.4',
+				phpVersion: `${ TEST_PHP_VERSION }.4`,
 				getOutput: phpOutput( { version: '8.4' } ),
 				log: () => {},
 			} ),
@@ -194,6 +207,8 @@ test( 'PHP fails verification when a compiled module is missing', () => {
 		() =>
 			verifyPhp( '/runtime/php', {
 				extensions,
+				phpVersion: TEST_PHP_VERSION,
+				withJit: false,
 				getOutput: phpOutput( { extensions: withoutBcmath } ),
 				log: () => {},
 			} ),
@@ -202,6 +217,7 @@ test( 'PHP fails verification when a compiled module is missing', () => {
 	assert.doesNotThrow( () =>
 		verifyPhp( '/runtime/php', {
 			extensions,
+			phpVersion: TEST_PHP_VERSION,
 			withJit: true,
 			getOutput: phpOutput( { extensions } ),
 			log: () => {},
@@ -213,7 +229,7 @@ test( 'Windows copies SPC directly and skips Unix-only setup', async () => {
 	const root = resolve( 'test-runtime-windows' );
 	const binDir = resolve( root, 'runtime/bin' );
 	const cacheDir = resolve( root, '.runtime-cache' );
-	const spcDir = resolve( cacheDir, 'spc-build-2.8.5' );
+	const spcDir = resolve( cacheDir, `spc-build-${ TEST_SPC_VERSION }` );
 	const spcDownload = resolve( cacheDir, 'spc-windows-x64.exe' );
 	const spcBin = resolve( spcDir, 'spc.exe' );
 	const builtPhp = resolve( spcDir, 'buildroot/bin/php.exe' );
@@ -223,6 +239,7 @@ test( 'Windows copies SPC directly and skips Unix-only setup', async () => {
 	await installPhp(
 		{ force: false, rebuild: false },
 		{
+			...TEST_RUNTIME_OPTIONS,
 			platform: 'win32',
 			arch: 'x64',
 			binDir,
@@ -233,7 +250,7 @@ test( 'Windows copies SPC directly and skips Unix-only setup', async () => {
 
 	assert.deepEqual( calls.downloads, [
 		{
-			url: 'https://github.com/crazywhalecc/static-php-cli/releases/download/2.8.5/spc-windows-x64.exe',
+			url: `https://github.com/crazywhalecc/static-php-cli/releases/download/${ TEST_SPC_VERSION }/spc-windows-x64.exe`,
 			destination: spcDownload,
 		},
 	] );
@@ -249,16 +266,16 @@ test( 'Windows copies SPC directly and skips Unix-only setup', async () => {
 			[
 				spcBin,
 				'download',
-				`--for-extensions=${ phpExtensions().join( ',' ) }`,
-				'--with-php=8.5',
+				`--for-extensions=${ TEST_EXTENSIONS.join( ',' ) }`,
+				`--with-php=${ TEST_PHP_VERSION }`,
 				'--prefer-pre-built',
 				'--retry=2',
 			],
-			[ spcBin, 'switch-php-version', '8.5' ],
+			[ spcBin, 'switch-php-version', TEST_PHP_VERSION ],
 			[
 				spcBin,
 				'build',
-				phpExtensions().join( ',' ),
+				TEST_EXTENSIONS.join( ',' ),
 				'--build-cli',
 				'--disable-opcache-jit',
 				'-I',
@@ -285,7 +302,7 @@ test( 'Windows skips doctor when PHP is already built', async () => {
 	const root = resolve( 'test-runtime-windows-built' );
 	const binDir = resolve( root, 'runtime/bin' );
 	const cacheDir = resolve( root, '.runtime-cache' );
-	const spcDir = resolve( cacheDir, 'spc-build-2.8.5' );
+	const spcDir = resolve( cacheDir, `spc-build-${ TEST_SPC_VERSION }` );
 	const spcBin = resolve( spcDir, 'spc.exe' );
 	const builtPhp = resolve( spcDir, 'buildroot/bin/php.exe' );
 	const dest = resolve( binDir, 'php.exe' );
@@ -296,6 +313,7 @@ test( 'Windows skips doctor when PHP is already built', async () => {
 	await installPhp(
 		{ force: false, rebuild: false },
 		{
+			...TEST_RUNTIME_OPTIONS,
 			platform: 'win32',
 			arch: 'x64',
 			binDir,
@@ -320,6 +338,7 @@ test( 'Windows verifies cached PHP before reusing it', async () => {
 	await installPhp(
 		{ force: false, rebuild: false },
 		{
+			...TEST_RUNTIME_OPTIONS,
 			platform: 'win32',
 			arch: 'x64',
 			binDir,
@@ -341,7 +360,7 @@ test( 'macOS still extracts SPC, installs pkg-config, and sets executable permis
 	const root = resolve( 'test-runtime-macos' );
 	const binDir = resolve( root, 'runtime/bin' );
 	const cacheDir = resolve( root, '.runtime-cache' );
-	const spcDir = resolve( cacheDir, 'spc-build-2.8.5' );
+	const spcDir = resolve( cacheDir, `spc-build-${ TEST_SPC_VERSION }` );
 	const spcDownload = resolve( cacheDir, 'spc-macos-aarch64.tar.gz' );
 	const spcBin = resolve( spcDir, 'spc' );
 	const dest = resolve( binDir, 'php' );
@@ -350,6 +369,7 @@ test( 'macOS still extracts SPC, installs pkg-config, and sets executable permis
 	await installPhp(
 		{ force: false, rebuild: false },
 		{
+			...TEST_RUNTIME_OPTIONS,
 			platform: 'darwin',
 			arch: 'arm64',
 			binDir,
@@ -359,7 +379,7 @@ test( 'macOS still extracts SPC, installs pkg-config, and sets executable permis
 	);
 
 	assert.deepEqual( calls.downloads[ 0 ], {
-		url: 'https://github.com/crazywhalecc/static-php-cli/releases/download/2.8.5/spc-macos-aarch64.tar.gz',
+		url: `https://github.com/crazywhalecc/static-php-cli/releases/download/${ TEST_SPC_VERSION }/spc-macos-aarch64.tar.gz`,
 		destination: spcDownload,
 	} );
 	assert.deepEqual( calls.run[ 0 ], {

--- a/apps/desktop/scripts/install-runtime.test.mjs
+++ b/apps/desktop/scripts/install-runtime.test.mjs
@@ -78,7 +78,7 @@ function fakeDependencies( { files = [], getOutput = phpOutput() } = {} ) {
 	};
 }
 
-test( 'PHP runtime descriptors preserve macOS artifacts and paths', () => {
+test( 'macOS keeps its existing SPC assets and paths', () => {
 	assert.deepEqual( phpRuntimeDescriptor( 'darwin', 'arm64' ), {
 		key: 'macos-aarch64',
 		spcAsset: 'spc-macos-aarch64.tar.gz',
@@ -99,7 +99,7 @@ test( 'PHP runtime descriptors preserve macOS artifacts and paths', () => {
 	} );
 } );
 
-test( 'the Windows descriptor uses native executable names', () => {
+test( 'Windows uses native executable names', () => {
 	assert.deepEqual( phpRuntimeDescriptor( 'win32', 'x64' ), {
 		key: 'windows-x64',
 		spcAsset: 'spc-windows-x64.exe',
@@ -111,31 +111,31 @@ test( 'the Windows descriptor uses native executable names', () => {
 	} );
 } );
 
-test( 'unsupported platforms and Windows architectures fail early', () => {
+test( 'unsupported platforms and architectures fail before setup starts', () => {
 	assert.throws(
 		() => phpRuntimeDescriptor( 'win32', 'arm64' ),
 		/Unsupported Windows architecture: arm64/
 	);
 	assert.throws(
 		() => phpRuntimeDescriptor( 'linux', 'x64' ),
-		/only supported on macOS and Windows/
+		/only supports macOS and Windows/
 	);
 } );
 
-test( 'FrankenPHP and Caddy remain macOS-only', () => {
+test( 'FrankenPHP and Caddy are still macOS-only', () => {
 	assert.equal( frankenPlatformName( 'darwin', 'arm64' ), 'mac-arm64' );
 	assert.equal( caddyPlatformName( 'darwin', 'x64' ), 'mac_amd64' );
 	assert.throws(
 		() => frankenPlatformName( 'win32', 'x64' ),
-		/only available on macOS/
+		/only supports macOS/
 	);
 	assert.throws(
 		() => caddyPlatformName( 'win32', 'x64' ),
-		/only available on macOS/
+		/only supports macOS/
 	);
 } );
 
-test( 'run and output preserve spawn errors', () => {
+test( 'spawn errors surface unchanged', () => {
 	const spawnError = Object.assign( new Error( 'spawn missing ENOENT' ), {
 		code: 'ENOENT',
 	} );
@@ -157,7 +157,7 @@ test( 'run and output preserve spawn errors', () => {
 	);
 } );
 
-test( 'required modules stay in sync with compiled extensions', () => {
+test( 'PHP verifies every extension it compiles', () => {
 	const extensions = phpExtensions( true );
 	const modules = requiredPhpModules( extensions );
 
@@ -172,7 +172,7 @@ test( 'required modules stay in sync with compiled extensions', () => {
 	assert.ok( modules.includes( 'apcu' ) );
 } );
 
-test( 'PHP verification checks the requested major and minor version', () => {
+test( 'PHP rejects the wrong major or minor version', () => {
 	assert.throws(
 		() =>
 			verifyPhp( '/runtime/php', {
@@ -180,11 +180,11 @@ test( 'PHP verification checks the requested major and minor version', () => {
 				getOutput: phpOutput( { version: '8.4' } ),
 				log: () => {},
 			} ),
-		/Bundled PHP 8\.4 does not match requested PHP 8\.5/
+		/Bundled PHP is 8\.4, but this build needs PHP 8\.5/
 	);
 } );
 
-test( 'PHP verification checks every compiled module', () => {
+test( 'PHP fails verification when a compiled module is missing', () => {
 	const extensions = phpExtensions( true );
 	const withoutBcmath = extensions.filter(
 		( extension ) => extension !== 'bcmath'
@@ -197,7 +197,7 @@ test( 'PHP verification checks every compiled module', () => {
 				getOutput: phpOutput( { extensions: withoutBcmath } ),
 				log: () => {},
 			} ),
-		/missing required module: bcmath/
+		/missing the bcmath module/
 	);
 	assert.doesNotThrow( () =>
 		verifyPhp( '/runtime/php', {
@@ -209,7 +209,7 @@ test( 'PHP verification checks every compiled module', () => {
 	);
 } );
 
-test( 'Windows installs SPC directly and compiles PHP without Unix tools', async () => {
+test( 'Windows copies SPC directly and skips Unix-only setup', async () => {
 	const root = resolve( 'test-runtime-windows' );
 	const binDir = resolve( root, 'runtime/bin' );
 	const cacheDir = resolve( root, '.runtime-cache' );
@@ -281,7 +281,7 @@ test( 'Windows installs SPC directly and compiles PHP without Unix tools', async
 	assert.equal( calls.output[ 0 ].command, dest );
 } );
 
-test( 'Windows only runs doctor when it needs to compile PHP', async () => {
+test( 'Windows skips doctor when PHP is already built', async () => {
 	const root = resolve( 'test-runtime-windows-built' );
 	const binDir = resolve( root, 'runtime/bin' );
 	const cacheDir = resolve( root, '.runtime-cache' );
@@ -310,7 +310,7 @@ test( 'Windows only runs doctor when it needs to compile PHP', async () => {
 	] );
 } );
 
-test( 'a cached Windows PHP binary is always verified', async () => {
+test( 'Windows verifies cached PHP before reusing it', async () => {
 	const root = resolve( 'test-runtime-windows-cached' );
 	const binDir = resolve( root, 'runtime/bin' );
 	const cacheDir = resolve( root, '.runtime-cache' );
@@ -337,7 +337,7 @@ test( 'a cached Windows PHP binary is always verified', async () => {
 	);
 } );
 
-test( 'macOS keeps tar extraction, pkg-config and executable modes', async () => {
+test( 'macOS still extracts SPC, installs pkg-config, and sets executable permissions', async () => {
 	const root = resolve( 'test-runtime-macos' );
 	const binDir = resolve( root, 'runtime/bin' );
 	const cacheDir = resolve( root, '.runtime-cache' );

--- a/apps/desktop/scripts/runtime.test.mjs
+++ b/apps/desktop/scripts/runtime.test.mjs
@@ -8,7 +8,6 @@ import test from 'node:test';
 import runtimeHelpers from '../lib/runtime.js';
 
 const {
-	bundledRuntimeExecutable,
 	childProcessOptions,
 	findRuntimeExecutable,
 	isPortBindFailure,
@@ -55,17 +54,6 @@ test( 'runtime lookup skips Windows batch wrappers', () => {
 			isFile: ( candidate ) => files.has( candidate.toLowerCase() ),
 		} ),
 		'C:\\native\\php.EXE'
-	);
-} );
-
-test( 'bundled PHP resolves to php.exe on Windows and php elsewhere', () => {
-	assert.equal(
-		bundledRuntimeExecutable( 'C:\\Cortext', 'php', 'win32' ),
-		path.win32.join( 'C:\\Cortext', 'runtime/bin', 'php.exe' )
-	);
-	assert.equal(
-		bundledRuntimeExecutable( '/Applications/Cortext', 'php', 'darwin' ),
-		path.join( '/Applications/Cortext', 'runtime/bin', 'php' )
 	);
 } );
 

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -418,6 +418,9 @@ function waitForProcessExit( app, timeoutMs = 10000 ) {
 }
 
 async function expectSecondInstanceToExit( app, userDataPath ) {
+	const executablePath = await app.evaluate( ( { app } ) =>
+		app.getPath( 'exe' )
+	);
 	await app.evaluate( ( { app } ) => {
 		globalThis.__cortextE2ESecondInstanceSeen = false;
 		app.once( 'second-instance', () => {
@@ -434,13 +437,14 @@ async function expectSecondInstanceToExit( app, userDataPath ) {
 	if ( process.platform === 'linux' ) {
 		secondInstanceArgs.unshift( '--no-sandbox' );
 	}
-	const secondInstance = spawn( app.process().spawnfile, secondInstanceArgs, {
+	const secondInstance = spawn( executablePath, secondInstanceArgs, {
 		env: {
 			...process.env,
 			CORTEXT_DEVTOOLS: '0',
 			CORTEXT_E2E: '1',
 		},
 		stdio: 'ignore',
+		windowsHide: true,
 	} );
 	let timeoutId;
 	const timeout = new Promise( ( _resolve, reject ) => {

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -13,6 +13,7 @@ const { test, expect, _electron: electron } = require( '@playwright/test' );
 const { spawn } = require( 'node:child_process' );
 const { once } = require( 'node:events' );
 const http = require( 'node:http' );
+const net = require( 'node:net' );
 const path = require( 'node:path' );
 const {
 	existsSync,
@@ -460,6 +461,46 @@ async function expectSecondInstanceToExit( app, userDataPath ) {
 		.toBe( true );
 }
 
+function canBindRuntimePort( origin ) {
+	const endpoint = new URL( origin );
+	return new Promise( ( resolve, reject ) => {
+		const server = net.createServer();
+		server.unref();
+		server.once( 'error', ( error ) => {
+			if ( [ 'EACCES', 'EADDRINUSE' ].includes( error.code ) ) {
+				resolve( false );
+				return;
+			}
+			reject( error );
+		} );
+		server.listen(
+			{
+				host: endpoint.hostname,
+				port: Number( endpoint.port ),
+				exclusive: true,
+			},
+			() => {
+				server.close( ( error ) => {
+					if ( error ) {
+						reject( error );
+						return;
+					}
+					resolve( true );
+				} );
+			}
+		);
+	} );
+}
+
+async function expectRuntimePortToBeFree( origin ) {
+	await expect
+		.poll( () => canBindRuntimePort( origin ), {
+			message: `Expected ${ origin } to be free after Cortext closed.`,
+			timeout: 15 * 1000,
+		} )
+		.toBe( true );
+}
+
 test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 	const occupiedPortServer = http.createServer( ( _request, response ) => {
 		response.writeHead( 200 );
@@ -747,6 +788,9 @@ test( 'opens Cortext and rejects untrusted runtime requests', async () => {
 		).toBe( true );
 	} finally {
 		await app.close();
+		if ( runtimeOrigin ) {
+			await expectRuntimePortToBeFree( runtimeOrigin );
+		}
 		await new Promise( ( resolve, reject ) => {
 			occupiedPortServer.close( ( error ) => {
 				if ( error ) {
@@ -790,6 +834,7 @@ test( 'reloads, preserves preferences, and exits with its window', async () => {
 		await window.close();
 		await exitPromise;
 		didExit = true;
+		await expectRuntimePortToBeFree( runtimeOrigin );
 
 		( { app: relaunchedApp } = await launchDesktopApp( userDataPath ) );
 		await expectTemporaryUserData( relaunchedApp, userDataPath );
@@ -812,6 +857,9 @@ test( 'reloads, preserves preferences, and exits with its window', async () => {
 		}
 		if ( relaunchedApp ) {
 			await relaunchedApp.close();
+		}
+		if ( runtimeOrigin ) {
+			await expectRuntimePortToBeFree( runtimeOrigin );
 		}
 	}
 } );

--- a/apps/desktop/tests/launch.spec.js
+++ b/apps/desktop/tests/launch.spec.js
@@ -495,7 +495,7 @@ function canBindRuntimePort( origin ) {
 async function expectRuntimePortToBeFree( origin ) {
 	await expect
 		.poll( () => canBindRuntimePort( origin ), {
-			message: `Expected ${ origin } to be free after Cortext closed.`,
+			message: `Cortext closed, but ${ origin } is still in use.`,
 			timeout: 15 * 1000,
 		} )
 		.toBe( true );


### PR DESCRIPTION
## What

Follow-up to #405.

This lets Cortext build and use its own PHP 8.5 runtime on Windows. CI compiles and verifies `php.exe`, builds the snapshot with it, and then launches Cortext without a system PHP override. The Windows E2E covers startup, persistence, shutdown, and releasing the runtime port.

macOS keeps its existing runtime flow. Packaging and signing remain separate follow-ups.

## Why

#405 made the snapshot builder work on Windows, but the desktop app still could not start there without a bundled PHP runtime. Shipping a known PHP version with Cortext means Windows users will not need to install or configure PHP themselves.

## Testing Instructions

1. On Windows x64 with Visual Studio 2022 and Git for Windows installed, build the bundled PHP runtime from `apps/desktop`. Confirm that it creates `runtime/bin/php.exe` and reports PHP 8.5.
2. Build the snapshot with that runtime, then launch Cortext without setting `CORTEXT_PHP_BIN`. Confirm that the app opens normally.
3. Create or edit some content, quit Cortext, and open it again. Confirm that the change is still there.
4. Quit Cortext and confirm that its `php.exe` process exits and the runtime port is no longer in use.
