### PR TITLE
tooling: Fix WordPress release changelogs

### DIFF
--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -13,6 +13,11 @@ on:
                 required: true
                 default: false
                 type: boolean
+            readme_only:
+                description: 'Update readme.txt in trunk and the existing version tag'
+                required: true
+                default: false
+                type: boolean
 
 permissions:
     contents: read
@@ -36,6 +41,7 @@ jobs:
             - name: Check release is deployable
               env:
                   GH_TOKEN: ${{ github.token }}
+                  README_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.readme_only || false }}
               run: |
                   set -euo pipefail
 
@@ -56,6 +62,18 @@ jobs:
                     exit 1
                   fi
 
+                  if [ "$README_ONLY" = "true" ]; then
+                    stable_tag="$(awk -F': *' '/^Stable tag:/ { print $2; exit }' readme.txt)"
+                    if [ "$stable_tag" != "$VERSION" ]; then
+                      echo "::error::Expected readme stable tag $VERSION, found $stable_tag"
+                      exit 1
+                    fi
+                    if ! awk -v version="$VERSION" '$0 == "= " version " =" { found = 1 } END { exit !found }' readme.txt; then
+                      echo "::error::readme.txt has no changelog entry for $VERSION"
+                      exit 1
+                    fi
+                  fi
+
             - name: Install Subversion
               run: |
                   sudo apt-get update
@@ -64,7 +82,11 @@ jobs:
             - name: Preview WordPress.org SVN deploy
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: ./scripts/deploy-wporg.sh --version "$VERSION"
+                  README_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.readme_only || false }}
+              run: |
+                  args=( --version "$VERSION" )
+                  [ "$README_ONLY" != "true" ] || args+=( --readme-only )
+                  ./scripts/deploy-wporg.sh "${args[@]}"
 
     publish:
         name: Publish
@@ -85,6 +107,7 @@ jobs:
             - name: Publish to WordPress.org SVN
               env:
                   GH_TOKEN: ${{ github.token }}
+                  README_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.readme_only || false }}
                   WPORG_USERNAME: ${{ secrets.WPORG_USERNAME }}
                   WPORG_PASSWORD: ${{ secrets.WPORG_PASSWORD }}
               run: |
@@ -95,4 +118,6 @@ jobs:
                     exit 1
                   fi
 
-                  ./scripts/deploy-wporg.sh --version "$VERSION" --commit
+                  args=( --version "$VERSION" --commit )
+                  [ "$README_ONLY" != "true" ] || args+=( --readme-only )
+                  ./scripts/deploy-wporg.sh "${args[@]}"

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -123,6 +123,11 @@ jobs:
                     --version "$VERSION" \
                     --strict > release-notes.md
 
+            - name: Update WordPress.org changelog
+              env:
+                  VERSION: ${{ steps.milestone.outputs.version }}
+              run: node scripts/update-readme-changelog.mjs "$VERSION" release-notes.md
+
             - name: Append desktop install note
               run: |
                   cat >> release-notes.md <<'EOF'
@@ -149,6 +154,7 @@ jobs:
                   plugin_version="$(unzip -p dist/cortext.zip cortext/cortext.php | awk -F': *' '/^[[:space:]]+\* Version:/ { print $2; exit }')"
                   constant_version="$(unzip -p dist/cortext.zip cortext/cortext.php | sed -n "s/.*define( 'CORTEXT_VERSION', '\([^']*\)' ).*/\1/p")"
                   stable_tag="$(unzip -p dist/cortext.zip cortext/readme.txt | awk -F': *' '/^Stable tag:/ { print $2; exit }')"
+                  changelog_version="$(unzip -p dist/cortext.zip cortext/readme.txt | awk -v version="$VERSION" '$0 == "= " version " =" { print version; exit }')"
                   zip_size="$(du -h dist/cortext.zip | cut -f1)"
                   zip_entries="$(wc -l < release-zip-contents.txt | tr -d ' ')"
 
@@ -164,6 +170,11 @@ jobs:
 
                   if [ "$stable_tag" != "$VERSION" ]; then
                     echo "::error::Expected readme stable tag $VERSION, found $stable_tag"
+                    exit 1
+                  fi
+
+                  if [ "$changelog_version" != "$VERSION" ]; then
+                    echo "::error::Expected readme changelog entry for $VERSION"
                     exit 1
                   fi
 
@@ -207,6 +218,7 @@ jobs:
                     echo "- Plugin header version: \`$plugin_version\`"
                     echo "- \`CORTEXT_VERSION\`: \`$constant_version\`"
                     echo "- Stable tag: \`$stable_tag\`"
+                    echo "- Changelog entry: \`$changelog_version\`"
                     echo "- Required runtime files: present"
                     echo "- Source and development-only paths: absent"
                   } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,23 @@ jobs:
                   VERSION: ${{ steps.milestone.outputs.version }}
               run: node scripts/bump-release-version.mjs "$VERSION"
 
+            - name: Update WordPress.org changelog
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  MILESTONE: ${{ steps.milestone.outputs.title }}
+                  REPOSITORY: ${{ github.repository }}
+                  VERSION: ${{ steps.milestone.outputs.version }}
+              run: |
+                  mkdir -p .context
+                  node scripts/release-notes.mjs \
+                    --repo "$REPOSITORY" \
+                    --milestone "$MILESTONE" \
+                    --version "$VERSION" \
+                    --strict > .context/release-notes.md
+                  node scripts/update-readme-changelog.mjs \
+                    "$VERSION" \
+                    .context/release-notes.md
+
             - name: Commit release metadata
               if: ${{ ! inputs.dry_run }}
               env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
                   fi
 
                   php_paths='^(\.github/workflows/unit-tests\.yml|composer\.(json|lock)|phpunit\.xml\.dist|cortext\.php|includes/|templates/|tests/php/)'
-                  js_paths='^(\.github/workflows/unit-tests\.yml|package\.json|pnpm-lock\.yaml|jest\.config\.js|scripts/(bump-release-version|release-notes)\.mjs|src/|tests/js/|tests/node/)'
+                  js_paths='^(\.github/workflows/unit-tests\.yml|package\.json|pnpm-lock\.yaml|jest\.config\.js|scripts/(bump-release-version|release-notes|update-readme-changelog)\.mjs|src/|tests/js/|tests/node/)'
 
                   if [ -n "$changed_files" ] && grep -Eq "$php_paths" <<< "$changed_files"; then
                     echo "php_changed=true" >> "$GITHUB_OUTPUT"

--- a/docs/release.md
+++ b/docs/release.md
@@ -127,11 +127,14 @@ Release.
 
 "Prepare release" first updates the plugin header, `CORTEXT_VERSION`,
 `readme.txt` stable tag, root package version, and desktop package versions to
-the requested milestone version. On a real release, it commits those changes as
-`chore: bump release to <version>` before building. It then calls
-`release-plugin.yml` against the bumped commit to build the plugin ZIP, validate
-the milestone, write release notes, and create or update the draft GitHub
-Release.
+the requested milestone version. It also converts the public GitHub release
+notes into WordPress readme markup and inserts the new version at the top of
+`readme.txt`'s changelog. On a real release, it commits those changes as `chore:
+bump release to <version>` before building. It then calls `release-plugin.yml`
+against the bumped commit to build the plugin ZIP, validate the milestone,
+write release notes, and create or update the draft GitHub Release. The ZIP
+validation fails if either the stable tag or the versioned changelog entry is
+missing.
 
 The version-bump job authenticates with a write-enabled deploy key scoped to
 this repository so it can push the release commit through the `main` ruleset.
@@ -175,6 +178,12 @@ You can still run the same workflow from the Actions tab for reruns and one-off
 deploys. Pass a `version` and choose whether to set `commit`. Without `commit`,
 the workflow stops after the dry run.
 
+For a documentation-only correction after a version has already been published,
+set `readme_only` as well. This updates only `readme.txt` in SVN `trunk` and the
+existing `tags/<version>` directory; it does not replace plugin runtime files or
+create another release tag. Review the dry run and approve the `wordpress-org`
+environment as usual.
+
 The script downloads the GitHub Release ZIP, syncs it into `trunk/`, copies
 `assets/wordpress-org/` into the SVN assets directory, removes deleted SVN
 entries, creates `tags/<version>`, and checks that the plugin header,
@@ -195,6 +204,12 @@ To publish from your machine instead of GitHub Actions:
 
 ```bash
 pnpm run deploy:wporg -- --version <version> --commit --username <wporg-user>
+```
+
+To stage a readme-only correction for an existing release:
+
+```bash
+pnpm run deploy:wporg -- --version <version> --readme-only
 ```
 
 When we add another distribution channel, such as a desktop update feed, give it

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,38 @@ Notion's Terms of Service (https://www.notion.so/28ffdd083dc3473e9c2da6ec011b58a
 
 == Changelog ==
 
+= 0.2.0 =
+Enhancements:
+
+**Canvas**
+
+* Add inline document mentions. ([#376](https://github.com/Automattic/cortext/pull/376))
+* Add backlinks for document mentions. ([#379](https://github.com/Automattic/cortext/pull/379))
+
+**Collections**
+
+* Add formula fields to collections. ([#274](https://github.com/Automattic/cortext/pull/274))
+
+**Shell**
+
+* Add sidebar settings view mode. ([#385](https://github.com/Automattic/cortext/pull/385))
+* Add experiment controls to Cortext settings. ([#388](https://github.com/Automattic/cortext/pull/388))
+
+**Desktop**
+
+* Desktop: Add desktop auto-updates. ([#381](https://github.com/Automattic/cortext/pull/381))
+* Desktop: authenticate local runtime requests. ([#397](https://github.com/Automattic/cortext/pull/397))
+* Desktop: assign each profile a runtime origin. ([#403](https://github.com/Automattic/cortext/pull/403))
+* Desktop: Remove POSIX dependencies from snapshots and runtime. ([#404](https://github.com/Automattic/cortext/pull/404))
+* Desktop: Build the snapshot on Windows. ([#405](https://github.com/Automattic/cortext/pull/405))
+* Desktop: lock down and test the packaged app. ([#407](https://github.com/Automattic/cortext/pull/407))
+
+**Performance**
+
+* Performance: Calculate table footer totals on the server. ([#378](https://github.com/Automattic/cortext/pull/378))
+* Perf: Lazy-load and paginate the sidebar tree. ([#380](https://github.com/Automattic/cortext/pull/380))
+* Perf: Add an ID-only response for rows. ([#393](https://github.com/Automattic/cortext/pull/393))
+
 = 0.1.1 =
 Patch release for the 0.1 beta line. In this release:
 

--- a/scripts/deploy-wporg.sh
+++ b/scripts/deploy-wporg.sh
@@ -7,6 +7,7 @@ cd "$(dirname "$0")/.."
 root_dir=$PWD
 version=
 mode=dry-run
+deploy_scope=release
 repo=${GITHUB_REPOSITORY:-Automattic/cortext}
 svn_url=${WPORG_SVN_URL:-https://plugins.svn.wordpress.org/cortext}
 wporg_username=${WPORG_USERNAME:-}
@@ -18,11 +19,13 @@ usage() {
 Usage:
   scripts/deploy-wporg.sh --version <version> [--dry-run]
   scripts/deploy-wporg.sh --version <version> --commit --username <wporg-user>
+  scripts/deploy-wporg.sh --version <version> --readme-only [--commit]
 
 Options:
   --version <version>   Release version, for example 0.2.0.
   --dry-run             Stage and validate the SVN deploy without committing.
   --commit              Commit the staged deploy to WordPress.org SVN.
+  --readme-only         Update readme.txt in trunk and an existing version tag.
   --username <user>     WordPress.org SVN username. Defaults to WPORG_USERNAME.
   --work-dir <path>     Scratch directory. Defaults to .context/wporg-deploy/<version>.
   --repo <owner/repo>   GitHub repo that owns the release ZIP.
@@ -69,6 +72,10 @@ while [ "$#" -gt 0 ]; do
 			mode=commit
 			shift
 			;;
+		--readme-only)
+			deploy_scope=readme
+			shift
+			;;
 		--username)
 			[ "$#" -ge 2 ] || die "--username needs a value"
 			wporg_username=$2
@@ -107,11 +114,19 @@ if [ "$mode" = commit ] && [ -n "${WPORG_PASSWORD:-}" ] && [ -z "$wporg_username
 	die "WPORG_PASSWORD requires --username or WPORG_USERNAME"
 fi
 
-for command in gh svn unzip rsync awk diff find jq; do
+required_commands=( svn awk )
+if [ "$deploy_scope" = release ]; then
+	required_commands+=( gh unzip rsync diff find jq )
+fi
+for command in "${required_commands[@]}"; do
 	require_command "$command"
 done
 
-default_work_dir="$root_dir/.context/wporg-deploy/$version"
+work_dir_suffix=$version
+if [ "$deploy_scope" = readme ]; then
+	work_dir_suffix="$version-readme"
+fi
+default_work_dir="$root_dir/.context/wporg-deploy/$work_dir_suffix"
 work_dir=${work_dir:-$default_work_dir}
 
 if [ "$work_dir" = "$default_work_dir" ]; then
@@ -120,75 +135,95 @@ elif [ -e "$work_dir" ]; then
 	die "Work dir already exists: $work_dir"
 fi
 
-release_dir="$work_dir/release"
-unpack_dir="$work_dir/unpacked"
 svn_dir="$work_dir/svn"
-zip_path="$release_dir/$asset_name"
+mkdir -p "$work_dir"
 
-mkdir -p "$release_dir" "$unpack_dir"
+if [ "$deploy_scope" = release ]; then
+	release_dir="$work_dir/release"
+	unpack_dir="$work_dir/unpacked"
+	zip_path="$release_dir/$asset_name"
+	mkdir -p "$release_dir" "$unpack_dir"
 
-echo "Downloading $asset_name from $repo release $version"
-gh release download "$version" \
-	--repo "$repo" \
-	--pattern "$asset_name" \
-	--dir "$release_dir" \
-	--clobber
+	echo "Downloading $asset_name from $repo release $version"
+	gh release download "$version" \
+		--repo "$repo" \
+		--pattern "$asset_name" \
+		--dir "$release_dir" \
+		--clobber
 
-assert_file "$zip_path"
-unzip -q "$zip_path" -d "$unpack_dir"
+	assert_file "$zip_path"
+	unzip -q "$zip_path" -d "$unpack_dir"
 
-plugin_dir="$unpack_dir/cortext"
-assert_dir "$plugin_dir"
+	plugin_dir="$unpack_dir/cortext"
+	assert_dir "$plugin_dir"
 
-plugin_version=$(awk -F': *' '/^[[:space:]]+\* Version:/ { print $2; exit }' "$plugin_dir/cortext.php")
-constant_version=$(sed -n "s/.*define( 'CORTEXT_VERSION', '\([^']*\)' ).*/\1/p" "$plugin_dir/cortext.php")
+	plugin_version=$(awk -F': *' '/^[[:space:]]+\* Version:/ { print $2; exit }' "$plugin_dir/cortext.php")
+	constant_version=$(sed -n "s/.*define( 'CORTEXT_VERSION', '\([^']*\)' ).*/\1/p" "$plugin_dir/cortext.php")
+
+	[ "$plugin_version" = "$version" ] ||
+		die "Plugin header version is $plugin_version, expected $version"
+	[ "$constant_version" = "$version" ] ||
+		die "CORTEXT_VERSION is $constant_version, expected $version"
+
+	for path in \
+		cortext.php \
+		readme.txt \
+		composer.json \
+		vendor/autoload.php \
+		build/index.js; do
+		assert_file "$plugin_dir/$path"
+	done
+
+	if find "$plugin_dir" \( \
+		-path '*/.github/*' -o \
+		-path '*/apps/*' -o \
+		-path '*/node_modules/*' -o \
+		-path '*/src/*' -o \
+		-path '*/tests/*' -o \
+		-name composer.lock -o \
+		-name package.json -o \
+		-name pnpm-lock.yaml -o \
+		-name "$asset_name" -o \
+		-name .DS_Store \
+		\) -print | grep .; then
+		die "Release ZIP contains development-only files"
+	fi
+
+	asset_dir="$root_dir/assets/wordpress-org"
+	for path in \
+		banner-1544x500.png \
+		banner-772x250.png \
+		icon-128x128.png \
+		icon-256x256.png \
+		screenshot-1.jpg \
+		blueprints/blueprint.json; do
+		assert_file "$asset_dir/$path"
+	done
+	jq empty "$asset_dir/blueprints/blueprint.json"
+else
+	plugin_dir=$root_dir
+	assert_file "$plugin_dir/readme.txt"
+fi
+
 stable_tag=$(awk -F': *' '/^Stable tag:/ { print $2; exit }' "$plugin_dir/readme.txt")
-
-[ "$plugin_version" = "$version" ] ||
-	die "Plugin header version is $plugin_version, expected $version"
-[ "$constant_version" = "$version" ] ||
-	die "CORTEXT_VERSION is $constant_version, expected $version"
 [ "$stable_tag" = "$version" ] ||
 	die "Stable tag is $stable_tag, expected $version"
 
-for path in \
-	cortext.php \
-	readme.txt \
-	composer.json \
-	vendor/autoload.php \
-	build/index.js; do
-	assert_file "$plugin_dir/$path"
-done
-
-if find "$plugin_dir" \( \
-	-path '*/.github/*' -o \
-	-path '*/apps/*' -o \
-	-path '*/node_modules/*' -o \
-	-path '*/src/*' -o \
-	-path '*/tests/*' -o \
-	-name composer.lock -o \
-	-name package.json -o \
-	-name pnpm-lock.yaml -o \
-	-name "$asset_name" -o \
-	-name .DS_Store \
-	\) -print | grep .; then
-	die "Release ZIP contains development-only files"
+if ! awk -v version="$version" '$0 == "= " version " =" { found = 1 } END { exit !found }' "$plugin_dir/readme.txt"; then
+	die "readme.txt has no changelog entry for $version"
 fi
 
-asset_dir="$root_dir/assets/wordpress-org"
-for path in \
-	banner-1544x500.png \
-	banner-772x250.png \
-	icon-128x128.png \
-	icon-256x256.png \
-	screenshot-1.jpg \
-	blueprints/blueprint.json; do
-	assert_file "$asset_dir/$path"
-done
-jq empty "$asset_dir/blueprints/blueprint.json"
-
 tag_name=$version
+tag_exists=false
 if svn ls "$svn_url/tags/$version" >/dev/null 2>&1; then
+	tag_exists=true
+fi
+
+if [ "$deploy_scope" = readme ] && [ "$tag_exists" = false ]; then
+	die "SVN tag does not exist: $svn_url/tags/$version"
+fi
+
+if [ "$deploy_scope" = release ] && [ "$tag_exists" = true ]; then
 	if [ "$mode" = commit ]; then
 		die "SVN tag already exists: $svn_url/tags/$version"
 	fi
@@ -199,32 +234,67 @@ fi
 
 echo "Checking out $svn_url"
 svn checkout --depth immediates "$svn_url" "$svn_dir" >/dev/null
-svn update --set-depth infinity "$svn_dir/trunk" "$svn_dir/assets" >/dev/null
 
-rsync -a --delete "$plugin_dir/" "$svn_dir/trunk/"
-rsync -a --delete "$asset_dir/" "$svn_dir/assets/"
+if [ "$deploy_scope" = release ]; then
+	svn update --set-depth infinity "$svn_dir/trunk" "$svn_dir/assets" >/dev/null
 
-svn status "$svn_dir/trunk" "$svn_dir/assets" |
-	awk '/^!/ { print substr($0, 9) }' |
-	while IFS= read -r path; do
-		[ -z "$path" ] || svn rm "$path"
-	done
+	rsync -a --delete "$plugin_dir/" "$svn_dir/trunk/"
+	rsync -a --delete "$asset_dir/" "$svn_dir/assets/"
 
-svn add --force "$svn_dir/trunk" "$svn_dir/assets" >/dev/null
-svn copy "$svn_dir/trunk" "$svn_dir/tags/$tag_name" >/dev/null
+	svn status "$svn_dir/trunk" "$svn_dir/assets" |
+		awk '/^!/ { print substr($0, 9) }' |
+		while IFS= read -r path; do
+			[ -z "$path" ] || svn rm "$path"
+		done
 
-diff -qr "$svn_dir/trunk" "$svn_dir/tags/$tag_name" >/dev/null ||
-	die "SVN tag contents differ from trunk"
+	svn add --force "$svn_dir/trunk" "$svn_dir/assets" >/dev/null
+	svn copy "$svn_dir/trunk" "$svn_dir/tags/$tag_name" >/dev/null
 
-if [ -z "$(svn status "$svn_dir")" ]; then
-	die "No SVN changes staged"
+	diff -qr "$svn_dir/trunk" "$svn_dir/tags/$tag_name" >/dev/null ||
+		die "SVN tag contents differ from trunk"
+
+	status_paths=( "$svn_dir" )
+	commit_message="Release Cortext $version"
+else
+	svn update --set-depth files "$svn_dir/trunk" >/dev/null
+	svn update --set-depth immediates "$svn_dir/tags" >/dev/null
+	svn update --set-depth files "$svn_dir/tags/$version" >/dev/null
+
+	cp "$plugin_dir/readme.txt" "$svn_dir/trunk/readme.txt"
+	cp "$plugin_dir/readme.txt" "$svn_dir/tags/$version/readme.txt"
+
+	status_paths=(
+		"$svn_dir/trunk/readme.txt"
+		"$svn_dir/tags/$version/readme.txt"
+	)
+	commit_message="Update Cortext $version readme"
+fi
+
+if [ -z "$(svn status "${status_paths[@]}")" ]; then
+	echo "WordPress.org SVN already matches the requested $deploy_scope deploy."
+	exit 0
 fi
 
 echo "SVN status:"
-svn status "$svn_dir"
+svn status "${status_paths[@]}"
+
+if [ "$deploy_scope" = readme ]; then
+	echo "SVN diff:"
+	svn diff "${status_paths[@]}"
+fi
 
 if [ "$mode" = dry-run ]; then
-	if [ "$tag_name" != "$version" ]; then
+	if [ "$deploy_scope" = readme ]; then
+		cat <<EOF
+
+Dry run complete. Nothing was committed to SVN.
+Work dir: $work_dir
+
+The readme was staged in trunk and tags/$version.
+To publish, rerun with:
+  scripts/deploy-wporg.sh --version $version --readme-only --commit --username <wporg-user>
+EOF
+	elif [ "$tag_name" != "$version" ]; then
 		cat <<EOF
 
 Dry run complete. Nothing was committed to SVN.
@@ -248,7 +318,7 @@ EOF
 	exit 0
 fi
 
-commit_args=( commit "$svn_dir" -m "Release Cortext $version" )
+commit_args=( commit "${status_paths[@]}" -m "$commit_message" )
 if [ -n "$wporg_username" ]; then
 	commit_args+=( --username "$wporg_username" )
 fi

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -37,10 +37,10 @@ const OTHER_AREA = 'Other';
 const AREA_ORDER = [
 	'Canvas',
 	'Collections',
+	'Shell',
 	'Desktop',
 	'Performance',
 	'Publishing',
-	'Shell',
 	OTHER_AREA,
 ];
 

--- a/scripts/update-readme-changelog.mjs
+++ b/scripts/update-readme-changelog.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const STOP_SECTIONS = new Set( [
+	'Contributors',
+	'Release note warnings',
+	'Installing the macOS app',
+] );
+
+function assertVersion( version ) {
+	if ( ! VERSION_PATTERN.test( version ) ) {
+		throw new Error(
+			`Release versions must use the WordPress-style format 0.1.0, without a leading "v". Received "${ version }".`
+		);
+	}
+}
+
+export function buildWordPressChangelog( version, releaseNotes ) {
+	assertVersion( version );
+
+	const lines = releaseNotes.replaceAll( '\r\n', '\n' ).split( '\n' );
+	const titleIndex = lines.findIndex(
+		( line ) => line.trim() === `# Cortext ${ version }`
+	);
+	if ( titleIndex === -1 ) {
+		throw new Error(
+			`Release notes must start with the heading "# Cortext ${ version }".`
+		);
+	}
+
+	const changelogLines = [];
+	for ( const line of lines.slice( titleIndex + 1 ) ) {
+		const section = line.match( /^## (.+)$/ );
+		if ( section ) {
+			if ( STOP_SECTIONS.has( section[ 1 ] ) ) {
+				break;
+			}
+			changelogLines.push( `${ section[ 1 ] }:` );
+			continue;
+		}
+
+		const area = line.match( /^### (.+)$/ );
+		if ( area ) {
+			changelogLines.push( `**${ area[ 1 ] }**` );
+			continue;
+		}
+
+		changelogLines.push( line.replace( /^- /, '* ' ) );
+	}
+
+	while ( changelogLines[ 0 ] === '' ) {
+		changelogLines.shift();
+	}
+	while ( changelogLines.at( -1 ) === '' ) {
+		changelogLines.pop();
+	}
+
+	if ( ! changelogLines.length ) {
+		throw new Error( `Release notes for ${ version } have no changelog.` );
+	}
+
+	return `= ${ version } =\n${ changelogLines.join( '\n' ) }\n`;
+}
+
+export function upsertReadmeChangelog( readme, version, releaseNotes ) {
+	const changelog = buildWordPressChangelog( version, releaseNotes );
+	const changelogSection = /^== Changelog ==$/m.exec( readme );
+	if ( ! changelogSection ) {
+		throw new Error(
+			'readme.txt is missing the "== Changelog ==" section.'
+		);
+	}
+
+	const versionHeadings = [
+		...readme.matchAll( /^= (\d+\.\d+\.\d+) =$/gm ),
+	].filter( ( match ) => match.index > changelogSection.index );
+	const existingIndex = versionHeadings.findIndex(
+		( match ) => match[ 1 ] === version
+	);
+
+	if ( existingIndex !== -1 ) {
+		const existing = versionHeadings[ existingIndex ];
+		const next = versionHeadings[ existingIndex + 1 ];
+		const end = next?.index ?? readme.length;
+		return `${ readme.slice(
+			0,
+			existing.index
+		) }${ changelog }\n${ readme.slice( end ) }`;
+	}
+
+	const insertAt = changelogSection.index + changelogSection[ 0 ].length;
+	const remainder = readme.slice( insertAt ).replace( /^\n*/, '' );
+	return `${ readme.slice( 0, insertAt ) }\n\n${ changelog }\n${ remainder }`;
+}
+
+function main() {
+	const [ version, releaseNotesPath, readmePath = 'readme.txt' ] =
+		process.argv.slice( 2 );
+	if ( ! version || ! releaseNotesPath ) {
+		throw new Error(
+			'Usage: node scripts/update-readme-changelog.mjs <version> <release-notes-path> [readme-path]'
+		);
+	}
+
+	const releaseNotes = fs.readFileSync( releaseNotesPath, 'utf8' );
+	const readme = fs.readFileSync( readmePath, 'utf8' );
+	fs.writeFileSync(
+		readmePath,
+		upsertReadmeChangelog( readme, version.trim(), releaseNotes )
+	);
+}
+
+if (
+	process.argv[ 1 ] &&
+	path.resolve( process.argv[ 1 ] ) === fileURLToPath( import.meta.url )
+) {
+	try {
+		main();
+	} catch ( error ) {
+		console.error( error.message );
+		process.exit( 1 );
+	}
+}

--- a/tests/node/release-notes.test.mjs
+++ b/tests/node/release-notes.test.mjs
@@ -111,6 +111,33 @@ describe( 'release notes', () => {
 		);
 	} );
 
+	it( 'uses product order for areas', () => {
+		const notes = buildReleaseNotes(
+			[
+				pullRequest( 24, 'feat: add desktop app', [
+					'type: enhancement',
+					'area: desktop',
+				] ),
+				pullRequest( 25, 'feat: add shell setting', [
+					'type: enhancement',
+					'area: shell',
+				] ),
+				pullRequest( 26, 'feat: improve collection speed', [
+					'type: enhancement',
+					'area: performance',
+				] ),
+			],
+			{ ...baseOptions, strict: true }
+		);
+
+		assert.ok(
+			notes.indexOf( '### Shell' ) < notes.indexOf( '### Desktop' )
+		);
+		assert.ok(
+			notes.indexOf( '### Desktop' ) < notes.indexOf( '### Performance' )
+		);
+	} );
+
 	it( 'groups full release notes by type and area', () => {
 		const notes = buildReleaseNotes(
 			[

--- a/tests/node/update-readme-changelog.test.mjs
+++ b/tests/node/update-readme-changelog.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+	buildWordPressChangelog,
+	upsertReadmeChangelog,
+} from '../../scripts/update-readme-changelog.mjs';
+
+const releaseNotes = `# Cortext 0.2.0
+
+## Enhancements
+
+### Canvas
+
+- Add inline document mentions. ([#376](https://github.com/Automattic/cortext/pull/376))
+
+### Collections
+
+- Add formula fields to collections. ([#274](https://github.com/Automattic/cortext/pull/274))
+
+## Contributors
+
+@priethor
+
+## Installing the macOS app
+
+Move Cortext to Applications before opening it.
+`;
+
+describe( 'update WordPress readme changelog', () => {
+	it( 'converts public GitHub release notes to WordPress readme markup', () => {
+		assert.equal(
+			buildWordPressChangelog( '0.2.0', releaseNotes ),
+			`= 0.2.0 =
+Enhancements:
+
+**Canvas**
+
+* Add inline document mentions. ([#376](https://github.com/Automattic/cortext/pull/376))
+
+**Collections**
+
+* Add formula fields to collections. ([#274](https://github.com/Automattic/cortext/pull/274))
+`
+		);
+	} );
+
+	it( 'inserts a new version at the top of the changelog', () => {
+		const readme = `=== Cortext ===
+
+== Changelog ==
+
+= 0.1.1 =
+Previous release.
+`;
+
+		const updated = upsertReadmeChangelog( readme, '0.2.0', releaseNotes );
+
+		assert.match(
+			updated,
+			/== Changelog ==\n\n= 0\.2\.0 =[\s\S]*\n= 0\.1\.1 =/
+		);
+	} );
+
+	it( 'replaces an existing version idempotently', () => {
+		const stale = `=== Cortext ===
+
+== Changelog ==
+
+= 0.2.0 =
+Stale notes.
+
+= 0.1.1 =
+Previous release.
+`;
+
+		const updated = upsertReadmeChangelog( stale, '0.2.0', releaseNotes );
+		assert.doesNotMatch( updated, /Stale notes/ );
+		assert.equal(
+			upsertReadmeChangelog( updated, '0.2.0', releaseNotes ),
+			updated
+		);
+	} );
+
+	it( 'rejects a readme without a changelog section', () => {
+		assert.throws(
+			() =>
+				upsertReadmeChangelog(
+					'=== Cortext ===\n',
+					'0.2.0',
+					releaseNotes
+				),
+			/missing the "== Changelog ==" section/
+		);
+	} );
+} );


### PR DESCRIPTION
## What

Add the 0.2.0 notes to the WordPress.org readme and generate future GitHub and WordPress changelogs from the same milestone data. Release ZIP validation now catches a missing versioned changelog entry.

## Why

Cortext 0.2.0 reached WordPress.org with the correct stable tag, but its changelog still ended at 0.1.1.

## How

- Supporting readme-only SVN updates for published versions without replacing plugin files.
- Keeping release sections in product order, with Shell before Desktop.

## Testing Instructions

1. Run a readme-only dry run for version 0.2.0.
2. Confirm the SVN status lists only `trunk/readme.txt` and `tags/0.2.0/readme.txt`.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.