### PR TITLE
Desktop: Use four PHP workers by default

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -135,8 +135,9 @@ CORTEXT_RUNTIME=php-fpm npm --prefix apps/desktop start
 
 `php` is the default. It uses `apps/desktop/runtime/bin/php` first, then
 falls back to `php` on `PATH`. Set `CORTEXT_PHP_BIN` to force a specific
-binary. Set `CORTEXT_PHP_CLI_SERVER_WORKERS=4` to run PHP's built-in server
-with worker children for request-heavy pages.
+binary. PHP's built-in server runs four worker children so request-heavy pages
+do not serialize; set `CORTEXT_PHP_CLI_SERVER_WORKERS` to change the count.
+Windows always uses a single worker.
 
 `franken` expects FrankenPHP at `apps/desktop/runtime/bin/frankenphp`, on
 `PATH`, or at `CORTEXT_FRANKENPHP_BIN`. Install the local binary with:

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -17,6 +17,10 @@ const LEGACY_PORT = 9402;
 const RUNTIME_PORT_FIRST = 9403;
 const RUNTIME_PORT_LAST = 9498;
 const DEFAULT_READY_PATH = '/wp-includes/images/blank.gif';
+// The Library hydrates several DataViews at once and opening a row fans out into
+// more requests. A single-worker built-in server serializes that burst, so the
+// desktop runtime forks a small pool. Override with the env vars read below.
+const DEFAULT_PHP_CLI_SERVER_WORKERS = '4';
 const RUNTIME_AUTH_HEADER = 'X-Cortext-Desktop-Token';
 const RUNTIME_AUTH_ENV = 'CORTEXT_DESKTOP_AUTH_TOKEN';
 const WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS = [ '.COM', '.EXE' ];
@@ -313,9 +317,11 @@ function phpCliWorkerConfig( env = process.env, platform = process.platform ) {
 		};
 	}
 
+	const workers = configured || DEFAULT_PHP_CLI_SERVER_WORKERS;
+
 	return {
-		workers: configured,
-		detached: Number.parseInt( configured || '1', 10 ) > 1,
+		workers,
+		detached: Number.parseInt( workers, 10 ) > 1,
 		ignoredWorkers: null,
 	};
 }

--- a/apps/desktop/scripts/runtime.test.mjs
+++ b/apps/desktop/scripts/runtime.test.mjs
@@ -123,6 +123,14 @@ test( 'POSIX keeps the configured PHP worker count and uses a process group', ()
 	);
 } );
 
+test( 'POSIX forks a worker pool when nothing is configured', () => {
+	assert.deepEqual( phpCliWorkerConfig( {}, 'darwin' ), {
+		workers: '4',
+		detached: true,
+		ignoredWorkers: null,
+	} );
+} );
+
 test( 'Windows stops processes without POSIX signals', async () => {
 	const child = new FakeChild();
 	const stopped = waitForProcessExit( child, {


### PR DESCRIPTION
## What

Part of #205.

The desktop app now starts PHP's built-in server with four workers on macOS and Linux instead of one. The existing environment variables can still override that default, and Windows remains single-worker.

## Why

The Library loads several DataViews in parallel, and opening a row triggers more requests. With one worker, PHP handles those requests one at a time. Our runtime benchmarks already used four workers, but the desktop app never enabled that setting by default.

The change targets request-heavy screens. I ran eight cold boots with each setting, and the time to a visible canvas only changed by about 3%.

## Testing Instructions

1. Start the desktop app from source on macOS or Linux.
2. Open the Library and a few rows, and confirm their content loads normally.
3. Inspect the PHP processes and confirm there is one parent with four workers.
4. Restart with `CORTEXT_PHP_CLI_SERVER_WORKERS=2` and confirm there are two workers.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.
