### PR TITLE
Desktop: Fix the packaged smoke test's canvas wait

### DIFF
--- a/apps/desktop/scripts/packaged-app-smoke.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.mjs
@@ -18,8 +18,6 @@ const CORTEXT_URL_PATTERN = /\/wp-admin\/admin\.php\?page=cortext(?:&|$)/;
 const CORTEXT_ROOT_SELECTOR = '#cortext-root';
 const ACTIVE_CANVAS_SELECTOR =
 	'.cortext-workspace__pane[data-active="true"] .cortext-canvas';
-const ACTIVE_CANVAS_LOADING_SELECTOR =
-	'.cortext-workspace__pane[data-active="true"] .cortext-canvas__loading';
 const START_TIMEOUT_MS = 120_000;
 const EXIT_TIMEOUT_MS = 30_000;
 const POLL_INTERVAL_MS = 250;
@@ -306,23 +304,51 @@ async function firstRendererPage( browser ) {
 	throw new Error( 'Cortext did not open a renderer page.' );
 }
 
-async function waitForCortextShell( page ) {
-	await page.waitForURL( CORTEXT_URL_PATTERN, {
-		timeout: START_TIMEOUT_MS,
-		waitUntil: 'domcontentloaded',
-	} );
-	await page.locator( CORTEXT_ROOT_SELECTOR ).waitFor( {
-		state: 'visible',
-		timeout: 30_000,
-	} );
-	await page.locator( ACTIVE_CANVAS_LOADING_SELECTOR ).waitFor( {
-		state: 'hidden',
-		timeout: 30_000,
-	} );
-	await page.locator( ACTIVE_CANVAS_SELECTOR ).waitFor( {
-		state: 'visible',
-		timeout: 30_000,
-	} );
+// Every milestone here shares the cold-start budget. The app is unpacking the
+// snapshot, installing WordPress and compiling PHP for the first time, and the
+// canvas is the last thing to land, so it needs at least as long as the URL it
+// depends on.
+//
+// The canvas replaces the loading pane rather than appearing beside it, and both
+// selectors need an active pane, so a visible canvas already means the load
+// finished. Waiting on the loader separately would pass against a pane that has
+// not mounted yet, since Playwright counts an absent element as hidden.
+export async function waitForCortextShell( page ) {
+	const started = Date.now();
+	const milestones = [];
+	const reached = ( name ) =>
+		milestones.push( `${ name } ${ Date.now() - started }ms` );
+
+	try {
+		await page.waitForURL( CORTEXT_URL_PATTERN, {
+			timeout: START_TIMEOUT_MS,
+			waitUntil: 'domcontentloaded',
+		} );
+		reached( 'url' );
+
+		await page.locator( CORTEXT_ROOT_SELECTOR ).waitFor( {
+			state: 'visible',
+			timeout: START_TIMEOUT_MS,
+		} );
+		reached( 'shell' );
+
+		await page.locator( ACTIVE_CANVAS_SELECTOR ).waitFor( {
+			state: 'visible',
+			timeout: START_TIMEOUT_MS,
+		} );
+		reached( 'canvas' );
+	} catch ( error ) {
+		// A bare locator timeout cannot distinguish a slow agent from a wedged
+		// one. Report how far the boot got so the first failure is diagnosable.
+		appendErrorDetails(
+			error,
+			`Shell milestones: ${ milestones.join( ', ' ) || 'none reached' }\n` +
+				`Gave up after ${ Date.now() - started }ms.`
+		);
+		throw error;
+	}
+
+	console.log( `Cortext shell ready: ${ milestones.join( ', ' ) }.` );
 }
 
 async function assertRuntimeIsClosed( runtimeOrigin ) {

--- a/apps/desktop/scripts/packaged-app-smoke.test.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.test.mjs
@@ -3,7 +3,11 @@ import http from 'node:http';
 import { once } from 'node:events';
 import test from 'node:test';
 
-import { appendErrorDetails, request } from './packaged-app-smoke.mjs';
+import {
+	appendErrorDetails,
+	request,
+	waitForCortextShell,
+} from './packaged-app-smoke.mjs';
 
 test( 'keeps packaged output in an already rendered error stack', () => {
 	const error = new Error( 'Canvas did not load.' );
@@ -13,6 +17,39 @@ test( 'keeps packaged output in an already rendered error stack', () => {
 
 	assert.match( error.message, /Packaged app output:\nPHP failed\./ );
 	assert.match( error.stack, /Packaged app output:\nPHP failed\./ );
+} );
+
+// Resolves the first `succeed` waits, then times out like Playwright would.
+function fakePage( succeed ) {
+	let calls = 0;
+	const step = async () => {
+		if ( calls++ >= succeed ) {
+			throw new Error( 'locator.waitFor: Timeout 120000ms exceeded.' );
+		}
+	};
+	return { waitForURL: step, locator: () => ( { waitFor: step } ) };
+}
+
+test( 'shell wait reports the milestones it reached before timing out', async () => {
+	await assert.rejects( waitForCortextShell( fakePage( 2 ) ), ( error ) => {
+		assert.match(
+			error.message,
+			/Shell milestones: url \d+ms, shell \d+ms\n/
+		);
+		assert.match( error.message, /Gave up after \d+ms\./ );
+		return true;
+	} );
+} );
+
+test( 'shell wait says so when the boot never reached the first milestone', async () => {
+	await assert.rejects( waitForCortextShell( fakePage( 0 ) ), ( error ) => {
+		assert.match( error.message, /Shell milestones: none reached/ );
+		return true;
+	} );
+} );
+
+test( 'shell wait resolves once the canvas is visible', async () => {
+	await waitForCortextShell( fakePage( 3 ) );
 } );
 
 async function listen( handler ) {


### PR DESCRIPTION
## What

The packaged app smoke test now gives the shell and canvas up to 120 seconds to appear. It also removes a loader check that could pass before the loader existed and records when the URL, shell, and canvas become ready. If startup times out, the log shows the last milestone reached.

## Why

The smoke test has intermittently timed out while waiting for the editor during release builds. Its old error only said that the canvas was missing, which did not tell us whether startup was slow or had stalled.

The 120-second limit is generous on purpose. The milestone timings should tell us what CI actually needs, and we can tighten it later.

## Testing Instructions

Not applicable.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.
