### PR TITLE
Desktop: Skip auto-updates for non-release builds

### DIFF
--- a/apps/desktop/lib/auto-update.js
+++ b/apps/desktop/lib/auto-update.js
@@ -49,6 +49,15 @@ function isTransientNetworkError( err ) {
 	);
 }
 
+// electron-updater reads the running version's prerelease suffix as a release
+// channel, and branch builds are versioned <version>-<sha>. That names a channel
+// no Release carries, so every check ends in "No published versions on GitHub",
+// which reads as a broken Release rather than as a build that was never on the
+// update channel. Leave those builds to the notify-only checker.
+function isReleaseBuild() {
+	return /^\d+\.\d+\.\d+$/.test( app.getVersion() );
+}
+
 // Downloads from a mounted DMG or ~/Downloads cannot replace the running app.
 // Ask the user to move Cortext before starting the update flow.
 function notInApplicationsFolder() {
@@ -181,7 +190,7 @@ function initAutoUpdates( {
 		mainWindow = window ?? mainWindow;
 		return true;
 	}
-	if ( ! app.isPackaged ) {
+	if ( ! app.isPackaged || ! isReleaseBuild() ) {
 		return false;
 	}
 	try {
@@ -244,10 +253,15 @@ function scheduleUpdateCheck( options = {} ) {
 
 function checkForUpdatesInteractive() {
 	if ( ! autoUpdater ) {
+		const branchBuild = ! isReleaseBuild();
 		showMessage( {
 			type: 'info',
-			message: 'Use the installed app for updates',
-			detail: 'Run the installed Cortext app to check for updates.',
+			message: branchBuild
+				? 'This build does not receive updates'
+				: 'Use the installed app for updates',
+			detail: branchBuild
+				? `Cortext ${ app.getVersion() } was built from a branch. Install a release to get updates.`
+				: 'Run the installed Cortext app to check for updates.',
 			buttons: [ 'OK' ],
 		} );
 		return;

--- a/apps/desktop/scripts/auto-update.test.mjs
+++ b/apps/desktop/scripts/auto-update.test.mjs
@@ -5,9 +5,7 @@ import test from 'node:test';
 const require = createRequire( import.meta.url );
 const Module = require( 'node:module' );
 
-function requireWithMocks( modulePath, mocks ) {
-	const resolved = require.resolve( modulePath );
-	delete require.cache[ resolved ];
+function withMocks( mocks, run ) {
 	const originalLoad = Module._load;
 	Module._load = function ( request, parent, isMain ) {
 		if ( Object.hasOwn( mocks, request ) ) {
@@ -17,10 +15,16 @@ function requireWithMocks( modulePath, mocks ) {
 	};
 
 	try {
-		return require( resolved );
+		return run();
 	} finally {
 		Module._load = originalLoad;
 	}
+}
+
+function requireWithMocks( modulePath, mocks ) {
+	const resolved = require.resolve( modulePath );
+	delete require.cache[ resolved ];
+	return withMocks( mocks, () => require( resolved ) );
 }
 
 test( 'E2E mode skips both update checkers', () => {
@@ -53,4 +57,75 @@ test( 'E2E mode skips both update checkers', () => {
 			process.env.CORTEXT_E2E = previousE2E;
 		}
 	}
+} );
+
+function loadUpdater( version ) {
+	const calls = { legacy: 0, checks: 0, dialogs: [] };
+	const mocks = {
+		electron: {
+			app: { isPackaged: true, getVersion: () => version },
+			dialog: {
+				showMessageBox: ( options ) => {
+					calls.dialogs.push( options );
+					return Promise.resolve( { response: 0 } );
+				},
+			},
+		},
+		'./update-check': {
+			scheduleUpdateCheck: () => {
+				calls.legacy += 1;
+			},
+		},
+		'electron-updater': {
+			autoUpdater: {
+				on: () => {},
+				checkForUpdates: () => {
+					calls.checks += 1;
+					return Promise.resolve();
+				},
+			},
+		},
+	};
+	const updater = requireWithMocks( '../lib/auto-update', mocks );
+
+	// electron-updater is required lazily, once a release build asks for it, so
+	// the mocks have to stay installed past the initial require.
+	return {
+		calls,
+		scheduleUpdateCheck: () =>
+			withMocks( mocks, updater.scheduleUpdateCheck ),
+		checkForUpdatesInteractive: () =>
+			withMocks( mocks, updater.checkForUpdatesInteractive ),
+	};
+}
+
+// A branch build's version is <version>-<sha>. electron-updater would read that
+// suffix as a release channel and fail every check, so it never starts.
+test( 'a branch build leaves updates to the notify-only checker', () => {
+	const { scheduleUpdateCheck, calls } = loadUpdater( '0.2.0-b6d0105' );
+
+	scheduleUpdateCheck();
+
+	assert.equal( calls.legacy, 1 );
+	assert.equal( calls.checks, 0 );
+} );
+
+test( 'a release build starts electron-updater', () => {
+	const { scheduleUpdateCheck, calls } = loadUpdater( '0.2.0' );
+
+	scheduleUpdateCheck();
+
+	assert.equal( calls.legacy, 0 );
+	assert.equal( calls.checks, 1 );
+} );
+
+test( 'a branch build says so instead of offering to check', () => {
+	const { checkForUpdatesInteractive, calls } =
+		loadUpdater( '0.2.0-b6d0105' );
+
+	checkForUpdatesInteractive();
+
+	assert.equal( calls.dialogs.length, 1 );
+	assert.match( calls.dialogs[ 0 ].message, /does not receive updates/ );
+	assert.match( calls.dialogs[ 0 ].detail, /0\.2\.0-b6d0105/ );
 } );


### PR DESCRIPTION
## What

Non-release desktop builds no longer try to update themselves. They still check whether a newer release exists, but they do not use the download-and-install flow. "Check for Updates…" now explains that the app came from a branch and recommends installing a release. Tagged release builds keep the regular updater.

## Why

Buildkite versions branch artifacts as `0.2.0-b6d0105`. `electron-updater` treats the SHA after the dash as a release channel, then reports "No published versions on GitHub" because that channel does not exist. A valid artifact ends up looking broken.

## Testing Instructions

1. Open a packaged Buildkite artifact whose version ends in a commit SHA.
2. Choose "Check for Updates…" and confirm Cortext recommends installing a release.
3. Open a tagged release build and confirm the menu runs the usual update check.

---

I used Claude to help implement these changes. I guided the work, then tested and reviewed the result.
