### PR TITLE
Fix: overlapping nested menus in the editor

### DIFF
--- a/src/hooks/useSubmenuPlacement.js
+++ b/src/hooks/useSubmenuPlacement.js
@@ -5,6 +5,54 @@ import {
 	useState,
 } from '@wordpress/element';
 
+// Rects use the viewport of their own document. Move the anchor's right edge
+// into the panel's document before comparing them.
+export function getElementRightInDocument( element, targetDocument ) {
+	let currentDocument = element?.ownerDocument;
+	let right = element?.getBoundingClientRect().right;
+
+	if ( ! currentDocument || ! Number.isFinite( right ) ) {
+		return null;
+	}
+
+	while ( currentDocument !== targetDocument ) {
+		let frameElement;
+		try {
+			frameElement = currentDocument.defaultView?.frameElement;
+		} catch {
+			return null;
+		}
+		if ( ! frameElement ) {
+			return null;
+		}
+
+		const frameRect = frameElement.getBoundingClientRect();
+		let cssWidth = 0;
+		let paddingLeft = 0;
+		try {
+			const style =
+				frameElement.ownerDocument.defaultView?.getComputedStyle(
+					frameElement
+				);
+			cssWidth = parseFloat( style?.width ) || 0;
+			paddingLeft = parseFloat( style?.paddingLeft ) || 0;
+		} catch {}
+		if ( Math.round( cssWidth ) !== frameElement.offsetWidth ) {
+			cssWidth = frameElement.offsetWidth;
+		}
+		let scaleX = frameRect.width / cssWidth;
+		if ( ! scaleX || ! Number.isFinite( scaleX ) ) {
+			scaleX = 1;
+		}
+		right =
+			frameRect.left +
+			( ( frameElement.clientLeft || 0 ) + paddingLeft + right ) * scaleX;
+		currentDocument = frameElement.ownerDocument;
+	}
+
+	return right;
+}
+
 // Picks a `Popover` placement for a row submenu inside a cascading menu,
 // adjusting after render if the chosen side overflows the viewport.
 // See docs/tech-debt.md#td-wp-menu-popover-limitations.
@@ -41,8 +89,12 @@ export function useSubmenuPlacement( outerAnchor, panelRef ) {
 			const panel = panelRef.current;
 			if ( panel && outerAnchor ) {
 				const panelLeft = panel.getBoundingClientRect().left;
-				const anchorRight = outerAnchor.getBoundingClientRect().right;
-				const outerFlipped = panelLeft + 1 < anchorRight;
+				const anchorRight = getElementRightInDocument(
+					outerAnchor,
+					panel.ownerDocument
+				);
+				const outerFlipped =
+					anchorRight !== null && panelLeft + 1 < anchorRight;
 				setPlacement( outerFlipped ? 'left-start' : 'right-start' );
 			}
 			setOpenKey( key );
@@ -59,7 +111,9 @@ export function useSubmenuPlacement( outerAnchor, panelRef ) {
 			return;
 		}
 		const rect = submenu.getBoundingClientRect();
-		if ( placement === 'right-start' && rect.right > window.innerWidth ) {
+		const viewportWidth =
+			submenu.ownerDocument.defaultView?.innerWidth ?? window.innerWidth;
+		if ( placement === 'right-start' && rect.right > viewportWidth ) {
 			setPlacement( 'left-start' );
 			return;
 		}

--- a/tests/e2e/specs/data-view-block.spec.js
+++ b/tests/e2e/specs/data-view-block.spec.js
@@ -3543,23 +3543,40 @@ test.describe( 'Collection view block', () => {
 			} );
 			await expect( yearLabelButton ).toHaveCSS( 'cursor', 'pointer' );
 			await yearLabelButton.click();
-			await expect(
-				detailCanvas.getByRole( 'menuitem', {
-					name: 'Format',
-				} )
-			).toBeVisible();
-			await detailCanvas
-				.getByRole( 'menuitem', {
-					name: 'Format',
-				} )
-				.click();
+			const formatItem = detailCanvas.getByRole( 'menuitem', {
+				name: 'Format',
+			} );
+			await expect( formatItem ).toBeVisible();
+			const formatItemBox = await formatItem.boundingBox();
+			await formatItem.click();
 			const formatPanel = page.locator( '.cortext-format-submenu' );
 			await expect( formatPanel ).toBeVisible();
+			const formatPanelSurface = page.locator(
+				'.cortext-format-submenu__panel'
+			);
+			const formatPanelBox = await formatPanelSurface.boundingBox();
+			expect( formatItemBox ).not.toBeNull();
+			expect( formatPanelBox ).not.toBeNull();
+			// `boundingBox()` puts both rects in page coordinates. The detail
+			// panel sits at the right edge, so Format and its flyout should open
+			// to the left.
+			expect(
+				formatPanelBox.x + formatPanelBox.width
+			).toBeLessThanOrEqual( formatItemBox.x + 2 );
 			await formatPanel
 				.getByRole( 'button', { name: /Number format/ } )
 				.click();
-			await page
-				.locator( '.cortext-format-submenu__flyout' )
+			const numberFormatFlyout = page.locator(
+				'.cortext-format-submenu__flyout'
+			);
+			await expect( numberFormatFlyout ).toBeVisible();
+			const numberFormatFlyoutBox =
+				await numberFormatFlyout.boundingBox();
+			expect( numberFormatFlyoutBox ).not.toBeNull();
+			expect(
+				numberFormatFlyoutBox.x + numberFormatFlyoutBox.width
+			).toBeLessThanOrEqual( formatPanelBox.x + 2 );
+			await numberFormatFlyout
 				.getByRole( 'menuitemradio', {
 					name: 'Number with commas',
 				} )

--- a/tests/js/hooks/useSubmenuPlacement.test.js
+++ b/tests/js/hooks/useSubmenuPlacement.test.js
@@ -24,9 +24,9 @@ describe( 'useSubmenuPlacement', () => {
 		const sourceDocument = { defaultView: {} };
 		const frameElement = {
 			ownerDocument: document,
-			offsetWidth: 140,
+			offsetWidth: 420,
 			clientLeft: 0,
-			getBoundingClientRect: () => mockRect( { left: 480, width: 140 } ),
+			getBoundingClientRect: () => mockRect( { left: 480, width: 420 } ),
 		};
 		sourceDocument.defaultView.frameElement = frameElement;
 
@@ -109,39 +109,5 @@ describe( 'getElementRightInDocument', () => {
 		};
 
 		expect( getElementRightInDocument( element, document ) ).toBe( 410 );
-	} );
-
-	it( 'works through nested, scaled iframes', () => {
-		const middleDocument = { defaultView: {} };
-		const sourceDocument = { defaultView: {} };
-
-		middleDocument.defaultView.frameElement = {
-			ownerDocument: document,
-			offsetWidth: 110,
-			clientLeft: 1,
-			getBoundingClientRect: () => mockRect( { left: 100, width: 220 } ),
-		};
-		sourceDocument.defaultView.frameElement = {
-			ownerDocument: middleDocument,
-			offsetWidth: 100,
-			clientLeft: 2,
-			getBoundingClientRect: () => mockRect( { left: 50, width: 100 } ),
-		};
-
-		const element = {
-			ownerDocument: sourceDocument,
-			getBoundingClientRect: () => mockRect( { left: 10, right: 30 } ),
-		};
-
-		expect( getElementRightInDocument( element, document ) ).toBe( 266 );
-	} );
-
-	it( 'returns null when the target document is not an ancestor', () => {
-		const element = {
-			ownerDocument: { defaultView: { frameElement: null } },
-			getBoundingClientRect: () => mockRect( { left: 10, right: 30 } ),
-		};
-
-		expect( getElementRightInDocument( element, document ) ).toBeNull();
 	} );
 } );

--- a/tests/js/hooks/useSubmenuPlacement.test.js
+++ b/tests/js/hooks/useSubmenuPlacement.test.js
@@ -1,0 +1,147 @@
+import { act, renderHook } from '@testing-library/react';
+
+import {
+	getElementRightInDocument,
+	useSubmenuPlacement,
+} from '../../../src/hooks/useSubmenuPlacement';
+
+function mockRect( values ) {
+	return {
+		x: values.left ?? 0,
+		y: 0,
+		left: values.left ?? 0,
+		top: 0,
+		right: values.right ?? values.left + values.width,
+		bottom: 0,
+		width: values.width ?? values.right - values.left,
+		height: 0,
+		toJSON: () => ( {} ),
+	};
+}
+
+describe( 'useSubmenuPlacement', () => {
+	it( 'opens left when the outer panel flips across an iframe', () => {
+		const sourceDocument = { defaultView: {} };
+		const frameElement = {
+			ownerDocument: document,
+			offsetWidth: 140,
+			clientLeft: 0,
+			getBoundingClientRect: () => mockRect( { left: 480, width: 140 } ),
+		};
+		sourceDocument.defaultView.frameElement = frameElement;
+
+		const outerAnchor = {
+			ownerDocument: sourceDocument,
+			getBoundingClientRect: () => mockRect( { left: 12, right: 233 } ),
+		};
+		const panel = document.createElement( 'div' );
+		panel.getBoundingClientRect = () =>
+			mockRect( { left: 244, width: 240 } );
+		const panelRef = { current: panel };
+
+		const { result } = renderHook( () =>
+			useSubmenuPlacement( outerAnchor, panelRef )
+		);
+
+		act( () => result.current.open( 'number-format' ) );
+
+		expect( result.current.placement ).toBe( 'left-start' );
+		expect( result.current.openKey ).toBe( 'number-format' );
+	} );
+
+	it( 'keeps a panel on the right when both rects share a document', () => {
+		const outerAnchor = document.createElement( 'button' );
+		outerAnchor.getBoundingClientRect = () =>
+			mockRect( { left: 370, right: 602 } );
+		const panel = document.createElement( 'div' );
+		panel.getBoundingClientRect = () =>
+			mockRect( { left: 610, width: 240 } );
+		const panelRef = { current: panel };
+
+		const { result } = renderHook( () =>
+			useSubmenuPlacement( outerAnchor, panelRef )
+		);
+
+		act( () => result.current.open( 'number-format' ) );
+
+		expect( result.current.placement ).toBe( 'right-start' );
+	} );
+
+	it( "uses the submenu's own viewport when checking overflow", () => {
+		const outerAnchor = document.createElement( 'button' );
+		outerAnchor.getBoundingClientRect = () =>
+			mockRect( { left: 100, right: 200 } );
+		const panel = document.createElement( 'div' );
+		panel.getBoundingClientRect = () =>
+			mockRect( { left: 220, width: 80 } );
+		const panelRef = { current: panel };
+		const submenu = {
+			ownerDocument: { defaultView: { innerWidth: 300 } },
+			getBoundingClientRect: () => mockRect( { left: 220, right: 350 } ),
+		};
+
+		const { result } = renderHook( () =>
+			useSubmenuPlacement( outerAnchor, panelRef )
+		);
+		result.current.submenuRef.current = submenu;
+
+		act( () => result.current.open( 'number-format' ) );
+
+		expect( result.current.placement ).toBe( 'left-start' );
+	} );
+} );
+
+describe( 'getElementRightInDocument', () => {
+	it( 'includes iframe borders, padding, and scale', () => {
+		const sourceDocument = { defaultView: {} };
+		const frameElement = document.createElement( 'iframe' );
+		frameElement.style.width = '200px';
+		frameElement.style.paddingLeft = '3px';
+		Object.defineProperty( frameElement, 'offsetWidth', { value: 200 } );
+		Object.defineProperty( frameElement, 'clientLeft', { value: 2 } );
+		frameElement.getBoundingClientRect = () =>
+			mockRect( { left: 300, width: 400 } );
+		sourceDocument.defaultView.frameElement = frameElement;
+
+		const element = {
+			ownerDocument: sourceDocument,
+			getBoundingClientRect: () => mockRect( { left: 10, right: 50 } ),
+		};
+
+		expect( getElementRightInDocument( element, document ) ).toBe( 410 );
+	} );
+
+	it( 'works through nested, scaled iframes', () => {
+		const middleDocument = { defaultView: {} };
+		const sourceDocument = { defaultView: {} };
+
+		middleDocument.defaultView.frameElement = {
+			ownerDocument: document,
+			offsetWidth: 110,
+			clientLeft: 1,
+			getBoundingClientRect: () => mockRect( { left: 100, width: 220 } ),
+		};
+		sourceDocument.defaultView.frameElement = {
+			ownerDocument: middleDocument,
+			offsetWidth: 100,
+			clientLeft: 2,
+			getBoundingClientRect: () => mockRect( { left: 50, width: 100 } ),
+		};
+
+		const element = {
+			ownerDocument: sourceDocument,
+			getBoundingClientRect: () => mockRect( { left: 10, right: 30 } ),
+		};
+
+		expect( getElementRightInDocument( element, document ) ).toBe( 266 );
+	} );
+
+	it( 'returns null when the target document is not an ancestor', () => {
+		const element = {
+			ownerDocument: { defaultView: { frameElement: null } },
+			getBoundingClientRect: () => mockRect( { left: 10, right: 30 } ),
+		};
+
+		expect( getElementRightInDocument( element, document ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
## What

Fix nested formatting and calculation menus that could open over the menu they came from. When a parent panel flips near the viewport edge, its submenus now continue in the same direction.

## Why

These menus can span the editor iframe and the parent page. Their positions were compared using different viewports, so a nested menu could choose the wrong side.

## Testing Instructions

1. Open Library and open a book in the side panel.
2. Click Year, then Format.
3. Open Number format and Decimal places.
4. Verify that both submenus open to the left of Format without covering the other menus.

## Screenshots

| Before | After |
| --- | --- |
| <img width="565" height="358" alt="image" src="https://github.com/user-attachments/assets/c2e657a0-b3b3-4dbb-ab97-e027ff13dea2" /> | <img width="764" height="363" alt="image" src="https://github.com/user-attachments/assets/84311bbf-7d9e-49d7-a8ee-d9fddef6c410" /> |
