### PR TITLE
a11y: Move focus into documents opened from the sidebar

### DIFF
--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -604,7 +604,14 @@ export default function Edit( {
 		context?.postType,
 		context?.postId
 	);
-	const { signalCollectionReady } = useCanvasReadySignals();
+	const {
+		signalCollectionReady,
+		surfaceFocusRequest,
+		isEditorSurfaceDisplayed,
+		isSurfaceFocusPending,
+		isSurfaceFocusReadOnly,
+		completeSurfaceFocus,
+	} = useCanvasReadySignals();
 	const blockProps = useBlockProps( {
 		className: isOwner ? 'is-document-owner' : undefined,
 	} );
@@ -728,6 +735,15 @@ export default function Edit( {
 					view={ view }
 					onChangeView={ setView }
 					onReady={ isOwner ? onCollectionReady : undefined }
+					surfaceFocusRequest={ isOwner ? surfaceFocusRequest : null }
+					isEditorSurfaceDisplayed={
+						isOwner && isEditorSurfaceDisplayed
+					}
+					isSurfaceFocusPending={ isOwner && isSurfaceFocusPending }
+					isSurfaceFocusReadOnly={ isOwner && isSurfaceFocusReadOnly }
+					completeSurfaceFocus={
+						isOwner ? completeSurfaceFocus : undefined
+					}
 					revealFieldId={ revealFieldId }
 					onFieldRevealed={ onFieldRevealed }
 					invalid={

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -182,9 +182,13 @@ function DocumentActions( {
 function VisualCanvas( {
 	featuredMedia,
 	isActive,
+	isEditorSurfaceDisplayed,
 	isLocked = false,
+	isSurfaceFocusPending = false,
 	postId,
 	postType,
+	surfaceFocusRequest,
+	completeSurfaceFocus,
 	onReady,
 	onRestored,
 } ) {
@@ -192,10 +196,14 @@ function VisualCanvas( {
 		<EditorBody
 			featuredMedia={ featuredMedia }
 			isActive={ isActive }
+			isEditorSurfaceDisplayed={ isEditorSurfaceDisplayed }
 			isDocumentCanvas
 			isLocked={ isLocked }
+			isSurfaceFocusPending={ isSurfaceFocusPending }
 			postId={ postId }
 			postType={ postType }
+			surfaceFocusRequest={ surfaceFocusRequest }
+			completeSurfaceFocus={ completeSurfaceFocus }
 			onReady={ onReady }
 			onRestored={ onRestored }
 		/>
@@ -387,6 +395,9 @@ function CanvasEditor( {
 	onSwitchPost,
 	onDisplayedPost,
 	isActive,
+	isEditorSurfaceDisplayed,
+	surfaceFocusRequest,
+	completeSurfaceFocus,
 	topBarActions,
 	notice,
 	onApi,
@@ -549,9 +560,19 @@ function CanvasEditor( {
 						<VisualCanvas
 							featuredMedia={ post.featured_media }
 							isActive={ isActive }
+							isEditorSurfaceDisplayed={
+								isEditorSurfaceDisplayed
+							}
 							isLocked={ postLock.isReadOnly }
+							isSurfaceFocusPending={
+								postLock.isReadOnly &&
+								! postLock.isFailed &&
+								! postLock.isLocked
+							}
 							postId={ post.id }
 							postType={ post.type ?? postType }
+							surfaceFocusRequest={ surfaceFocusRequest }
+							completeSurfaceFocus={ completeSurfaceFocus }
 							onReady={ onDisplayedPost }
 							onRestored={ onRestored }
 						/>
@@ -591,6 +612,9 @@ export default function Canvas( {
 	propertiesResolving = false,
 	onDisplayedPost,
 	isActive,
+	isEditorSurfaceDisplayed = false,
+	surfaceFocusRequest = null,
+	completeSurfaceFocus = null,
 	topBarActions = null,
 	notice = null,
 	onApi,
@@ -783,6 +807,9 @@ export default function Canvas( {
 					onSwitchPost={ switchDisplayedPost }
 					onDisplayedPost={ handleDisplayedPost }
 					isActive={ isActive }
+					isEditorSurfaceDisplayed={ isEditorSurfaceDisplayed }
+					surfaceFocusRequest={ surfaceFocusRequest }
+					completeSurfaceFocus={ completeSurfaceFocus }
 					topBarActions={ topBarActions }
 					notice={ notice }
 					onApi={ onApi }

--- a/src/components/CanvasReadyContext.js
+++ b/src/components/CanvasReadyContext.js
@@ -2,6 +2,11 @@ import { createContext, useContext } from '@wordpress/element';
 
 const EMPTY_SIGNALS = {
 	signalCollectionReady: null,
+	surfaceFocusRequest: null,
+	isEditorSurfaceDisplayed: false,
+	isSurfaceFocusPending: false,
+	isSurfaceFocusReadOnly: false,
+	completeSurfaceFocus: null,
 };
 
 const CanvasReadyContext = createContext( EMPTY_SIGNALS );

--- a/src/components/CollectionDataViewChrome.js
+++ b/src/components/CollectionDataViewChrome.js
@@ -22,6 +22,7 @@ export function DataViewsChrome( { footer } ) {
 					justify="start"
 					expanded={ false }
 					className="dataviews__search"
+					data-cortext-focus-region="search"
 				>
 					<DataViews.Search />
 					<DataViews.FiltersToggle />
@@ -30,6 +31,7 @@ export function DataViewsChrome( { footer } ) {
 					spacing={ 1 }
 					expanded={ false }
 					style={ { flexShrink: 0 } }
+					data-cortext-focus-region="view-controls"
 				>
 					<DataViews.LayoutSwitcher />
 					<DataViews.ViewConfig />

--- a/src/components/CollectionDataViews.js
+++ b/src/components/CollectionDataViews.js
@@ -42,6 +42,7 @@ import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
 } from '../hooks/useDelayedFlag';
 import afterNextPaint from '../hooks/afterNextPaint';
+import { whenViewTransitionsSettled } from '../hooks/viewTransition';
 import allSettledWithConcurrency from './allSettledWithConcurrency';
 import {
 	DEFAULT_LAYOUTS,
@@ -88,6 +89,11 @@ import { useFavorites } from '../hooks/useFavorites';
 import { elementsFromOptions } from '../hooks/optionElements';
 import { notifyDocumentTrashChanged } from '../hooks/documentTrashInvalidation';
 import { notifyCollectionRowsChanged } from '../hooks/rowInvalidation';
+import {
+	getCollectionSurfaceFocusTarget,
+	isCollectionTrulyEmpty,
+	isSurfaceFocusOriginCurrent,
+} from './collectionSurfaceFocus';
 
 const BULK_DELETE_CONCURRENCY = 4;
 // tech-debt.md#td-dataviews-list-row-hooks: DataViews ties list focus to its own selection. Cortext
@@ -106,6 +112,11 @@ export default function CollectionDataViews( {
 	onReady,
 	revealFieldId = null,
 	onFieldRevealed,
+	surfaceFocusRequest = null,
+	isEditorSurfaceDisplayed = false,
+	isSurfaceFocusPending = false,
+	isSurfaceFocusReadOnly = false,
+	completeSurfaceFocus,
 } ) {
 	const { fields, collection, isResolving, fieldsResolved } =
 		useCollectionFieldsContext();
@@ -210,6 +221,9 @@ export default function CollectionDataViews( {
 	const showLoadingShell = isShellLoading || holdLoadingShell;
 
 	const tableWrapperRef = useRef( null );
+	const surfaceFocusRequestRef = useRef( surfaceFocusRequest );
+	surfaceFocusRequestRef.current = surfaceFocusRequest;
+	const claimedSurfaceFocusTokenRef = useRef( null );
 	const [ localRevealFieldId, setLocalRevealFieldId ] = useState( null );
 	const pendingRevealFieldId = revealFieldId ?? localRevealFieldId;
 	const requestRevealCreatedField = useCallback( ( created ) => {
@@ -1363,6 +1377,125 @@ export default function CollectionDataViews( {
 		isTableLayout,
 		showLoadingShell,
 		view?.fields,
+	] );
+
+	useEffect( () => {
+		const request = surfaceFocusRequest;
+		const token = request?.token;
+		const isMatchingCollection =
+			request?.documentId !== undefined &&
+			request?.documentId !== null &&
+			String( request.documentId ) === String( collectionId );
+
+		if (
+			! isMatchingCollection ||
+			! isEditorSurfaceDisplayed ||
+			token === undefined ||
+			token === null ||
+			typeof completeSurfaceFocus !== 'function' ||
+			claimedSurfaceFocusTokenRef.current === token
+		) {
+			return undefined;
+		}
+
+		const claimRequest = ( onConsume ) => {
+			claimedSurfaceFocusTokenRef.current = token;
+			return onConsume
+				? completeSurfaceFocus( token, onConsume )
+				: completeSurfaceFocus( token );
+		};
+
+		if ( isSurfaceFocusPending ) {
+			return undefined;
+		}
+
+		if ( isSurfaceFocusReadOnly ) {
+			claimRequest();
+			return undefined;
+		}
+
+		// These states have no primary action, so consume the request without
+		// moving focus to a notice.
+		if (
+			( ! isResolving && collectionId && ! collection ) ||
+			( ! isResolving && rowError )
+		) {
+			claimRequest();
+			return undefined;
+		}
+
+		if (
+			isResolving ||
+			! fieldsResolved ||
+			! rowsResolved ||
+			showLoadingShell
+		) {
+			return undefined;
+		}
+
+		let cancelled = false;
+		async function focusCollectionSurface() {
+			const root = tableWrapperRef.current;
+			const ownerWindow = root?.ownerDocument?.defaultView;
+			await whenViewTransitionsSettled( 0 );
+			await afterNextPaint( ownerWindow );
+
+			if ( cancelled ) {
+				return;
+			}
+
+			const currentRequest = surfaceFocusRequestRef.current;
+			if ( currentRequest?.token !== token ) {
+				return;
+			}
+
+			// If focus moves while rows or the transition settle, consume the stale
+			// request without moving it again.
+			if (
+				! isSurfaceFocusOriginCurrent( currentRequest.originElement )
+			) {
+				claimRequest();
+				return;
+			}
+
+			const currentRoot = tableWrapperRef.current;
+			const target = getCollectionSurfaceFocusTarget( currentRoot, {
+				isTrulyEmpty: isCollectionTrulyEmpty( {
+					rowsResolved,
+					totalItems: activePaginationInfo?.totalItems,
+					view,
+				} ),
+				layoutType: view?.type,
+			} );
+
+			// Claim the request before focusing the target. Otherwise, its `focusin`
+			// event would cancel the request while it is still pending.
+			claimRequest( () => {
+				if ( target && currentRoot?.contains( target ) ) {
+					target.focus();
+				}
+			} );
+		}
+
+		focusCollectionSurface();
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		activePaginationInfo?.totalItems,
+		collection,
+		collectionId,
+		completeSurfaceFocus,
+		fieldsResolved,
+		isEditorSurfaceDisplayed,
+		isResolving,
+		isSurfaceFocusPending,
+		isSurfaceFocusReadOnly,
+		rowError,
+		rowsResolved,
+		showLoadingShell,
+		surfaceFocusRequest,
+		view,
 	] );
 
 	useEffect( () => {

--- a/src/components/EditorBody.js
+++ b/src/components/EditorBody.js
@@ -43,7 +43,9 @@ import {
 } from './CanvasOwnerInspector';
 import MediaPicker, { MediaUploadCheck } from './MediaPicker';
 import { parseDocumentIcon } from './DocumentIcon';
+import { isSurfaceFocusOriginCurrent } from './collectionSurfaceFocus';
 import afterNextPaint from '../hooks/afterNextPaint';
+import { whenViewTransitionsSettled } from '../hooks/viewTransition';
 
 const DOCUMENT_ICON_BLOCK = 'cortext/document-icon';
 const DOCUMENT_COVER_BLOCK = 'cortext/document-cover';
@@ -323,6 +325,64 @@ function isHeaderBlock( block, ownerBlockName, record = null, postId = null ) {
 		return true;
 	}
 	return isCanvasOwnerBlock( block, record, postId );
+}
+
+// Choose the block editor target for pages and full-page rows. Focus an empty
+// title; otherwise, focus the first body block. Collections use their own
+// DataViews focus rules.
+export function getDocumentSurfaceFocusClientId( {
+	blocks = [],
+	title = '',
+	ownerBlockName = null,
+	record = null,
+	postId = null,
+} ) {
+	if ( ownerBlockName ) {
+		return null;
+	}
+
+	const titleBlock = blocks.find(
+		( block ) => block?.name === POST_TITLE_BLOCK
+	);
+	if ( String( title ?? '' ).trim() === '' ) {
+		return titleBlock?.clientId ?? null;
+	}
+
+	const firstBodyBlock = blocks.find(
+		( block ) => ! isHeaderBlock( block, ownerBlockName, record, postId )
+	);
+	return firstBodyBlock?.clientId ?? titleBlock?.clientId ?? null;
+}
+
+export function scheduleDocumentSurfaceFocus( {
+	clientId,
+	completeSurfaceFocus,
+	originIsCurrent,
+	ownerWindow,
+	requestIsCurrent,
+	selectBlock,
+	token,
+} ) {
+	let cancelled = false;
+	let focusFrame = ownerWindow.requestAnimationFrame( () => {
+		focusFrame = null;
+		if ( cancelled || ! requestIsCurrent() || ! originIsCurrent() ) {
+			return;
+		}
+
+		completeSurfaceFocus?.( token, () => selectBlock( clientId, 0 ) );
+	} );
+
+	// Clear the rich-text position now. The next frame restores the caret and
+	// claims the request, which remains cancellable until then.
+	selectBlock( clientId, null );
+
+	return () => {
+		cancelled = true;
+		if ( focusFrame !== null ) {
+			ownerWindow.cancelAnimationFrame( focusFrame );
+		}
+	};
 }
 
 // Returns clientIds of header blocks that should be removed by the next
@@ -1682,6 +1742,125 @@ async function waitForCriticalImages(
 	await Promise.all( waits );
 }
 
+function DocumentSurfaceFocusEffect( {
+	isActive,
+	isEditorSurfaceDisplayed,
+	isReadOnly,
+	isSurfaceFocusPending,
+	postId,
+	ownerBlockName,
+	record,
+	canvasRootRef,
+	surfaceFocusRequest,
+	completeSurfaceFocus,
+} ) {
+	const requestRef = useRef( surfaceFocusRequest );
+	requestRef.current = surfaceFocusRequest;
+	const { blocks, title } = useSelect(
+		( select ) => ( {
+			blocks: select( blockEditorStore ).getBlocks(),
+			title: select( editorStore ).getEditedPostAttribute( 'title' ),
+		} ),
+		[]
+	);
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		const request = surfaceFocusRequest;
+		if (
+			! request ||
+			! isActive ||
+			! isEditorSurfaceDisplayed ||
+			ownerBlockName ||
+			Number( request.documentId ) !== Number( postId )
+		) {
+			return undefined;
+		}
+
+		const token = request.token;
+		let cancelled = false;
+		let cancelScheduledFocus = null;
+		const ownerWindow =
+			canvasRootRef.current?.ownerDocument?.defaultView ?? window;
+		const requestIsCurrent = () => requestRef.current?.token === token;
+		const originIsCurrent = () =>
+			isSurfaceFocusOriginCurrent( requestRef.current?.originElement );
+
+		async function focusDocumentSurface() {
+			await whenViewTransitionsSettled( 0 );
+			// `DOCUMENT_DISPLAYED` may fire in the same commit that hydrates the
+			// editor registry. Wait for one paint before reading the block list so a
+			// transient empty list does not consume the request.
+			await afterNextPaint( ownerWindow );
+			if ( cancelled || ! requestIsCurrent() ) {
+				return;
+			}
+			if ( ! originIsCurrent() ) {
+				completeSurfaceFocus?.( token );
+				return;
+			}
+
+			if ( isSurfaceFocusPending ) {
+				return;
+			}
+			if ( isReadOnly ) {
+				completeSurfaceFocus?.( token );
+				return;
+			}
+
+			const clientId = getDocumentSurfaceFocusClientId( {
+				blocks,
+				title,
+				ownerBlockName,
+				record,
+				postId,
+			} );
+			if ( ! clientId ) {
+				// Header repair will update the block list and rerun this effect. Leave
+				// the request pending until a title or body block exists.
+				return;
+			}
+
+			// Reset the selection across a paint so the current document can receive
+			// focus again. Keep the token pending until focus returns so later input
+			// can still cancel it.
+			cancelScheduledFocus = scheduleDocumentSurfaceFocus( {
+				clientId,
+				completeSurfaceFocus,
+				originIsCurrent: () =>
+					Boolean( canvasRootRef.current?.isConnected ) &&
+					originIsCurrent(),
+				ownerWindow,
+				requestIsCurrent,
+				selectBlock,
+				token,
+			} );
+		}
+
+		focusDocumentSurface();
+		return () => {
+			cancelled = true;
+			cancelScheduledFocus?.();
+		};
+	}, [
+		blocks,
+		canvasRootRef,
+		completeSurfaceFocus,
+		isActive,
+		isEditorSurfaceDisplayed,
+		isReadOnly,
+		isSurfaceFocusPending,
+		ownerBlockName,
+		postId,
+		record,
+		selectBlock,
+		surfaceFocusRequest,
+		title,
+	] );
+
+	return null;
+}
+
 function CanvasReadyEffect( {
 	featuredMedia,
 	postId,
@@ -1802,11 +1981,15 @@ function CanvasReadyEffect( {
 export default function EditorBody( {
 	featuredMedia,
 	isActive = true,
+	isEditorSurfaceDisplayed = false,
 	isDocumentCanvas = false,
 	isLocked = false,
+	isSurfaceFocusPending = false,
 	postId,
 	postType,
 	extraStyles,
+	surfaceFocusRequest = null,
+	completeSurfaceFocus = null,
 	onReady,
 	onRestored,
 } ) {
@@ -1853,6 +2036,7 @@ export default function EditorBody( {
 			'trash',
 		[]
 	);
+	const isReadOnly = isTrashed || isLocked;
 	const record = useDocumentRecord( postType, postId );
 	const ownerBlockName = getCanvasOwnerBlockNameForRecord( record );
 	const ownerKey = ownerBlockName ? `${ postType }:${ postId }` : null;
@@ -1866,8 +2050,22 @@ export default function EditorBody( {
 		[ ownerKey, postId ]
 	);
 	const canvasReadySignals = useMemo(
-		() => ( { signalCollectionReady } ),
-		[ signalCollectionReady ]
+		() => ( {
+			signalCollectionReady,
+			surfaceFocusRequest,
+			isEditorSurfaceDisplayed,
+			isSurfaceFocusPending,
+			isSurfaceFocusReadOnly: isReadOnly,
+			completeSurfaceFocus,
+		} ),
+		[
+			completeSurfaceFocus,
+			isEditorSurfaceDisplayed,
+			isReadOnly,
+			isSurfaceFocusPending,
+			signalCollectionReady,
+			surfaceFocusRequest,
+		]
 	);
 	const shouldUseHeaderAwareAppender = useSelect(
 		( select ) => {
@@ -1884,7 +2082,6 @@ export default function EditorBody( {
 		},
 		[ ownerBlockName, postId, record ]
 	);
-	const isReadOnly = isTrashed || isLocked;
 	const renderAppender =
 		shouldUseHeaderAwareAppender && ! isReadOnly
 			? () => (
@@ -1946,6 +2143,18 @@ export default function EditorBody( {
 							renderAppender={ renderAppender }
 						/>
 					</div>
+					<DocumentSurfaceFocusEffect
+						isActive={ isActive }
+						isEditorSurfaceDisplayed={ isEditorSurfaceDisplayed }
+						isReadOnly={ isReadOnly }
+						isSurfaceFocusPending={ isSurfaceFocusPending }
+						postId={ postId }
+						ownerBlockName={ ownerBlockName }
+						record={ record }
+						canvasRootRef={ blockCanvasRef }
+						surfaceFocusRequest={ surfaceFocusRequest }
+						completeSurfaceFocus={ completeSurfaceFocus }
+					/>
 					<CanvasReadyEffect
 						featuredMedia={ featuredMedia }
 						postId={ postId }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -100,6 +100,7 @@ import useSidebarNavigation from './sidebar/useSidebarNavigation';
 import useSidebarTree, { ROOT_PARENT_ID } from './sidebar/useSidebarTree';
 import DocumentRow from './sidebar/DocumentRow';
 import { isWordPressAffordancesEnabled } from '../settings';
+import { useSurfaceFocusIntent } from './SurfaceFocusContext';
 
 export default function Sidebar( {
 	collapsed = false,
@@ -175,6 +176,15 @@ export default function Sidebar( {
 	);
 	const { navigate, selectedId, selectedCollectionId, onSelect, goHome } =
 		useSidebarNavigation( { pages, homePath } );
+	const { requestFromActivation } = useSurfaceFocusIntent();
+	const homeDocumentId = home?.id ?? fallbackHomePage?.id ?? null;
+	const openHome = useCallback(
+		( event ) => {
+			requestFromActivation( event, homeDocumentId );
+			goHome();
+		},
+		[ goHome, homeDocumentId, requestFromActivation ]
+	);
 	const { isSelected: isRowSelected, selectRecord: onRowSelect } =
 		useDocumentSelection( { selectedId, selectedCollectionId } );
 	const adminUrl = window.cortextSettings?.adminUrl ?? '/wp-admin/';
@@ -525,7 +535,7 @@ export default function Sidebar( {
 							className="cortext-sidebar__quick-action cortext-sidebar__quick-action--home"
 							label={ __( 'Home', 'cortext' ) }
 							disabled={ ! homePath || isResolvingHomePath }
-							onClick={ goHome }
+							onClick={ openHome }
 						>
 							<Icon icon={ homeIcon } size={ 16 } />
 							{ ! collapsed && (

--- a/src/components/SidebarFavorites.js
+++ b/src/components/SidebarFavorites.js
@@ -33,6 +33,7 @@ import {
 import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
 } from '../hooks/useDelayedFlag';
+import { useSurfaceFocusIntent } from './SurfaceFocusContext';
 import { DOCUMENT_POST_TYPE } from '../collections';
 import { collectDescendants } from './document-tree';
 import { whenViewTransitionsSettled } from '../hooks/viewTransition';
@@ -162,6 +163,7 @@ function mergeDisplayFavorites( currentDisplay, nextFavorites, removingKeys ) {
 }
 
 function SortableFavoriteRow( { item, isDisabled, onSelect, onRemove } ) {
+	const { requestFromActivation } = useSurfaceFocusIntent();
 	// Favorites wire shape only carries id/title/path/icon. Capability checks
 	// need `meta.cortext_fields` / `crtxt_trait`, so we load the document
 	// record at render time when the sidebar lists did not already supply
@@ -240,6 +242,7 @@ function SortableFavoriteRow( { item, isDisabled, onSelect, onRemove } ) {
 					type="button"
 					className="cortext-sidebar__favorite-title"
 					onClick={ ( event ) => {
+						requestFromActivation( event, item.id );
 						const isMouseClick = event.detail > 0;
 						if ( ! isMouseClick ) {
 							onSelect( item );

--- a/src/components/SidebarRecents.js
+++ b/src/components/SidebarRecents.js
@@ -12,6 +12,7 @@ import { useRecents } from '../hooks/useRecents';
 import { useDocumentRecord } from '../documents';
 import { DOCUMENT_POST_TYPE } from '../collections';
 import { definesTrait } from '../documents/capabilities';
+import { useSurfaceFocusIntent } from './SurfaceFocusContext';
 
 const RECENT_REPOSITION_OPTIONS = {
 	duration: 180,
@@ -86,6 +87,7 @@ function SidebarRecentsRow( {
 	setNodeRef,
 	onSelect,
 } ) {
+	const { requestFromActivation } = useSurfaceFocusIntent();
 	// Recents wire shape only carries id/title/path/icon (and optional row
 	// context). Capability checks need `meta.cortext_fields` / `crtxt_trait`,
 	// so we load the document record at render time and merge it with the
@@ -132,7 +134,10 @@ function SidebarRecentsRow( {
 					size="compact"
 					variant="tertiary"
 					onClick={ ( event ) => {
-						event.currentTarget.blur();
+						requestFromActivation( event, recent.id );
+						if ( event.detail > 0 ) {
+							event.currentTarget.blur();
+						}
 						onSelect( recent );
 					} }
 					aria-label={ ariaLabel }

--- a/src/components/SurfaceFocusContext.js
+++ b/src/components/SurfaceFocusContext.js
@@ -1,0 +1,120 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+
+const NO_SURFACE_FOCUS_INTENT = {
+	request: null,
+	requestFromActivation: () => null,
+	cancel: () => {},
+	consume: () => false,
+};
+
+const SurfaceFocusContext = createContext( NO_SURFACE_FOCUS_INTENT );
+
+/*
+ * Stores a one-shot focus request for keyboard activation in the main sidebar.
+ * It lives outside router state so back/forward navigation cannot replay it.
+ */
+export function SurfaceFocusProvider( { children } ) {
+	const [ request, setRequest ] = useState( null );
+	const requestRef = useRef( null );
+	const nextTokenRef = useRef( 0 );
+
+	const cancel = useCallback( () => {
+		if ( requestRef.current === null ) {
+			return;
+		}
+		requestRef.current = null;
+		setRequest( null );
+	}, [] );
+
+	const consume = useCallback( ( token, onConsume ) => {
+		if ( requestRef.current?.token !== token ) {
+			return false;
+		}
+
+		requestRef.current = null;
+		// Claim the token, then run the focus callback before updating context.
+		// Updating context first can rerender the editor and interrupt focus.
+		onConsume?.();
+		setRequest( ( current ) =>
+			current?.token === token ? null : current
+		);
+		return true;
+	}, [] );
+
+	const requestFromActivation = useCallback(
+		( event, documentId ) => {
+			// `click.detail === 0` covers keyboard and assistive-technology clicks.
+			// Pointer activation leaves focus alone and cancels any pending request.
+			if (
+				event?.detail !== 0 ||
+				documentId === null ||
+				documentId === undefined ||
+				! event.currentTarget
+			) {
+				cancel();
+				return null;
+			}
+
+			const nextRequest = {
+				token: ++nextTokenRef.current,
+				documentId,
+				originElement: event.currentTarget,
+			};
+			requestRef.current = nextRequest;
+			setRequest( nextRequest );
+			return nextRequest.token;
+		},
+		[ cancel ]
+	);
+
+	useEffect( () => {
+		const handlePopState = () => cancel();
+		const handlePointerDown = () => cancel();
+		const handleWindowBlur = () => cancel();
+		const handleFocusIn = ( event ) => {
+			const pending = requestRef.current;
+			if ( pending && event.target !== pending.originElement ) {
+				cancel();
+			}
+		};
+
+		// Capture `popstate` before the router publishes the new location.
+		window.addEventListener( 'popstate', handlePopState, true );
+		window.addEventListener( 'blur', handleWindowBlur, true );
+		document.addEventListener( 'pointerdown', handlePointerDown, true );
+		document.addEventListener( 'focusin', handleFocusIn, true );
+		return () => {
+			window.removeEventListener( 'popstate', handlePopState, true );
+			window.removeEventListener( 'blur', handleWindowBlur, true );
+			document.removeEventListener(
+				'pointerdown',
+				handlePointerDown,
+				true
+			);
+			document.removeEventListener( 'focusin', handleFocusIn, true );
+		};
+	}, [ cancel ] );
+
+	const value = useMemo(
+		() => ( { request, requestFromActivation, cancel, consume } ),
+		[ request, requestFromActivation, cancel, consume ]
+	);
+
+	return (
+		<SurfaceFocusContext.Provider value={ value }>
+			{ children }
+		</SurfaceFocusContext.Provider>
+	);
+}
+
+export function useSurfaceFocusIntent() {
+	return useContext( SurfaceFocusContext );
+}

--- a/src/components/collectionSurfaceFocus.js
+++ b/src/components/collectionSurfaceFocus.js
@@ -1,0 +1,121 @@
+const ENABLED_BUTTON_SELECTOR =
+	'button:not(:disabled):not([aria-disabled="true"])';
+const SEARCH_SELECTOR =
+	'[data-cortext-focus-region="search"] input[type="search"]:not(:disabled):not([aria-disabled="true"])';
+const NEW_ROW_SELECTOR =
+	'.cortext-data-view__new-row:not(:disabled):not([aria-disabled="true"])';
+const VIEW_CONTROL_SELECTOR = `[data-cortext-focus-region="view-controls"] ${ ENABLED_BUTTON_SELECTOR }`;
+
+function getTableRowTarget( root ) {
+	const row = root.querySelector( 'tbody tr.dataviews-view-table__row' );
+	if ( ! row ) {
+		return null;
+	}
+
+	return row.querySelector(
+		[
+			'.cortext-title-cell .cortext-editable-cell__shell:not([tabindex="-1"]):not([aria-disabled="true"])',
+			`.cortext-title-cell ${ ENABLED_BUTTON_SELECTOR }`,
+			'.cortext-title-cell a[href]',
+			'.cortext-title-cell [tabindex]:not([tabindex="-1"]):not([aria-disabled="true"])',
+		].join( ', ' )
+	);
+}
+
+function getGridRowTarget( root ) {
+	return root.querySelector(
+		[
+			'.dataviews-view-grid [role="gridcell"].dataviews-view-grid__card:not(.cortext-data-view__new-row-gridcell):not(.dataviews-view-grid__placeholder)',
+			'.dataviews-view-grid-infinite-scroll [role="article"].dataviews-view-grid__card:not(.cortext-data-view__new-row-gridcell):not(.dataviews-view-grid__placeholder)',
+		].join( ', ' )
+	);
+}
+
+function getListRowTarget( root ) {
+	return root.querySelector(
+		'.dataviews-view-list__item:not([aria-disabled="true"])'
+	);
+}
+
+/**
+ * Find the preferred focus target in a rendered collection.
+ *
+ * Cortext data attributes mark stable toolbar regions. Row selectors follow
+ * the DataViews 17 markup until it exposes a public focus API.
+ *
+ * @param {Element} root                 Collection wrapper.
+ * @param {Object}  options              Target selection options.
+ * @param {boolean} options.isTrulyEmpty Whether the unfiltered collection is empty.
+ * @param {string}  options.layoutType   Active DataViews layout.
+ * @return {HTMLElement|null} Focusable collection control or row.
+ */
+export function getCollectionSurfaceFocusTarget(
+	root,
+	{ isTrulyEmpty, layoutType }
+) {
+	if ( ! root ) {
+		return null;
+	}
+
+	if ( isTrulyEmpty ) {
+		const newRowButton = root.querySelector( NEW_ROW_SELECTOR );
+		if ( newRowButton ) {
+			return newRowButton;
+		}
+	}
+
+	const search = root.querySelector( SEARCH_SELECTOR );
+	if ( search ) {
+		return search;
+	}
+
+	const viewControl = root.querySelector( VIEW_CONTROL_SELECTOR );
+	if ( viewControl ) {
+		return viewControl;
+	}
+
+	if ( layoutType === 'table' ) {
+		return getTableRowTarget( root );
+	}
+	if ( layoutType === 'grid' ) {
+		return getGridRowTarget( root );
+	}
+	if ( layoutType === 'list' ) {
+		return getListRowTarget( root );
+	}
+
+	return null;
+}
+
+/**
+ * A search or filter with no matches does not make the collection empty.
+ * Keep Search as the focus target so users can clear the constraint.
+ *
+ * @param {Object}           options              Collection state.
+ * @param {boolean}          options.rowsResolved Whether the first row query resolved.
+ * @param {number|undefined} options.totalItems   Total unfiltered/filtered rows from the active query.
+ * @param {Object|undefined} options.view         Saved collection view.
+ * @return {boolean} Whether the collection itself is empty.
+ */
+export function isCollectionTrulyEmpty( { rowsResolved, totalItems, view } ) {
+	return (
+		rowsResolved &&
+		totalItems === 0 &&
+		! String( view?.search ?? '' ).trim() &&
+		! ( view?.filters?.length ?? 0 )
+	);
+}
+
+/**
+ * Loading may finish after the user moves on. Move focus only while the
+ * original control is still mounted and focused.
+ *
+ * @param {HTMLElement|null|undefined} originElement Activation control.
+ * @return {boolean} Whether destination focus may still be applied.
+ */
+export function isSurfaceFocusOriginCurrent( originElement ) {
+	return Boolean(
+		originElement?.isConnected &&
+			originElement.ownerDocument?.activeElement === originElement
+	);
+}

--- a/src/components/sidebar/DocumentRow.js
+++ b/src/components/sidebar/DocumentRow.js
@@ -19,6 +19,7 @@ import { useDraggable, useDroppable } from '@dnd-kit/core';
 
 import { collectionIcon } from '../cortextIcons';
 import { useDocumentActions, useDocumentRecord } from '../../documents';
+import { useSurfaceFocusIntent } from '../SurfaceFocusContext';
 
 /**
  * Sidebar row shared by pages and collections. The document layer tells it
@@ -80,6 +81,7 @@ export default function DocumentRow( {
 	autoRenameId = null,
 	onAutoRenameConsumed,
 } ) {
+	const { requestFromActivation } = useSurfaceFocusIntent();
 	const { title, icon, features } = useDocumentRecord( record );
 	const { rename, duplicate, trash } = useDocumentActions();
 
@@ -272,7 +274,18 @@ export default function DocumentRow( {
 						<Button
 							className="cortext-sidebar__title"
 							size="compact"
-							onClick={ () => onSelect( record ) }
+							onKeyDown={ ( event ) => {
+								if (
+									event.key === 'Enter' ||
+									event.key === ' '
+								) {
+									event.stopPropagation();
+								}
+							} }
+							onClick={ ( event ) => {
+								requestFromActivation( event, record.id );
+								onSelect( record );
+							} }
 							isPressed={ rowIsSelected }
 						>
 							{ title }

--- a/src/router.js
+++ b/src/router.js
@@ -16,6 +16,7 @@ import BetaNoticeModal from './components/BetaNoticeModal';
 import { DocumentPeekProvider } from './components/DocumentPeekProvider';
 import DocumentPeekHost from './components/DocumentPeekHost';
 import { RowDetailSidebarSlot } from './components/RowDetailSidebarSlot';
+import { SurfaceFocusProvider } from './components/SurfaceFocusContext';
 import useSidebarLayout from './hooks/useSidebarLayout';
 import useBetaNotice from './hooks/useBetaNotice';
 import { FavoritesProvider } from './hooks/useFavorites';
@@ -69,39 +70,43 @@ function RootLayout() {
 	}, [ toggleCollapsed ] );
 
 	return (
-		<SlotFillProvider>
-			<WorkspaceHomeProvider>
-				<FavoritesProvider>
-					<RecentsProvider>
-						<DocumentPeekProvider>
-							<DocumentPeekHost />
-							<div className="cortext-shell">
-								<Sidebar
-									collapsed={ collapsed }
-									width={ width }
-									onToggleCollapsed={ toggleCollapsed }
-									onWidthChange={ setWidth }
-								/>
-								<main
-									ref={ canvasRef }
-									className="cortext-shell__canvas"
-									tabIndex={ -1 }
-								>
-									<EntityRoute history={ router.history } />
-								</main>
-								<RowDetailSidebarSlot />
-							</div>
-							<CommandPalette canvasRef={ canvasRef } />
-							{ betaNotice.isOpen && (
-								<BetaNoticeModal
-									onAcknowledge={ betaNotice.acknowledge }
-								/>
-							) }
-						</DocumentPeekProvider>
-					</RecentsProvider>
-				</FavoritesProvider>
-			</WorkspaceHomeProvider>
-		</SlotFillProvider>
+		<SurfaceFocusProvider>
+			<SlotFillProvider>
+				<WorkspaceHomeProvider>
+					<FavoritesProvider>
+						<RecentsProvider>
+							<DocumentPeekProvider>
+								<DocumentPeekHost />
+								<div className="cortext-shell">
+									<Sidebar
+										collapsed={ collapsed }
+										width={ width }
+										onToggleCollapsed={ toggleCollapsed }
+										onWidthChange={ setWidth }
+									/>
+									<main
+										ref={ canvasRef }
+										className="cortext-shell__canvas"
+										tabIndex={ -1 }
+									>
+										<EntityRoute
+											history={ router.history }
+										/>
+									</main>
+									<RowDetailSidebarSlot />
+								</div>
+								<CommandPalette canvasRef={ canvasRef } />
+								{ betaNotice.isOpen && (
+									<BetaNoticeModal
+										onAcknowledge={ betaNotice.acknowledge }
+									/>
+								) }
+							</DocumentPeekProvider>
+						</RecentsProvider>
+					</FavoritesProvider>
+				</WorkspaceHomeProvider>
+			</SlotFillProvider>
+		</SurfaceFocusProvider>
 	);
 }
 

--- a/src/router/EntityRoute.js
+++ b/src/router/EntityRoute.js
@@ -35,6 +35,8 @@ import PublishedDocumentsPane from '../components/PublishedDocumentsPane';
 import { CanvasProgressBar } from '../components/Skeleton';
 import useDelayedFlag from '../hooks/useDelayedFlag';
 import CortextSnackbars from '../components/CortextSnackbars';
+import { useSurfaceFocusIntent } from '../components/SurfaceFocusContext';
+import { isSurfaceFocusOriginCurrent } from '../components/collectionSurfaceFocus';
 import WorkspaceTopBar from '../components/WorkspaceTopBar';
 import {
 	ACTIVE_PAGES_QUERY,
@@ -43,7 +45,11 @@ import {
 } from '../components/page-queries';
 import { firstDocumentInTree } from '../components/document-tree';
 import { isPublicWebAffordancesEnabled } from '../settings';
-import { withViewTransition } from '../hooks/viewTransition';
+import afterNextPaint from '../hooks/afterNextPaint';
+import {
+	whenViewTransitionsSettled,
+	withViewTransition,
+} from '../hooks/viewTransition';
 import { useRecents } from '../hooks/useRecents';
 import { useWorkspaceHome } from '../hooks/useWorkspaceHome';
 import useCollectionFields from '../hooks/useCollectionFields';
@@ -77,9 +83,15 @@ function NotFoundPane() {
 	);
 }
 
-function WorkspacePane( { active, preservePaint = false, children } ) {
+function WorkspacePane( {
+	active,
+	preservePaint = false,
+	paneRef = null,
+	children,
+} ) {
 	return (
 		<div
+			ref={ paneRef }
 			className="cortext-workspace__pane"
 			data-active={ active ? 'true' : 'false' }
 			data-preserve-paint={ preservePaint ? 'true' : 'false' }
@@ -89,6 +101,57 @@ function WorkspacePane( { active, preservePaint = false, children } ) {
 			{ children }
 		</div>
 	);
+}
+
+function useTerminalSurfaceFocus( {
+	isActive,
+	containerRef,
+	request,
+	documentId = null,
+	complete,
+} ) {
+	const requestRef = useRef( request );
+	requestRef.current = request;
+
+	useEffect( () => {
+		if (
+			! isActive ||
+			! request ||
+			( documentId !== null &&
+				Number( request.documentId ) !== Number( documentId ) )
+		) {
+			return undefined;
+		}
+
+		const token = request.token;
+		let cancelled = false;
+		async function focusTerminalAction() {
+			await whenViewTransitionsSettled( 0 );
+			await afterNextPaint(
+				containerRef.current?.ownerDocument?.defaultView
+			);
+			if ( cancelled || requestRef.current?.token !== token ) {
+				return;
+			}
+			if (
+				! isSurfaceFocusOriginCurrent(
+					requestRef.current?.originElement
+				)
+			) {
+				complete?.( token );
+				return;
+			}
+
+			const primaryAction = containerRef.current?.querySelector(
+				'.components-button.is-primary:not(:disabled):not([aria-disabled="true"]), [data-cortext-primary-action]:not(:disabled):not([aria-disabled="true"])'
+			);
+			complete?.( token, () => primaryAction?.focus() );
+		}
+		focusTerminalAction();
+		return () => {
+			cancelled = true;
+		};
+	}, [ complete, containerRef, documentId, isActive, request ] );
 }
 
 // Default mutation context for documents reached by deep link or direct
@@ -132,6 +195,20 @@ export default function EntityRoute( { history } ) {
 
 	const [ state, rawDispatch ] = useReducer( reducer, target, init );
 	const { active, mountedDocumentId, displayedDocumentId } = state;
+	const { request: surfaceFocusRequest, consume: consumeSurfaceFocus } =
+		useSurfaceFocusIntent();
+	const completeSurfaceFocus = useCallback(
+		( token, onConsume ) => consumeSurfaceFocus?.( token, onConsume ),
+		[ consumeSurfaceFocus ]
+	);
+	const notFoundPaneRef = useRef( null );
+	useTerminalSurfaceFocus( {
+		isActive: active.kind === 'document-not-found',
+		containerRef: notFoundPaneRef,
+		request: surfaceFocusRequest,
+		documentId: target.kind === 'document' ? target.id : null,
+		complete: completeSurfaceFocus,
+	} );
 
 	// Keep the old pane up until the next Canvas has painted.
 	const isWorkspaceNavigating =
@@ -383,6 +460,18 @@ export default function EntityRoute( { history } ) {
 	// `DOCUMENT_DISPLAYED` until it renders, and `active` can't flip to
 	// `document` until that dispatch arrives.
 	const editorPostId = mountedDocumentId;
+	const isEditorSurfaceDisplayed = Boolean(
+		isDocumentActive &&
+			editorPostId !== null &&
+			displayedDocumentId === editorPostId &&
+			active.id === editorPostId
+	);
+	const editorSurfaceFocusRequest =
+		isEditorSurfaceDisplayed &&
+		surfaceFocusRequest &&
+		Number( surfaceFocusRequest.documentId ) === Number( editorPostId )
+			? surfaceFocusRequest
+			: null;
 	const editorRowContext = rowDocumentContextForEditorPost(
 		rowContextCacheRef.current,
 		editorPostId,
@@ -453,6 +542,9 @@ export default function EntityRoute( { history } ) {
 					}
 					onDisplayedPost={ handleDocumentDisplayed }
 					isActive={ isDocumentActive }
+					isEditorSurfaceDisplayed={ isEditorSurfaceDisplayed }
+					surfaceFocusRequest={ editorSurfaceFocusRequest }
+					completeSurfaceFocus={ completeSurfaceFocus }
 					onRestored={ onRestoreDocument }
 					recentTarget={ editorRecentTarget }
 				/>
@@ -494,7 +586,10 @@ export default function EntityRoute( { history } ) {
 				<WorkspacePane active={ active.kind === 'empty' }>
 					<EmptyState isWorkspaceEmpty={ isWorkspaceEmpty } />
 				</WorkspacePane>
-				<WorkspacePane active={ active.kind === 'document-not-found' }>
+				<WorkspacePane
+					active={ active.kind === 'document-not-found' }
+					paneRef={ notFoundPaneRef }
+				>
 					<NotFoundPane />
 				</WorkspacePane>
 				<WorkspacePane active={ active.kind === 'loading' }>

--- a/tests/e2e/specs/surface-focus.spec.js
+++ b/tests/e2e/specs/surface-focus.spec.js
@@ -1,0 +1,596 @@
+/**
+ * Covers focus moving from the main sidebar into pages and collections opened
+ * from the keyboard. Pointer navigation and browser history keep their usual
+ * focus behavior.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const READY_TIMEOUT_MS = 15_000;
+const SUFFIX = Date.now().toString( 36 ).slice( -5 );
+const CANVAS_SELECTOR = 'iframe[name="editor-canvas"]';
+const TITLE_BLOCK_SELECTOR = '[data-type="core/post-title"]';
+const PARAGRAPH_BLOCK_SELECTOR = '[data-type="core/paragraph"]';
+
+test.describe.configure( { mode: 'serial' } );
+
+async function deleteIfCreated( requestUtils, path ) {
+	if ( ! path ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path,
+			params: { force: true },
+		} );
+	} catch {
+		// Ignore cleanup errors because the record may already be gone.
+	}
+}
+
+async function deleteDocument( requestUtils, record ) {
+	await deleteIfCreated(
+		requestUtils,
+		record?.id ? `/wp/v2/crtxt_documents/${ record.id }` : null
+	);
+}
+
+async function createDocument( requestUtils, data ) {
+	return requestUtils.rest( {
+		method: 'POST',
+		path: '/wp/v2/crtxt_documents',
+		data: {
+			status: 'private',
+			...data,
+		},
+	} );
+}
+
+async function createCollectionFixture( requestUtils, title, withRow ) {
+	const collection = await createDocument( requestUtils, {
+		title,
+		cortext_collection: true,
+	} );
+	let row = null;
+
+	if ( withRow ) {
+		row = await createDocument( requestUtils, {
+			title: `${ title } row`,
+			content:
+				'<!-- wp:paragraph --><p>Notes for this row.</p><!-- /wp:paragraph -->',
+			cortext_trait: collection.id,
+		} );
+	}
+
+	return { collection, row };
+}
+
+function documentUri( record ) {
+	return record.slug
+		? `${ record.slug }-${ record.id }`
+		: String( record.id );
+}
+
+async function visitDocument( admin, page, record ) {
+	await admin.visitAdminPage(
+		'admin.php',
+		`page=cortext&p=/${ documentUri( record ) }`
+	);
+	await waitForEditorPost( page, record.id );
+}
+
+async function waitForEditorPost( page, postId ) {
+	await page.waitForFunction(
+		( expectedPostId ) =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ===
+			expectedPostId,
+		postId,
+		{ timeout: READY_TIMEOUT_MS }
+	);
+}
+
+async function currentEditorPostId( page ) {
+	return page.evaluate(
+		() =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ?? 0
+	);
+}
+
+function editorCanvas( page ) {
+	return page.frameLocator( '[name="editor-canvas"]' );
+}
+
+async function canvasHasFocusWithin( page, selector ) {
+	try {
+		const outerHasCanvasFocus = await page
+			.locator( 'body' )
+			.evaluate(
+				( body, canvasSelector ) =>
+					body.ownerDocument.activeElement?.matches?.(
+						canvasSelector
+					) === true,
+				CANVAS_SELECTOR
+			);
+		if ( ! outerHasCanvasFocus ) {
+			return false;
+		}
+
+		return editorCanvas( page )
+			.locator( selector )
+			.first()
+			.evaluate( ( target ) =>
+				target.contains( target.ownerDocument.activeElement )
+			);
+	} catch ( error ) {
+		if (
+			/Frame was detached|Execution context was destroyed/.test(
+				error?.message ?? ''
+			)
+		) {
+			return false;
+		}
+		throw error;
+	}
+}
+
+async function expectCanvasFocusWithin( page, selector ) {
+	await expect(
+		editorCanvas( page ).locator( selector ).first()
+	).toBeVisible( { timeout: READY_TIMEOUT_MS } );
+	await expect
+		.poll( () => canvasHasFocusWithin( page, selector ), {
+			timeout: READY_TIMEOUT_MS,
+		} )
+		.toBe( true );
+}
+
+async function expectCanvasControlFocused( page, selector ) {
+	const control = editorCanvas( page ).locator( selector ).first();
+	await expect( control ).toBeVisible( { timeout: READY_TIMEOUT_MS } );
+	await expect
+		.poll( () => canvasHasFocusWithin( page, selector ), {
+			timeout: READY_TIMEOUT_MS,
+		} )
+		.toBe( true );
+	await expect( control ).toBeFocused();
+}
+
+async function keyboardActivate( locator ) {
+	await locator.focus();
+	await expect( locator ).toBeFocused();
+	await locator.press( 'Enter' );
+}
+
+async function expandSidebarSection( page, title ) {
+	const expand = page
+		.locator( '.cortext-sidebar' )
+		.getByRole( 'button', { name: `Expand ${ title }`, exact: true } );
+	if ( ( await expand.count() ) > 0 && ( await expand.isVisible() ) ) {
+		await expand.click();
+	}
+}
+
+function sidebarTreeButton( page, title ) {
+	return page
+		.locator( '[data-sidebar-section="pages"]' )
+		.getByRole( 'button', { name: title, exact: true } );
+}
+
+test.describe( 'Sidebar surface focus', () => {
+	test( 'keyboard activation from the tree and Home focuses empty and titled pages', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			fixture.parent = await createDocument( requestUtils, {
+				title: `E2E Focus Parent ${ SUFFIX }`,
+				menu_order: -2_100_000,
+			} );
+			fixture.untitled = await createDocument( requestUtils, {
+				title: '',
+				content: '',
+				parent: fixture.parent.id,
+				menu_order: -2_100_001,
+			} );
+			fixture.home = await createDocument( requestUtils, {
+				title: `E2E Focus Home ${ SUFFIX }`,
+				content:
+					'<!-- wp:paragraph --><p>Welcome home.</p><!-- /wp:paragraph -->',
+				menu_order: -2_100_002,
+			} );
+			await requestUtils.rest( {
+				method: 'PUT',
+				path: '/cortext/v1/workspace-home',
+				data: { id: fixture.home.id },
+			} );
+
+			await visitDocument( admin, page, fixture.parent );
+			await expandSidebarSection( page, 'Documents' );
+
+			const parentNode = sidebarTreeButton(
+				page,
+				fixture.parent.title.rendered
+			).locator(
+				'xpath=ancestor::li[contains(@class,"cortext-sidebar__node")][1]'
+			);
+			const expandParent = parentNode.getByRole( 'button', {
+				name: 'Expand',
+				exact: true,
+			} );
+			if ( ( await expandParent.count() ) > 0 ) {
+				await expandParent.click();
+			}
+
+			const untitled = parentNode.getByRole( 'button', {
+				name: '(untitled)',
+				exact: true,
+			} );
+			await expect( untitled ).toBeVisible();
+			await keyboardActivate( untitled );
+			await waitForEditorPost( page, fixture.untitled.id );
+			await expectCanvasFocusWithin( page, TITLE_BLOCK_SELECTOR );
+
+			// Pressing Enter again should move focus back into the open canvas.
+			await keyboardActivate( untitled );
+			await expectCanvasFocusWithin( page, TITLE_BLOCK_SELECTOR );
+
+			const home = page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', { name: 'Home', exact: true } );
+			await keyboardActivate( home );
+			await waitForEditorPost( page, fixture.home.id );
+			await expectCanvasFocusWithin( page, PARAGRAPH_BLOCK_SELECTOR );
+		} finally {
+			await deleteDocument( requestUtils, fixture.untitled );
+			await deleteDocument( requestUtils, fixture.parent );
+			await deleteDocument( requestUtils, fixture.home );
+		}
+	} );
+
+	test( 'keyboard activation from Recents focuses a full-page row and a populated collection', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			Object.assign(
+				fixture,
+				await createCollectionFixture(
+					requestUtils,
+					`E2E Focus Recent Collection ${ SUFFIX }`,
+					true
+				)
+			);
+
+			// Visit the row and collection first so both appear in Recents.
+			await visitDocument( admin, page, fixture.row );
+			await visitDocument( admin, page, fixture.collection );
+			await expect(
+				editorCanvas( page ).locator( '.cortext-data-view' )
+			).toBeVisible( { timeout: READY_TIMEOUT_MS } );
+			await expandSidebarSection( page, 'Recents' );
+
+			const sidebar = page.locator( '.cortext-sidebar' );
+			const recentRow = sidebar.getByRole( 'button', {
+				name: `Recent: ${ fixture.row.title.rendered } in ${ fixture.collection.title.rendered }`,
+				exact: true,
+			} );
+			await expect( recentRow ).toBeVisible( {
+				timeout: READY_TIMEOUT_MS,
+			} );
+			await keyboardActivate( recentRow );
+			await waitForEditorPost( page, fixture.row.id );
+			await expectCanvasFocusWithin( page, PARAGRAPH_BLOCK_SELECTOR );
+
+			const recentCollection = sidebar.getByRole( 'button', {
+				name: `Recent: ${ fixture.collection.title.rendered }`,
+				exact: true,
+			} );
+			await expect( recentCollection ).toBeVisible( {
+				timeout: READY_TIMEOUT_MS,
+			} );
+			await keyboardActivate( recentCollection );
+			await waitForEditorPost( page, fixture.collection.id );
+			await expectCanvasControlFocused(
+				page,
+				'.dataviews-search input[type="search"]'
+			);
+		} finally {
+			await deleteDocument( requestUtils, fixture.row );
+			await deleteDocument( requestUtils, fixture.collection );
+		}
+	} );
+
+	test( 'keyboard activation from Favorites focuses pages and both populated and empty collections', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			fixture.neutral = await createDocument( requestUtils, {
+				title: `E2E Focus Favorite Neutral ${ SUFFIX }`,
+				menu_order: -2_100_020,
+			} );
+			fixture.page = await createDocument( requestUtils, {
+				title: `E2E Focus Favorite Page ${ SUFFIX }`,
+				content:
+					'<!-- wp:paragraph --><p>Notes from a favorite page.</p><!-- /wp:paragraph -->',
+				menu_order: -2_100_021,
+			} );
+			const populated = await createCollectionFixture(
+				requestUtils,
+				`E2E Focus Favorite Populated ${ SUFFIX }`,
+				true
+			);
+			fixture.populatedCollection = populated.collection;
+			fixture.populatedRow = populated.row;
+			const empty = await createCollectionFixture(
+				requestUtils,
+				`E2E Focus Favorite Empty ${ SUFFIX }`,
+				false
+			);
+			fixture.emptyCollection = empty.collection;
+
+			await requestUtils.rest( {
+				method: 'PUT',
+				path: '/cortext/v1/favorites',
+				data: {
+					favorites: [
+						{ id: fixture.page.id },
+						{ id: fixture.populatedCollection.id },
+						{ id: fixture.emptyCollection.id },
+					],
+				},
+			} );
+
+			await visitDocument( admin, page, fixture.neutral );
+			await expandSidebarSection( page, 'Favorites' );
+			const favorites = page.locator( '.cortext-sidebar__favorites' );
+
+			const favoritePage = favorites.getByRole( 'button', {
+				name: fixture.page.title.rendered,
+				exact: true,
+			} );
+			await expect( favoritePage ).toBeVisible( {
+				timeout: READY_TIMEOUT_MS,
+			} );
+			await keyboardActivate( favoritePage );
+			await waitForEditorPost( page, fixture.page.id );
+			await expectCanvasFocusWithin( page, PARAGRAPH_BLOCK_SELECTOR );
+
+			const populatedCollection = favorites.getByRole( 'button', {
+				name: fixture.populatedCollection.title.rendered,
+				exact: true,
+			} );
+			await keyboardActivate( populatedCollection );
+			await waitForEditorPost( page, fixture.populatedCollection.id );
+			await expectCanvasControlFocused(
+				page,
+				'.dataviews-search input[type="search"]'
+			);
+
+			const emptyCollection = favorites.getByRole( 'button', {
+				name: fixture.emptyCollection.title.rendered,
+				exact: true,
+			} );
+			await keyboardActivate( emptyCollection );
+			await waitForEditorPost( page, fixture.emptyCollection.id );
+			await expectCanvasControlFocused(
+				page,
+				'.cortext-data-view__new-row'
+			);
+		} finally {
+			try {
+				await requestUtils.rest( {
+					method: 'PUT',
+					path: '/cortext/v1/favorites',
+					data: { favorites: [] },
+				} );
+			} catch {
+				// Keep deleting records even if clearing Favorites fails.
+			}
+			await deleteDocument( requestUtils, fixture.populatedRow );
+			await deleteDocument( requestUtils, fixture.emptyCollection );
+			await deleteDocument( requestUtils, fixture.populatedCollection );
+			await deleteDocument( requestUtils, fixture.page );
+			await deleteDocument( requestUtils, fixture.neutral );
+		}
+	} );
+
+	test( 'pointer clicks, history navigation, and cancelled slow loads leave focus alone', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+		let releaseDelayedDestination = () => {};
+
+		try {
+			fixture.first = await createDocument( requestUtils, {
+				title: `E2E Focus History A ${ SUFFIX }`,
+				content:
+					'<!-- wp:paragraph --><p>First page in history.</p><!-- /wp:paragraph -->',
+				menu_order: -2_100_030,
+			} );
+			fixture.second = await createDocument( requestUtils, {
+				title: `E2E Focus History B ${ SUFFIX }`,
+				content:
+					'<!-- wp:paragraph --><p>Second page in history.</p><!-- /wp:paragraph -->',
+				menu_order: -2_100_031,
+			} );
+			fixture.delayed = await createDocument( requestUtils, {
+				title: `E2E Focus Delayed ${ SUFFIX }`,
+				content:
+					'<!-- wp:paragraph --><p>This page loads slowly.</p><!-- /wp:paragraph -->',
+				menu_order: -2_100_032,
+			} );
+
+			await visitDocument( admin, page, fixture.first );
+			await expandSidebarSection( page, 'Documents' );
+			const second = sidebarTreeButton(
+				page,
+				fixture.second.title.rendered
+			);
+			await second.click();
+			await waitForEditorPost( page, fixture.second.id );
+			await expect( second ).toBeFocused();
+
+			const focusSentinel = page
+				.locator( '.cortext-sidebar' )
+				.getByRole( 'button', {
+					name: 'Collapse sidebar',
+					exact: true,
+				} );
+			await focusSentinel.focus();
+			await expect( focusSentinel ).toBeFocused();
+
+			await page.goBack();
+			await waitForEditorPost( page, fixture.first.id );
+			await expect( focusSentinel ).toBeFocused();
+
+			await page.goForward();
+			await waitForEditorPost( page, fixture.second.id );
+			await expect( focusSentinel ).toBeFocused();
+
+			const delayedGate = new Promise( ( resolve ) => {
+				releaseDelayedDestination = resolve;
+			} );
+			await page.route(
+				`**/wp-json/cortext/v1/documents/${ fixture.delayed.id }**`,
+				async ( route ) => {
+					await delayedGate;
+					await route.continue();
+				}
+			);
+			const delayedRequest = page.waitForRequest( ( request ) =>
+				request
+					.url()
+					.includes(
+						`/wp-json/cortext/v1/documents/${ fixture.delayed.id }`
+					)
+			);
+
+			const delayed = sidebarTreeButton(
+				page,
+				fixture.delayed.title.rendered
+			);
+			await keyboardActivate( delayed );
+			await delayedRequest;
+
+			// The page is still loading. Moving focus now cancels the request, so
+			// the canvas must not take it back when loading finishes.
+			await focusSentinel.focus();
+			await expect( focusSentinel ).toBeFocused();
+			releaseDelayedDestination();
+			await waitForEditorPost( page, fixture.delayed.id );
+			await expect( focusSentinel ).toBeFocused();
+		} finally {
+			releaseDelayedDestination();
+			await deleteDocument( requestUtils, fixture.delayed );
+			await deleteDocument( requestUtils, fixture.second );
+			await deleteDocument( requestUtils, fixture.first );
+		}
+	} );
+
+	test( 'creating or duplicating a document keeps the rename field focused', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const fixture = {};
+
+		try {
+			fixture.source = await createDocument( requestUtils, {
+				title: `E2E Focus Duplicate Source ${ SUFFIX }`,
+				menu_order: -2_100_040,
+			} );
+			await visitDocument( admin, page, fixture.source );
+			await expandSidebarSection( page, 'Documents' );
+
+			const newDocument = page
+				.locator( '[data-sidebar-section="pages"]' )
+				.getByRole( 'button', {
+					name: 'New document',
+					exact: true,
+				} );
+			await keyboardActivate( newDocument );
+
+			const renameInput = page.locator(
+				'.cortext-sidebar__rename input'
+			);
+			await expect( renameInput ).toBeVisible( {
+				timeout: READY_TIMEOUT_MS,
+			} );
+			await expect( renameInput ).toBeFocused();
+			await expect
+				.poll(
+					async () => {
+						const postId = await currentEditorPostId( page );
+						return postId > 0 && postId !== fixture.source.id
+							? postId
+							: 0;
+					},
+					{ timeout: READY_TIMEOUT_MS }
+				)
+				.toBeGreaterThan( 0 );
+			fixture.createdId = await currentEditorPostId( page );
+			expect( fixture.createdId ).toBeGreaterThan( 0 );
+
+			await renameInput.press( 'Escape' );
+			await visitDocument( admin, page, fixture.source );
+			const sidebar = page.locator( '.cortext-sidebar' );
+			const source = sidebarTreeButton(
+				page,
+				fixture.source.title.rendered
+			);
+			await source.hover();
+			const actions = sidebar.getByRole( 'button', {
+				name: `Actions for ${ fixture.source.title.rendered }`,
+				exact: true,
+			} );
+			await actions.click();
+			const duplicate = page.getByRole( 'menuitem', {
+				name: /^Duplicate/,
+			} );
+			await expect( duplicate ).toBeVisible();
+			const duplicateResponse = page.waitForResponse(
+				( response ) =>
+					response
+						.url()
+						.includes(
+							`/cortext/v1/documents/${ fixture.source.id }/duplicate`
+						) && response.request().method() === 'POST'
+			);
+			await duplicate.click();
+			const duplicateRecord = await ( await duplicateResponse ).json();
+			fixture.duplicateId = duplicateRecord.id;
+
+			await expect( renameInput ).toBeVisible( {
+				timeout: READY_TIMEOUT_MS,
+			} );
+			await expect( renameInput ).toBeFocused();
+		} finally {
+			await deleteIfCreated(
+				requestUtils,
+				fixture.duplicateId
+					? `/wp/v2/crtxt_documents/${ fixture.duplicateId }`
+					: null
+			);
+			await deleteIfCreated(
+				requestUtils,
+				fixture.createdId
+					? `/wp/v2/crtxt_documents/${ fixture.createdId }`
+					: null
+			);
+			await deleteDocument( requestUtils, fixture.source );
+		}
+	} );
+} );

--- a/tests/js/components/CollectionDataViews.test.js
+++ b/tests/js/components/CollectionDataViews.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { DataViews as mockDataViews } from '@wordpress/dataviews/wp';
 
 const mockDataViewRowReorder = jest.fn( () => null );
@@ -10,10 +10,10 @@ jest.mock( '@wordpress/dataviews/wp', () => {
 			{ children }
 		</div>
 	) );
-	MockDataViews.Search = () => null;
+	MockDataViews.Search = () => <input type="search" aria-label="Search" />;
 	MockDataViews.FiltersToggle = () => null;
-	MockDataViews.LayoutSwitcher = () => null;
-	MockDataViews.ViewConfig = () => null;
+	MockDataViews.LayoutSwitcher = () => <button>Layout</button>;
+	MockDataViews.ViewConfig = () => <button>View options</button>;
 	MockDataViews.FiltersToggled = () => null;
 	MockDataViews.Layout = () => (
 		<div className="dataviews-layout__container" />
@@ -82,13 +82,18 @@ jest.mock(
 	'../../../src/components/fields/ColumnHeaderActions',
 	() => () => null
 );
-jest.mock( '../../../src/components/DataViewNewRowButton', () => () => null );
+jest.mock( '../../../src/components/DataViewNewRowButton', () => () => (
+	<button className="cortext-data-view__new-row">New</button>
+) );
 jest.mock( '../../../src/components/Skeleton', () => ( {
 	CollectionRowsSkeleton: () => <div data-testid="rows-skeleton" />,
 } ) );
 jest.mock( '../../../src/hooks/afterNextPaint', () => ( {
 	__esModule: true,
 	default: jest.fn( () => Promise.resolve() ),
+} ) );
+jest.mock( '../../../src/hooks/viewTransition', () => ( {
+	whenViewTransitionsSettled: jest.fn( () => Promise.resolve() ),
 } ) );
 jest.mock( '../../../src/components/dataViewScroll', () => {
 	const actual = jest.requireActual(
@@ -103,6 +108,7 @@ jest.mock( '../../../src/components/dataViewScroll', () => {
 import { useCollectionFieldsContext } from '../../../src/components/CollectionFieldsContext';
 import CollectionDataViews from '../../../src/components/CollectionDataViews';
 import { scrollToEndQuickly } from '../../../src/components/dataViewScroll';
+import { whenViewTransitionsSettled } from '../../../src/hooks/viewTransition';
 import useCollectionRows from '../../../src/hooks/useCollectionRows';
 
 const tableView = {
@@ -168,6 +174,9 @@ describe( 'CollectionDataViews loading state', () => {
 	beforeEach( () => {
 		mockDataViews.mockClear();
 		mockDataViewRowReorder.mockClear();
+		whenViewTransitionsSettled.mockImplementation( () =>
+			Promise.resolve()
+		);
 		useCollectionFieldsContext.mockReturnValue( collectionFieldState );
 	} );
 
@@ -218,6 +227,277 @@ describe( 'CollectionDataViews loading state', () => {
 
 		expect( mockDataViews ).toHaveBeenCalled();
 		expect( mockDataViews.mock.calls.at( -1 )[ 0 ].isLoading ).toBe( true );
+	} );
+} );
+
+describe( 'CollectionDataViews surface focus', () => {
+	beforeEach( () => {
+		mockDataViews.mockClear();
+		mockDataViewRowReorder.mockClear();
+		useCollectionFieldsContext.mockReturnValue( collectionFieldState );
+	} );
+
+	function focusOrigin() {
+		const originElement = document.createElement( 'button' );
+		document.body.appendChild( originElement );
+		originElement.focus();
+		return originElement;
+	}
+
+	function createFulfillingCompletion() {
+		return jest.fn( ( token, onConsume ) => {
+			onConsume?.();
+			return true;
+		} );
+	}
+
+	it( 'focuses Search when the collection has rows', async () => {
+		useCollectionRows.mockReturnValue(
+			collectionRowsState( {
+				data: [ { id: 1, title: { raw: 'First row' } } ],
+				paginationInfo: { totalItems: 1, totalPages: 1 },
+			} )
+		);
+		const originElement = focusOrigin();
+		const completeSurfaceFocus = createFulfillingCompletion();
+		const { container } = render(
+			<CollectionDataViews
+				collectionId={ 7 }
+				view={ tableView }
+				onChangeView={ jest.fn() }
+				surfaceFocusRequest={ {
+					token: 11,
+					documentId: '7',
+					originElement,
+				} }
+				isEditorSurfaceDisplayed
+				completeSurfaceFocus={ completeSurfaceFocus }
+			/>
+		);
+
+		await waitFor( () => {
+			expect( completeSurfaceFocus ).toHaveBeenCalledWith(
+				11,
+				expect.any( Function )
+			);
+			expect(
+				container.querySelector( 'input[type="search"]' )
+			).toHaveFocus();
+		} );
+		originElement.remove();
+	} );
+
+	it( 'focuses New when the collection is empty and unfiltered', async () => {
+		useCollectionRows.mockReturnValue( collectionRowsState() );
+		const originElement = focusOrigin();
+		const completeSurfaceFocus = createFulfillingCompletion();
+		const { container } = render(
+			<CollectionDataViews
+				collectionId={ 7 }
+				view={ tableView }
+				onChangeView={ jest.fn() }
+				surfaceFocusRequest={ {
+					token: 12,
+					documentId: 7,
+					originElement,
+				} }
+				isEditorSurfaceDisplayed
+				completeSurfaceFocus={ completeSurfaceFocus }
+			/>
+		);
+
+		await waitFor( () => {
+			expect( completeSurfaceFocus ).toHaveBeenCalledWith(
+				12,
+				expect.any( Function )
+			);
+			expect(
+				container.querySelector( '.cortext-data-view__new-row' )
+			).toHaveFocus();
+		} );
+		originElement.remove();
+	} );
+
+	it( 'waits until the requested collection is visible', async () => {
+		useCollectionRows.mockReturnValue(
+			collectionRowsState( {
+				data: [ { id: 1, title: { raw: 'First row' } } ],
+				paginationInfo: { totalItems: 1, totalPages: 1 },
+			} )
+		);
+		const originElement = focusOrigin();
+		const completeSurfaceFocus = createFulfillingCompletion();
+		const request = { token: 13, documentId: 7, originElement };
+		const props = {
+			collectionId: 7,
+			view: tableView,
+			onChangeView: jest.fn(),
+			surfaceFocusRequest: request,
+			completeSurfaceFocus,
+		};
+		const { rerender } = render(
+			<CollectionDataViews
+				{ ...props }
+				isEditorSurfaceDisplayed={ false }
+			/>
+		);
+
+		expect( completeSurfaceFocus ).not.toHaveBeenCalled();
+		expect( originElement ).toHaveFocus();
+
+		rerender(
+			<CollectionDataViews { ...props } isEditorSurfaceDisplayed />
+		);
+		await waitFor( () =>
+			expect( completeSurfaceFocus ).toHaveBeenCalledWith(
+				13,
+				expect.any( Function )
+			)
+		);
+		originElement.remove();
+	} );
+
+	it( 'consumes the request without moving focus when rows fail', () => {
+		useCollectionRows.mockReturnValue(
+			collectionRowsState( { error: new Error( 'Rows failed' ) } )
+		);
+		const originElement = focusOrigin();
+		const completeSurfaceFocus = jest.fn( () => true );
+
+		render(
+			<CollectionDataViews
+				collectionId={ 7 }
+				view={ tableView }
+				onChangeView={ jest.fn() }
+				surfaceFocusRequest={ {
+					token: 14,
+					documentId: 7,
+					originElement,
+				} }
+				isEditorSurfaceDisplayed
+				completeSurfaceFocus={ completeSurfaceFocus }
+			/>
+		);
+
+		expect( completeSurfaceFocus ).toHaveBeenCalledWith( 14 );
+		expect( originElement ).toHaveFocus();
+		originElement.remove();
+	} );
+
+	it( 'waits for the editor lock, then consumes without moving focus if the surface is read-only', async () => {
+		useCollectionRows.mockReturnValue(
+			collectionRowsState( {
+				data: [ { id: 1, title: { raw: 'First row' } } ],
+				paginationInfo: { totalItems: 1, totalPages: 1 },
+			} )
+		);
+		const originElement = focusOrigin();
+		const completeSurfaceFocus = jest.fn( () => true );
+		const request = { token: 17, documentId: 7, originElement };
+		const props = {
+			collectionId: 7,
+			view: tableView,
+			onChangeView: jest.fn(),
+			surfaceFocusRequest: request,
+			isEditorSurfaceDisplayed: true,
+			completeSurfaceFocus,
+		};
+		const { rerender } = render(
+			<CollectionDataViews { ...props } isSurfaceFocusPending />
+		);
+
+		expect( completeSurfaceFocus ).not.toHaveBeenCalled();
+		expect( originElement ).toHaveFocus();
+
+		rerender( <CollectionDataViews { ...props } isSurfaceFocusReadOnly /> );
+		await waitFor( () =>
+			expect( completeSurfaceFocus ).toHaveBeenCalledWith( 17 )
+		);
+		expect( originElement ).toHaveFocus();
+		originElement.remove();
+	} );
+
+	it( "keeps the user's new focus while the view transition finishes", async () => {
+		useCollectionRows.mockReturnValue(
+			collectionRowsState( {
+				data: [ { id: 1, title: { raw: 'First row' } } ],
+				paginationInfo: { totalItems: 1, totalPages: 1 },
+			} )
+		);
+		let settleTransition;
+		whenViewTransitionsSettled.mockImplementationOnce(
+			() =>
+				new Promise( ( resolve ) => {
+					settleTransition = resolve;
+				} )
+		);
+		const originElement = focusOrigin();
+		const newTarget = document.createElement( 'button' );
+		document.body.appendChild( newTarget );
+		const completeSurfaceFocus = jest.fn( () => true );
+		const { container } = render(
+			<CollectionDataViews
+				collectionId={ 7 }
+				view={ tableView }
+				onChangeView={ jest.fn() }
+				surfaceFocusRequest={ {
+					token: 15,
+					documentId: 7,
+					originElement,
+				} }
+				isEditorSurfaceDisplayed
+				completeSurfaceFocus={ completeSurfaceFocus }
+			/>
+		);
+
+		newTarget.focus();
+		settleTransition();
+		await waitFor( () =>
+			expect( completeSurfaceFocus ).toHaveBeenCalledWith( 15 )
+		);
+		expect( newTarget ).toHaveFocus();
+		expect(
+			container.querySelector( 'input[type="search"]' )
+		).not.toHaveFocus();
+		originElement.remove();
+		newTarget.remove();
+	} );
+
+	it( 'leaves focus alone when another consumer has claimed the request', async () => {
+		useCollectionRows.mockReturnValue(
+			collectionRowsState( {
+				data: [ { id: 1, title: { raw: 'First row' } } ],
+				paginationInfo: { totalItems: 1, totalPages: 1 },
+			} )
+		);
+		const originElement = focusOrigin();
+		const completeSurfaceFocus = jest.fn( () => false );
+		const { container } = render(
+			<CollectionDataViews
+				collectionId={ 7 }
+				view={ tableView }
+				onChangeView={ jest.fn() }
+				surfaceFocusRequest={ {
+					token: 16,
+					documentId: 7,
+					originElement,
+				} }
+				isEditorSurfaceDisplayed
+				completeSurfaceFocus={ completeSurfaceFocus }
+			/>
+		);
+
+		await waitFor( () =>
+			expect( completeSurfaceFocus ).toHaveBeenCalledWith(
+				16,
+				expect.any( Function )
+			)
+		);
+		expect( originElement ).toHaveFocus();
+		expect(
+			container.querySelector( 'input[type="search"]' )
+		).not.toHaveFocus();
+		originElement.remove();
 	} );
 } );
 

--- a/tests/js/components/EditorBody.test.js
+++ b/tests/js/components/EditorBody.test.js
@@ -79,8 +79,10 @@ const {
 	areCanvasReadyRequirementsMet,
 	collectCollectionBodyClientIdsToRemove,
 	collectDuplicateHeaderClientIds,
+	getDocumentSurfaceFocusClientId,
 	projectIframeRectToParent,
 	rectsOverlap,
+	scheduleDocumentSurfaceFocus,
 	useEditorBodyStyles,
 } = require( '../../../src/components/EditorBody' );
 const { renderHook } = require( '@testing-library/react' );
@@ -99,6 +101,131 @@ function ownerBlock( clientId, collectionId ) {
 function namedBlock( clientId, name, attributes = {} ) {
 	return { clientId, name, attributes };
 }
+
+describe( 'getDocumentSurfaceFocusClientId', () => {
+	const headerBlocks = [
+		namedBlock( 'cover', 'cortext/document-cover' ),
+		namedBlock( 'icon', 'cortext/document-icon' ),
+		namedBlock( 'title', 'core/post-title' ),
+		namedBlock( 'properties', 'cortext/document-properties' ),
+	];
+
+	it.each( [ '', '   ', '\n\t' ] )(
+		'focuses the title when its content is %j',
+		( title ) => {
+			expect(
+				getDocumentSurfaceFocusClientId( {
+					blocks: [
+						...headerBlocks,
+						namedBlock( 'body', 'core/paragraph' ),
+					],
+					title,
+				} )
+			).toBe( 'title' );
+		}
+	);
+
+	it( 'skips document headers and focuses the first root body block', () => {
+		expect(
+			getDocumentSurfaceFocusClientId( {
+				blocks: [
+					...headerBlocks,
+					namedBlock( 'first-body', 'core/heading' ),
+					namedBlock( 'second-body', 'core/paragraph' ),
+				],
+				title: 'Titled document',
+			} )
+		).toBe( 'first-body' );
+	} );
+
+	it( 'falls back to the title when a titled document has no body block', () => {
+		expect(
+			getDocumentSurfaceFocusClientId( {
+				blocks: headerBlocks,
+				title: 'Titled document',
+			} )
+		).toBe( 'title' );
+	} );
+
+	it( 'returns no page target for collections', () => {
+		expect(
+			getDocumentSurfaceFocusClientId( {
+				blocks: headerBlocks,
+				title: '',
+				ownerBlockName: OWNER,
+			} )
+		).toBeNull();
+	} );
+} );
+
+describe( 'scheduleDocumentSurfaceFocus', () => {
+	function setup() {
+		let frameCallback;
+		const ownerWindow = {
+			requestAnimationFrame: jest.fn( ( callback ) => {
+				frameCallback = callback;
+				return 7;
+			} ),
+			cancelAnimationFrame: jest.fn(),
+		};
+		const selectBlock = jest.fn();
+		const completeSurfaceFocus = jest.fn( ( token, onConsume ) => {
+			onConsume();
+			return true;
+		} );
+
+		return {
+			completeSurfaceFocus,
+			ownerWindow,
+			runFrame: () => frameCallback(),
+			selectBlock,
+		};
+	}
+
+	it( 'clears the selection, then revalidates and places the caret on the next frame', () => {
+		const state = setup();
+		scheduleDocumentSurfaceFocus( {
+			clientId: 'body',
+			completeSurfaceFocus: state.completeSurfaceFocus,
+			originIsCurrent: () => true,
+			ownerWindow: state.ownerWindow,
+			requestIsCurrent: () => true,
+			selectBlock: state.selectBlock,
+			token: 9,
+		} );
+
+		expect( state.selectBlock ).toHaveBeenCalledWith( 'body', null );
+		expect( state.completeSurfaceFocus ).not.toHaveBeenCalled();
+
+		state.runFrame();
+
+		expect( state.completeSurfaceFocus ).toHaveBeenCalledWith(
+			9,
+			expect.any( Function )
+		);
+		expect( state.selectBlock ).toHaveBeenLastCalledWith( 'body', 0 );
+	} );
+
+	it( 'stops if the request is cancelled before the next frame', () => {
+		const state = setup();
+		let requestIsCurrent = true;
+		scheduleDocumentSurfaceFocus( {
+			clientId: 'body',
+			completeSurfaceFocus: state.completeSurfaceFocus,
+			originIsCurrent: () => true,
+			ownerWindow: state.ownerWindow,
+			requestIsCurrent: () => requestIsCurrent,
+			selectBlock: state.selectBlock,
+			token: 9,
+		} );
+		requestIsCurrent = false;
+
+		state.runFrame();
+
+		expect( state.completeSurfaceFocus ).not.toHaveBeenCalled();
+		expect( state.selectBlock ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
 
 describe( 'rectsOverlap', () => {
 	const toolbarRect = { left: 100, top: 100, right: 200, bottom: 150 };

--- a/tests/js/components/SidebarFavorites.test.js
+++ b/tests/js/components/SidebarFavorites.test.js
@@ -1,4 +1,12 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+const mockRequestFromActivation = jest.fn();
+
+jest.mock( '../../../src/components/SurfaceFocusContext', () => ( {
+	useSurfaceFocusIntent: () => ( {
+		requestFromActivation: mockRequestFromActivation,
+	} ),
+} ) );
 
 jest.mock( '@wordpress/core-data', () => ( {
 	__esModule: true,
@@ -31,6 +39,10 @@ function renderFavorites( props = {} ) {
 
 afterEach( () => {
 	jest.useRealTimers();
+} );
+
+beforeEach( () => {
+	mockRequestFromActivation.mockReset();
 } );
 
 describe( 'SidebarFavorites helpers', () => {
@@ -349,5 +361,88 @@ describe( 'SidebarFavorites helpers', () => {
 		expect(
 			container.querySelector( '.cortext-sidebar__loading' )
 		).toBeNull();
+	} );
+
+	it( 'requests canvas focus without blurring the selected favorite', () => {
+		const onSelect = jest.fn( () => false );
+		const blurSpy = jest.spyOn( window.HTMLElement.prototype, 'blur' );
+		const { container } = renderFavorites( {
+			favorites: [ { id: 1 } ],
+			pages: [
+				{
+					id: 1,
+					slug: 'notes',
+					title: { rendered: 'Notes', raw: 'Notes' },
+				},
+			],
+			onSelect,
+		} );
+		const button = container.querySelector(
+			'.cortext-sidebar__favorite-title'
+		);
+
+		button.focus();
+		fireEvent.click( button, { detail: 0 } );
+
+		expect( mockRequestFromActivation ).toHaveBeenCalledWith(
+			expect.objectContaining( { detail: 0 } ),
+			1
+		);
+		expect( onSelect ).toHaveBeenCalled();
+		expect( blurSpy ).not.toHaveBeenCalled();
+		blurSpy.mockRestore();
+	} );
+
+	it( 'lets unrelated shortcuts bubble from a favorite title', () => {
+		const { container } = renderFavorites( {
+			favorites: [ { id: 1 } ],
+			pages: [
+				{
+					id: 1,
+					slug: 'notes',
+					title: { rendered: 'Notes', raw: 'Notes' },
+				},
+			],
+		} );
+		const keyDown = jest.fn();
+		container.addEventListener( 'keydown', keyDown );
+
+		fireEvent.keyDown(
+			container.querySelector( '.cortext-sidebar__favorite-title' ),
+			{ key: '\\', metaKey: true }
+		);
+
+		expect( keyDown ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'still blurs a favorite after pointer activation', () => {
+		const onSelect = jest.fn( () => false );
+		const blurSpy = jest
+			.spyOn( window.HTMLElement.prototype, 'blur' )
+			.mockImplementation( () => {} );
+		const { container } = renderFavorites( {
+			favorites: [ { id: 1 } ],
+			pages: [
+				{
+					id: 1,
+					slug: 'notes',
+					title: { rendered: 'Notes', raw: 'Notes' },
+				},
+			],
+			onSelect,
+		} );
+
+		const button = container.querySelector(
+			'.cortext-sidebar__favorite-title'
+		);
+		fireEvent.click( button, { detail: 1 } );
+
+		expect( mockRequestFromActivation ).toHaveBeenCalledWith(
+			expect.objectContaining( { detail: 1 } ),
+			1
+		);
+		expect( onSelect ).toHaveBeenCalled();
+		expect( blurSpy ).toHaveBeenCalled();
+		blurSpy.mockRestore();
 	} );
 } );

--- a/tests/js/components/SidebarRecents.test.js
+++ b/tests/js/components/SidebarRecents.test.js
@@ -4,6 +4,13 @@ let mockRecents = [];
 let mockIsResolving = false;
 let mockRecordsById = new Map();
 const mockNavigate = jest.fn();
+const mockRequestFromActivation = jest.fn();
+
+jest.mock( '../../../src/components/SurfaceFocusContext', () => ( {
+	useSurfaceFocusIntent: () => ( {
+		requestFromActivation: mockRequestFromActivation,
+	} ),
+} ) );
 
 jest.mock( '@tanstack/react-router', () => ( {
 	useNavigate: () => mockNavigate,
@@ -85,6 +92,7 @@ const rectForIndex = ( index ) => ( {
 
 beforeEach( () => {
 	mockNavigate.mockReset();
+	mockRequestFromActivation.mockReset();
 	mockRecents = [];
 	mockIsResolving = false;
 	mockRecordsById = new Map();
@@ -130,7 +138,30 @@ describe( 'SidebarRecents animation', () => {
 		);
 	} );
 
-	it( 'blurs the clicked recent before navigating', () => {
+	it( 'keeps focus on a recent activated from the keyboard', () => {
+		const blurSpy = jest
+			.spyOn( window.HTMLElement.prototype, 'blur' )
+			.mockImplementation( () => {} );
+		mockRecents = [ pageRecent( 1, 'Alpha' ) ];
+
+		render( <SidebarRecents /> );
+		const button = screen.getByRole( 'button', { name: 'Recent: Alpha' } );
+		button.focus();
+		button.click();
+
+		expect( mockRequestFromActivation ).toHaveBeenCalledWith(
+			expect.objectContaining( { detail: 0 } ),
+			1
+		);
+		expect( blurSpy ).not.toHaveBeenCalled();
+		expect( mockNavigate ).toHaveBeenCalledWith( {
+			to: '/$',
+			params: { _splat: 'alpha-1' },
+		} );
+		blurSpy.mockRestore();
+	} );
+
+	it( 'blurs a pointer-activated recent before navigating', () => {
 		const blurSpy = jest
 			.spyOn( window.HTMLElement.prototype, 'blur' )
 			.mockImplementation( () => {} );
@@ -138,9 +169,16 @@ describe( 'SidebarRecents animation', () => {
 
 		render( <SidebarRecents /> );
 		fireEvent.click(
-			screen.getByRole( 'button', { name: 'Recent: Alpha' } )
+			screen.getByRole( 'button', { name: 'Recent: Alpha' } ),
+			{
+				detail: 1,
+			}
 		);
 
+		expect( mockRequestFromActivation ).toHaveBeenCalledWith(
+			expect.objectContaining( { detail: 1 } ),
+			1
+		);
 		expect( blurSpy ).toHaveBeenCalled();
 		expect( mockNavigate ).toHaveBeenCalledWith( {
 			to: '/$',

--- a/tests/js/components/SurfaceFocusContext.test.js
+++ b/tests/js/components/SurfaceFocusContext.test.js
@@ -1,0 +1,184 @@
+import { act, renderHook } from '@testing-library/react';
+
+import {
+	SurfaceFocusProvider,
+	useSurfaceFocusIntent,
+} from '../../../src/components/SurfaceFocusContext';
+
+function wrapper( { children } ) {
+	return <SurfaceFocusProvider>{ children }</SurfaceFocusProvider>;
+}
+
+function activation( originElement, detail = 0 ) {
+	return { currentTarget: originElement, detail };
+}
+
+describe( 'SurfaceFocusProvider', () => {
+	it( 'creates a keyboard request and replaces the previous one', () => {
+		const firstOrigin = document.createElement( 'button' );
+		const secondOrigin = document.createElement( 'button' );
+		const { result } = renderHook( () => useSurfaceFocusIntent(), {
+			wrapper,
+		} );
+
+		let firstToken;
+		act( () => {
+			firstToken = result.current.requestFromActivation(
+				activation( firstOrigin ),
+				41
+			);
+		} );
+		expect( result.current.request ).toEqual( {
+			token: firstToken,
+			documentId: 41,
+			originElement: firstOrigin,
+		} );
+
+		let secondToken;
+		act( () => {
+			secondToken = result.current.requestFromActivation(
+				activation( secondOrigin ),
+				42
+			);
+		} );
+		expect( secondToken ).toBeGreaterThan( firstToken );
+		expect( result.current.request ).toEqual( {
+			token: secondToken,
+			documentId: 42,
+			originElement: secondOrigin,
+		} );
+	} );
+
+	it( 'cancels a pending request on pointer activation', () => {
+		const origin = document.createElement( 'button' );
+		const { result } = renderHook( () => useSurfaceFocusIntent(), {
+			wrapper,
+		} );
+
+		act( () => {
+			result.current.requestFromActivation( activation( origin ), 41 );
+		} );
+		act( () => {
+			result.current.requestFromActivation( activation( origin, 1 ), 41 );
+		} );
+
+		expect( result.current.request ).toBeNull();
+	} );
+
+	it( 'consumes only the request with the current token', () => {
+		const origin = document.createElement( 'button' );
+		const { result } = renderHook( () => useSurfaceFocusIntent(), {
+			wrapper,
+		} );
+		let firstToken;
+		let secondToken;
+		const onConsume = jest.fn();
+
+		act( () => {
+			firstToken = result.current.requestFromActivation(
+				activation( origin ),
+				41
+			);
+			secondToken = result.current.requestFromActivation(
+				activation( origin ),
+				42
+			);
+		} );
+
+		act( () => {
+			expect( result.current.consume( firstToken, onConsume ) ).toBe(
+				false
+			);
+		} );
+		expect( onConsume ).not.toHaveBeenCalled();
+		expect( result.current.request?.token ).toBe( secondToken );
+
+		act( () => {
+			expect( result.current.consume( secondToken, onConsume ) ).toBe(
+				true
+			);
+			expect( result.current.consume( secondToken, onConsume ) ).toBe(
+				false
+			);
+		} );
+		expect( onConsume ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.request ).toBeNull();
+	} );
+
+	it( 'cancels when focus leaves the activating control', () => {
+		const origin = document.createElement( 'button' );
+		const next = document.createElement( 'button' );
+		document.body.append( origin, next );
+		origin.focus();
+		const { result } = renderHook( () => useSurfaceFocusIntent(), {
+			wrapper,
+		} );
+
+		act( () => {
+			result.current.requestFromActivation( activation( origin ), 41 );
+		} );
+		act( () => next.focus() );
+
+		expect( result.current.request ).toBeNull();
+		origin.remove();
+		next.remove();
+	} );
+
+	it( 'cancels on pointer input even if focus stays put', () => {
+		const origin = document.createElement( 'button' );
+		const nonFocusableTarget = document.createElement( 'div' );
+		document.body.append( origin, nonFocusableTarget );
+		origin.focus();
+		const { result } = renderHook( () => useSurfaceFocusIntent(), {
+			wrapper,
+		} );
+
+		act( () => {
+			result.current.requestFromActivation( activation( origin ), 41 );
+		} );
+		act( () => {
+			nonFocusableTarget.dispatchEvent(
+				new window.MouseEvent( 'pointerdown', { bubbles: true } )
+			);
+		} );
+
+		expect( document.activeElement ).toBe( origin );
+		expect( result.current.request ).toBeNull();
+		origin.remove();
+		nonFocusableTarget.remove();
+	} );
+
+	it( 'cancels on back or forward navigation', () => {
+		const origin = document.createElement( 'button' );
+		const { result } = renderHook( () => useSurfaceFocusIntent(), {
+			wrapper,
+		} );
+
+		act( () => {
+			result.current.requestFromActivation( activation( origin ), 41 );
+		} );
+		act( () =>
+			window.dispatchEvent( new window.PopStateEvent( 'popstate' ) )
+		);
+
+		expect( result.current.request ).toBeNull();
+	} );
+
+	it( 'cancels when focus leaves the browser window', () => {
+		const origin = document.createElement( 'button' );
+		document.body.appendChild( origin );
+		origin.focus();
+		const { result } = renderHook( () => useSurfaceFocusIntent(), {
+			wrapper,
+		} );
+
+		act( () => {
+			result.current.requestFromActivation( activation( origin ), 41 );
+		} );
+		act( () => window.dispatchEvent( new window.FocusEvent( 'blur' ) ) );
+
+		expect( document.activeElement ).toBe( origin );
+		expect( result.current.request ).toBeNull();
+		origin.remove();
+	} );
+} );

--- a/tests/js/components/collectionSurfaceFocus.test.js
+++ b/tests/js/components/collectionSurfaceFocus.test.js
@@ -1,0 +1,153 @@
+import {
+	getCollectionSurfaceFocusTarget,
+	isCollectionTrulyEmpty,
+	isSurfaceFocusOriginCurrent,
+} from '../../../src/components/collectionSurfaceFocus';
+
+function collectionRoot( markup ) {
+	const root = document.createElement( 'div' );
+	root.innerHTML = markup;
+	return root;
+}
+
+describe( 'getCollectionSurfaceFocusTarget', () => {
+	it( 'chooses New before Search when the collection is empty and unfiltered', () => {
+		const root = collectionRoot( `
+			<div data-cortext-focus-region="search"><input type="search" /></div>
+			<button class="cortext-data-view__new-row">New</button>
+		` );
+
+		expect(
+			getCollectionSurfaceFocusTarget( root, {
+				isTrulyEmpty: true,
+				layoutType: 'table',
+			} )
+		).toHaveTextContent( 'New' );
+	} );
+
+	it( 'chooses Search when the collection is not truly empty', () => {
+		const root = collectionRoot( `
+			<div data-cortext-focus-region="search"><input type="search" /></div>
+			<button class="cortext-data-view__new-row">New</button>
+		` );
+
+		expect(
+			getCollectionSurfaceFocusTarget( root, {
+				isTrulyEmpty: false,
+				layoutType: 'table',
+			} )
+		).toHaveAttribute( 'type', 'search' );
+	} );
+
+	it( 'uses the first enabled view control when Search is unavailable', () => {
+		const root = collectionRoot( `
+			<div data-cortext-focus-region="view-controls">
+				<button disabled>Layout</button>
+				<button>View options</button>
+			</div>
+		` );
+
+		expect(
+			getCollectionSurfaceFocusTarget( root, {
+				isTrulyEmpty: false,
+				layoutType: 'table',
+			} )
+		).toHaveTextContent( 'View options' );
+	} );
+
+	it.each( [
+		[
+			'table',
+			`<table><tbody><tr class="dataviews-view-table__row"><td><div class="cortext-title-cell"><div class="cortext-editable-cell__shell" role="button" tabindex="0">Title</div></div></td></tr></tbody></table>`,
+			'.cortext-editable-cell__shell',
+		],
+		[
+			'grid',
+			`<div class="dataviews-view-grid"><div role="gridcell" class="dataviews-view-grid__card" tabindex="0">Card</div></div>`,
+			'[role="gridcell"]',
+		],
+		[
+			'list',
+			`<div class="dataviews-view-list"><div class="dataviews-view-list__item" tabindex="0">List item</div></div>`,
+			'.dataviews-view-list__item',
+		],
+	] )(
+		'uses the first accessible %s row when no controls are available',
+		( layoutType, markup, selector ) => {
+			const root = collectionRoot( markup );
+
+			expect(
+				getCollectionSurfaceFocusTarget( root, {
+					isTrulyEmpty: false,
+					layoutType,
+				} )
+			).toBe( root.querySelector( selector ) );
+		}
+	);
+
+	it( 'skips placeholders and the New card in grid view', () => {
+		const root = collectionRoot( `
+			<div class="dataviews-view-grid">
+				<div role="gridcell" class="dataviews-view-grid__card dataviews-view-grid__placeholder"></div>
+				<div role="gridcell" class="dataviews-view-grid__card cortext-data-view__new-row-gridcell"></div>
+				<div role="gridcell" class="dataviews-view-grid__card" tabindex="0">First row</div>
+			</div>
+		` );
+
+		expect(
+			getCollectionSurfaceFocusTarget( root, {
+				isTrulyEmpty: false,
+				layoutType: 'grid',
+			} )
+		).toHaveTextContent( 'First row' );
+	} );
+} );
+
+describe( 'isCollectionTrulyEmpty', () => {
+	it( 'treats zero rows as empty only after loading, with no search or filters', () => {
+		expect(
+			isCollectionTrulyEmpty( {
+				rowsResolved: true,
+				totalItems: 0,
+				view: {},
+			} )
+		).toBe( true );
+		expect(
+			isCollectionTrulyEmpty( {
+				rowsResolved: true,
+				totalItems: 0,
+				view: { search: 'missing' },
+			} )
+		).toBe( false );
+		expect(
+			isCollectionTrulyEmpty( {
+				rowsResolved: true,
+				totalItems: 0,
+				view: { filters: [ { field: 'status' } ] },
+			} )
+		).toBe( false );
+		expect(
+			isCollectionTrulyEmpty( {
+				rowsResolved: false,
+				totalItems: 0,
+				view: {},
+			} )
+		).toBe( false );
+	} );
+} );
+
+describe( 'isSurfaceFocusOriginCurrent', () => {
+	it( 'returns true only while the origin is connected and focused', () => {
+		const origin = document.createElement( 'button' );
+		const other = document.createElement( 'button' );
+		document.body.append( origin, other );
+		origin.focus();
+
+		expect( isSurfaceFocusOriginCurrent( origin ) ).toBe( true );
+		other.focus();
+		expect( isSurfaceFocusOriginCurrent( origin ) ).toBe( false );
+
+		origin.remove();
+		other.remove();
+	} );
+} );

--- a/tests/js/components/sidebar/DocumentRow.test.js
+++ b/tests/js/components/sidebar/DocumentRow.test.js
@@ -16,6 +16,13 @@ import { DndContext } from '@dnd-kit/core';
 const mockRename = jest.fn();
 const mockDuplicate = jest.fn();
 const mockTrash = jest.fn();
+const mockRequestFromActivation = jest.fn();
+
+jest.mock( '../../../../src/components/SurfaceFocusContext', () => ( {
+	useSurfaceFocusIntent: () => ( {
+		requestFromActivation: mockRequestFromActivation,
+	} ),
+} ) );
 
 jest.mock( '../../../../src/documents', () => {
 	const ReactLib = require( 'react' );
@@ -108,11 +115,11 @@ function baseProps( overrides = {} ) {
 	};
 }
 
-function renderRow( overrides = {} ) {
+function renderRow( overrides = {}, wrapperProps = {} ) {
 	const props = baseProps( overrides );
 	const utils = render(
 		<DndContext>
-			<ul>
+			<ul { ...wrapperProps }>
 				<DocumentRow { ...props } />
 			</ul>
 		</DndContext>
@@ -123,11 +130,13 @@ function renderRow( overrides = {} ) {
 // Popover positioning can finish after a test has already unmounted. Jest
 // then sees React's act warning during the next test and fails the suite.
 // Ignore only that warning; every other console.error should still fail.
+// eslint-disable-next-line no-console
 const originalError = console.error;
 beforeEach( () => {
 	mockRename.mockReset();
 	mockDuplicate.mockReset();
 	mockTrash.mockReset();
+	mockRequestFromActivation.mockReset();
 	jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
 		const first = args[ 0 ];
 		if (
@@ -141,6 +150,7 @@ beforeEach( () => {
 } );
 
 afterEach( () => {
+	// eslint-disable-next-line no-console
 	console.error.mockRestore?.();
 } );
 
@@ -273,8 +283,39 @@ describe( 'DocumentRow (hierarchical mode)', () => {
 
 	it( 'calls onSelect with the record when the title is clicked', () => {
 		const { container, props } = renderRow();
-		fireEvent.click( container.querySelector( '.cortext-sidebar__title' ) );
+		fireEvent.click( container.querySelector( '.cortext-sidebar__title' ), {
+			detail: 0,
+		} );
+		expect( mockRequestFromActivation ).toHaveBeenCalledWith(
+			expect.objectContaining( { detail: 0 } ),
+			props.record.id
+		);
 		expect( props.onSelect ).toHaveBeenCalledWith( props.record );
+	} );
+
+	it( 'forwards pointer clicks to cancel a pending focus request', () => {
+		const { container, props } = renderRow();
+		fireEvent.click( container.querySelector( '.cortext-sidebar__title' ), {
+			detail: 1,
+		} );
+
+		expect( mockRequestFromActivation ).toHaveBeenCalledWith(
+			expect.objectContaining( { detail: 1 } ),
+			props.record.id
+		);
+		expect( props.onSelect ).toHaveBeenCalledWith( props.record );
+	} );
+
+	it( 'stops activation keys at the title but lets other shortcuts bubble', () => {
+		const keyDown = jest.fn();
+		const { container } = renderRow( {}, { onKeyDown: keyDown } );
+		const title = container.querySelector( '.cortext-sidebar__title' );
+
+		fireEvent.keyDown( title, { key: 'Enter' } );
+		expect( keyDown ).not.toHaveBeenCalled();
+
+		fireEvent.keyDown( title, { key: '\\', metaKey: true } );
+		expect( keyDown ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'adds is-selected when the predicate matches', () => {


### PR DESCRIPTION
## What

Closes #145.

When someone opens a document from the sidebar with the keyboard or assistive technology, focus now moves into the content once it is ready. Pages and full-page rows use the title or first body block. Empty collections start at New, while collections with content start at Search. Pointer clicks, browser history, and focus changes during loading leave focus alone.

## Why

Opening a document changed the main view but left keyboard and screen reader users behind in the sidebar.

## Testing Instructions

1. Prepare an untitled page, a titled page with a body block, an empty collection, and a collection with a full-page row.
2. Using only Tab and Enter, open the untitled and titled pages from Documents and Home. Focus should move to the title of the untitled page and the first body block of the titled page.
3. With the keyboard, open the full-page row and both collections from Recents or Favorites. Focus should move to the row body, New in the empty collection, and Search in the populated collection.
4. Press Enter again on the currently open item. Focus should return to the same place in the document.
5. Repeat the navigation with a mouse, then use browser back and forward. Focus should not move into the document.
6. Throttle a document request, open it with Enter, and move focus elsewhere before it finishes loading. The document should not take focus back.
7. Create and duplicate a document from the sidebar. The rename field should keep focus in both cases.
8. Repeat one keyboard flow with VoiceOver. It should announce one useful target: the title, body block, New, Search, or a row.
