### PR TITLE
tooling: Accept any `type:` PR label

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -23,13 +23,11 @@ jobs:
               with:
                   mode: exactly
                   count: 1
-                  labels: '^(type: enhancement|type: bug|type: docs|type: tooling|type: dependencies|type: code quality)$'
+                  labels: '^type:'
                   use_regex: true
                   add_comment: true
                   message: |
                       **Choose one PR type**
 
-                      Add exactly one `type:*` label before merging this PR.
-
-                      Use one of: `type: enhancement`, `type: bug`, `type: docs`, `type: tooling`, `type: dependencies`, `type: code quality`.
+                      Add exactly one label starting with `type:` before merging this PR.
                   exit_type: failure


### PR DESCRIPTION
## What

Accept any PR label that starts with `type:` instead of listing every allowed type in the workflow. PRs still need exactly one.

## Why

Keeping a second list here means updating the workflow whenever the repository's `type:` labels change. Checking the prefix removes that maintenance step.

## Testing Instructions

1. Add one `type:` label and confirm the check passes.
2. Remove it, then add two `type:` labels, and confirm the check fails in both cases.
