### PR TITLE
Refactor: Extract shared document cascade logic

### DIFF
--- a/includes/PostType/DocumentCascade.php
+++ b/includes/PostType/DocumentCascade.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Provides shared traversal for document status cascades.
+ *
+ * Cascades follow two relationships:
+ *   - Children follow their immediate `post_parent`.
+ *   - Rows follow the collection whose trait term tags them.
+ *
+ * Callers provide the statuses, marker keys, and transition callback. This
+ * class handles marker lookups and walks descendants.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\PostType;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\Relations;
+use Cortext\Taxonomy\TraitTaxonomy;
+
+final class DocumentCascade {
+
+	/**
+	 * Creates a cascade for one target status.
+	 *
+	 * @param string[] $active_statuses       Statuses eligible for the cascade.
+	 * @param string   $target_status         Status to move documents into.
+	 * @param string   $parent_marker_meta    Meta key that links a child to its parent.
+	 * @param string   $collection_marker_meta Meta key that links a row to its collection.
+	 */
+	public function __construct(
+		private array $active_statuses,
+		private string $target_status,
+		private string $parent_marker_meta,
+		private string $collection_marker_meta
+	) {}
+
+	/**
+	 * Moves a document's active children and rows to the target status.
+	 *
+	 * @param int      $post_id    Document whose children and rows should move.
+	 * @param callable $transition Moves each child or row.
+	 */
+	public function cascade( int $post_id, callable $transition ): void {
+		if ( Document::POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		foreach ( $this->active_child_ids( $post_id ) as $child_id ) {
+			update_post_meta( $child_id, $this->parent_marker_meta, $post_id );
+			$transition( $child_id );
+		}
+
+		if ( Document::is_collection( $post_id ) ) {
+			foreach ( $this->active_row_ids( $post_id ) as $row_id ) {
+				update_post_meta( $row_id, $this->collection_marker_meta, $post_id );
+				$transition( $row_id );
+			}
+		}
+	}
+
+	/**
+	 * Restores the children and rows marked by this document.
+	 *
+	 * @param int      $post_id    Document whose children and rows should be restored.
+	 * @param callable $transition Restores each marked child or row.
+	 */
+	public function restore( int $post_id, callable $transition ): void {
+		if ( Document::POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		// Clear the restored document's own markers so a later ancestor
+		// restore cannot pull it through the cascade again.
+		delete_post_meta( $post_id, $this->parent_marker_meta );
+		delete_post_meta( $post_id, $this->collection_marker_meta );
+
+		foreach ( $this->children_marked_by( $post_id ) as $child_id ) {
+			$transition( $child_id );
+			delete_post_meta( $child_id, $this->parent_marker_meta );
+		}
+
+		if ( Document::is_collection( $post_id ) ) {
+			foreach ( $this->rows_marked_by( $post_id ) as $row_id ) {
+				$transition( $row_id );
+				delete_post_meta( $row_id, $this->collection_marker_meta );
+			}
+		}
+	}
+
+	/**
+	 * Finds all marked descendants below a document.
+	 *
+	 * @param int $root_id Root document ID.
+	 * @return int[] Descendant IDs, excluding the root.
+	 */
+	public function descendants_for_root( int $root_id ): array {
+		if ( Document::POST_TYPE !== get_post_type( $root_id ) ) {
+			return array();
+		}
+
+		$collected = array();
+		$seen      = array( $root_id => true );
+		$frontier  = array( $root_id );
+
+		while ( ! empty( $frontier ) ) {
+			$next = array();
+			foreach ( $frontier as $current ) {
+				foreach ( $this->children_marked_by( $current ) as $child_id ) {
+					if ( isset( $seen[ $child_id ] ) ) {
+						continue;
+					}
+					$seen[ $child_id ] = true;
+					$collected[]       = $child_id;
+					$next[]            = $child_id;
+				}
+				if ( Document::is_collection( $current ) ) {
+					foreach ( $this->rows_marked_by( $current ) as $row_id ) {
+						if ( isset( $seen[ $row_id ] ) ) {
+							continue;
+						}
+						$seen[ $row_id ] = true;
+						$collected[]     = $row_id;
+						$next[]          = $row_id;
+					}
+				}
+			}
+			$frontier = $next;
+		}
+
+		return $collected;
+	}
+
+	/**
+	 * Finds collection rows in any of the given statuses.
+	 *
+	 * @param int      $collection_id Collection document ID.
+	 * @param string[] $statuses      Statuses to include.
+	 * @return int[]
+	 */
+	public function row_ids_for_collection( int $collection_id, array $statuses ): array {
+		$term_id = Relations::trait_term_id_for_collection( $collection_id );
+		if ( $term_id < 1 ) {
+			return array();
+		}
+
+		$ids = get_posts(
+			array(
+				'post_type'      => Document::POST_TYPE,
+				'post_status'    => $statuses,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					array(
+						'taxonomy' => TraitTaxonomy::TAXONOMY,
+						'field'    => 'term_id',
+						'terms'    => array( $term_id ),
+					),
+				),
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Finds active children through `post_parent`.
+	 *
+	 * @param int $parent_id Parent document ID.
+	 * @return int[]
+	 */
+	private function active_child_ids( int $parent_id ): array {
+		$ids = get_posts(
+			array(
+				'post_type'      => Document::POST_TYPE,
+				'post_parent'    => $parent_id,
+				'post_status'    => $this->active_statuses,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Finds children in the target status marked by this parent.
+	 *
+	 * @param int $parent_id Parent ID stored in the marker.
+	 * @return int[]
+	 */
+	private function children_marked_by( int $parent_id ): array {
+		$ids = get_posts(
+			array(
+				'post_type'      => Document::POST_TYPE,
+				'post_status'    => $this->target_status,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_key'       => $this->parent_marker_meta, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => (string) $parent_id,        // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Finds active rows in a collection.
+	 *
+	 * @param int $collection_id Collection document ID.
+	 * @return int[]
+	 */
+	private function active_row_ids( int $collection_id ): array {
+		return $this->row_ids_for_collection( $collection_id, $this->active_statuses );
+	}
+
+	/**
+	 * Finds rows in the target status marked by this collection.
+	 *
+	 * @param int $collection_id Collection ID stored in the marker.
+	 * @return int[]
+	 */
+	private function rows_marked_by( int $collection_id ): array {
+		$term_id = Relations::trait_term_id_for_collection( $collection_id );
+		if ( $term_id < 1 ) {
+			return array();
+		}
+
+		$ids = get_posts(
+			array(
+				'post_type'      => Document::POST_TYPE,
+				'post_status'    => $this->target_status,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_key'       => $this->collection_marker_meta, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => (string) $collection_id,       // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					array(
+						'taxonomy' => TraitTaxonomy::TAXONOMY,
+						'field'    => 'term_id',
+						'terms'    => array( $term_id ),
+					),
+				),
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+}

--- a/includes/PostType/TrashCascade.php
+++ b/includes/PostType/TrashCascade.php
@@ -26,8 +26,8 @@ namespace Cortext\PostType;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\Relations;
-use Cortext\Taxonomy\TraitTaxonomy;
 use WP_Post;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -51,6 +51,17 @@ final class TrashCascade {
 
 	private const ACTIVE_STATUSES = array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft' );
 
+	private DocumentCascade $cascade;
+
+	public function __construct( ?DocumentCascade $cascade = null ) {
+		$this->cascade = $cascade ?? new DocumentCascade(
+			self::ACTIVE_STATUSES,
+			Documents::STATUS_TRASH,
+			self::PARENT_MARKER_META,
+			self::COLLECTION_MARKER_META
+		);
+	}
+
 	public function register(): void {
 		// Attach filters immediately so tests and admin flows see them right
 		// after register(). Marker meta still waits for init, matching
@@ -59,7 +70,7 @@ final class TrashCascade {
 		add_action( 'wp_trash_post', array( $this, 'on_trash' ), 10, 1 );
 		add_action( 'untrashed_post', array( $this, 'on_restore' ), 10, 1 );
 		// Runs before `TraitTaxonomy::sync_term_on_delete` (priority 10), so
-		// `all_row_ids()` still resolves the trait term and can collect the
+		// `row_ids_for_collection()` still resolves the trait term and can collect the
 		// collection's rows. Direct `wp_delete_post( $collection_id, true )`
 		// would otherwise orphan rows if the term were gone first.
 		add_action( 'before_delete_post', array( $this, 'on_delete' ), 5, 1 );
@@ -134,21 +145,12 @@ final class TrashCascade {
 	 * @param int $post_id Document id that was just moved to trash.
 	 */
 	public function on_trash( int $post_id ): void {
-		if ( Document::POST_TYPE !== get_post_type( $post_id ) ) {
-			return;
-		}
-
-		foreach ( $this->active_child_ids( $post_id ) as $child_id ) {
-			update_post_meta( $child_id, self::PARENT_MARKER_META, $post_id );
-			wp_trash_post( $child_id );
-		}
-
-		if ( Document::is_collection( $post_id ) ) {
-			foreach ( $this->active_row_ids( $post_id ) as $row_id ) {
-				update_post_meta( $row_id, self::COLLECTION_MARKER_META, $post_id );
-				wp_trash_post( $row_id );
+		$this->cascade->cascade(
+			$post_id,
+			static function ( int $child_id ): void {
+				wp_trash_post( $child_id );
 			}
-		}
+		);
 	}
 
 	/**
@@ -159,26 +161,12 @@ final class TrashCascade {
 	 * @param int $post_id Document id that was just restored.
 	 */
 	public function on_restore( int $post_id ): void {
-		if ( Document::POST_TYPE !== get_post_type( $post_id ) ) {
-			return;
-		}
-
-		// Clear the restored document's own markers so a later ancestor
-		// restore cannot pull it through the cascade again.
-		delete_post_meta( $post_id, self::PARENT_MARKER_META );
-		delete_post_meta( $post_id, self::COLLECTION_MARKER_META );
-
-		foreach ( $this->trashed_children_marked_by( $post_id ) as $child_id ) {
-			wp_untrash_post( $child_id );
-			delete_post_meta( $child_id, self::PARENT_MARKER_META );
-		}
-
-		if ( Document::is_collection( $post_id ) ) {
-			foreach ( $this->trashed_rows_marked_by( $post_id ) as $row_id ) {
-				wp_untrash_post( $row_id );
-				delete_post_meta( $row_id, self::COLLECTION_MARKER_META );
+		$this->cascade->restore(
+			$post_id,
+			static function ( int $child_id ): void {
+				wp_untrash_post( $child_id );
 			}
-		}
+		);
 	}
 
 	/**
@@ -206,7 +194,12 @@ final class TrashCascade {
 			return;
 		}
 
-		foreach ( $this->all_row_ids( $post_id ) as $row_id ) {
+		foreach (
+			$this->cascade->row_ids_for_collection(
+				$post_id,
+				array_merge( self::ACTIVE_STATUSES, array( Documents::STATUS_TRASH ) )
+			) as $row_id
+		) {
 			wp_delete_post( $row_id, true );
 		}
 	}
@@ -224,40 +217,7 @@ final class TrashCascade {
 	 * @return int[] Trashed descendant ids (root excluded), no guaranteed order.
 	 */
 	public function descendants_for_root( int $root_id ): array {
-		if ( Document::POST_TYPE !== get_post_type( $root_id ) ) {
-			return array();
-		}
-
-		$collected = array();
-		$seen      = array( $root_id => true );
-		$frontier  = array( $root_id );
-
-		while ( ! empty( $frontier ) ) {
-			$next = array();
-			foreach ( $frontier as $current ) {
-				foreach ( $this->trashed_children_marked_by( $current ) as $child_id ) {
-					if ( isset( $seen[ $child_id ] ) ) {
-						continue;
-					}
-					$seen[ $child_id ] = true;
-					$collected[]       = $child_id;
-					$next[]            = $child_id;
-				}
-				if ( Document::is_collection( $current ) ) {
-					foreach ( $this->trashed_rows_marked_by( $current ) as $row_id ) {
-						if ( isset( $seen[ $row_id ] ) ) {
-							continue;
-						}
-						$seen[ $row_id ] = true;
-						$collected[]     = $row_id;
-						$next[]          = $row_id;
-					}
-				}
-			}
-			$frontier = $next;
-		}
-
-		return $collected;
+		return $this->cascade->descendants_for_root( $root_id );
 	}
 
 	/**
@@ -297,135 +257,6 @@ final class TrashCascade {
 			return $new_status;
 		}
 		return '' !== $previous_status ? $previous_status : $new_status;
-	}
-
-	/**
-	 * Active children of `$parent_id` via `post_parent`.
-	 *
-	 * @param int $parent_id Document id.
-	 * @return int[]
-	 */
-	private function active_child_ids( int $parent_id ): array {
-		$ids = get_posts(
-			array(
-				'post_type'      => Document::POST_TYPE,
-				'post_parent'    => $parent_id,
-				'post_status'    => self::ACTIVE_STATUSES,
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-			)
-		);
-		return array_map( 'intval', $ids );
-	}
-
-	/**
-	 * Trashed children tagged with `$parent_id`'s parent marker.
-	 *
-	 * @param int $parent_id Document id whose marker tags the children.
-	 * @return int[]
-	 */
-	private function trashed_children_marked_by( int $parent_id ): array {
-		$ids = get_posts(
-			array(
-				'post_type'      => Document::POST_TYPE,
-				'post_status'    => 'trash',
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
-				'meta_key'       => self::PARENT_MARKER_META,  // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value'     => (string) $parent_id,       // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			)
-		);
-		return array_map( 'intval', $ids );
-	}
-
-	/**
-	 * Active rows of the collection `$collection_id`.
-	 *
-	 * @param int $collection_id Collection document id.
-	 * @return int[]
-	 */
-	private function active_row_ids( int $collection_id ): array {
-		return $this->row_ids_for_collection( $collection_id, self::ACTIVE_STATUSES );
-	}
-
-	/**
-	 * Trashed rows tagged with `$collection_id`'s collection marker.
-	 *
-	 * @param int $collection_id Collection document id whose marker tags the rows.
-	 * @return int[]
-	 */
-	private function trashed_rows_marked_by( int $collection_id ): array {
-		$term_id = Relations::trait_term_id_for_collection( $collection_id );
-		if ( $term_id < 1 ) {
-			return array();
-		}
-		$ids = get_posts(
-			array(
-				'post_type'      => Document::POST_TYPE,
-				'post_status'    => 'trash',
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
-				'meta_key'       => self::COLLECTION_MARKER_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value'     => (string) $collection_id,      // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-				'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-					array(
-						'taxonomy' => TraitTaxonomy::TAXONOMY,
-						'field'    => 'term_id',
-						'terms'    => array( $term_id ),
-					),
-				),
-			)
-		);
-		return array_map( 'intval', $ids );
-	}
-
-	/**
-	 * All rows of `$collection_id`, including trashed ones. Used on permanent
-	 * delete to clean up rows that the trait term still points at.
-	 *
-	 * @param int $collection_id Collection document id.
-	 * @return int[]
-	 */
-	private function all_row_ids( int $collection_id ): array {
-		return $this->row_ids_for_collection(
-			$collection_id,
-			array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft', 'trash' )
-		);
-	}
-
-	/**
-	 * Rows of a collection in the given statuses.
-	 *
-	 * @param int      $collection_id Collection document id.
-	 * @param string[] $statuses      Post status filter.
-	 */
-	private function row_ids_for_collection( int $collection_id, array $statuses ): array {
-		$term_id = Relations::trait_term_id_for_collection( $collection_id );
-		if ( $term_id < 1 ) {
-			return array();
-		}
-		$ids = get_posts(
-			array(
-				'post_type'      => Document::POST_TYPE,
-				'post_status'    => $statuses,
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
-				'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-					array(
-						'taxonomy' => TraitTaxonomy::TAXONOMY,
-						'field'    => 'term_id',
-						'terms'    => array( $term_id ),
-					),
-				),
-			)
-		);
-		return array_map( 'intval', $ids );
 	}
 
 	/**

--- a/src/components/SidebarTrash.js
+++ b/src/components/SidebarTrash.js
@@ -12,6 +12,7 @@ import { useNavigate } from '@tanstack/react-router';
 import DocumentIcon from './DocumentIcon';
 import { SidebarListSkeleton } from './Skeleton';
 import TypeToConfirmDialog from './TypeToConfirmDialog';
+import computeCascadeRoots from './computeCascadeRoots';
 import { POST_TYPE, TRASHED_PAGES_QUERY } from './page-queries';
 import useDelayedFlag, {
 	SKELETON_MIN_VISIBLE_MS,
@@ -32,56 +33,13 @@ const EMPTY_TRASHED_DOCUMENTS_STATE = {
 // of a collection, but the value carries the same meaning ("trashed by this
 // document"), so the sidebar treats either marker as a pointer back to the
 // cascade root.
-const PARENT_MARKER_META = '_cortext_trashed_by_parent';
-const COLLECTION_MARKER_META = '_cortext_trashed_by_collection';
+const TRASH_MARKER_META_KEYS = [
+	'_cortext_trashed_by_parent',
+	'_cortext_trashed_by_collection',
+];
 
 export function computeSidebarTrashRoots( trashedDocuments = [] ) {
-	const all = Array.isArray( trashedDocuments ) ? trashedDocuments : [];
-	const trashedById = new Map(
-		all.map( ( document ) => [ document.id, document ] )
-	);
-	const childrenByMarker = new Map();
-
-	const markerOf = ( document ) => {
-		const meta = document.meta ?? {};
-		const parent = Number( meta[ PARENT_MARKER_META ] ?? 0 );
-		if ( parent > 0 ) {
-			return parent;
-		}
-		return Number( meta[ COLLECTION_MARKER_META ] ?? 0 );
-	};
-
-	all.forEach( ( document ) => {
-		const marker = markerOf( document );
-		if ( marker > 0 && trashedById.has( marker ) ) {
-			if ( ! childrenByMarker.has( marker ) ) {
-				childrenByMarker.set( marker, [] );
-			}
-			childrenByMarker.get( marker ).push( document );
-		}
-	} );
-
-	const roots = all.filter( ( document ) => {
-		const marker = markerOf( document );
-		return marker === 0 || ! trashedById.has( marker );
-	} );
-
-	const descendantCountById = new Map();
-	roots.forEach( ( root ) => {
-		const counts = { total: 0 };
-		const stack = [ ...( childrenByMarker.get( root.id ) ?? [] ) ];
-		while ( stack.length ) {
-			const node = stack.pop();
-			counts.total++;
-			const kids = childrenByMarker.get( node.id );
-			if ( kids ) {
-				stack.push( ...kids );
-			}
-		}
-		descendantCountById.set( root.id, counts );
-	} );
-
-	return { roots, descendantCountById };
+	return computeCascadeRoots( trashedDocuments, TRASH_MARKER_META_KEYS );
 }
 
 function optionalTitleText( title ) {

--- a/src/components/computeCascadeRoots.js
+++ b/src/components/computeCascadeRoots.js
@@ -1,0 +1,66 @@
+/**
+ * Groups document records by cascade root.
+ *
+ * Each marker identifies the document that triggered the status change. A
+ * marked record stays hidden while that document is present. When the document
+ * is missing, the record becomes a root so it can still be recovered.
+ *
+ * @param {Array}    documents  Document records to group.
+ * @param {string[]} markerKeys Meta keys that may contain a cascade parent ID.
+ * @return {{roots: Array, descendantCountById: Map}} Root records and descendant counts.
+ */
+export default function computeCascadeRoots( documents = [], markerKeys = [] ) {
+	const all = Array.isArray( documents ) ? documents : [];
+	const documentsById = new Map(
+		all.map( ( document ) => [ document.id, document ] )
+	);
+	const childrenByMarker = new Map();
+
+	const markerOf = ( document ) => {
+		const meta = document.meta ?? {};
+		for ( const markerKey of markerKeys ) {
+			const marker = Number( meta[ markerKey ] ?? 0 );
+			if ( marker > 0 ) {
+				return marker;
+			}
+		}
+		return 0;
+	};
+
+	all.forEach( ( document ) => {
+		const marker = markerOf( document );
+		if ( marker > 0 && documentsById.has( marker ) ) {
+			if ( ! childrenByMarker.has( marker ) ) {
+				childrenByMarker.set( marker, [] );
+			}
+			childrenByMarker.get( marker ).push( document );
+		}
+	} );
+
+	const roots = all.filter( ( document ) => {
+		const marker = markerOf( document );
+		return marker === 0 || ! documentsById.has( marker );
+	} );
+
+	const descendantCountById = new Map();
+	roots.forEach( ( root ) => {
+		const counts = { total: 0 };
+		const stack = [ ...( childrenByMarker.get( root.id ) ?? [] ) ];
+		const visited = new Set();
+		while ( stack.length ) {
+			const node = stack.pop();
+			if ( ! node || visited.has( node.id ) ) {
+				continue;
+			}
+			visited.add( node.id );
+			counts.total++;
+			const children = childrenByMarker.get( node.id );
+			if ( children ) {
+				stack.push( ...children );
+			}
+		}
+		descendantCountById.set( root.id, counts );
+	} );
+
+	return { roots, descendantCountById };
+}


### PR DESCRIPTION
## What

Part of #423.

This pulls the cascade traversal out of Trash and into shared PHP and JavaScript helpers. It does not change how trashing or restoring documents works.

## Why

The archived state will use the same cascade rules. Doing this first means the next PR only needs to add the new behavior.

## Testing Instructions

1. Create a page with a nested page, then move the parent to Trash.
2. Open Trash and confirm it shows the parent once, with the nested page included in the count. Restore the parent and confirm the nested page comes back.
3. Repeat the check with a collection that has at least one row. Confirm the row follows the collection to Trash and returns when you restore it.
