### PR TITLE
Archiving documents: Add server support

### DIFF
--- a/includes/CLI/FieldValues.php
+++ b/includes/CLI/FieldValues.php
@@ -11,6 +11,7 @@ namespace Cortext\CLI;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\FieldValues\FieldValueIndex;
 use Cortext\PostType\Document;
 use Cortext\PostType\Field;
@@ -169,7 +170,7 @@ final class FieldValues {
 			get_posts(
 				array(
 					'post_type'      => Document::POST_TYPE,
-					'post_status'    => array( 'draft', 'private', 'publish' ),
+					'post_status'    => array( 'draft', 'private', 'publish', Documents::STATUS_ARCHIVED ),
 					'fields'         => 'ids',
 					'posts_per_page' => -1,
 					// A document is a collection when its mirror term exists. An

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -12,6 +12,7 @@ namespace Cortext\CLI;
 defined( 'ABSPATH' ) || exit;
 
 use Cortext\CLI\Dev\SeedImageFetcher;
+use Cortext\Documents;
 use Cortext\Media\CortextMedia;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
@@ -21,10 +22,16 @@ use Cortext\Taxonomy\TraitTaxonomy;
 
 final class SeedDummyCollections {
 
-	private const WORKSPACE_HOME_META_KEY = 'cortext_workspace_home';
-	private const FAVORITES_META_KEY      = 'cortext_favorites';
-	private const PAGE_CONTENT_VERSION    = 'public-beta-page-seed-2026-06-02-humanized';
-	private const ENTRY_CONTENT_VERSION   = 'public-beta-row-seed-2026-06-02-humanized';
+	private const WORKSPACE_HOME_META_KEY   = 'cortext_workspace_home';
+	private const FAVORITES_META_KEY        = 'cortext_favorites';
+	private const PAGE_CONTENT_VERSION      = 'public-beta-page-seed-2026-06-02-humanized';
+	private const ENTRY_CONTENT_VERSION     = 'public-beta-row-seed-2026-06-02-humanized';
+	private const SEED_LOOKUP_POST_STATUSES = array(
+		'draft',
+		'private',
+		'publish',
+		Documents::STATUS_ARCHIVED,
+	);
 
 	private bool $seed_full_dataset = false;
 	private bool $fetch_real_images = false;
@@ -3820,7 +3827,7 @@ final class SeedDummyCollections {
 			$ids = get_posts(
 				array(
 					'post_type'   => Document::POST_TYPE,
-					'post_status' => array( 'draft', 'private', 'publish' ),
+					'post_status' => self::SEED_LOOKUP_POST_STATUSES,
 					'post_parent' => $parent_id,
 					'title'       => (string) $candidate_title,
 					'numberposts' => 1,
@@ -3836,7 +3843,7 @@ final class SeedDummyCollections {
 			$ids = get_posts(
 				array(
 					'post_type'   => Document::POST_TYPE,
-					'post_status' => array( 'draft', 'private', 'publish' ),
+					'post_status' => self::SEED_LOOKUP_POST_STATUSES,
 					'title'       => (string) $candidate_title,
 					'numberposts' => 1,
 					'fields'      => 'ids',
@@ -4039,7 +4046,7 @@ final class SeedDummyCollections {
 		$pages = get_posts(
 			array(
 				'post_type'   => Document::POST_TYPE,
-				'post_status' => array( 'draft', 'private', 'publish' ),
+				'post_status' => self::SEED_LOOKUP_POST_STATUSES,
 				'title'       => $title,
 				'numberposts' => 1,
 				'fields'      => 'ids',
@@ -4758,7 +4765,7 @@ final class SeedDummyCollections {
 		$existing = get_posts(
 			array(
 				'post_type'   => Document::POST_TYPE,
-				'post_status' => array( 'draft', 'private', 'publish' ),
+				'post_status' => self::SEED_LOOKUP_POST_STATUSES,
 				// phpcs:ignore WordPress.DB.SlowDBQuery
 				'meta_key'    => 'cortext_seed_slug',
 				// phpcs:ignore WordPress.DB.SlowDBQuery
@@ -6089,7 +6096,7 @@ final class SeedDummyCollections {
 		$collections = get_posts(
 			array(
 				'post_type'   => Document::POST_TYPE,
-				'post_status' => array( 'draft', 'private', 'publish' ),
+				'post_status' => self::SEED_LOOKUP_POST_STATUSES,
 				// phpcs:ignore WordPress.DB.SlowDBQuery
 				'meta_key'    => 'cortext_seed_slug',
 				// phpcs:ignore WordPress.DB.SlowDBQuery
@@ -6109,7 +6116,7 @@ final class SeedDummyCollections {
 		$entries = get_posts(
 			array(
 				'post_type'   => Document::POST_TYPE,
-				'post_status' => array( 'draft', 'private', 'publish' ),
+				'post_status' => self::SEED_LOOKUP_POST_STATUSES,
 				'title'       => $title,
 				'numberposts' => 1,
 				'fields'      => 'ids',
@@ -6207,7 +6214,7 @@ final class SeedDummyCollections {
 		$pages = get_posts(
 			array(
 				'post_type'   => Document::POST_TYPE,
-				'post_status' => array( 'draft', 'private', 'publish', 'pending', 'future', 'trash' ),
+				'post_status' => array( 'draft', 'private', 'publish', 'pending', 'future', 'trash', Documents::STATUS_ARCHIVED ),
 				'numberposts' => -1,
 				'fields'      => 'ids',
 			)

--- a/includes/CLI/SeedDummyCollections.php
+++ b/includes/CLI/SeedDummyCollections.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
 use Cortext\CLI\Dev\SeedImageFetcher;
 use Cortext\Documents;
 use Cortext\Media\CortextMedia;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -333,14 +334,21 @@ final class SeedDummyCollections {
 				continue;
 			}
 			$collection = get_post( $collection_id );
-			if ( ! $collection instanceof \WP_Post || (int) $collection->post_parent === $parent_id ) {
+			if ( ! $collection instanceof \WP_Post ) {
 				continue;
 			}
-			wp_update_post(
-				array(
-					'ID'          => $collection_id,
-					'post_parent' => $parent_id,
-				)
+			if ( (int) $collection->post_parent !== $parent_id ) {
+				wp_update_post(
+					array(
+						'ID'          => $collection_id,
+						'post_parent' => $parent_id,
+					)
+				);
+			}
+			$this->archive_seeded_descendant_if_needed(
+				$collection_id,
+				$parent_id,
+				ArchiveCascade::PARENT_MARKER_META
 			);
 		}
 	}
@@ -3808,6 +3816,11 @@ final class SeedDummyCollections {
 		if ( isset( $node['content'] ) ) {
 			update_post_meta( $page_id, '_cortext_seed_content_version', self::PAGE_CONTENT_VERSION );
 		}
+		$this->archive_seeded_descendant_if_needed(
+			(int) $page_id,
+			$parent_id,
+			ArchiveCascade::PARENT_MARKER_META
+		);
 
 		foreach ( $node['children'] ?? array() as $child ) {
 			$this->seed_page_tree( $child, (int) $page_id );
@@ -3937,13 +3950,12 @@ final class SeedDummyCollections {
 	}
 
 	private function seed_workspace_home( int $user_id, int $page_id ): void {
-		if ( $page_id <= 0 ) {
+		$current = get_user_meta( $user_id, self::WORKSPACE_HOME_META_KEY, true );
+		if ( $this->workspace_home_exists( $current ) ) {
+			$this->log( 'Workspace home already exists. Skipping.' );
 			return;
 		}
-
-		$current = get_user_meta( $user_id, self::WORKSPACE_HOME_META_KEY, true );
-		if ( is_string( $current ) && '' !== $current && $this->workspace_home_exists( $current ) ) {
-			$this->log( 'Workspace home already exists. Skipping.' );
+		if ( $page_id <= 0 || ! $this->active_seed_preference_target_exists( "page:{$page_id}" ) ) {
 			return;
 		}
 
@@ -3952,13 +3964,8 @@ final class SeedDummyCollections {
 		$this->log( "Set workspace home to page '{$page_title}' (ID {$page_id})." );
 	}
 
-	private function workspace_home_exists( string $raw ): bool {
-		$parts = explode( ':', $raw, 2 );
-		if ( 2 !== count( $parts ) ) {
-			return false;
-		}
-
-		$id = (int) $parts[1];
+	private function workspace_home_exists( mixed $raw ): bool {
+		$id = $this->stored_preference_target_id( $raw );
 		if ( $id <= 0 ) {
 			return false;
 		}
@@ -3968,6 +3975,11 @@ final class SeedDummyCollections {
 			return false;
 		}
 
+		if ( is_int( $raw ) || ( is_string( $raw ) && ctype_digit( $raw ) ) ) {
+			return Document::POST_TYPE === $post->post_type;
+		}
+
+		$parts = explode( ':', (string) $raw, 2 );
 		if ( 'page' === $parts[0] ) {
 			return Document::POST_TYPE === $post->post_type && ! Document::is_collection( $id );
 		}
@@ -4003,7 +4015,7 @@ final class SeedDummyCollections {
 			$kind = $candidate[0];
 			$id   = (int) $candidate[1];
 			$key  = "{$kind}:{$id}";
-			if ( $id < 1 || isset( $seen[ $key ] ) || ! $this->workspace_home_exists( $key ) ) {
+			if ( $id < 1 || isset( $seen[ $key ] ) || ! $this->active_seed_preference_target_exists( $key ) ) {
 				continue;
 			}
 
@@ -4034,12 +4046,46 @@ final class SeedDummyCollections {
 		}
 
 		foreach ( $raw as $favorite ) {
-			if ( is_string( $favorite ) && $this->workspace_home_exists( $favorite ) ) {
+			if ( $this->workspace_home_exists( $favorite ) ) {
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks a new seeded preference without invalidating an archived value
+	 * the user already saved.
+	 *
+	 * @param string $raw Preference key in `kind:id` form.
+	 */
+	private function active_seed_preference_target_exists( string $raw ): bool {
+		if ( ! $this->workspace_home_exists( $raw ) ) {
+			return false;
+		}
+
+		return Documents::STATUS_ARCHIVED !== get_post_status( $this->stored_preference_target_id( $raw ) );
+	}
+
+	/**
+	 * Reads canonical integer IDs and the old `kind:id` preference format.
+	 *
+	 * @param mixed $raw Stored preference value.
+	 */
+	private function stored_preference_target_id( mixed $raw ): int {
+		if ( is_int( $raw ) ) {
+			return $raw;
+		}
+		if ( ! is_string( $raw ) || '' === $raw ) {
+			return 0;
+		}
+		if ( ctype_digit( $raw ) ) {
+			return (int) $raw;
+		}
+
+		$parts = explode( ':', $raw, 2 );
+		return 2 === count( $parts ) ? (int) $parts[1] : 0;
 	}
 
 	private function find_seeded_page_id( string $title ): int {
@@ -4927,6 +4973,11 @@ final class SeedDummyCollections {
 				$this->update_entry_content( $existing_entry_id, $entry_content );
 				$this->maybe_apply_row_icon( $existing_entry_id, $spec['slug'], $entry_title );
 				$this->maybe_apply_row_cover( $existing_entry_id, $spec['slug'], $entry_title );
+				$this->archive_seeded_descendant_if_needed(
+					$existing_entry_id,
+					(int) $collection_id,
+					ArchiveCascade::COLLECTION_MARKER_META
+				);
 				$this->log( "Entry '{$entry_title}' already exists. Skipping." );
 				continue;
 			}
@@ -4972,11 +5023,50 @@ final class SeedDummyCollections {
 
 				update_post_meta( $entry_id, "field-{$field_id}", $value );
 			}
+			$this->archive_seeded_descendant_if_needed(
+				(int) $entry_id,
+				(int) $collection_id,
+				ArchiveCascade::COLLECTION_MARKER_META
+			);
 
 			$this->log( "Created entry '{$entry_title}' (ID {$entry_id})." );
 		}
 
 		return (int) $collection_id;
+	}
+
+	/**
+	 * Keeps a seeded document in the same lifecycle state as its container.
+	 *
+	 * The marker is written before the status change so restoring the container
+	 * brings this document back with the rest of its cascade.
+	 *
+	 * @param int    $document_id Document being seeded.
+	 * @param int    $container_id Parent page or collection ID.
+	 * @param string $marker_key Archive marker for this relationship.
+	 */
+	private function archive_seeded_descendant_if_needed( int $document_id, int $container_id, string $marker_key ): void {
+		if (
+			$document_id < 1
+			|| $container_id < 1
+			|| Documents::STATUS_ARCHIVED !== get_post_status( $container_id )
+			|| Documents::STATUS_ARCHIVED === get_post_status( $document_id )
+		) {
+			return;
+		}
+
+		update_post_meta( $document_id, $marker_key, $container_id );
+		$result = wp_update_post(
+			array(
+				'ID'          => $document_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			),
+			true
+		);
+		if ( $result instanceof \WP_Error || 0 === $result ) {
+			delete_post_meta( $document_id, $marker_key );
+			$this->error( "Could not archive seeded document {$document_id} with its container." );
+		}
 	}
 
 	/**

--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -24,6 +24,7 @@ defined( 'ABSPATH' ) || exit;
 use Cortext\Documents\DocumentDuplicator;
 use Cortext\Relations;
 use Cortext\Fields\FieldTypeRegistry;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\TrashCascade;
@@ -39,7 +40,8 @@ final class Documents {
 	public const KIND_ROW        = 'row';
 	public const KIND_COLLECTION = 'collection';
 
-	public const STATUS_TRASH = 'trash';
+	public const STATUS_ARCHIVED = 'crtxt_archived';
+	public const STATUS_TRASH    = 'trash';
 
 	private const DEFAULT_STATUSES = array( 'publish', 'draft', 'private' );
 	private const DEFAULT_PER_PAGE = 20;
@@ -276,8 +278,8 @@ final class Documents {
 	 * Arguments:
 	 *   - `search` (string): split-term match across title, excerpt, content.
 	 *   - `status` (string|string[]): post status filter. Defaults to
-	 *     `publish, draft, private`. Pass `'trash'` to list every trashed
-	 *     document.
+	 *     `publish, draft, private`. Use `'trash'` or `'crtxt_archived'` to list
+	 *     trashed or archived documents.
 	 *   - `page`   (int):    1-based page number.
 	 *   - `per_page` (int):  page size, clamped to MAX_PER_PAGE.
 	 *   - `include_excerpt` (bool): include excerpt in formatted documents.
@@ -286,14 +288,16 @@ final class Documents {
 	 * @return array{documents: array<int,array<string,mixed>>, total: int}
 	 */
 	public function list( array $args = array() ): array {
-		$statuses = $this->normalize_statuses( $args['status'] ?? null );
-		$is_trash = array( self::STATUS_TRASH ) === $statuses;
-		$page     = max( 1, (int) ( $args['page'] ?? 1 ) );
-		$per_page = min(
+		$statuses             = $this->normalize_statuses( $args['status'] ?? null );
+		$is_trash             = array( self::STATUS_TRASH ) === $statuses;
+		$is_archived          = array( self::STATUS_ARCHIVED ) === $statuses;
+		$is_lifecycle_listing = $is_trash || $is_archived;
+		$page                 = max( 1, (int) ( $args['page'] ?? 1 ) );
+		$per_page             = min(
 			self::MAX_PER_PAGE,
 			max( 1, (int) ( $args['per_page'] ?? self::DEFAULT_PER_PAGE ) )
 		);
-		$search   = isset( $args['search'] ) ? trim( (string) $args['search'] ) : '';
+		$search               = isset( $args['search'] ) ? trim( (string) $args['search'] ) : '';
 
 		$query_args = array(
 			'post_type'           => Document::POST_TYPE,
@@ -341,13 +345,14 @@ final class Documents {
 			)
 		);
 		$total        = count( $editable_ids );
-		$page_ids     = $is_trash
+		$page_ids     = $is_lifecycle_listing
 			? $editable_ids
 			: array_slice( $editable_ids, ( $page - 1 ) * $per_page, $per_page );
 
 		$opts      = array(
-			'include_excerpt'    => ! empty( $args['include_excerpt'] ),
-			'include_trash_meta' => $is_trash,
+			'include_excerpt'      => ! empty( $args['include_excerpt'] ),
+			'include_trash_meta'   => $is_trash,
+			'include_archive_meta' => $is_archived,
 		);
 		$documents = array();
 		foreach ( $page_ids as $post_id ) {
@@ -392,7 +397,7 @@ final class Documents {
 			return self::DEFAULT_STATUSES;
 		}
 
-		$allowed = array_merge( self::DEFAULT_STATUSES, array( self::STATUS_TRASH ) );
+		$allowed = array_merge( self::DEFAULT_STATUSES, array( self::STATUS_ARCHIVED, self::STATUS_TRASH ) );
 		$valid   = array_values( array_intersect( $candidates, $allowed ) );
 
 		return empty( $valid ) ? self::DEFAULT_STATUSES : $valid;
@@ -447,26 +452,36 @@ final class Documents {
 			);
 		}
 
-		if ( ! empty( $opts['include_trait_flags'] ) || ! empty( $opts['include_trash_meta'] ) ) {
-			// Mirror the `cortext_defines_trait` (collection) and `crtxt_trait`
-			// (row) fields that `/wp/v2/crtxt_documents` exposes, so list icons
-			// and the Trash panel can tell collections and rows apart from pages.
-			// The Trash panel also uses them for the cascade-count copy and the
-			// type-to-confirm guard on collection deletes.
+		$include_trash_meta     = ! empty( $opts['include_trash_meta'] );
+		$include_archive_meta   = ! empty( $opts['include_archive_meta'] );
+		$include_lifecycle_meta = $include_trash_meta || $include_archive_meta;
+
+		if ( ! empty( $opts['include_trait_flags'] ) || $include_lifecycle_meta ) {
+			// Mirror the `cortext_defines_trait` and `crtxt_trait` fields exposed by
+			// `/wp/v2/crtxt_documents`, so callers can tell pages, collections, and
+			// rows apart. Trash and archived listings also use these fields for
+			// cascade details and collection actions.
 			$document['cortext_defines_trait'] = Document::is_collection_post( $post );
 			$document['crtxt_trait']           = array_values(
 				array_map( 'intval', wp_get_object_terms( $post->ID, TraitTaxonomy::TAXONOMY, array( 'fields' => 'ids' ) ) )
 			);
 		}
 
-		if ( ! empty( $opts['include_trash_meta'] ) ) {
+		if ( $include_lifecycle_meta ) {
 			$document['modified_at'] = $this->format_gmt_date( $post->post_modified_gmt );
-			$document['meta']        = array(
-				'cortext_document_icon'              => $icon,
-				'cortext_fields'                     => Document::collection_field_ids( (int) $post->ID ),
-				TrashCascade::PARENT_MARKER_META     => (int) get_post_meta( $post->ID, TrashCascade::PARENT_MARKER_META, true ),
-				TrashCascade::COLLECTION_MARKER_META => (int) get_post_meta( $post->ID, TrashCascade::COLLECTION_MARKER_META, true ),
+			$meta                    = array(
+				'cortext_document_icon' => $icon,
+				'cortext_fields'        => Document::collection_field_ids( (int) $post->ID ),
 			);
+			if ( $include_trash_meta ) {
+				$meta[ TrashCascade::PARENT_MARKER_META ]     = (int) get_post_meta( $post->ID, TrashCascade::PARENT_MARKER_META, true );
+				$meta[ TrashCascade::COLLECTION_MARKER_META ] = (int) get_post_meta( $post->ID, TrashCascade::COLLECTION_MARKER_META, true );
+			}
+			if ( $include_archive_meta ) {
+				$meta[ ArchiveCascade::PARENT_MARKER_META ]     = (int) get_post_meta( $post->ID, ArchiveCascade::PARENT_MARKER_META, true );
+				$meta[ ArchiveCascade::COLLECTION_MARKER_META ] = (int) get_post_meta( $post->ID, ArchiveCascade::COLLECTION_MARKER_META, true );
+			}
+			$document['meta'] = $meta;
 		}
 
 		return $document;
@@ -595,6 +610,9 @@ final class Documents {
 		if ( null === $kind ) {
 			return $this->target_not_found_error();
 		}
+		if ( self::STATUS_ARCHIVED === $post->post_status ) {
+			return $this->target_hidden_error();
+		}
 
 		if ( self::KIND_ROW === $kind ) {
 			$row_check = $this->validate_row_target( $post, $require_edit );
@@ -633,11 +651,11 @@ final class Documents {
 	 */
 	private function validate_row_target( WP_Post $row, bool $require_edit ): ?WP_Error {
 		$trait = $this->find_trait_for_document( $row );
-		if (
-			! $trait instanceof WP_Post
-			|| self::STATUS_TRASH === $trait->post_status
-		) {
+		if ( ! $trait instanceof WP_Post || self::STATUS_TRASH === $trait->post_status ) {
 			return $this->target_not_found_error();
+		}
+		if ( self::STATUS_ARCHIVED === $trait->post_status ) {
+			return $this->target_hidden_error();
 		}
 
 		if ( $require_edit
@@ -662,6 +680,14 @@ final class Documents {
 		return new WP_Error(
 			'cortext_document_target_not_found',
 			__( 'Target document was not found.', 'cortext' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	private function target_hidden_error(): WP_Error {
+		return new WP_Error(
+			'cortext_document_target_hidden',
+			__( 'Target document is hidden.', 'cortext' ),
 			array( 'status' => 404 )
 		);
 	}

--- a/includes/Documents/DocumentDuplicator.php
+++ b/includes/Documents/DocumentDuplicator.php
@@ -73,7 +73,7 @@ final class DocumentDuplicator {
 		$new_id = wp_insert_post(
 			array(
 				'post_type'    => Document::POST_TYPE,
-				'post_status'  => 'auto-draft' === $source->post_status ? 'private' : $source->post_status,
+				'post_status'  => in_array( $source->post_status, array( 'auto-draft', Documents::STATUS_ARCHIVED ), true ) ? 'private' : $source->post_status,
 				'post_title'   => $this->copy_title( $source ),
 				'post_content' => $source->post_content,
 				'post_excerpt' => $source->post_excerpt,

--- a/includes/Documents/DocumentDuplicator.php
+++ b/includes/Documents/DocumentDuplicator.php
@@ -70,6 +70,19 @@ final class DocumentDuplicator {
 			);
 		}
 
+		$parent          = (int) $source->post_parent > 0 ? get_post( (int) $source->post_parent ) : null;
+		$collection_post = $this->documents->find_trait_for_document( $source );
+		if (
+			( $parent instanceof WP_Post && Documents::STATUS_ARCHIVED === $parent->post_status )
+			|| ( $collection_post instanceof WP_Post && Documents::STATUS_ARCHIVED === $collection_post->post_status )
+		) {
+			return new WP_Error(
+				'cortext_duplicate_archived_container',
+				__( 'Restore the archived parent or collection before making a copy.', 'cortext' ),
+				array( 'status' => 409 )
+			);
+		}
+
 		$new_id = wp_insert_post(
 			array(
 				'post_type'    => Document::POST_TYPE,
@@ -98,8 +111,7 @@ final class DocumentDuplicator {
 			( new TraitTaxonomy() )->ensure_mirror_term( $new_id );
 		}
 
-		$collection_id   = 0;
-		$collection_post = $this->documents->find_trait_for_document( $source );
+		$collection_id = 0;
 		if ( $collection_post instanceof WP_Post ) {
 			$collection_id = (int) $collection_post->ID;
 			$result        = $this->copy_membership_and_values( $source, $new_id, $collection_id );

--- a/includes/FieldValues/FieldValueIndex.php
+++ b/includes/FieldValues/FieldValueIndex.php
@@ -11,6 +11,7 @@ namespace Cortext\FieldValues;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\Fields\FieldTypeRegistry;
 use Cortext\PostType\Document;
 use Cortext\PostType\Field;
@@ -50,8 +51,7 @@ final class FieldValueIndex {
 		add_action( 'added_post_meta', array( $this, 'sync_meta_change' ), 10, 4 );
 		add_action( 'updated_post_meta', array( $this, 'sync_meta_change' ), 10, 4 );
 		add_action( 'deleted_post_meta', array( $this, 'sync_meta_change' ), 10, 4 );
-		add_action( 'wp_trash_post', array( $this, 'sync_row_status' ), 20, 1 );
-		add_action( 'untrashed_post', array( $this, 'sync_row_status' ), 20, 1 );
+		add_action( 'transition_post_status', array( $this, 'sync_row_status' ), 20, 3 );
 		add_action( 'before_delete_post', array( $this, 'cleanup_deleted_post' ), 20, 2 );
 		// Invalidate the row->collection cache when a document's trait
 		// membership changes, so the next meta sync resolves the new trait.
@@ -300,7 +300,7 @@ final class FieldValueIndex {
 			$query = new WP_Query(
 				array(
 					'post_type'      => Document::POST_TYPE,
-					'post_status'    => array( 'draft', 'private', 'publish', 'trash' ),
+					'post_status'    => array( 'draft', 'private', 'publish', 'trash', Documents::STATUS_ARCHIVED ),
 					'fields'         => 'ids',
 					'posts_per_page' => self::PAGE_SIZE,
 					'paged'          => $page,
@@ -362,7 +362,7 @@ final class FieldValueIndex {
 			$query = new WP_Query(
 				array(
 					'post_type'      => Document::POST_TYPE,
-					'post_status'    => array( 'draft', 'private', 'publish', 'trash' ),
+					'post_status'    => array( 'draft', 'private', 'publish', 'trash', Documents::STATUS_ARCHIVED ),
 					'fields'         => 'ids',
 					'posts_per_page' => self::PAGE_SIZE,
 					'paged'          => $page,
@@ -556,8 +556,13 @@ final class FieldValueIndex {
 		);
 	}
 
-	public function sync_row_status( int $post_id ): void {
-		if ( ! $this->can_write() || $this->collection_id_for_row( $post_id ) < 1 ) {
+	public function sync_row_status( string $new_status, string $old_status, WP_Post $post ): void {
+		if (
+			$new_status === $old_status
+			|| Document::POST_TYPE !== $post->post_type
+			|| ! $this->can_write()
+			|| $this->collection_id_for_row( (int) $post->ID ) < 1
+		) {
 			return;
 		}
 
@@ -566,8 +571,8 @@ final class FieldValueIndex {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Keeps row status in the derived index current.
 		$result = $wpdb->update(
 			$this->table_name(),
-			array( 'post_status' => (string) get_post_status( $post_id ) ),
-			array( 'row_id' => $post_id ),
+			array( 'post_status' => $new_status ),
+			array( 'row_id' => (int) $post->ID ),
 			array( '%s' ),
 			array( '%d' )
 		);
@@ -1022,7 +1027,7 @@ final class FieldValueIndex {
 			get_posts(
 				array(
 					'post_type'      => Document::POST_TYPE,
-					'post_status'    => array( 'draft', 'private', 'publish' ),
+					'post_status'    => array( 'draft', 'private', 'publish', Documents::STATUS_ARCHIVED ),
 					'fields'         => 'ids',
 					'posts_per_page' => -1,
 					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/includes/Formula/Materializer.php
+++ b/includes/Formula/Materializer.php
@@ -12,6 +12,7 @@ namespace Cortext\Formula;
 // phpcs:disable Generic.Commenting.DocComment.MissingShort
 // phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag,Squiz.Commenting.FunctionComment.ParamNameNoMatch,Squiz.Commenting.FunctionComment.IncorrectTypeHint,Squiz.Commenting.FunctionCommentThrowTag.Missing,Squiz.Commenting.FunctionComment.SpacingAfterParamType
 
+use Cortext\Documents;
 use Cortext\PostType\Document;
 use Cortext\Relations;
 use Cortext\Taxonomy\TraitTaxonomy;
@@ -148,7 +149,7 @@ final class Materializer {
 				if (
 					is_object( $post ) &&
 					Document::POST_TYPE === $post->post_type &&
-					in_array( $post->post_status, array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit' ), true )
+					in_array( $post->post_status, array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit', Documents::STATUS_ARCHIVED ), true )
 				) {
 					$term_ids = wp_get_object_terms( (int) $post->ID, TraitTaxonomy::TAXONOMY, array( 'fields' => 'ids' ) );
 					if ( is_array( $term_ids ) && in_array( $term_id, array_map( 'intval', $term_ids ), true ) ) {
@@ -163,7 +164,7 @@ final class Materializer {
 			get_posts(
 				array(
 					'post_type'      => Document::POST_TYPE,
-					'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit' ),
+					'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit', Documents::STATUS_ARCHIVED ),
 					'posts_per_page' => -1,
 					'fields'         => 'ids',
 					'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query

--- a/includes/Frontend/MentionRenderer.php
+++ b/includes/Frontend/MentionRenderer.php
@@ -11,6 +11,7 @@ namespace Cortext\Frontend;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\Mention\Mention;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
@@ -193,7 +194,7 @@ final class MentionRenderer {
 		if ( ! $post instanceof WP_Post ) {
 			return false;
 		}
-		if ( 'trash' === $post->post_status ) {
+		if ( in_array( $post->post_status, array( Documents::STATUS_TRASH, Documents::STATUS_ARCHIVED ), true ) ) {
 			return false;
 		}
 		if ( ! post_type_supports( $post->post_type, 'cortext-document' ) ) {

--- a/includes/Media/CortextMedia.php
+++ b/includes/Media/CortextMedia.php
@@ -24,6 +24,7 @@ namespace Cortext\Media;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\PostType\Document;
 use WP_Post;
 use WP_REST_Request;
@@ -96,7 +97,7 @@ final class CortextMedia {
 		$document_ids = get_posts(
 			array(
 				'post_type'      => Document::POST_TYPE,
-				'post_status'    => array( 'publish', 'future', 'draft', 'pending', 'private', 'trash' ),
+				'post_status'    => array( 'publish', 'future', 'draft', 'pending', 'private', 'trash', Documents::STATUS_ARCHIVED ),
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 			)

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -23,6 +23,7 @@ use Cortext\Frontend\Assets;
 use Cortext\Frontend\MentionRenderer;
 use Cortext\Frontend\Template;
 use Cortext\Media\CortextMedia;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -65,6 +66,9 @@ final class Plugin {
 		( new Field() )->register();
 		( new FieldValueIndex() )->register();
 
+		$archive_cascade = new ArchiveCascade();
+		$archive_cascade->register();
+
 		// Single instance owns every trash cascade hook and also answers
 		// `descendants_for_root` for the REST endpoints.
 		$trash_cascade = new TrashCascade();
@@ -78,7 +82,7 @@ final class Plugin {
 		( new FieldsController() )->register();
 		( new BacklinksController() )->register();
 		( new DocumentLocatorController() )->register();
-		( new DocumentsController( null, $trash_cascade ) )->register();
+		( new DocumentsController( null, $trash_cascade, $archive_cascade ) )->register();
 		( new ExperimentsController() )->register();
 		( new PostLocksController() )->register();
 		( new RecentsController() )->register();

--- a/includes/PostType/ArchiveCascade.php
+++ b/includes/PostType/ArchiveCascade.php
@@ -1,0 +1,459 @@
+<?php
+/**
+ * Archive handling for `crtxt_document` posts.
+ *
+ * An archived document keeps its data but does not appear in regular workspace
+ * views or on the public site. Its children and collection rows follow it.
+ * Restoring the root returns each marked document to the status it had before
+ * it was archived.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\PostType;
+
+defined( 'ABSPATH' ) || exit;
+
+use Cortext\Documents;
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+
+final class ArchiveCascade {
+
+	/** Previous status recorded before a document is archived. */
+	public const STATUS_META = '_cortext_archive_meta_status';
+
+	/** Unix timestamp recorded when a document is archived. */
+	public const TIME_META = '_cortext_archive_meta_time';
+
+	/** Parent that caused this document to be archived. */
+	public const PARENT_MARKER_META = '_cortext_archived_by_parent';
+
+	/** Collection that caused this row to be archived. */
+	public const COLLECTION_MARKER_META = '_cortext_archived_by_collection';
+
+	private const ACTIVE_STATUSES        = array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft' );
+	private const DESIRED_POST_SLUG_META = '_wp_desired_post_slug';
+
+	private DocumentCascade $cascade;
+
+	/**
+	 * IDs of archived documents being restored from Trash.
+	 *
+	 * @var array<int,true>
+	 */
+	private array $archived_untrash_ids = array();
+
+	/**
+	 * Original slug data saved while handling a Trash-to-Archive write.
+	 *
+	 * @var array<int,array{post_name:string,desired_post_slug:string,had_desired_post_slug:bool}>
+	 */
+	private array $trash_archive_slug_state = array();
+
+	public function __construct( ?DocumentCascade $cascade = null ) {
+		$this->cascade = $cascade ?? new DocumentCascade(
+			self::ACTIVE_STATUSES,
+			Documents::STATUS_ARCHIVED,
+			self::PARENT_MARKER_META,
+			self::COLLECTION_MARKER_META
+		);
+	}
+
+	public function register(): void {
+		add_action( 'init', array( $this, 'register_status' ) );
+		add_action( 'init', array( $this, 'register_meta' ) );
+		add_action( 'transition_post_status', array( $this, 'on_transition' ), 10, 3 );
+		add_filter( 'rest_pre_insert_' . Document::POST_TYPE, array( $this, 'validate_rest_archive_transition' ), 5, 2 );
+		add_filter( 'wp_untrash_post_status', array( $this, 'allow_archived_untrash_status' ), PHP_INT_MAX, 3 );
+		add_filter( 'wp_insert_post_parent', array( $this, 'capture_trash_archive_slug_state' ), 5, 4 );
+		add_filter( 'wp_insert_post_data', array( $this, 'prevent_trash_archive_transition' ), 5, 4 );
+	}
+
+	public function register_status(): void {
+		register_post_status(
+			Documents::STATUS_ARCHIVED,
+			array(
+				'label'                     => __( 'Archived', 'cortext' ),
+				// translators: %s: Number of archived documents.
+				'label_count'               => _n_noop(
+					'Archived <span class="count">(%s)</span>',
+					'Archived <span class="count">(%s)</span>',
+					'cortext'
+				),
+				'internal'                  => false,
+				'public'                    => false,
+				'protected'                 => true,
+				'exclude_from_search'       => false,
+				'show_in_admin_all_list'    => false,
+				'show_in_admin_status_list' => true,
+			)
+		);
+	}
+
+	public function register_meta(): void {
+		register_post_meta(
+			Document::POST_TYPE,
+			self::STATUS_META,
+			array(
+				'type'          => 'string',
+				'single'        => true,
+				'show_in_rest'  => false,
+				'auth_callback' => static function () {
+					return false;
+				},
+			)
+		);
+
+		register_post_meta(
+			Document::POST_TYPE,
+			self::TIME_META,
+			array(
+				'type'          => 'integer',
+				'single'        => true,
+				'show_in_rest'  => false,
+				'auth_callback' => static function () {
+					return false;
+				},
+			)
+		);
+
+		register_post_meta(
+			Document::POST_TYPE,
+			self::PARENT_MARKER_META,
+			array(
+				'type'          => 'integer',
+				'single'        => true,
+				'show_in_rest'  => true,
+				'auth_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+			)
+		);
+
+		register_post_meta(
+			Document::POST_TYPE,
+			self::COLLECTION_MARKER_META,
+			array(
+				'type'          => 'integer',
+				'single'        => true,
+				'show_in_rest'  => false,
+				'auth_callback' => static function () {
+					return false;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Runs archive or restore cascades when a document status changes.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Previous post status.
+	 * @param WP_Post $post       Post whose status changed.
+	 */
+	public function on_transition( string $new_status, string $old_status, WP_Post $post ): void {
+		if ( Document::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+
+		if (
+			Documents::STATUS_ARCHIVED === $new_status
+			&& ! in_array( $old_status, array( Documents::STATUS_ARCHIVED, Documents::STATUS_TRASH ), true )
+		) {
+			update_post_meta( (int) $post->ID, self::STATUS_META, $old_status );
+			update_post_meta( (int) $post->ID, self::TIME_META, time() );
+
+			$this->cascade->cascade(
+				(int) $post->ID,
+				static function ( int $child_id ): void {
+					wp_update_post(
+						array(
+							'ID'          => $child_id,
+							'post_status' => Documents::STATUS_ARCHIVED,
+						),
+						true
+					);
+				}
+			);
+			return;
+		}
+
+		if (
+			Documents::STATUS_ARCHIVED === $old_status
+			&& ! in_array( $new_status, array( Documents::STATUS_ARCHIVED, Documents::STATUS_TRASH ), true )
+		) {
+			delete_post_meta( (int) $post->ID, self::STATUS_META );
+			delete_post_meta( (int) $post->ID, self::TIME_META );
+
+			$this->cascade->restore(
+				(int) $post->ID,
+				function ( int $child_id ): void {
+					wp_update_post(
+						array(
+							'ID'          => $child_id,
+							'post_status' => $this->restore_status_for( $child_id ),
+						),
+						true
+					);
+				}
+			);
+		}
+	}
+
+	/**
+	 * Checks core REST status changes against the archive rules.
+	 *
+	 * @param mixed           $prepared_post Post data prepared by core REST.
+	 * @param WP_REST_Request $request       Incoming core REST request.
+	 * @return mixed|WP_Error
+	 */
+	public function validate_rest_archive_transition( $prepared_post, WP_REST_Request $request ) {
+		if ( is_wp_error( $prepared_post ) || Documents::STATUS_ARCHIVED !== $request->get_param( 'status' ) ) {
+			return $prepared_post;
+		}
+
+		$post_id = (int) $request->get_param( 'id' );
+		if ( $post_id < 1 ) {
+			return $prepared_post;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+			return $prepared_post;
+		}
+
+		return $this->archive_transition_error( $post ) ?? $prepared_post;
+	}
+
+	/**
+	 * Tracks Trash restores for documents that were archived before trashing.
+	 *
+	 * @param string $new_status      Status WordPress will assign on restore.
+	 * @param int    $post_id         ID of the document being restored.
+	 * @param string $previous_status Status held before the document was trashed.
+	 */
+	public function allow_archived_untrash_status( string $new_status, int $post_id, string $previous_status ): string {
+		if (
+			Documents::STATUS_ARCHIVED === $new_status
+			&& Documents::STATUS_ARCHIVED === $previous_status
+			&& Document::POST_TYPE === get_post_type( $post_id )
+		) {
+			$this->archived_untrash_ids[ $post_id ] = true;
+		}
+
+		return $new_status;
+	}
+
+	/**
+	 * Saves the original slug data before WordPress prepares an untrash.
+	 *
+	 * Core restores and deletes `_wp_desired_post_slug` before
+	 * `wp_insert_post_data` runs. The later filter uses these values to block a
+	 * direct Trash-to-Archive write without changing the trashed document.
+	 *
+	 * @param int                 $post_parent Parent ID selected for the write.
+	 * @param int                 $post_id     ID of the document being updated.
+	 * @param array<string,mixed> $new_postarr Processed post data.
+	 * @param array<string,mixed> $postarr     Sanitized post data.
+	 */
+	public function capture_trash_archive_slug_state( int $post_parent, int $post_id, array $new_postarr, array $postarr ): int {
+		unset( $postarr );
+
+		if (
+			Document::POST_TYPE === ( $new_postarr['post_type'] ?? '' )
+			&& Documents::STATUS_ARCHIVED === ( $new_postarr['post_status'] ?? '' )
+			&& Documents::STATUS_TRASH === get_post_status( $post_id )
+		) {
+			$this->trash_archive_slug_state[ $post_id ] = array(
+				'post_name'             => (string) get_post_field( 'post_name', $post_id, 'raw' ),
+				'desired_post_slug'     => (string) get_post_meta( $post_id, self::DESIRED_POST_SLUG_META, true ),
+				'had_desired_post_slug' => metadata_exists( 'post', $post_id, self::DESIRED_POST_SLUG_META ),
+			);
+		}
+
+		return $post_parent;
+	}
+
+	/**
+	 * Keeps a trashed document in Trash when a direct update tries to archive it.
+	 *
+	 * `wp_insert_post_data` also handles calls from WP-CLI and plugins, but the
+	 * filter cannot return a custom error. It changes the invalid status back to
+	 * Trash. The only allowed transition is `wp_untrash_post()` restoring a
+	 * document whose saved pre-trash status was Archived.
+	 *
+	 * @param array<string,mixed> $data                Processed post data.
+	 * @param array<string,mixed> $postarr             Sanitized post data.
+	 * @param array<string,mixed> $unsanitized_postarr Original post data.
+	 * @param bool                $update              Whether this is an update.
+	 * @return array<string,mixed>
+	 */
+	public function prevent_trash_archive_transition( array $data, array $postarr, array $unsanitized_postarr, bool $update ): array {
+		unset( $unsanitized_postarr );
+
+		if ( ! $update || Document::POST_TYPE !== ( $data['post_type'] ?? '' ) ) {
+			return $data;
+		}
+
+		$post_id    = (int) ( $postarr['ID'] ?? 0 );
+		$slug_state = $this->trash_archive_slug_state[ $post_id ] ?? null;
+		unset( $this->trash_archive_slug_state[ $post_id ] );
+		$is_valid_restore = isset( $this->archived_untrash_ids[ $post_id ] )
+			&& '' === (string) get_post_meta( $post_id, '_wp_trash_meta_status', true );
+		unset( $this->archived_untrash_ids[ $post_id ] );
+
+		if (
+			! $is_valid_restore
+			&& Documents::STATUS_ARCHIVED === ( $data['post_status'] ?? '' )
+			&& Documents::STATUS_TRASH === get_post_status( $post_id )
+		) {
+			$data['post_status'] = Documents::STATUS_TRASH;
+			if ( is_array( $slug_state ) ) {
+				$data['post_name'] = wp_slash( $slug_state['post_name'] );
+				if ( $slug_state['had_desired_post_slug'] ) {
+					update_post_meta(
+						$post_id,
+						self::DESIRED_POST_SLUG_META,
+						$slug_state['desired_post_slug']
+					);
+				}
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Archives a document and every descendant in its cascade.
+	 *
+	 * @param int $post_id Root document ID.
+	 * @return int[]|WP_Error Archived IDs, including the root.
+	 */
+	public function archive( int $post_id ): array|WP_Error {
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'cortext_document_not_found',
+				__( 'Document not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$transition_error = $this->archive_transition_error( $post );
+		if ( $transition_error instanceof WP_Error ) {
+			return $transition_error;
+		}
+
+		$result = wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			),
+			true
+		);
+		if ( $result instanceof WP_Error || 0 === $result ) {
+			return new WP_Error(
+				'cortext_document_archive_failed',
+				__( 'Document could not be archived.', 'cortext' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return array_values(
+			array_unique(
+				array_merge( array( $post_id ), $this->descendants_for_root( $post_id ) )
+			)
+		);
+	}
+
+	/**
+	 * Restores an archived document and every descendant in its cascade.
+	 *
+	 * @param int $post_id Root document ID.
+	 * @return int[]|WP_Error Restored IDs, including the root.
+	 */
+	public function unarchive( int $post_id ): array|WP_Error {
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'cortext_document_not_found',
+				__( 'Document not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( Documents::STATUS_ARCHIVED !== $post->post_status ) {
+			return new WP_Error(
+				'cortext_document_not_archived',
+				__( 'Document is not archived.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$candidates = $this->descendants_for_root( $post_id );
+		$result     = wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => $this->restore_status_for( $post_id ),
+			),
+			true
+		);
+
+		if ( $result instanceof WP_Error || 0 === $result ) {
+			return new WP_Error(
+				'cortext_document_unarchive_failed',
+				__( 'Document could not be restored.', 'cortext' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$restored = array( $post_id );
+		foreach ( $candidates as $candidate_id ) {
+			$candidate = get_post( $candidate_id );
+			if ( $candidate instanceof WP_Post && Documents::STATUS_ARCHIVED !== $candidate->post_status ) {
+				$restored[] = $candidate_id;
+			}
+		}
+
+		return array_values( array_unique( $restored ) );
+	}
+
+	/**
+	 * Returns archived descendants marked by this document's cascade.
+	 *
+	 * @param int $root_id Root document ID.
+	 * @return int[] Archived descendant IDs, excluding the root.
+	 */
+	public function descendants_for_root( int $root_id ): array {
+		return $this->cascade->descendants_for_root( $root_id );
+	}
+
+	private function restore_status_for( int $post_id ): string {
+		$status = (string) get_post_meta( $post_id, self::STATUS_META, true );
+		return in_array( $status, self::ACTIVE_STATUSES, true ) ? $status : 'draft';
+	}
+
+	private function archive_transition_error( WP_Post $post ): ?WP_Error {
+		if ( Documents::STATUS_ARCHIVED === $post->post_status ) {
+			return new WP_Error(
+				'cortext_document_already_archived',
+				__( 'Document is already archived.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( Documents::STATUS_TRASH === $post->post_status ) {
+			return new WP_Error(
+				'cortext_document_in_trash',
+				__( 'Restore the document from Trash before archiving it.', 'cortext' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return null;
+	}
+}

--- a/includes/PostType/ArchiveCascade.php
+++ b/includes/PostType/ArchiveCascade.php
@@ -68,6 +68,8 @@ final class ArchiveCascade {
 		add_action( 'init', array( $this, 'register_meta' ) );
 		add_action( 'transition_post_status', array( $this, 'on_transition' ), 10, 3 );
 		add_filter( 'rest_pre_insert_' . Document::POST_TYPE, array( $this, 'validate_rest_archive_transition' ), 5, 2 );
+		add_filter( 'rest_dispatch_request', array( $this, 'block_archived_autosave' ), 10, 4 );
+		add_filter( 'map_meta_cap', array( $this, 'preserve_original_status_capabilities' ), 10, 4 );
 		add_filter( 'wp_untrash_post_status', array( $this, 'allow_archived_untrash_status' ), PHP_INT_MAX, 3 );
 		add_filter( 'wp_insert_post_parent', array( $this, 'capture_trash_archive_slug_state' ), 5, 4 );
 		add_filter( 'wp_insert_post_data', array( $this, 'prevent_trash_archive_transition' ), 5, 4 );
@@ -205,14 +207,14 @@ final class ArchiveCascade {
 	}
 
 	/**
-	 * Checks core REST status changes against the archive rules.
+	 * Checks core REST writes against the archive rules.
 	 *
 	 * @param mixed           $prepared_post Post data prepared by core REST.
 	 * @param WP_REST_Request $request       Incoming core REST request.
 	 * @return mixed|WP_Error
 	 */
 	public function validate_rest_archive_transition( $prepared_post, WP_REST_Request $request ) {
-		if ( is_wp_error( $prepared_post ) || Documents::STATUS_ARCHIVED !== $request->get_param( 'status' ) ) {
+		if ( is_wp_error( $prepared_post ) ) {
 			return $prepared_post;
 		}
 
@@ -226,7 +228,115 @@ final class ArchiveCascade {
 			return $prepared_post;
 		}
 
-		return $this->archive_transition_error( $post ) ?? $prepared_post;
+		if ( Documents::STATUS_ARCHIVED === $post->post_status ) {
+			return $this->archived_write_error();
+		}
+
+		if ( Documents::STATUS_ARCHIVED !== $request->get_param( 'status' ) ) {
+			return $prepared_post;
+		}
+
+		$transition_error = $this->archive_transition_error( $post );
+		if ( $transition_error instanceof WP_Error ) {
+			return $transition_error;
+		}
+
+		if ( ! $this->current_user_can_archive( $post_id ) ) {
+			return new WP_Error(
+				'cortext_document_archive_forbidden',
+				__( 'You are not allowed to archive this document.', 'cortext' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return $prepared_post;
+	}
+
+	/**
+	 * Stops core's autosave controller before it can create a revision for an
+	 * archived document.
+	 *
+	 * The autosave controller ignores errors returned by its parent post
+	 * controller's prepare method, so the regular pre-insert guard is not enough
+	 * for this route.
+	 *
+	 * @param mixed           $dispatch_result Result supplied by an earlier filter.
+	 * @param WP_REST_Request $request         Incoming REST request.
+	 * @param string          $route           Matched route pattern.
+	 * @param array           $handler         Matched route handler.
+	 * @return mixed|WP_Error
+	 */
+	public function block_archived_autosave( $dispatch_result, WP_REST_Request $request, string $route, array $handler ) {
+		unset( $route );
+
+		$callback = $handler['callback'] ?? null;
+		if (
+			null !== $dispatch_result
+			|| 'POST' !== $request->get_method()
+			|| ! is_array( $callback )
+			|| ! isset( $callback[0], $callback[1] )
+			|| ! $callback[0] instanceof \WP_REST_Autosaves_Controller
+			|| 'create_item' !== $callback[1]
+		) {
+			return $dispatch_result;
+		}
+
+		$post = get_post( (int) $request->get_param( 'id' ) );
+		if (
+			$post instanceof WP_Post
+			&& Document::POST_TYPE === $post->post_type
+			&& Documents::STATUS_ARCHIVED === $post->post_status
+		) {
+			return $this->archived_write_error();
+		}
+
+		return $dispatch_result;
+	}
+
+	/**
+	 * Keeps edit and delete checks tied to the status held before Archive.
+	 *
+	 * WordPress treats custom statuses like drafts when it maps these
+	 * capabilities. Use the saved status for the checks core would otherwise
+	 * drop, including while the archived document is in Trash.
+	 *
+	 * @param string[] $caps    Primitive capabilities from WordPress.
+	 * @param string   $cap     Requested meta capability.
+	 * @param int      $user_id User ID being checked.
+	 * @param mixed[]  $args    Arguments passed to the capability check.
+	 * @return string[]
+	 */
+	public function preserve_original_status_capabilities( array $caps, string $cap, int $user_id, array $args ): array {
+		if ( ! in_array( $cap, array( 'edit_post', 'delete_post' ), true ) || empty( $args[0] ) ) {
+			return $caps;
+		}
+
+		$post = get_post( (int) $args[0] );
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+			return $caps;
+		}
+
+		$is_archived = Documents::STATUS_ARCHIVED === $post->post_status;
+		$is_in_trash = Documents::STATUS_TRASH === $post->post_status
+			&& Documents::STATUS_ARCHIVED === (string) get_post_meta( (int) $post->ID, '_wp_trash_meta_status', true );
+		if ( ! $is_archived && ! $is_in_trash ) {
+			return $caps;
+		}
+
+		$post_type = get_post_type_object( Document::POST_TYPE );
+		if ( null === $post_type ) {
+			return $caps;
+		}
+
+		$original_status = $this->restore_status_for( (int) $post->ID );
+		$prefix          = 'edit_post' === $cap ? 'edit' : 'delete';
+		if ( in_array( $original_status, array( 'publish', 'future' ), true ) ) {
+			$caps[] = $post_type->cap->{"{$prefix}_published_posts"};
+		} elseif ( 'private' === $original_status && $user_id !== (int) $post->post_author ) {
+			$caps[] = $post_type->cap->{"{$prefix}_private_posts"};
+		}
+
+		return array_values( array_unique( $caps ) );
 	}
 
 	/**
@@ -432,9 +542,62 @@ final class ArchiveCascade {
 		return $this->cascade->descendants_for_root( $root_id );
 	}
 
+	/**
+	 * Checks edit permission for every document an Archive request would move.
+	 *
+	 * @param int $root_id Root document ID.
+	 */
+	public function current_user_can_archive( int $root_id ): bool {
+		$ids = array_merge( array( $root_id ), $this->cascade->candidates_for_cascade( $root_id ) );
+		foreach ( array_unique( $ids ) as $post_id ) {
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks edit and publication permission for every document restored by an
+	 * Unarchive request.
+	 *
+	 * @param int $root_id Root document ID.
+	 */
+	public function current_user_can_unarchive( int $root_id ): bool {
+		$post_type = get_post_type_object( Document::POST_TYPE );
+		if ( null === $post_type ) {
+			return false;
+		}
+
+		$ids = array_merge( array( $root_id ), $this->descendants_for_root( $root_id ) );
+		foreach ( array_unique( $ids ) as $post_id ) {
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+				return false;
+			}
+
+			if (
+				in_array( $this->restore_status_for( $post_id ), array( 'private', 'publish', 'future' ), true )
+				&& ! current_user_can( $post_type->cap->publish_posts )
+			) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	private function restore_status_for( int $post_id ): string {
 		$status = (string) get_post_meta( $post_id, self::STATUS_META, true );
 		return in_array( $status, self::ACTIVE_STATUSES, true ) ? $status : 'draft';
+	}
+
+	private function archived_write_error(): WP_Error {
+		return new WP_Error(
+			'cortext_document_archived',
+			__( 'Restore this document before editing it.', 'cortext' ),
+			array( 'status' => 409 )
+		);
 	}
 
 	private function archive_transition_error( WP_Post $post ): ?WP_Error {

--- a/includes/PostType/DocumentCascade.php
+++ b/includes/PostType/DocumentCascade.php
@@ -63,6 +63,44 @@ final class DocumentCascade {
 	}
 
 	/**
+	 * Finds every active descendant a cascade from this document would move.
+	 *
+	 * @param int $root_id Root document ID.
+	 * @return int[] Active descendant IDs, excluding the root.
+	 */
+	public function candidates_for_cascade( int $root_id ): array {
+		if ( Document::POST_TYPE !== get_post_type( $root_id ) ) {
+			return array();
+		}
+
+		$collected = array();
+		$seen      = array( $root_id => true );
+		$frontier  = array( $root_id );
+
+		while ( ! empty( $frontier ) ) {
+			$next = array();
+			foreach ( $frontier as $current ) {
+				$candidates = $this->active_child_ids( $current );
+				if ( Document::is_collection( $current ) ) {
+					$candidates = array_merge( $candidates, $this->active_row_ids( $current ) );
+				}
+
+				foreach ( $candidates as $candidate_id ) {
+					if ( isset( $seen[ $candidate_id ] ) ) {
+						continue;
+					}
+					$seen[ $candidate_id ] = true;
+					$collected[]           = $candidate_id;
+					$next[]                = $candidate_id;
+				}
+			}
+			$frontier = $next;
+		}
+
+		return $collected;
+	}
+
+	/**
 	 * Restores the children and rows marked by this document.
 	 *
 	 * @param int      $post_id    Document whose children and rows should be restored.

--- a/includes/PostType/Field.php
+++ b/includes/PostType/Field.php
@@ -11,6 +11,7 @@ namespace Cortext\PostType;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\Fields\FieldDefaults;
 use Cortext\Fields\FieldTypeRegistry;
 use WP_Error;
@@ -213,7 +214,7 @@ final class Field {
 		$owner_ids    = get_posts(
 			array(
 				'post_type'      => Document::POST_TYPE,
-				'post_status'    => array( 'draft', 'private', 'publish', 'trash' ),
+				'post_status'    => array( 'draft', 'private', 'publish', 'trash', Documents::STATUS_ARCHIVED ),
 				'fields'         => 'ids',
 				'posts_per_page' => -1,
 				'no_found_rows'  => true,

--- a/includes/PostType/TrashCascade.php
+++ b/includes/PostType/TrashCascade.php
@@ -49,7 +49,7 @@ final class TrashCascade {
 	 */
 	public const COLLECTION_MARKER_META = '_cortext_trashed_by_collection';
 
-	private const ACTIVE_STATUSES = array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft' );
+	private const ACTIVE_STATUSES = array( 'publish', 'private', 'draft', 'pending', 'future', 'auto-draft', Documents::STATUS_ARCHIVED );
 
 	private DocumentCascade $cascade;
 

--- a/includes/Rest/DocumentsController.php
+++ b/includes/Rest/DocumentsController.php
@@ -2,8 +2,8 @@
 /**
  * REST endpoints for Cortext documents.
  *
- * Handles listing, restore, permanent delete, duplicate, and collection
- * create through the `Documents` service.
+ * Handles listing, archive, restore, permanent delete, duplicate, and
+ * collection create through the `Documents` service.
  *
  * Restore and permanent-delete walk descendants via `TrashCascade` so the
  * subtree moves with its root. Single-resource reads still go through
@@ -19,6 +19,7 @@ namespace Cortext\Rest;
 defined( 'ABSPATH' ) || exit;
 
 use Cortext\Documents;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\TrashCascade;
 use Cortext\Rest\RowsManualOrder;
@@ -35,9 +36,16 @@ final class DocumentsController {
 
 	private TrashCascade $cascade;
 
-	public function __construct( ?Documents $documents = null, ?TrashCascade $cascade = null ) {
-		$this->documents = $documents ?? new Documents();
-		$this->cascade   = $cascade ?? new TrashCascade();
+	private ArchiveCascade $archive_cascade;
+
+	public function __construct(
+		?Documents $documents = null,
+		?TrashCascade $cascade = null,
+		?ArchiveCascade $archive_cascade = null
+	) {
+		$this->documents       = $documents ?? new Documents();
+		$this->cascade         = $cascade ?? new TrashCascade();
+		$this->archive_cascade = $archive_cascade ?? new ArchiveCascade();
 	}
 
 	public function register(): void {
@@ -61,7 +69,7 @@ final class DocumentsController {
 						'status'   => array(
 							'type'    => 'string',
 							'default' => '',
-							'enum'    => array( '', Documents::STATUS_TRASH ),
+							'enum'    => array( '', Documents::STATUS_ARCHIVED, Documents::STATUS_TRASH ),
 						),
 						'page'     => array(
 							'type'    => 'integer',
@@ -83,6 +91,32 @@ final class DocumentsController {
 				'type'     => 'integer',
 				'required' => true,
 			),
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/documents/(?P<id>\d+)/archive',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'archive' ),
+					'permission_callback' => array( $this, 'check_editable_document' ),
+					'args'                => $id_arg,
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/documents/(?P<id>\d+)/unarchive',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'unarchive' ),
+					'permission_callback' => array( $this, 'check_editable_document' ),
+					'args'                => $id_arg,
+				),
+			)
 		);
 
 		register_rest_route(
@@ -181,7 +215,7 @@ final class DocumentsController {
 				'status'          => '' === $status ? null : $status,
 				'page'            => (int) $request->get_param( 'page' ),
 				'per_page'        => (int) $request->get_param( 'per_page' ),
-				'include_excerpt' => Documents::STATUS_TRASH !== $status,
+				'include_excerpt' => ! in_array( $status, array( Documents::STATUS_ARCHIVED, Documents::STATUS_TRASH ), true ),
 			)
 		);
 
@@ -218,6 +252,64 @@ final class DocumentsController {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks permission for archive and unarchive requests.
+	 *
+	 * Neither action deletes the document, so these routes require edit
+	 * permission rather than the delete permission used by Trash.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 * @return bool|WP_Error
+	 */
+	public function check_editable_document( WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$post = get_post( $id );
+
+		if ( ! $post instanceof WP_Post || ! post_type_supports( $post->post_type, 'cortext-document' ) ) {
+			return new WP_Error(
+				'cortext_document_not_found',
+				__( 'Document not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return current_user_can( 'edit_post', $id );
+	}
+
+	public function archive( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$id       = (int) $request->get_param( 'id' );
+		$archived = $this->archive_cascade->archive( $id );
+		if ( $archived instanceof WP_Error ) {
+			return $archived;
+		}
+
+		$post = get_post( $id );
+		return new WP_REST_Response(
+			array(
+				'archived' => $archived,
+				'post'     => $post instanceof WP_Post ? $this->prepared_post( $post ) : null,
+			),
+			200
+		);
+	}
+
+	public function unarchive( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$id       = (int) $request->get_param( 'id' );
+		$restored = $this->archive_cascade->unarchive( $id );
+		if ( $restored instanceof WP_Error ) {
+			return $restored;
+		}
+
+		$post = get_post( $id );
+		return new WP_REST_Response(
+			array(
+				'restored' => $restored,
+				'post'     => $post instanceof WP_Post ? $this->prepared_post( $post ) : null,
+			),
+			200
+		);
 	}
 
 	public function restore( WP_REST_Request $request ) {

--- a/includes/Rest/DocumentsController.php
+++ b/includes/Rest/DocumentsController.php
@@ -100,7 +100,7 @@ final class DocumentsController {
 				array(
 					'methods'             => 'POST',
 					'callback'            => array( $this, 'archive' ),
-					'permission_callback' => array( $this, 'check_editable_document' ),
+					'permission_callback' => array( $this, 'check_archive_permission' ),
 					'args'                => $id_arg,
 				),
 			)
@@ -113,7 +113,7 @@ final class DocumentsController {
 				array(
 					'methods'             => 'POST',
 					'callback'            => array( $this, 'unarchive' ),
-					'permission_callback' => array( $this, 'check_editable_document' ),
+					'permission_callback' => array( $this, 'check_unarchive_permission' ),
 					'args'                => $id_arg,
 				),
 			)
@@ -255,15 +255,15 @@ final class DocumentsController {
 	}
 
 	/**
-	 * Checks permission for archive and unarchive requests.
+	 * Checks permission to archive a document and its active descendants.
 	 *
-	 * Neither action deletes the document, so these routes require edit
-	 * permission rather than the delete permission used by Trash.
+	 * Archive does not delete the document, so it requires edit permission
+	 * rather than the delete permission used by Trash.
 	 *
 	 * @param WP_REST_Request $request Incoming REST request.
 	 * @return bool|WP_Error
 	 */
-	public function check_editable_document( WP_REST_Request $request ) {
+	public function check_archive_permission( WP_REST_Request $request ) {
 		$id   = (int) $request->get_param( 'id' );
 		$post = get_post( $id );
 
@@ -275,7 +275,28 @@ final class DocumentsController {
 			);
 		}
 
-		return current_user_can( 'edit_post', $id );
+		return $this->archive_cascade->current_user_can_archive( $id );
+	}
+
+	/**
+	 * Checks permission to restore an archived document and its descendants.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 * @return bool|WP_Error
+	 */
+	public function check_unarchive_permission( WP_REST_Request $request ) {
+		$id   = (int) $request->get_param( 'id' );
+		$post = get_post( $id );
+
+		if ( ! $post instanceof WP_Post || ! post_type_supports( $post->post_type, 'cortext-document' ) ) {
+			return new WP_Error(
+				'cortext_document_not_found',
+				__( 'Document not found.', 'cortext' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $this->archive_cascade->current_user_can_unarchive( $id );
 	}
 
 	public function archive( WP_REST_Request $request ): WP_REST_Response|WP_Error {

--- a/includes/Rest/FavoritesController.php
+++ b/includes/Rest/FavoritesController.php
@@ -88,9 +88,22 @@ final class FavoritesController {
 			);
 		}
 
-		$formatted = array();
-		$stored    = array();
-		$seen      = array();
+		$user_id          = get_current_user_id();
+		$existing_slots   = $this->stored_favorite_slots( $user_id );
+		$existing_hidden  = array_fill_keys(
+			array_column(
+				array_filter(
+					$existing_slots,
+					static fn( array $slot ): bool => $slot['hidden']
+				),
+				'id'
+			),
+			true
+		);
+		$formatted        = array();
+		$requested        = array();
+		$requested_hidden = array();
+		$seen             = array();
 
 		foreach ( $favorites as $favorite ) {
 			if ( ! is_array( $favorite ) ) {
@@ -108,15 +121,28 @@ final class FavoritesController {
 
 			$target = $this->documents->format_target( $id );
 			if ( is_wp_error( $target ) ) {
+				if ( 'cortext_document_target_hidden' === $target->get_error_code() ) {
+					if ( ! isset( $existing_hidden[ $id ] ) ) {
+						return $target;
+					}
+					$seen[ $id ]        = true;
+					$requested_hidden[] = $id;
+					continue;
+				}
 				return $target;
 			}
 
 			$seen[ $id ] = true;
-			$stored[]    = (int) $target['id'];
+			$requested[] = (int) $target['id'];
 			$formatted[] = $target;
 		}
 
-		update_user_meta( get_current_user_id(), self::META_KEY, $stored );
+		$stored = $this->merge_with_hidden_favorites(
+			$existing_slots,
+			$requested,
+			$requested_hidden
+		);
+		update_user_meta( $user_id, self::META_KEY, $stored );
 
 		return new WP_REST_Response(
 			array(
@@ -124,6 +150,111 @@ final class FavoritesController {
 			),
 			200
 		);
+	}
+
+	/**
+	 * Merges the visible order sent by the client with archived favorites. Each
+	 * archived favorite keeps its current slot.
+	 *
+	 * @param array<int, array{id: int, hidden: bool}> $slots Existing valid slots.
+	 * @param array<int, int>                          $requested Requested visible IDs.
+	 * @param array<int, int>                          $requested_hidden Requested hidden IDs.
+	 * @return array<int, int>
+	 */
+	private function merge_with_hidden_favorites(
+		array $slots,
+		array $requested,
+		array $requested_hidden
+	): array {
+		$stored          = array();
+		$emitted         = array();
+		$requested_index = 0;
+
+		foreach ( $slots as $slot ) {
+			if ( $slot['hidden'] ) {
+				if ( ! isset( $emitted[ $slot['id'] ] ) ) {
+					$stored[]               = $slot['id'];
+					$emitted[ $slot['id'] ] = true;
+				}
+				continue;
+			}
+
+			if ( ! isset( $requested[ $requested_index ] ) ) {
+				continue;
+			}
+
+			$id = $requested[ $requested_index ];
+			++$requested_index;
+			if ( isset( $emitted[ $id ] ) ) {
+				continue;
+			}
+			$stored[]       = $id;
+			$emitted[ $id ] = true;
+		}
+
+		for ( $count = count( $requested ); $requested_index < $count; ++$requested_index ) {
+			$id = $requested[ $requested_index ];
+			if ( isset( $emitted[ $id ] ) ) {
+				continue;
+			}
+			$stored[]       = $id;
+			$emitted[ $id ] = true;
+		}
+
+		foreach ( $requested_hidden as $id ) {
+			if ( isset( $emitted[ $id ] ) ) {
+				continue;
+			}
+			$stored[]       = $id;
+			$emitted[ $id ] = true;
+		}
+
+		return $stored;
+	}
+
+	/**
+	 * Builds visible and hidden slots from the user's saved favorites. Invalid,
+	 * deleted, and inaccessible documents are left out.
+	 *
+	 * @param int $user_id User whose stored favorites should be resolved.
+	 * @return array<int, array{id: int, hidden: bool}>
+	 */
+	private function stored_favorite_slots( int $user_id ): array {
+		$raw = get_user_meta( $user_id, self::META_KEY, true );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$slots = array();
+		$seen  = array();
+		foreach ( $raw as $entry ) {
+			$id = $this->stored_entry_id( $entry );
+			if ( $id < 1 || isset( $seen[ $id ] ) ) {
+				continue;
+			}
+
+			$target = $this->documents->format_target( $id );
+			if ( is_wp_error( $target ) ) {
+				if ( 'cortext_document_target_hidden' !== $target->get_error_code() ) {
+					continue;
+				}
+				$slots[]     = array(
+					'id'     => $id,
+					'hidden' => true,
+				);
+				$seen[ $id ] = true;
+				continue;
+			}
+
+			$canonical_id = (int) $target['id'];
+			$slots[]      = array(
+				'id'     => $canonical_id,
+				'hidden' => false,
+			);
+			$seen[ $id ]  = true;
+		}
+
+		return $slots;
 	}
 
 	private function resolve_stored_favorites( int $user_id ): array {
@@ -143,6 +274,10 @@ final class FavoritesController {
 
 			$target = $this->documents->format_target( $id );
 			if ( is_wp_error( $target ) ) {
+				if ( 'cortext_document_target_hidden' === $target->get_error_code() ) {
+					$seen[ $id ] = true;
+					$valid[]     = $id;
+				}
 				continue;
 			}
 

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -11,6 +11,7 @@ namespace Cortext\Rest;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\Fields\FieldDefaults;
 use Cortext\Fields\FieldTypeConverter;
 use Cortext\Fields\FieldTypeRegistry;
@@ -688,7 +689,7 @@ final class FieldsController {
 			$row_ids = get_posts(
 				array(
 					'post_type'      => Document::POST_TYPE,
-					'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit' ),
+					'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit', Documents::STATUS_ARCHIVED ),
 					'posts_per_page' => -1,
 					'fields'         => 'ids',
 					'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
@@ -886,7 +887,7 @@ final class FieldsController {
 		$row_ids = get_posts(
 			array(
 				'post_type'      => Document::POST_TYPE,
-				'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit' ),
+				'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit', Documents::STATUS_ARCHIVED ),
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- bounded migration over Cortext rows.
@@ -932,7 +933,7 @@ final class FieldsController {
 		$row_ids  = get_posts(
 			array(
 				'post_type'      => Document::POST_TYPE,
-				'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit' ),
+				'post_status'    => array( 'draft', 'pending', 'private', 'publish', 'future', 'inherit', Documents::STATUS_ARCHIVED ),
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- bounded count over Cortext rows.

--- a/includes/Rest/PostLocksController.php
+++ b/includes/Rest/PostLocksController.php
@@ -11,6 +11,7 @@ namespace Cortext\Rest;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use WP_Error;
 use WP_Post;
 use WP_REST_Request;
@@ -81,13 +82,21 @@ final class PostLocksController {
 			);
 		}
 
-		if ( 'trash' === $post->post_status ) {
+		if ( Documents::STATUS_TRASH === $post->post_status ) {
 			return new WP_Error(
 				'cortext_document_in_trash',
 				__(
 					'Move this document out of Trash before editing it.',
 					'cortext'
 				),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( Documents::STATUS_ARCHIVED === $post->post_status ) {
+			return new WP_Error(
+				'cortext_document_archived',
+				__( 'Restore this document before editing it.', 'cortext' ),
 				array( 'status' => 409 )
 			);
 		}

--- a/includes/Rest/RecentsController.php
+++ b/includes/Rest/RecentsController.php
@@ -119,6 +119,9 @@ final class RecentsController {
 		foreach ( $items as $item ) {
 			$target = $this->documents->format_target( $item['id'] );
 			if ( is_wp_error( $target ) ) {
+				if ( 'cortext_document_target_hidden' === $target->get_error_code() ) {
+					$valid[] = $item;
+				}
 				continue;
 			}
 

--- a/includes/Rest/RowsManualOrder.php
+++ b/includes/Rest/RowsManualOrder.php
@@ -15,6 +15,7 @@ namespace Cortext\Rest;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\PostType\Document;
 use Cortext\Relations;
 use Cortext\Taxonomy\TraitTaxonomy;
@@ -333,7 +334,7 @@ final class RowsManualOrder {
 
 		$args = array(
 			'post_type'      => Document::POST_TYPE,
-			'post_status'    => array( 'draft', 'private', 'publish' ),
+			'post_status'    => array( 'draft', 'private', 'publish', Documents::STATUS_ARCHIVED ),
 			'posts_per_page' => -1,
 			'no_found_rows'  => true,
 			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
@@ -398,7 +399,7 @@ final class RowsManualOrder {
 				$store->posts,
 				static fn( $post ) =>
 					Document::POST_TYPE === $post->post_type &&
-					in_array( $post->post_status, array( 'draft', 'private', 'publish' ), true ) &&
+					in_array( $post->post_status, array( 'draft', 'private', 'publish', Documents::STATUS_ARCHIVED ), true ) &&
 					has_term( $trait_term_id, TraitTaxonomy::TAXONOMY, (int) $post->ID )
 			)
 		);

--- a/includes/Rest/SampleContentController.php
+++ b/includes/Rest/SampleContentController.php
@@ -12,6 +12,7 @@ namespace Cortext\Rest;
 defined( 'ABSPATH' ) || exit;
 
 use Cortext\CLI\SeedDummyCollections;
+use Cortext\Documents;
 use Cortext\PostType\Document;
 use WP_Error;
 use WP_REST_Response;
@@ -88,7 +89,7 @@ final class SampleContentController {
 		$posts = get_posts(
 			array(
 				'post_type'      => Document::POST_TYPE,
-				'post_status'    => array( 'draft', 'private', 'publish', 'pending', 'future', 'trash' ),
+				'post_status'    => array( 'draft', 'private', 'publish', 'pending', 'future', 'trash', Documents::STATUS_ARCHIVED ),
 				'fields'         => 'ids',
 				'posts_per_page' => -1,
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key

--- a/includes/Taxonomy/TraitTaxonomy.php
+++ b/includes/Taxonomy/TraitTaxonomy.php
@@ -41,6 +41,7 @@ namespace Cortext\Taxonomy;
 
 defined( 'ABSPATH' ) || exit;
 
+use Cortext\Documents;
 use Cortext\PostType\Document;
 use WP_Post;
 
@@ -392,9 +393,10 @@ final class TraitTaxonomy {
 				FROM {$wpdb->term_relationships} tr
 				INNER JOIN {$wpdb->posts} p ON p.ID = tr.object_id
 				WHERE tr.term_taxonomy_id = %d
-				AND p.post_status IN ('draft', 'private', 'publish')
+				AND p.post_status IN ('draft', 'private', 'publish', %s)
 				AND p.ID != %d",
 				$term_taxonomy_id,
+				Documents::STATUS_ARCHIVED,
 				$exclude_post_id
 			)
 		);

--- a/tests/php/InMemoryPostsQuery.php
+++ b/tests/php/InMemoryPostsQuery.php
@@ -72,6 +72,7 @@ trait InMemoryPostsQuery {
 		$wants_tax_query       = ! empty( $vars['tax_query'] ) && is_array( $vars['tax_query'] );
 		$wants_post_type_query = ! empty( $vars['post_type'] ) && 'any' !== $vars['post_type'];
 		$wants_search          = isset( $vars['s'] ) && '' !== (string) $vars['s'];
+		$wants_title           = isset( $vars['title'] ) && '' !== (string) $vars['title'];
 		$statuses              = (array) ( $vars['post_status'] ?? array() );
 		$any_status            = in_array( 'any', $statuses, true );
 		$excluded_statuses     = $any_status
@@ -86,6 +87,7 @@ trait InMemoryPostsQuery {
 			! $wants_tax_query &&
 			! $wants_post_type_query &&
 			! $wants_search &&
+			! $wants_title &&
 			! $wants_trash_query
 		) {
 			return $pre;
@@ -161,6 +163,14 @@ trait InMemoryPostsQuery {
 					}
 					return true;
 				}
+			);
+		}
+
+		if ( $wants_title ) {
+			$title      = (string) $vars['title'];
+			$candidates = array_filter(
+				$candidates,
+				static fn( WP_Post $post ): bool => (string) $post->post_title === $title
 			);
 		}
 

--- a/tests/php/InMemoryPostsQuery.php
+++ b/tests/php/InMemoryPostsQuery.php
@@ -73,6 +73,10 @@ trait InMemoryPostsQuery {
 		$wants_post_type_query = ! empty( $vars['post_type'] ) && 'any' !== $vars['post_type'];
 		$wants_search          = isset( $vars['s'] ) && '' !== (string) $vars['s'];
 		$statuses              = (array) ( $vars['post_status'] ?? array() );
+		$any_status            = in_array( 'any', $statuses, true );
+		$excluded_statuses     = $any_status
+			? get_post_stati( array( 'exclude_from_search' => true ) )
+			: array();
 		$wants_trash_query     = in_array( 'trash', $statuses, true );
 
 		if (
@@ -108,7 +112,9 @@ trait InMemoryPostsQuery {
 		if ( ! empty( $statuses ) ) {
 			$candidates = array_filter(
 				$candidates,
-				static fn( WP_Post $post ): bool => in_array( $post->post_status, $statuses, true )
+				static fn( WP_Post $post ): bool => $any_status
+					? ! in_array( $post->post_status, $excluded_statuses, true )
+					: in_array( $post->post_status, $statuses, true )
 			);
 		}
 
@@ -210,8 +216,8 @@ trait InMemoryPostsQuery {
 		self::$in_memory_found_posts[ $query ] = $total;
 		$query->found_posts                    = $total;
 
-		$per_page = (int) ( $vars['posts_per_page'] ?? 0 );
-		$page     = max( 1, (int) ( $vars['paged'] ?? 1 ) );
+		$per_page             = (int) ( $vars['posts_per_page'] ?? 0 );
+		$page                 = max( 1, (int) ( $vars['paged'] ?? 1 ) );
 		$query->max_num_pages = $per_page > 0 ? (int) ceil( $total / $per_page ) : 0;
 		if ( $per_page > 0 ) {
 			$candidates = array_slice( $candidates, ( $page - 1 ) * $per_page, $per_page );
@@ -255,6 +261,9 @@ trait InMemoryPostsQuery {
 	 * Returns the tier (1-best, 5-worst) for a post against a search
 	 * needle. Matches the CASE expression `Documents::list()` registers via
 	 * the `posts_search_orderby` filter.
+	 *
+	 * @param WP_Post $post   Post being ranked.
+	 * @param string  $needle Normalized search needle.
 	 */
 	private function search_relevance_tier( WP_Post $post, string $needle ): int {
 		if ( '' === $needle ) {

--- a/tests/php/test-archive-cascade.php
+++ b/tests/php/test-archive-cascade.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Tests for archive and restore cascades.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Documents;
+use Cortext\PostType\ArchiveCascade;
+use Cortext\PostType\Document;
+use Cortext\PostType\Field;
+use Cortext\PostType\TrashCascade;
+use Cortext\Relations;
+use Cortext\Taxonomy\TraitTaxonomy;
+use WorDBless\BaseTestCase;
+
+final class Test_Archive_Cascade extends BaseTestCase {
+
+	use InMemoryPostsQuery;
+	use InMemoryTermStore;
+
+	private ArchiveCascade $archive_cascade;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Document() )->register_post_type();
+		( new TraitTaxonomy() )->register_taxonomy();
+		( new Field() )->register_post_type();
+
+		remove_all_actions( 'transition_post_status' );
+		remove_all_actions( 'wp_trash_post' );
+		remove_all_actions( 'untrashed_post' );
+		remove_all_actions( 'before_delete_post' );
+		remove_all_filters( 'wp_untrash_post_status' );
+
+		$this->install_in_memory_term_store();
+		$this->install_in_memory_posts_query();
+
+		$trait_taxonomy = new TraitTaxonomy();
+		add_action( 'added_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'updated_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'deleted_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
+		add_action( 'before_delete_post', array( $trait_taxonomy, 'sync_term_on_delete' ), 10, 2 );
+
+		$this->archive_cascade = new ArchiveCascade();
+		$this->archive_cascade->register_status();
+		$this->archive_cascade->register_meta();
+		$this->archive_cascade->register();
+		( new TrashCascade() )->register();
+	}
+
+	public function tear_down(): void {
+		$this->uninstall_in_memory_posts_query();
+		$this->uninstall_in_memory_term_store();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_registers_archived_status_as_protected_and_searchable(): void {
+		$status = get_post_status_object( Documents::STATUS_ARCHIVED );
+
+		$this->assertNotNull( $status );
+		$this->assertSame( 'Archived', $status->label );
+		$this->assertFalse( $status->internal );
+		$this->assertFalse( $status->public );
+		$this->assertTrue( $status->protected );
+		$this->assertFalse( $status->exclude_from_search );
+		$this->assertFalse( $status->show_in_admin_all_list );
+		$this->assertTrue( $status->show_in_admin_status_list );
+	}
+
+	public function test_archives_page_tree_and_restores_original_statuses(): void {
+		$parent_id     = $this->create_page( array( 'post_status' => 'private' ) );
+		$child_id      = $this->create_page(
+			array(
+				'post_parent' => $parent_id,
+				'post_status' => 'publish',
+			)
+		);
+		$grandchild_id = $this->create_page(
+			array(
+				'post_parent' => $child_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$archived = $this->archive_cascade->archive( $parent_id );
+
+		$this->assertEqualsCanonicalizing( array( $parent_id, $child_id, $grandchild_id ), $archived );
+		foreach ( array( $parent_id, $child_id, $grandchild_id ) as $post_id ) {
+			$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $post_id ) );
+			$this->assertGreaterThan( 0, (int) get_post_meta( $post_id, ArchiveCascade::TIME_META, true ) );
+		}
+		$this->assertSame( 'private', get_post_meta( $parent_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( 'publish', get_post_meta( $child_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( 'draft', get_post_meta( $grandchild_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( (string) $parent_id, (string) get_post_meta( $child_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+		$this->assertSame( (string) $child_id, (string) get_post_meta( $grandchild_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+
+		$restored = $this->archive_cascade->unarchive( $parent_id );
+
+		$this->assertEqualsCanonicalizing( array( $parent_id, $child_id, $grandchild_id ), $restored );
+		$this->assertSame( 'private', get_post_status( $parent_id ) );
+		$this->assertSame( 'publish', get_post_status( $child_id ) );
+		$this->assertSame( 'draft', get_post_status( $grandchild_id ) );
+		foreach ( array( $parent_id, $child_id, $grandchild_id ) as $post_id ) {
+			$this->assertSame( '', (string) get_post_meta( $post_id, ArchiveCascade::STATUS_META, true ) );
+			$this->assertSame( '', (string) get_post_meta( $post_id, ArchiveCascade::TIME_META, true ) );
+			$this->assertSame( '', (string) get_post_meta( $post_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+		}
+	}
+
+	public function test_archives_collection_rows_and_restores_original_statuses(): void {
+		$collection_id = $this->create_collection();
+		$published_row = $this->create_row( $collection_id, 'publish' );
+		$draft_row     = $this->create_row( $collection_id, 'draft' );
+
+		$archived = $this->archive_cascade->archive( $collection_id );
+
+		$this->assertEqualsCanonicalizing( array( $collection_id, $published_row, $draft_row ), $archived );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $published_row ) );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $draft_row ) );
+		$this->assertSame( 'publish', get_post_meta( $published_row, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( 'draft', get_post_meta( $draft_row, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( (string) $collection_id, (string) get_post_meta( $published_row, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+		$this->assertSame( (string) $collection_id, (string) get_post_meta( $draft_row, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+
+		$this->archive_cascade->unarchive( $collection_id );
+
+		$this->assertSame( 'private', get_post_status( $collection_id ) );
+		$this->assertSame( 'publish', get_post_status( $published_row ) );
+		$this->assertSame( 'draft', get_post_status( $draft_row ) );
+		$this->assertSame( '', (string) get_post_meta( $published_row, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+		$this->assertSame( '', (string) get_post_meta( $draft_row, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+	}
+
+	public function test_pre_archived_row_is_not_restored_with_collection(): void {
+		$collection_id = $this->create_collection();
+		$pre_archived  = $this->create_row( $collection_id, 'private' );
+		$cascaded_row  = $this->create_row( $collection_id, 'private' );
+		$first_archive = $this->archive_cascade->archive( $pre_archived );
+
+		$this->assertSame( array( $pre_archived ), $first_archive );
+		$this->archive_cascade->archive( $collection_id );
+		$this->assertSame( '', (string) get_post_meta( $pre_archived, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+		$this->assertSame( (string) $collection_id, (string) get_post_meta( $cascaded_row, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+
+		$this->archive_cascade->unarchive( $collection_id );
+
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $pre_archived ) );
+		$this->assertSame( 'private', get_post_status( $cascaded_row ) );
+	}
+
+	public function test_original_statuses_survive_archive_trash_restore_and_unarchive(): void {
+		$collection_id = $this->create_collection();
+		$row_id        = $this->create_row( $collection_id, 'publish' );
+
+		$this->archive_cascade->archive( $collection_id );
+		wp_trash_post( $collection_id );
+
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $collection_id ) );
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $row_id ) );
+		$this->assertSame( 'private', get_post_meta( $collection_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( 'publish', get_post_meta( $row_id, ArchiveCascade::STATUS_META, true ) );
+
+		wp_untrash_post( $collection_id );
+
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $collection_id ) );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $row_id ) );
+
+		$restored = $this->archive_cascade->unarchive( $collection_id );
+
+		$this->assertEqualsCanonicalizing( array( $collection_id, $row_id ), $restored );
+		$this->assertSame( 'private', get_post_status( $collection_id ) );
+		$this->assertSame( 'publish', get_post_status( $row_id ) );
+	}
+
+	public function test_updating_status_cannot_archive_a_trashed_document(): void {
+		$post_id = $this->create_page();
+		wp_trash_post( $post_id );
+		$trashed_slug = (string) get_post_field( 'post_name', $post_id, 'raw' );
+		$desired_slug = (string) get_post_meta( $post_id, '_wp_desired_post_slug', true );
+
+		$result = wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			),
+			true
+		);
+
+		$this->assertSame( $post_id, $result );
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $post_id ) );
+		$this->assertSame( $trashed_slug, get_post_field( 'post_name', $post_id, 'raw' ) );
+		$this->assertSame( $desired_slug, get_post_meta( $post_id, '_wp_desired_post_slug', true ) );
+		$this->assertSame( 'publish', get_post_meta( $post_id, '_wp_trash_meta_status', true ) );
+		$this->assertGreaterThan( 0, (int) get_post_meta( $post_id, '_wp_trash_meta_time', true ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, ArchiveCascade::TIME_META, true ) );
+	}
+
+	public function test_force_deleting_collection_removes_archived_rows(): void {
+		$collection_id = $this->create_collection();
+		$archived_row  = $this->create_row( $collection_id, 'private' );
+		$active_row    = $this->create_row( $collection_id, 'private' );
+		$this->archive_cascade->archive( $archived_row );
+
+		wp_delete_post( $collection_id, true );
+
+		$this->assertNull( get_post( $collection_id ) );
+		$this->assertNull( get_post( $archived_row ) );
+		$this->assertNull( get_post( $active_row ) );
+	}
+
+	public function test_relation_can_target_an_archived_row(): void {
+		$source_collection = $this->create_collection();
+		$target_collection = $this->create_collection();
+		$source_row        = $this->create_row( $source_collection, 'private' );
+		$target_row        = $this->create_row( $target_collection, 'private' );
+		$forward_field     = $this->create_relation_field( $source_collection, $target_collection );
+		$reverse_field     = $this->create_relation_field( $target_collection, $source_collection );
+
+		update_post_meta( $forward_field, 'relation_reverse_field_id', (string) $reverse_field );
+		update_post_meta( $reverse_field, 'relation_reverse_field_id', (string) $forward_field );
+		$this->archive_cascade->archive( $target_row );
+
+		$result = Relations::sync_relation_value( $source_row, $forward_field, array( $target_row ) );
+
+		$this->assertTrue( $result );
+		$this->assertSame(
+			array( $target_row ),
+			Relations::relation_values( $source_row, $forward_field )
+		);
+	}
+
+	private function create_page( array $args = array() ): int {
+		$id = wp_insert_post(
+			array_merge(
+				array(
+					'post_type'   => Document::POST_TYPE,
+					'post_status' => 'publish',
+					'post_title'  => 'Page ' . wp_generate_uuid4(),
+				),
+				$args
+			)
+		);
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+		return (int) $id;
+	}
+
+	private function create_collection(): int {
+		$collection_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Collection ' . wp_generate_uuid4(),
+			)
+		);
+		$this->assertGreaterThan( 0, $collection_id );
+
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Title',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		$this->assertGreaterThan( 0, $field_id );
+		add_post_meta( $collection_id, 'cortext_fields', (string) $field_id );
+
+		return $collection_id;
+	}
+
+	private function create_row( int $collection_id, string $status ): int {
+		$row_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => $status,
+				'post_title'  => 'Row ' . wp_generate_uuid4(),
+			)
+		);
+		$this->assertGreaterThan( 0, $row_id );
+
+		$term_id = TraitTaxonomy::term_id_for_trait( $collection_id );
+		$this->assertGreaterThan( 0, $term_id );
+		wp_set_object_terms( $row_id, array( $term_id ), TraitTaxonomy::TAXONOMY, false );
+
+		return $row_id;
+	}
+
+	private function create_relation_field( int $collection_id, int $target_collection_id ): int {
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Relation ' . wp_generate_uuid4(),
+				'meta_input'  => array(
+					'type'                  => 'relation',
+					'related_collection_id' => (string) $target_collection_id,
+					'relation_multiple'     => '1',
+				),
+			)
+		);
+		$this->assertGreaterThan( 0, $field_id );
+		add_post_meta( $collection_id, 'cortext_fields', (string) $field_id );
+
+		return $field_id;
+	}
+}

--- a/tests/php/test-archive-cascade.php
+++ b/tests/php/test-archive-cascade.php
@@ -180,6 +180,83 @@ final class Test_Archive_Cascade extends BaseTestCase {
 		$this->assertSame( 'publish', get_post_status( $row_id ) );
 	}
 
+	public function test_archived_published_document_keeps_published_capabilities_in_archive_and_trash(): void {
+		$author_id = $this->create_user( 'contributor' );
+		$post_id   = $this->create_page(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->archive_cascade->archive( $post_id );
+		wp_set_current_user( $author_id );
+
+		$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
+		$this->assertFalse( current_user_can( 'delete_post', $post_id ) );
+
+		wp_trash_post( $post_id );
+
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_meta( $post_id, '_wp_trash_meta_status', true ) );
+		$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
+		$this->assertFalse( current_user_can( 'delete_post', $post_id ) );
+
+		wp_untrash_post( $post_id );
+
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $post_id ) );
+		$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
+		$this->assertFalse( current_user_can( 'delete_post', $post_id ) );
+	}
+
+	public function test_archived_draft_keeps_its_authors_normal_capabilities(): void {
+		$author_id = $this->create_user( 'contributor' );
+		$post_id   = $this->create_page(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$this->archive_cascade->archive( $post_id );
+		wp_set_current_user( $author_id );
+
+		$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+		$this->assertTrue( current_user_can( 'delete_post', $post_id ) );
+
+		wp_trash_post( $post_id );
+
+		$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+		$this->assertTrue( current_user_can( 'delete_post', $post_id ) );
+	}
+
+	public function test_archived_private_document_keeps_private_caps_for_other_users(): void {
+		$owner_id = $this->create_user( 'subscriber' );
+		$user_id  = $this->create_user( 'editor' );
+		$post_id  = $this->create_page(
+			array(
+				'post_author' => $owner_id,
+				'post_status' => 'private',
+			)
+		);
+		$this->archive_cascade->archive( $post_id );
+
+		$edit_caps = $this->archive_cascade->preserve_original_status_capabilities(
+			array( 'edit_others_posts' ),
+			'edit_post',
+			$user_id,
+			array( $post_id )
+		);
+		$delete_caps = $this->archive_cascade->preserve_original_status_capabilities(
+			array( 'delete_others_posts' ),
+			'delete_post',
+			$user_id,
+			array( $post_id )
+		);
+
+		$this->assertContains( 'edit_private_posts', $edit_caps );
+		$this->assertContains( 'delete_private_posts', $delete_caps );
+	}
+
 	public function test_updating_status_cannot_archive_a_trashed_document(): void {
 		$post_id = $this->create_page();
 		wp_trash_post( $post_id );
@@ -312,5 +389,15 @@ final class Test_Archive_Cascade extends BaseTestCase {
 		add_post_meta( $collection_id, 'cortext_fields', (string) $field_id );
 
 		return $field_id;
+	}
+
+	private function create_user( string $role ): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_archive_', false ),
+				'user_pass'  => 'password',
+				'role'       => $role,
+			)
+		);
 	}
 }

--- a/tests/php/test-cli-seed-dummy-collections.php
+++ b/tests/php/test-cli-seed-dummy-collections.php
@@ -23,16 +23,23 @@ final class Test_CLI_Seed_Dummy_Collections extends BaseTestCase {
 	use InMemoryTermStore;
 
 	private SeedDummyCollections $seeder;
+	private ArchiveCascade $archive_cascade;
 
 	public function set_up(): void {
 		parent::set_up();
 
 		( new Document() )->register_post_type();
 		( new TraitTaxonomy() )->register_taxonomy();
-		( new ArchiveCascade() )->register_status();
+		remove_all_actions( 'transition_post_status' );
+		remove_all_filters( 'map_meta_cap' );
 
 		$this->install_in_memory_term_store();
 		$this->install_in_memory_posts_query();
+
+		$this->archive_cascade = new ArchiveCascade();
+		$this->archive_cascade->register_status();
+		$this->archive_cascade->register_meta();
+		$this->archive_cascade->register();
 		$this->seeder = new SeedDummyCollections();
 	}
 
@@ -104,10 +111,138 @@ final class Test_CLI_Seed_Dummy_Collections extends BaseTestCase {
 		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $row_id ) );
 	}
 
+	public function test_seed_page_tree_archives_new_child_with_archived_parent(): void {
+		$parent_id = $this->create_page( 'Archived parent' );
+		$this->archive_cascade->archive( $parent_id );
+
+		$child_id = $this->invoke_seeder_method(
+			'seed_page_tree',
+			array( 'title' => 'New child' ),
+			$parent_id
+		);
+
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $child_id ) );
+		$this->assertSame( 'private', get_post_meta( $child_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( (string) $parent_id, (string) get_post_meta( $child_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+
+		$this->archive_cascade->unarchive( $parent_id );
+
+		$this->assertSame( 'private', get_post_status( $child_id ) );
+	}
+
+	public function test_seed_collection_archives_new_row_with_archived_collection(): void {
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Archived fixture',
+				'meta_input'  => array( 'cortext_seed_slug' => 'archived-new-row' ),
+			)
+		);
+		$this->memo_insert_term( 'Archived fixture', (string) $collection_id, TraitTaxonomy::TAXONOMY );
+		$this->archive_cascade->archive( (int) $collection_id );
+
+		$this->invoke_seeder_method(
+			'seed_collection',
+			array(
+				'slug'    => 'archived-new-row',
+				'title'   => 'Archived fixture',
+				'fields'  => array(),
+				'entries' => array( array( 'title' => 'New archived row' ) ),
+			)
+		);
+		$row_id = $this->invoke_seeder_method( 'entry_id_by_title', 'archived-new-row', 'New archived row' );
+
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $row_id ) );
+		$this->assertSame( 'private', get_post_meta( $row_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( (string) $collection_id, (string) get_post_meta( $row_id, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+
+		$this->archive_cascade->unarchive( (int) $collection_id );
+
+		$this->assertSame( 'private', get_post_status( $row_id ) );
+	}
+
+	public function test_nesting_collection_under_archived_page_archives_collection_and_rows(): void {
+		$page_id = $this->create_page( 'Library' );
+		$this->archive_cascade->archive( $page_id );
+
+		$collection_id = $this->create_page( 'Books' );
+		$term_id       = $this->memo_insert_term( 'Books', (string) $collection_id, TraitTaxonomy::TAXONOMY );
+		$row_id        = $this->create_page( 'Book row' );
+		$this->memo_set_object_terms( $row_id, array( $term_id ) );
+
+		$this->invoke_seeder_method( 'nest_collections_under_pages', array( 'books' => $collection_id ) );
+
+		$this->assertSame( $page_id, (int) get_post( $collection_id )->post_parent );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $collection_id ) );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $row_id ) );
+		$this->assertSame( (string) $page_id, (string) get_post_meta( $collection_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+		$this->assertSame( (string) $collection_id, (string) get_post_meta( $row_id, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+
+		$this->archive_cascade->unarchive( $page_id );
+
+		$this->assertSame( 'private', get_post_status( $collection_id ) );
+		$this->assertSame( 'private', get_post_status( $row_id ) );
+	}
+
+	public function test_seed_preferences_skip_archived_candidates(): void {
+		$user_id           = $this->create_user();
+		$workspace_page_id = $this->create_page( 'Welcome' );
+		$library_id        = $this->create_page( 'Library' );
+		$music_id          = $this->create_page( 'Music Catalog' );
+		$team_id           = $this->create_page( 'Team Workspace' );
+		$this->archive_cascade->archive( $workspace_page_id );
+		$this->archive_cascade->archive( $library_id );
+
+		$this->invoke_seeder_method( 'seed_workspace_home', $user_id, $workspace_page_id );
+		$this->invoke_seeder_method( 'seed_favorites', $user_id, $workspace_page_id );
+
+		$this->assertSame( '', get_user_meta( $user_id, 'cortext_workspace_home', true ) );
+		$this->assertSame(
+			array( "page:{$music_id}", "page:{$team_id}" ),
+			get_user_meta( $user_id, 'cortext_favorites', true )
+		);
+	}
+
+	public function test_seed_preferences_keep_existing_archived_values(): void {
+		$user_id     = $this->create_user();
+		$archived_id = $this->create_page( 'Archived preference' );
+		$active_id   = $this->create_page( 'Active candidate' );
+		$this->archive_cascade->archive( $archived_id );
+		update_user_meta( $user_id, 'cortext_workspace_home', $archived_id );
+		update_user_meta( $user_id, 'cortext_favorites', array( $archived_id ) );
+
+		$this->invoke_seeder_method( 'seed_workspace_home', $user_id, $active_id );
+		$this->invoke_seeder_method( 'seed_favorites', $user_id, $active_id );
+
+		$this->assertSame( $archived_id, get_user_meta( $user_id, 'cortext_workspace_home', true ) );
+		$this->assertSame( array( $archived_id ), get_user_meta( $user_id, 'cortext_favorites', true ) );
+	}
+
 	private function invoke_seeder_method( string $name, ...$arguments ) {
 		$method = new ReflectionMethod( $this->seeder, $name );
 		$method->setAccessible( true );
 
 		return $method->invoke( $this->seeder, ...$arguments );
+	}
+
+	private function create_page( string $title ): int {
+		return (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => $title,
+			)
+		);
+	}
+
+	private function create_user(): int {
+		return (int) wp_insert_user(
+			array(
+				'user_login' => uniqid( 'cortext_seed_', false ),
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
 	}
 }

--- a/tests/php/test-cli-seed-dummy-collections.php
+++ b/tests/php/test-cli-seed-dummy-collections.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Tests for Cortext\CLI\SeedDummyCollections.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\CLI\SeedDummyCollections;
+use Cortext\Documents;
+use Cortext\PostType\ArchiveCascade;
+use Cortext\PostType\Document;
+use Cortext\Taxonomy\TraitTaxonomy;
+use ReflectionMethod;
+use WorDBless\BaseTestCase;
+
+final class Test_CLI_Seed_Dummy_Collections extends BaseTestCase {
+
+	use InMemoryPostsQuery;
+	use InMemoryTermStore;
+
+	private SeedDummyCollections $seeder;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		( new Document() )->register_post_type();
+		( new TraitTaxonomy() )->register_taxonomy();
+		( new ArchiveCascade() )->register_status();
+
+		$this->install_in_memory_term_store();
+		$this->install_in_memory_posts_query();
+		$this->seeder = new SeedDummyCollections();
+	}
+
+	public function tear_down(): void {
+		$this->uninstall_in_memory_posts_query();
+		$this->uninstall_in_memory_term_store();
+
+		parent::tear_down();
+	}
+
+	public function test_seed_page_tree_reuses_archived_page(): void {
+		$page_id = wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => Documents::STATUS_ARCHIVED,
+				'post_title'  => 'Archived sample page',
+			)
+		);
+
+		$result = $this->invoke_seeder_method(
+			'seed_page_tree',
+			array( 'title' => 'Archived sample page' ),
+			0
+		);
+
+		$this->assertSame( $page_id, $result );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $page_id ) );
+	}
+
+	public function test_seed_collection_reuses_archived_collection_and_row(): void {
+		$collection_id = wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => Documents::STATUS_ARCHIVED,
+				'post_title'  => 'Archived sample collection',
+				'meta_input'  => array( 'cortext_seed_slug' => 'archived-fixture' ),
+			)
+		);
+		$term_id       = $this->memo_insert_term(
+			'Archived sample collection',
+			(string) $collection_id,
+			TraitTaxonomy::TAXONOMY
+		);
+		$row_id        = wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => Documents::STATUS_ARCHIVED,
+				'post_title'  => 'Archived sample row',
+			)
+		);
+		$this->memo_set_object_terms( $row_id, array( $term_id ) );
+
+		$result = $this->invoke_seeder_method(
+			'seed_collection',
+			array(
+				'slug'    => 'archived-fixture',
+				'title'   => 'Archived sample collection',
+				'fields'  => array(),
+				'entries' => array( array( 'title' => 'Archived sample row' ) ),
+			)
+		);
+
+		$this->assertSame( $collection_id, $result );
+		$this->assertSame(
+			$row_id,
+			$this->invoke_seeder_method( 'entry_id_by_title', 'archived-fixture', 'Archived sample row' )
+		);
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $collection_id ) );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $row_id ) );
+	}
+
+	private function invoke_seeder_method( string $name, ...$arguments ) {
+		$method = new ReflectionMethod( $this->seeder, $name );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->seeder, ...$arguments );
+	}
+}

--- a/tests/php/test-document-duplicator.php
+++ b/tests/php/test-document-duplicator.php
@@ -137,6 +137,21 @@ final class Test_Document_Duplicator extends BaseTestCase {
 		$this->assertSame( $parent_id, (int) $document->post_parent );
 	}
 
+	public function test_duplicate_archived_page_is_private(): void {
+		$source_id = $this->create_page( 'Archived source' );
+		wp_update_post(
+			array(
+				'ID'          => $source_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$result = $this->duplicator->duplicate( get_post( $source_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'private', $result['document']->post_status );
+	}
+
 	public function test_duplicate_collection_clones_schema_with_new_field_posts(): void {
 		$collection_id = $this->create_collection_with_fields(
 			array(

--- a/tests/php/test-document-duplicator.php
+++ b/tests/php/test-document-duplicator.php
@@ -11,6 +11,7 @@ namespace Cortext\Tests;
 
 use Cortext\Documents;
 use Cortext\Documents\DocumentDuplicator;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -31,6 +32,7 @@ final class Test_Document_Duplicator extends BaseTestCase {
 		parent::set_up();
 
 		( new Document() )->register_post_type();
+		( new ArchiveCascade() )->register_status();
 		( new DocumentIdentity() )->register();
 		$trait_taxonomy = new TraitTaxonomy();
 		$trait_taxonomy->register_taxonomy();
@@ -150,6 +152,63 @@ final class Test_Document_Duplicator extends BaseTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertSame( 'private', $result['document']->post_status );
+	}
+
+	public function test_duplicate_rejects_document_under_archived_parent(): void {
+		$parent_id = $this->create_page( 'Archived parent' );
+		$source_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Child',
+				'post_parent' => $parent_id,
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'          => $parent_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$result = $this->duplicator->duplicate( get_post( $source_id ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'cortext_duplicate_archived_container', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+	}
+
+	public function test_duplicate_rejects_row_in_archived_collection(): void {
+		$collection_id = $this->create_collection_with_fields( array() );
+		$row_id        = $this->create_row( $collection_id, 'Active row' );
+		wp_update_post(
+			array(
+				'ID'          => $collection_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$result = $this->duplicator->duplicate( get_post( $row_id ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'cortext_duplicate_archived_container', $result->get_error_code() );
+	}
+
+	public function test_duplicate_allows_independently_archived_row_in_active_collection(): void {
+		$collection_id = $this->create_collection_with_fields( array() );
+		$row_id        = $this->create_row( $collection_id, 'Archived row' );
+		wp_update_post(
+			array(
+				'ID'          => $row_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$result = $this->duplicator->duplicate( get_post( $row_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'private', $result['document']->post_status );
+		$this->assertSame( $collection_id, $result['collection_id'] );
 	}
 
 	public function test_duplicate_collection_clones_schema_with_new_field_posts(): void {

--- a/tests/php/test-documents.php
+++ b/tests/php/test-documents.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Cortext\Tests;
 
 use Cortext\Documents;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -39,6 +40,7 @@ final class Test_Documents extends BaseTestCase {
 		add_action( 'deleted_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
 		add_action( 'before_delete_post', array( $trait_taxonomy, 'sync_term_on_delete' ), 10, 2 );
 		( new Field() )->register_post_type();
+		( new ArchiveCascade() )->register_status();
 
 		$this->install_in_memory_term_store();
 		$this->install_in_memory_posts_query();
@@ -378,6 +380,34 @@ final class Test_Documents extends BaseTestCase {
 		$by_id = array_column( $result['documents'], null, 'id' );
 		$this->assertArrayHasKey( 'meta', $by_id[ $trashed ] );
 		$this->assertArrayHasKey( TrashCascade::PARENT_MARKER_META, $by_id[ $trashed ]['meta'] );
+	}
+
+	public function test_format_target_hides_archived_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$page_id = $this->create_page( array( 'post_status' => Documents::STATUS_ARCHIVED ) );
+
+		$result = $this->documents->format_target( $page_id );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'cortext_document_target_hidden', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+
+	public function test_format_target_hides_row_when_its_collection_is_archived(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection( 'archived-projects', 'Archived projects' );
+		$row_id        = $this->create_row( $collection_id, 'Still active' );
+		wp_update_post(
+			array(
+				'ID'          => $collection_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$result = $this->documents->format_target( $row_id );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'cortext_document_target_hidden', $result->get_error_code() );
 	}
 
 	public function test_list_excludes_trashed_documents(): void {

--- a/tests/php/test-field-value-index.php
+++ b/tests/php/test-field-value-index.php
@@ -9,10 +9,13 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
 use Cortext\FieldValues\FieldValueIndex;
 use Cortext\FieldValues\FieldValueStore;
+use Cortext\PostType\Document;
 use Cortext\Relations;
 use WorDBless\BaseTestCase;
+use WP_Post;
 
 final class Test_Field_Value_Index extends BaseTestCase {
 
@@ -131,6 +134,72 @@ final class Test_Field_Value_Index extends BaseTestCase {
 				'field_id' => 202,
 			),
 			$pending['101:202']
+		);
+	}
+
+	public function test_registers_status_sync_for_every_post_status_transition(): void {
+		$index = new FieldValueIndex();
+
+		$index->register();
+
+		$this->assertSame( 20, has_action( 'transition_post_status', array( $index, 'sync_row_status' ) ) );
+		$this->assertFalse( has_action( 'wp_trash_post', array( $index, 'sync_row_status' ) ) );
+		$this->assertFalse( has_action( 'untrashed_post', array( $index, 'sync_row_status' ) ) );
+		remove_action( 'transition_post_status', array( $index, 'sync_row_status' ), 20 );
+	}
+
+	public function test_status_transition_updates_indexed_row_status(): void {
+		$index      = new FieldValueIndex();
+		$reflection = new \ReflectionClass( FieldValueIndex::class );
+
+		update_option( 'cortext_field_values_index_status', FieldValueIndex::STATUS_READY, false );
+		update_option( 'cortext_field_values_schema_version', 2, false );
+
+		$table_cache = $reflection->getProperty( 'table_exists_cache' );
+		$table_cache->setAccessible( true );
+		$table_cache->setValue( null, array( $index->table_name() => true ) );
+
+		$collection_cache = $reflection->getProperty( 'collection_id_by_row_cache' );
+		$collection_cache->setAccessible( true );
+		$collection_cache->setValue( null, array( 101 => 202 ) );
+
+		$updates = array();
+		$capture = static function ( $result, $table, $data, $where ) use ( &$updates, $index ) {
+			if ( $index->table_name() === $table ) {
+				$updates[] = array(
+					'data'  => $data,
+					'where' => $where,
+				);
+				return 1;
+			}
+			return $result;
+		};
+		add_filter( 'wordbless_wpdb_update', $capture, 10, 4 );
+
+		$index->register();
+		do_action(
+			'transition_post_status',
+			Documents::STATUS_ARCHIVED,
+			'private',
+			new WP_Post(
+				(object) array(
+					'ID'          => 101,
+					'post_type'   => Document::POST_TYPE,
+					'post_status' => Documents::STATUS_ARCHIVED,
+				)
+			)
+		);
+		remove_action( 'transition_post_status', array( $index, 'sync_row_status' ), 20 );
+		remove_filter( 'wordbless_wpdb_update', $capture, 10 );
+
+		$this->assertSame(
+			array(
+				array(
+					'data'  => array( 'post_status' => Documents::STATUS_ARCHIVED ),
+					'where' => array( 'row_id' => 101 ),
+				),
+			),
+			$updates
 		);
 	}
 

--- a/tests/php/test-frontend-mention-renderer.php
+++ b/tests/php/test-frontend-mention-renderer.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
 use Cortext\Frontend\MentionRenderer;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
@@ -103,6 +104,28 @@ final class Test_Frontend_Mention_Renderer extends BaseTestCase {
 	public function test_trashed_target_renders_saved_label_as_missing_mention(): void {
 		$target = $this->create_document( 'Trashed' );
 		wp_trash_post( $target );
+		$html = sprintf(
+			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="old">Snapshot</a></p>',
+			$target
+		);
+
+		$rendered = $this->renderer->refresh_mentions( $html );
+
+		$this->assertStringContainsString(
+			'<span class="cortext-mention cortext-mention--missing">Snapshot</span>',
+			$rendered
+		);
+		$this->assertStringNotContainsString( '<a class="cortext-mention"', $rendered );
+	}
+
+	public function test_archived_target_renders_saved_label_as_missing_mention(): void {
+		$target = $this->create_document( 'Archived' );
+		wp_update_post(
+			array(
+				'ID'          => $target,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
 		$html = sprintf(
 			'<p><a class="cortext-mention" data-crtxt-mention="%d" href="old">Snapshot</a></p>',
 			$target

--- a/tests/php/test-rest-documents-controller-mutations.php
+++ b/tests/php/test-rest-documents-controller-mutations.php
@@ -13,6 +13,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -43,15 +45,22 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 
 		remove_all_actions( 'wp_trash_post' );
 		remove_all_actions( 'untrashed_post' );
+		remove_all_actions( 'transition_post_status' );
 		remove_all_filters( 'wp_untrash_post_status' );
 
 		$this->install_in_memory_term_store();
 		$this->install_in_memory_posts_query();
 
-		( new TrashCascade() )->register();
+		$archive_cascade = new ArchiveCascade();
+		$archive_cascade->register_status();
+		$archive_cascade->register_meta();
+		$archive_cascade->register();
+
+		$trash_cascade = new TrashCascade();
+		$trash_cascade->register();
 
 		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
-		( new DocumentsController() )->register();
+		( new DocumentsController( null, $trash_cascade, $archive_cascade ) )->register();
 		do_action( 'rest_api_init' );
 	}
 
@@ -65,8 +74,112 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 	public function test_routes_are_registered(): void {
 		$routes = rest_get_server()->get_routes();
 
+		$this->assertArrayHasKey( '/cortext/v1/documents/(?P<id>\d+)/archive', $routes );
+		$this->assertArrayHasKey( '/cortext/v1/documents/(?P<id>\d+)/unarchive', $routes );
 		$this->assertArrayHasKey( '/cortext/v1/documents/(?P<id>\d+)/restore', $routes );
 		$this->assertArrayHasKey( '/cortext/v1/documents/(?P<id>\d+)/permanent-delete', $routes );
+	}
+
+	public function test_archive_and_unarchive_return_affected_ids_and_updated_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id = $this->create_page( array( 'post_status' => 'private' ) );
+		$child_id  = $this->create_page(
+			array(
+				'post_parent' => $parent_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$response = $this->archive( $parent_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEqualsCanonicalizing( array( $parent_id, $child_id ), $data['archived'] );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $parent_id ) );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $child_id ) );
+		$this->assertSame( $parent_id, $data['post']['id'] );
+		$this->assertSame( Documents::STATUS_ARCHIVED, $data['post']['status'] );
+
+		$response = $this->unarchive( $parent_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEqualsCanonicalizing( array( $parent_id, $child_id ), $data['restored'] );
+		$this->assertSame( 'private', get_post_status( $parent_id ) );
+		$this->assertSame( 'publish', get_post_status( $child_id ) );
+		$this->assertSame( 'private', $data['post']['status'] );
+	}
+
+	public function test_updating_status_through_core_rest_archives_document_tree(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id = $this->create_page();
+		$child_id  = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$request   = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $parent_id );
+		$request->set_param( 'status', Documents::STATUS_ARCHIVED );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( Documents::STATUS_ARCHIVED, $response->get_data()['status'] );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $child_id ) );
+
+		$list = new WP_REST_Request( 'GET', '/wp/v2/crtxt_documents' );
+		$list->set_param( 'context', 'edit' );
+		$list->set_param( 'status', Documents::STATUS_ARCHIVED );
+		$listed_ids = array_column( rest_do_request( $list )->get_data(), 'id' );
+		$this->assertContains( $parent_id, $listed_ids );
+		$this->assertContains( $child_id, $listed_ids );
+	}
+
+	public function test_core_rest_rejects_archiving_a_trashed_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$post_id = $this->create_page();
+		wp_trash_post( $post_id );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $post_id );
+		$request->set_param( 'status', Documents::STATUS_ARCHIVED );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_document_in_trash', $response->get_data()['code'] );
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $post_id ) );
+		$this->assertSame( '', (string) get_post_meta( $post_id, ArchiveCascade::STATUS_META, true ) );
+	}
+
+	public function test_archive_rejects_archived_and_trashed_documents(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$archived_id = $this->create_page();
+		$this->archive( $archived_id );
+		$response = $this->archive( $archived_id );
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_document_already_archived', $response->get_data()['code'] );
+
+		$trashed_id = $this->create_page();
+		wp_trash_post( $trashed_id );
+		$response = $this->archive( $trashed_id );
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_document_in_trash', $response->get_data()['code'] );
+	}
+
+	public function test_unarchive_rejects_document_that_is_not_archived(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$response = $this->unarchive( $this->create_page() );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'cortext_document_not_archived', $response->get_data()['code'] );
+	}
+
+	public function test_archive_requires_edit_post_capability(): void {
+		wp_set_current_user( $this->create_user( 'subscriber' ) );
+
+		$response = $this->archive( $this->create_page() );
+
+		$this->assertSame( 403, $response->get_status() );
 	}
 
 	public function test_restores_a_trashed_page_and_returns_its_id(): void {
@@ -367,6 +480,16 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 
 	private function restore( int $id ) {
 		$request = new WP_REST_Request( 'POST', '/cortext/v1/documents/' . $id . '/restore' );
+		return rest_do_request( $request );
+	}
+
+	private function archive( int $id ) {
+		$request = new WP_REST_Request( 'POST', '/cortext/v1/documents/' . $id . '/archive' );
+		return rest_do_request( $request );
+	}
+
+	private function unarchive( int $id ) {
+		$request = new WP_REST_Request( 'POST', '/cortext/v1/documents/' . $id . '/unarchive' );
 		return rest_do_request( $request );
 	}
 

--- a/tests/php/test-rest-documents-controller-mutations.php
+++ b/tests/php/test-rest-documents-controller-mutations.php
@@ -133,6 +133,139 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 		$this->assertContains( $child_id, $listed_ids );
 	}
 
+	public function test_core_rest_rejects_writes_to_archived_documents(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$post_id = $this->create_page(
+			array(
+				'post_title'   => 'Original title',
+				'post_content' => 'Original content',
+			)
+		);
+		$icon    = '{"type":"emoji","value":"A"}';
+		update_post_meta( $post_id, DocumentIdentity::META_KEY, $icon );
+		$this->archive( $post_id );
+		$before = get_post( $post_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $post_id );
+		$request->set_param( 'title', 'Changed title' );
+		$request->set_param( 'content', 'Changed content' );
+		$request->set_param(
+			'meta',
+			array( DocumentIdentity::META_KEY => '{"type":"emoji","value":"B"}' )
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived', $response->get_data()['code'] );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $post_id ) );
+		$this->assertSame( $before->post_title, get_post( $post_id )->post_title );
+		$this->assertSame( $before->post_content, get_post( $post_id )->post_content );
+		$this->assertSame( $icon, get_post_meta( $post_id, DocumentIdentity::META_KEY, true ) );
+	}
+
+	public function test_core_rest_rejects_stale_status_writes_to_archived_documents(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$post_id = $this->create_page( array( 'post_title' => 'Keep this title' ) );
+		$this->archive( $post_id );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $post_id );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'title', 'Stale editor title' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived', $response->get_data()['code'] );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $post_id ) );
+		$this->assertSame( 'Keep this title', get_post( $post_id )->post_title );
+		$this->assertSame( 'publish', get_post_meta( $post_id, ArchiveCascade::STATUS_META, true ) );
+	}
+
+	public function test_core_rest_requires_the_unarchive_endpoint_to_restore_status(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$post_id = $this->create_page( array( 'post_status' => 'private' ) );
+		$this->archive( $post_id );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $post_id );
+		$request->set_param( 'status', 'private' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $post_id ) );
+
+		$response = $this->unarchive( $post_id );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'private', get_post_status( $post_id ) );
+	}
+
+	public function test_core_rest_rejects_autosaves_for_archived_documents(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$post_id = $this->create_page( array( 'post_content' => 'Saved content' ) );
+		$this->archive( $post_id );
+		$before_revisions = get_posts(
+			array(
+				'post_type'      => 'revision',
+				'post_status'    => 'inherit',
+				'post_parent'    => $post_id,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+		$request          = new WP_REST_Request( 'POST', '/wp/v2/crtxt_documents/' . $post_id . '/autosaves' );
+		$request->set_param( 'content', 'Unsaved stale content' );
+
+		$response = rest_do_request( $request );
+
+		$after_revisions = get_posts(
+			array(
+				'post_type'      => 'revision',
+				'post_status'    => 'inherit',
+				'post_parent'    => $post_id,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived', $response->get_data()['code'] );
+		$this->assertSame( 'Saved content', get_post( $post_id )->post_content );
+		$this->assertSame( $before_revisions, $after_revisions );
+	}
+
+	public function test_core_rest_archive_checks_every_page_in_the_cascade(): void {
+		$author_id = $this->create_user( 'contributor' );
+		$other_id  = $this->create_user( 'contributor' );
+		$parent_id = $this->create_page(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'draft',
+			)
+		);
+		$child_id  = $this->create_page(
+			array(
+				'post_author' => $other_id,
+				'post_parent' => $parent_id,
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_current_user( $author_id );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $parent_id );
+		$request->set_param( 'status', Documents::STATUS_ARCHIVED );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'cortext_document_archive_forbidden', $response->get_data()['code'] );
+		$this->assertSame( 'draft', get_post_status( $parent_id ) );
+		$this->assertSame( 'draft', get_post_status( $child_id ) );
+		$this->assertSame( '', (string) get_post_meta( $parent_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( '', (string) get_post_meta( $child_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+	}
+
 	public function test_core_rest_rejects_archiving_a_trashed_document(): void {
 		wp_set_current_user( $this->create_user( 'administrator' ) );
 
@@ -180,6 +313,125 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 		$response = $this->archive( $this->create_page() );
 
 		$this->assertSame( 403, $response->get_status() );
+	}
+
+	public function test_archive_checks_every_page_in_the_cascade(): void {
+		$author_id = $this->create_user( 'contributor' );
+		$other_id  = $this->create_user( 'contributor' );
+		$parent_id = $this->create_page(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'draft',
+			)
+		);
+		$child_id  = $this->create_page(
+			array(
+				'post_author' => $other_id,
+				'post_parent' => $parent_id,
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_current_user( $author_id );
+
+		$response = $this->archive( $parent_id );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'draft', get_post_status( $parent_id ) );
+		$this->assertSame( 'draft', get_post_status( $child_id ) );
+		$this->assertSame( '', (string) get_post_meta( $child_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+	}
+
+	public function test_archive_checks_every_row_in_the_cascade(): void {
+		$author_id = $this->create_user( 'contributor' );
+		$other_id  = $this->create_user( 'contributor' );
+		wp_set_current_user( $author_id );
+		$collection_id = $this->create_full_page_collection( 'mixed-owners' );
+		$row_id        = $this->create_row( $collection_id );
+		wp_update_post(
+			array(
+				'ID'          => $row_id,
+				'post_author' => $other_id,
+			)
+		);
+
+		$response = $this->archive( $collection_id );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'private', get_post_status( $collection_id ) );
+		$this->assertSame( 'private', get_post_status( $row_id ) );
+		$this->assertSame( '', (string) get_post_meta( $row_id, ArchiveCascade::COLLECTION_MARKER_META, true ) );
+	}
+
+	public function test_unarchive_checks_every_page_in_the_cascade(): void {
+		$admin_id  = $this->create_user( 'administrator' );
+		$author_id = $this->create_user( 'contributor' );
+		$other_id  = $this->create_user( 'contributor' );
+		$parent_id = $this->create_page(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'draft',
+			)
+		);
+		$child_id  = $this->create_page(
+			array(
+				'post_author' => $other_id,
+				'post_parent' => $parent_id,
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_current_user( $admin_id );
+		$this->archive( $parent_id );
+		wp_set_current_user( $author_id );
+
+		$response = $this->unarchive( $parent_id );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $parent_id ) );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $child_id ) );
+		$this->assertSame( 'draft', get_post_meta( $parent_id, ArchiveCascade::STATUS_META, true ) );
+		$this->assertSame( (string) $parent_id, (string) get_post_meta( $child_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+	}
+
+	public function test_unarchive_requires_publish_capability_for_private_documents(): void {
+		$admin_id  = $this->create_user( 'administrator' );
+		$author_id = $this->create_user( 'contributor' );
+		$post_id   = $this->create_page(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'private',
+			)
+		);
+		wp_set_current_user( $admin_id );
+		$this->archive( $post_id );
+		wp_set_current_user( $author_id );
+
+		$response = $this->unarchive( $post_id );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $post_id ) );
+	}
+
+	public function test_contributor_cannot_unarchive_or_force_delete_originally_published_document(): void {
+		$admin_id  = $this->create_user( 'administrator' );
+		$author_id = $this->create_user( 'contributor' );
+		$post_id   = $this->create_page(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+			)
+		);
+		wp_set_current_user( $admin_id );
+		$this->archive( $post_id );
+		wp_set_current_user( $author_id );
+
+		$unarchive_response = $this->unarchive( $post_id );
+		$delete_request     = new WP_REST_Request( 'DELETE', '/wp/v2/crtxt_documents/' . $post_id );
+		$delete_request->set_param( 'force', true );
+		$delete_response = rest_do_request( $delete_request );
+
+		$this->assertSame( 403, $unarchive_response->get_status() );
+		$this->assertSame( 403, $delete_response->get_status() );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $post_id ) );
 	}
 
 	public function test_restores_a_trashed_page_and_returns_its_id(): void {

--- a/tests/php/test-rest-documents-controller.php
+++ b/tests/php/test-rest-documents-controller.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -39,6 +41,9 @@ final class Test_Rest_Documents_Controller extends BaseTestCase {
 
 		$this->install_in_memory_term_store();
 		$this->install_in_memory_posts_query();
+		$archive_cascade = new ArchiveCascade();
+		$archive_cascade->register_status();
+		$archive_cascade->register_meta();
 
 		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
 		( new DocumentsController() )->register();
@@ -118,7 +123,7 @@ final class Test_Rest_Documents_Controller extends BaseTestCase {
 				'post_title'  => 'Trashed page',
 				'post_parent' => 123,
 				'meta_input'  => array(
-					DocumentIdentity::META_KEY => '{"type":"emoji","value":"P"}',
+					DocumentIdentity::META_KEY       => '{"type":"emoji","value":"P"}',
 					TrashCascade::PARENT_MARKER_META => '99',
 				),
 			)
@@ -195,6 +200,53 @@ final class Test_Rest_Documents_Controller extends BaseTestCase {
 		// document lists.
 		$this->assertArrayHasKey( 'meta', $by_id[ $page_id ] );
 		$this->assertArrayNotHasKey( 'excerpt', $by_id[ $page_id ] );
+	}
+
+	public function test_archived_listing_is_unpaginated_and_includes_archive_metadata(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$root_id    = $this->create_page(
+			array(
+				'post_status' => Documents::STATUS_ARCHIVED,
+				'post_title'  => 'Archived root',
+			)
+		);
+		$child_id   = $this->create_page(
+			array(
+				'post_status' => Documents::STATUS_ARCHIVED,
+				'post_parent' => $root_id,
+				'post_title'  => 'Archived child',
+				'meta_input'  => array(
+					ArchiveCascade::PARENT_MARKER_META => $root_id,
+				),
+			)
+		);
+		$visible_id = $this->create_page( array( 'post_title' => 'Visible page' ) );
+
+		$response = $this->query(
+			array(
+				'status'   => Documents::STATUS_ARCHIVED,
+				'per_page' => 1,
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$data  = $response->get_data();
+		$by_id = array_column( $data['documents'], null, 'id' );
+		$this->assertSame( 2, $data['total'] );
+		$this->assertCount( 2, $data['documents'], 'Archived listings ignore per_page.' );
+		$this->assertArrayHasKey( $root_id, $by_id );
+		$this->assertArrayHasKey( $child_id, $by_id );
+		$this->assertArrayNotHasKey( $visible_id, $by_id );
+		$this->assertSame( $root_id, $by_id[ $child_id ]['meta'][ ArchiveCascade::PARENT_MARKER_META ] );
+		$this->assertArrayHasKey( ArchiveCascade::COLLECTION_MARKER_META, $by_id[ $child_id ]['meta'] );
+		$this->assertArrayHasKey( 'cortext_defines_trait', $by_id[ $child_id ] );
+		$this->assertArrayNotHasKey( 'excerpt', $by_id[ $child_id ] );
+
+		$default_ids = array_column( $this->query()->get_data()['documents'], 'id' );
+		$this->assertContains( $visible_id, $default_ids );
+		$this->assertNotContains( $root_id, $default_ids );
+		$this->assertNotContains( $child_id, $default_ids );
 	}
 
 	public function test_default_listing_excludes_trashed_documents(): void {

--- a/tests/php/test-rest-favorites-controller.php
+++ b/tests/php/test-rest-favorites-controller.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -271,6 +272,129 @@ final class Test_Rest_Favorites_Controller extends BaseTestCase {
 			array( $kept_row ),
 			get_user_meta( $user_id, self::META_KEY, true )
 		);
+	}
+
+	public function test_get_hides_archived_favorite_without_pruning_it(): void {
+		$user_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_id );
+		$page_id = $this->create_page();
+		$this->set_favorites( array( array( 'id' => $page_id ) ) );
+
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$response = $this->get_favorites();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data()['favorites'] );
+		$this->assertSame( array( $page_id ), get_user_meta( $user_id, self::META_KEY, true ) );
+
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_status' => 'private',
+			)
+		);
+
+		$this->assertSame(
+			array( $page_id ),
+			array_column( $this->get_favorites()->get_data()['favorites'], 'id' )
+		);
+	}
+
+	public function test_update_keeps_an_archived_favorite_in_its_original_position(): void {
+		$user_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_id );
+		$page_a = $this->create_page( array( 'post_name' => 'a' ) );
+		$page_b = $this->create_page( array( 'post_name' => 'b' ) );
+		$page_c = $this->create_page( array( 'post_name' => 'c' ) );
+		$page_d = $this->create_page( array( 'post_name' => 'd' ) );
+		$this->set_favorites(
+			array(
+				array( 'id' => $page_b ),
+				array( 'id' => $page_a ),
+				array( 'id' => $page_c ),
+			)
+		);
+
+		wp_update_post(
+			array(
+				'ID'          => $page_a,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$response = $this->set_favorites(
+			array(
+				array( 'id' => $page_c ),
+				array( 'id' => $page_b ),
+				array( 'id' => $page_d ),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array( $page_c, $page_b, $page_d ),
+			array_column( $response->get_data()['favorites'], 'id' )
+		);
+		$this->assertSame(
+			array( $page_c, $page_a, $page_b, $page_d ),
+			get_user_meta( $user_id, self::META_KEY, true )
+		);
+
+		wp_update_post(
+			array(
+				'ID'          => $page_a,
+				'post_status' => 'private',
+			)
+		);
+
+		$this->assertSame(
+			array( $page_c, $page_a, $page_b, $page_d ),
+			array_column( $this->get_favorites()->get_data()['favorites'], 'id' )
+		);
+	}
+
+	public function test_update_accepts_an_archived_favorite_from_a_stale_client(): void {
+		$user_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_id );
+		$page_id = $this->create_page();
+		$this->set_favorites( array( array( 'id' => $page_id ) ) );
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$response = $this->set_favorites( array( array( 'id' => $page_id ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data()['favorites'] );
+		$this->assertSame( array( $page_id ), get_user_meta( $user_id, self::META_KEY, true ) );
+	}
+
+	public function test_update_rejects_a_new_archived_favorite_owned_by_another_user(): void {
+		$owner_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $owner_id );
+		$page_id = $this->create_page(
+			array(
+				'post_author' => $owner_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$user_id = $this->create_user( 'contributor' );
+		wp_set_current_user( $user_id );
+		$response = $this->set_favorites( array( array( 'id' => $page_id ) ) );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'cortext_document_target_hidden', $response->get_data()['code'] );
+		$this->assertSame( '', get_user_meta( $user_id, self::META_KEY, true ) );
 	}
 
 	public function test_get_migrates_legacy_kind_id_string_shape(): void {

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -9,6 +9,8 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\Field;
 use Cortext\Rest\FieldsController;
@@ -1371,6 +1373,74 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$this->assertSame( '{"mode":"value","value":"doing"}', get_post_meta( $field_id, 'default_value', true ) );
 	}
 
+	public function test_update_options_migrates_and_counts_an_archived_row(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		( new ArchiveCascade() )->register_status();
+
+		$collection_id = $this->create_collection_with_slug( 'Archived options', 'archived-options' );
+		$field_id      = (int) $this->create_field(
+			$collection_id,
+			array(
+				'title'   => 'Status',
+				'type'    => 'select',
+				'options' => array(
+					array(
+						'value' => 'parked',
+						'label' => 'Parked',
+					),
+				),
+			)
+		)->get_data()['id'];
+		$row_id        = (int) wp_insert_post(
+			array(
+				'post_type'   => Document::POST_TYPE,
+				'post_status' => Documents::STATUS_ARCHIVED,
+				'post_title'  => 'Archived row',
+				'meta_input'  => array( "field-{$field_id}" => 'parked' ),
+			)
+		);
+
+		$this->with_archived_row_query(
+			$row_id,
+			function () use ( $field_id ): void {
+				$response = $this->update_options(
+					$field_id,
+					array(
+						'options'    => array(
+							array(
+								'value' => 'done',
+								'label' => 'Done',
+							),
+						),
+						'migrations' => array(
+							array(
+								'from'   => 'parked',
+								'action' => 'replace',
+								'to'     => 'done',
+							),
+						),
+					)
+				);
+
+				$this->assertSame( 200, $response->get_status() );
+				$this->assertSame( 1, ( (array) $response->get_data()['migrated'] )['parked'] );
+
+				$request = new WP_REST_Request(
+					'GET',
+					"/cortext/v1/fields/{$field_id}/options/done/usage"
+				);
+				$request->set_param( 'field_id', $field_id );
+				$request->set_param( 'value', 'done' );
+				$usage = rest_do_request( $request );
+
+				$this->assertSame( 200, $usage->get_status() );
+				$this->assertSame( 1, $usage->get_data()['count'] );
+			}
+		);
+
+		$this->assertSame( 'done', get_post_meta( $row_id, "field-{$field_id}", true ) );
+	}
+
 	public function test_update_options_prunes_missing_multiselect_defaults(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		$collection_id = $this->create_collection_with_slug( 'Multi Defaults', 'mdefopts' );
@@ -1590,6 +1660,35 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$tokens = $this->collect_option_tokens( $field_id, 'select', $row_ids );
 
 		$this->assertSame( array( 'Open' ), $tokens );
+	}
+
+	public function test_convert_collects_option_tokens_from_an_archived_row(): void {
+		wp_set_current_user( $this->create_user( 'editor' ) );
+		( new ArchiveCascade() )->register_status();
+
+		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
+			'archived-token',
+			array( 'Waiting' )
+		);
+
+		$row_id = $row_ids[0];
+		wp_update_post(
+			array(
+				'ID'          => $row_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$response = null;
+		$this->with_archived_row_query(
+			$row_id,
+			function () use ( $field_id, &$response ): void {
+				$response = $this->convert_field( $field_id, 'select' );
+			}
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( 'Waiting' ), $response->get_data()['new_options'] );
 	}
 
 	public function test_convert_text_to_number_returns_lean_response_without_scanning_rows(): void {
@@ -1917,6 +2016,49 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$method     = new \ReflectionMethod( $controller, 'collect_option_tokens' );
 		$method->setAccessible( true );
 		return $method->invoke( $controller, $field_id, $target_type, $row_ids );
+	}
+
+	/**
+	 * Adds one archived row to matching controller queries in WorDBless.
+	 *
+	 * @param int      $row_id   ID of the archived row.
+	 * @param callable $callback Assertions to run while the query shim is active.
+	 */
+	private function with_archived_row_query( int $row_id, callable $callback ): void {
+		$filter = static function ( $posts, \WP_Query $query ) use ( $row_id ) {
+			$vars     = $query->query_vars;
+			$statuses = (array) ( $vars['post_status'] ?? array() );
+			$post     = get_post( $row_id );
+			if (
+				! $post instanceof \WP_Post
+				|| Document::POST_TYPE !== ( $vars['post_type'] ?? '' )
+				|| ! in_array( Documents::STATUS_ARCHIVED, $statuses, true )
+				|| Documents::STATUS_ARCHIVED !== $post->post_status
+			) {
+				return $posts;
+			}
+
+			foreach ( (array) ( $vars['meta_query'] ?? array() ) as $clause ) {
+				if (
+					is_array( $clause )
+					&& isset( $clause['key'], $clause['value'] )
+					&& (string) get_post_meta( $row_id, (string) $clause['key'], true ) !== (string) $clause['value']
+				) {
+					return array();
+				}
+			}
+
+			$query->found_posts   = 1;
+			$query->max_num_pages = 1;
+			return 'ids' === ( $vars['fields'] ?? '' ) ? array( $row_id ) : array( $post );
+		};
+
+		add_filter( 'posts_pre_query', $filter, 10, 2 );
+		try {
+			$callback();
+		} finally {
+			remove_filter( 'posts_pre_query', $filter, 10 );
+		}
 	}
 
 	private function convert_field( int $field_id, string $target_type ) {

--- a/tests/php/test-rest-post-locks-controller.php
+++ b/tests/php/test-rest-post-locks-controller.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\Rest\PostLocksController;
@@ -115,6 +116,22 @@ final class Test_Rest_Post_Locks_Controller extends BaseTestCase {
 
 		$this->assertSame( 409, $response->get_status() );
 		$this->assertSame( 'cortext_document_in_trash', $response->as_error()->get_error_code() );
+	}
+
+	public function test_rejects_archived_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$post_id = $this->create_document();
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$response = $this->lock( $post_id );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived', $response->as_error()->get_error_code() );
 	}
 
 	public function test_rejects_user_without_edit_permission(): void {

--- a/tests/php/test-rest-recents-controller.php
+++ b/tests/php/test-rest-recents-controller.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -231,6 +232,39 @@ final class Test_Rest_Recents_Controller extends BaseTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( array(), $response->get_data()['recents'] );
+	}
+
+	public function test_get_hides_archived_recent_without_pruning_it(): void {
+		$user_id = $this->create_user( 'administrator' );
+		wp_set_current_user( $user_id );
+		$page_id = $this->create_page();
+		$this->touch_recent( $page_id );
+		$stored = get_user_meta( $user_id, self::META_KEY, true );
+
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$response = $this->get_recents();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data()['recents'] );
+		$this->assertSame( $stored, get_user_meta( $user_id, self::META_KEY, true ) );
+
+		wp_update_post(
+			array(
+				'ID'          => $page_id,
+				'post_status' => 'private',
+			)
+		);
+
+		$this->assertSame(
+			array( $page_id ),
+			array_column( $this->get_recents()->get_data()['recents'], 'id' )
+		);
 	}
 
 	public function test_recents_are_capped_at_five_items(): void {

--- a/tests/php/test-rest-rows-controller.php
+++ b/tests/php/test-rest-rows-controller.php
@@ -19,10 +19,12 @@ declare( strict_types=1 );
 
 namespace Cortext\Tests;
 
+use Cortext\Documents;
 use Cortext\FieldValues\FieldValueIndex;
 use Cortext\Formula\Compiler as FormulaCompiler;
 use Cortext\Formula\Functions as FormulaFunctions;
 use Cortext\Formula\Materializer as FormulaMaterializer;
+use Cortext\PostType\ArchiveCascade;
 use Cortext\PostType\Document;
 use Cortext\PostType\DocumentIdentity;
 use Cortext\PostType\Field;
@@ -604,6 +606,26 @@ final class Test_Rest_Rows_Controller extends BaseTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 20.0, $data['rows'][0]['meta'][ "field-{$formula_id}" ] );
+		$this->assertSame( 20.0, (float) get_post_meta( $row_id, "field-{$formula_id}", true ) );
+	}
+
+	public function test_recomputing_collection_formulas_includes_archived_rows(): void {
+		( new ArchiveCascade() )->register_status();
+
+		$fixture    = $this->create_collection_fixture( 'formula-archived', 'number' );
+		$row_id     = $this->create_row_fixture(
+			$fixture['collection_id'],
+			'Archived invoice',
+			Documents::STATUS_ARCHIVED,
+			array( "field-{$fixture['field_id']}" => '10' )
+		);
+		$formula_id = $this->create_formula_field(
+			$fixture['collection_id'],
+			'Total',
+			'field("Score") * 2'
+		);
+
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $row_id ) );
 		$this->assertSame( 20.0, (float) get_post_meta( $row_id, "field-{$formula_id}", true ) );
 	}
 


### PR DESCRIPTION
## What

Part of #423.

This adds server support for archiving and restoring documents. Archived documents stay out of regular workspace results and the public site, but keep their data. Favorites and Recents hide them until they are restored.

Archiving a page also archives its nested pages, while archiving a collection includes its rows. Restoring brings each affected document back with its previous status, even after the root has moved through Trash.

Archived documents and collection schemas are read-only. The server blocks active documents from being created or restored inside archived parents and collections, and a document must pass through Trash before it can be permanently deleted.

## Why

Archive hides documents without deleting their content. Restoring a parent only restores the documents archived with it, so anything archived separately stays archived.

## How

- Registering a protected `crtxt_archived` status and REST routes for listing, archiving, and restoring.
- Recording each document's previous status and which root archived it.
- Keeping archived records in indexes and data updates while excluding them from regular listings and editor locks.
- Rejecting direct or cascaded writes that would change archived documents or collection schemas.

## Testing Instructions

1. Create a published parent page with two draft child pages, plus a collection with one row. Favorite and open the parent so it appears in Favorites and Recents.
2. With an authenticated REST client, archive one child on its own. Then archive the parent and collection using `POST /wp-json/cortext/v1/documents/{id}/archive`. Confirm the responses include the other child and the row, but not the child already archived. Refresh Cortext and confirm the roots are absent from the sidebar, search, Favorites, and Recents. Confirm the public page returns 404.
3. Request `GET /wp-json/cortext/v1/documents?status=crtxt_archived&per_page=1`. Confirm it returns every archived document despite the page size and includes cascade markers where applied. Unarchive both roots using `POST /wp-json/cortext/v1/documents/{id}/unarchive`. Confirm their cascades return to their previous statuses, the child archived on its own stays archived, and the parent returns to Favorites and Recents.
4. Archive the page tree again. Try to force-delete its root through core REST and confirm the request is rejected. Move the root to Trash without `force`, restore it with `POST /wp-json/cortext/v1/documents/{id}/restore`, and confirm it returns as `crtxt_archived`. Unarchive it and confirm the root and its cascade return to their original statuses while the independently archived child stays archived.
5. While the parent and collection are archived, try to create or update an active child or row inside them. Confirm each request is rejected and no content changes. Try to update or delete one of the collection's fields and confirm its schema stays unchanged. Confirm the field can still be read.
