### PR TITLE
Fix: Keep archived content read-only

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -722,6 +722,8 @@ WorDBless still cannot run the SQL that Cortext assembles outside `WP_Query`'s n
 
 This is fine while collections are small and formulas are few. It becomes the wrong shape for large tables with several dependent formulas, or for sorting thousands of rows by something like `dateBetween(now(), field("Created"), "days")`. The code stores dependency ids already, but it does not yet use them as a dirty graph or background job plan.
 
+Archived rows remain part of these collection-wide passes because relations and rollups still include their values. As an archive grows, formula edits and volatile sort or filter requests therefore spend more time updating rows that regular collection views do not show.
+
 **Where.** `includes/Formula/Materializer.php`, formula refresh calls in `includes/PostType/Document.php`, `includes/Rest/RowsController.php`, and `includes/Rest/FieldsController.php`, plus formula indexing in `includes/FieldValues/FieldValueIndex.php`.
 
 **Solution.** For non-volatile formulas, keep materialized row meta as the source of truth and make refresh narrower. Row writes should recompute only formulas that depend on the changed field, in dependency order. Formula create/update can mark affected rows dirty and process them in batches instead of blocking the request on the whole collection.

--- a/includes/PostType/ArchiveCascade.php
+++ b/includes/PostType/ArchiveCascade.php
@@ -17,6 +17,7 @@ namespace Cortext\PostType;
 defined( 'ABSPATH' ) || exit;
 
 use Cortext\Documents;
+use Cortext\Taxonomy\TraitTaxonomy;
 use WP_Error;
 use WP_Post;
 use WP_REST_Request;
@@ -68,7 +69,7 @@ final class ArchiveCascade {
 		add_action( 'init', array( $this, 'register_meta' ) );
 		add_action( 'transition_post_status', array( $this, 'on_transition' ), 10, 3 );
 		add_filter( 'rest_pre_insert_' . Document::POST_TYPE, array( $this, 'validate_rest_archive_transition' ), 5, 2 );
-		add_filter( 'rest_dispatch_request', array( $this, 'block_archived_autosave' ), 10, 4 );
+		add_filter( 'rest_dispatch_request', array( $this, 'guard_archived_core_rest_request' ), 10, 4 );
 		add_filter( 'map_meta_cap', array( $this, 'preserve_original_status_capabilities' ), 10, 4 );
 		add_filter( 'wp_untrash_post_status', array( $this, 'allow_archived_untrash_status' ), PHP_INT_MAX, 3 );
 		add_filter( 'wp_insert_post_parent', array( $this, 'capture_trash_archive_slug_state' ), 5, 4 );
@@ -219,17 +220,22 @@ final class ArchiveCascade {
 		}
 
 		$post_id = (int) $request->get_param( 'id' );
-		if ( $post_id < 1 ) {
+		$post    = $post_id > 0 ? get_post( $post_id ) : null;
+		if ( $post instanceof WP_Post && Document::POST_TYPE !== $post->post_type ) {
 			return $prepared_post;
 		}
 
-		$post = get_post( $post_id );
-		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
-			return $prepared_post;
-		}
-
-		if ( Documents::STATUS_ARCHIVED === $post->post_status ) {
+		if ( $post instanceof WP_Post && Documents::STATUS_ARCHIVED === $post->post_status ) {
 			return $this->archived_write_error();
+		}
+
+		$container_error = $this->rest_container_error( $prepared_post, $post, $request );
+		if ( $container_error instanceof WP_Error ) {
+			return $container_error;
+		}
+
+		if ( ! $post instanceof WP_Post ) {
+			return $prepared_post;
 		}
 
 		if ( Documents::STATUS_ARCHIVED !== $request->get_param( 'status' ) ) {
@@ -253,12 +259,10 @@ final class ArchiveCascade {
 	}
 
 	/**
-	 * Stops core's autosave controller before it can create a revision for an
-	 * archived document.
+	 * Handles core REST paths that skip the pre-insert guard.
 	 *
-	 * The autosave controller ignores errors returned by its parent post
-	 * controller's prepare method, so the regular pre-insert guard is not enough
-	 * for this route.
+	 * The autosave controller ignores errors from its parent controller's prepare
+	 * method. Delete requests never run the pre-insert filter. Check both here.
 	 *
 	 * @param mixed           $dispatch_result Result supplied by an earlier filter.
 	 * @param WP_REST_Request $request         Incoming REST request.
@@ -266,28 +270,51 @@ final class ArchiveCascade {
 	 * @param array           $handler         Matched route handler.
 	 * @return mixed|WP_Error
 	 */
-	public function block_archived_autosave( $dispatch_result, WP_REST_Request $request, string $route, array $handler ) {
+	public function guard_archived_core_rest_request( $dispatch_result, WP_REST_Request $request, string $route, array $handler ) {
 		unset( $route );
 
 		$callback = $handler['callback'] ?? null;
 		if (
 			null !== $dispatch_result
-			|| 'POST' !== $request->get_method()
 			|| ! is_array( $callback )
 			|| ! isset( $callback[0], $callback[1] )
-			|| ! $callback[0] instanceof \WP_REST_Autosaves_Controller
-			|| 'create_item' !== $callback[1]
 		) {
 			return $dispatch_result;
 		}
 
+		$method       = $request->get_method();
+		$is_autosave  = 'POST' === $method
+			&& $callback[0] instanceof \WP_REST_Autosaves_Controller
+			&& 'create_item' === $callback[1];
+		$force_delete = 'DELETE' === $method
+			&& $callback[0] instanceof \WP_REST_Posts_Controller
+			&& 'delete_item' === $callback[1]
+			&& rest_sanitize_boolean( $request->get_param( 'force' ) );
+		if ( ! $is_autosave && ! $force_delete ) {
+			return $dispatch_result;
+		}
+
 		$post = get_post( (int) $request->get_param( 'id' ) );
-		if (
-			$post instanceof WP_Post
-			&& Document::POST_TYPE === $post->post_type
-			&& Documents::STATUS_ARCHIVED === $post->post_status
-		) {
-			return $this->archived_write_error();
+		if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+			return $dispatch_result;
+		}
+
+		if ( $is_autosave ) {
+			if ( Documents::STATUS_ARCHIVED === $post->post_status ) {
+				return $this->archived_write_error();
+			}
+			$container_error = $this->container_error_for_document( $post );
+			if ( $container_error instanceof WP_Error ) {
+				return $container_error;
+			}
+		}
+
+		if ( $force_delete && Documents::STATUS_ARCHIVED === $post->post_status ) {
+			return new WP_Error(
+				'cortext_document_not_trashed',
+				__( 'Move this document to Trash before deleting it permanently.', 'cortext' ),
+				array( 'status' => 400 )
+			);
 		}
 
 		return $dispatch_result;
@@ -504,8 +531,14 @@ final class ArchiveCascade {
 			);
 		}
 
-		$candidates = $this->descendants_for_root( $post_id );
-		$result     = wp_update_post(
+		$candidates      = $this->descendants_for_root( $post_id );
+		$restoring_ids   = array_values( array_unique( array_merge( array( $post_id ), $candidates ) ) );
+		$container_error = $this->container_error_for_documents( $restoring_ids, $restoring_ids );
+		if ( $container_error instanceof WP_Error ) {
+			return $container_error;
+		}
+
+		$result = wp_update_post(
 			array(
 				'ID'          => $post_id,
 				'post_status' => $this->restore_status_for( $post_id ),
@@ -587,9 +620,205 @@ final class ArchiveCascade {
 		return true;
 	}
 
+	/**
+	 * Rejects an active write when its parent or collection is archived.
+	 *
+	 * @param WP_Post $post                  Document that would be active.
+	 * @param int[]   $ignored_container_ids Containers that will become active in the same operation.
+	 */
+	public function container_error_for_document( WP_Post $post, array $ignored_container_ids = array() ): ?WP_Error {
+		return $this->archived_container_error( $this->direct_container_ids( $post ), $ignored_container_ids );
+	}
+
+	/**
+	 * Checks every document that will become active in the same operation.
+	 * It collects the container IDs first to avoid walking the same ancestors
+	 * more than once.
+	 *
+	 * @param int[] $post_ids              Documents that would become active.
+	 * @param int[] $ignored_container_ids Containers that will become active in the same operation.
+	 */
+	public function container_error_for_documents( array $post_ids, array $ignored_container_ids = array() ): ?WP_Error {
+		$container_ids = array();
+		foreach ( array_unique( array_map( 'intval', $post_ids ) ) as $post_id ) {
+			$post = get_post( $post_id );
+			if ( ! $post instanceof WP_Post || Document::POST_TYPE !== $post->post_type ) {
+				continue;
+			}
+
+			$container_ids = array_merge( $container_ids, $this->direct_container_ids( $post ) );
+		}
+
+		return $this->archived_container_error( $container_ids, $ignored_container_ids );
+	}
+
+	/**
+	 * Returns the parent and collections a document hangs from.
+	 *
+	 * @param WP_Post $post Document to inspect.
+	 * @return int[]
+	 */
+	private function direct_container_ids( WP_Post $post ): array {
+		$container_ids = array();
+		if ( $post->post_parent > 0 ) {
+			$container_ids[] = (int) $post->post_parent;
+		}
+
+		return array_merge( $container_ids, $this->stored_trait_ids( (int) $post->ID ) );
+	}
+
 	private function restore_status_for( int $post_id ): string {
 		$status = (string) get_post_meta( $post_id, self::STATUS_META, true );
 		return in_array( $status, self::ACTIVE_STATUSES, true ) ? $status : 'draft';
+	}
+
+	/**
+	 * Checks the parent and collection assigned by a core REST write.
+	 *
+	 * The check skips archived and trashed documents because they stay hidden.
+	 *
+	 * @param mixed           $prepared_post Prepared post from core REST.
+	 * @param WP_Post|null    $post          Existing post on updates.
+	 * @param WP_REST_Request $request       Incoming request.
+	 */
+	private function rest_container_error( $prepared_post, ?WP_Post $post, WP_REST_Request $request ): ?WP_Error {
+		$status = isset( $prepared_post->post_status )
+			? (string) $prepared_post->post_status
+			: ( $post instanceof WP_Post ? $post->post_status : 'draft' );
+		if ( in_array( $status, array( Documents::STATUS_ARCHIVED, Documents::STATUS_TRASH ), true ) ) {
+			return null;
+		}
+
+		$container_ids = array();
+		if ( isset( $prepared_post->post_parent ) ) {
+			$parent_id = (int) $prepared_post->post_parent;
+		} else {
+			$parent_id = $post instanceof WP_Post ? (int) $post->post_parent : 0;
+		}
+		if ( $parent_id > 0 ) {
+			$container_ids[] = $parent_id;
+		}
+
+		// Cortext applies a valid `cortext_trait` after WordPress's native terms,
+		// so it sets the final collection. Otherwise, use the native terms. If
+		// neither parameter is present, keep the stored terms.
+		$requested_trait_ids = $request->has_param( 'cortext_trait' )
+			? $this->requested_trait_ids( $request->get_param( 'cortext_trait' ) )
+			: array();
+		if ( ! empty( $requested_trait_ids ) ) {
+			$container_ids = array_merge( $container_ids, $requested_trait_ids );
+		} elseif ( $request->has_param( TraitTaxonomy::TAXONOMY ) ) {
+			$container_ids = array_merge(
+				$container_ids,
+				$this->requested_term_trait_ids( $request->get_param( TraitTaxonomy::TAXONOMY ) )
+			);
+		} elseif ( $post instanceof WP_Post ) {
+			$container_ids = array_merge( $container_ids, $this->stored_trait_ids( (int) $post->ID ) );
+		}
+
+		return $this->archived_container_error( $container_ids );
+	}
+
+	/**
+	 * Resolves collection document IDs from Cortext's custom trait parameter.
+	 *
+	 * @param mixed $raw_trait Requested trait value.
+	 * @return int[]
+	 */
+	private function requested_trait_ids( $raw_trait ): array {
+		$trait_id = (int) $raw_trait;
+		return $trait_id > 0 && TraitTaxonomy::term_id_for_trait( $trait_id ) > 0
+			? array( $trait_id )
+			: array();
+	}
+
+	/**
+	 * Resolves collection document IDs from core's native trait term IDs.
+	 * Skips terms it cannot resolve, matching `wp_set_object_terms()`.
+	 *
+	 * @param mixed $raw_terms Requested taxonomy terms.
+	 * @return int[]
+	 */
+	private function requested_term_trait_ids( $raw_terms ): array {
+		$trait_ids = array();
+		foreach ( (array) $raw_terms as $term_id ) {
+			$trait_id = TraitTaxonomy::trait_id_for_term( (int) $term_id );
+			if ( $trait_id > 0 ) {
+				$trait_ids[] = $trait_id;
+			}
+		}
+		return array_values( array_unique( $trait_ids ) );
+	}
+
+	/**
+	 * Returns every collection document attached to a row.
+	 *
+	 * @param int $post_id Row document ID.
+	 * @return int[]
+	 */
+	private function stored_trait_ids( int $post_id ): array {
+		$term_ids = wp_get_object_terms(
+			$post_id,
+			TraitTaxonomy::TAXONOMY,
+			array( 'fields' => 'ids' )
+		);
+		if ( ! is_array( $term_ids ) ) {
+			return array();
+		}
+
+		$trait_ids = array();
+		foreach ( $term_ids as $term_id ) {
+			$trait_id = TraitTaxonomy::trait_id_for_term( (int) $term_id );
+			if ( $trait_id > 0 ) {
+				$trait_ids[] = $trait_id;
+			}
+		}
+		return array_values( array_unique( $trait_ids ) );
+	}
+
+	/**
+	 * Returns a conflict when a container or one of its parents is archived.
+	 *
+	 * @param int[] $container_ids         Parent and collection document IDs.
+	 * @param int[] $ignored_container_ids Containers that will become active in the same operation.
+	 */
+	private function archived_container_error( array $container_ids, array $ignored_container_ids = array() ): ?WP_Error {
+		$ignored = array_fill_keys( array_map( 'intval', $ignored_container_ids ), true );
+		$queue   = array_values( array_unique( array_map( 'intval', $container_ids ) ) );
+		$seen    = array();
+		while ( ! empty( $queue ) ) {
+			$container_id = (int) array_pop( $queue );
+			if ( $container_id < 1 || isset( $seen[ $container_id ] ) ) {
+				continue;
+			}
+			$seen[ $container_id ] = true;
+			$container             = get_post( $container_id );
+			if ( ! $container instanceof WP_Post || Document::POST_TYPE !== $container->post_type ) {
+				continue;
+			}
+
+			$is_archived = Documents::STATUS_ARCHIVED === $container->post_status;
+			if ( Documents::STATUS_TRASH === $container->post_status ) {
+				$is_archived = Documents::STATUS_ARCHIVED
+					=== (string) get_post_meta( $container_id, '_wp_trash_meta_status', true );
+			}
+			if ( ! isset( $ignored[ $container_id ] ) && $is_archived ) {
+				return new WP_Error(
+					'cortext_document_archived_container',
+					__( 'Restore this document\'s parent or collection from Archive first.', 'cortext' ),
+					array(
+						'status'       => 409,
+						'container_id' => $container_id,
+					)
+				);
+			}
+
+			if ( $container->post_parent > 0 ) {
+				$queue[] = (int) $container->post_parent;
+			}
+		}
+
+		return null;
 	}
 
 	private function archived_write_error(): WP_Error {

--- a/includes/PostType/Field.php
+++ b/includes/PostType/Field.php
@@ -243,6 +243,19 @@ final class Field {
 	 * @param int $field_id Field post ID being deleted.
 	 */
 	private function delete_dependent_rollups( int $field_id ): void {
+		foreach ( $this->dependent_rollup_ids( $field_id ) as $rollup_id ) {
+			$this->detach_from_collections( $rollup_id );
+			wp_delete_post( $rollup_id, true );
+		}
+	}
+
+	/**
+	 * Finds rollup fields that use a field as their relation or target.
+	 *
+	 * @param int $field_id Dependency field post ID.
+	 * @return int[]
+	 */
+	private function dependent_rollup_ids( int $field_id ): array {
 		$field_id_str = (string) $field_id;
 		$rollup_ids   = array();
 		foreach ( array( 'rollup_relation_field_id', 'rollup_target_field_id' ) as $meta_key ) {
@@ -265,17 +278,14 @@ final class Field {
 			$rollup_ids = array_merge( $rollup_ids, array_map( 'intval', $dependents ) );
 		}
 
-		foreach ( array_unique( $rollup_ids ) as $rollup_id ) {
-			if (
-				$rollup_id === $field_id
-				|| self::POST_TYPE !== get_post_type( $rollup_id )
-				|| 'rollup' !== (string) get_post_meta( $rollup_id, 'type', true )
-			) {
-				continue;
-			}
-			$this->detach_from_collections( $rollup_id );
-			wp_delete_post( $rollup_id, true );
-		}
+		return array_values(
+			array_filter(
+				array_unique( $rollup_ids ),
+				static fn ( int $rollup_id ): bool => $rollup_id !== $field_id
+					&& self::POST_TYPE === get_post_type( $rollup_id )
+					&& 'rollup' === (string) get_post_meta( $rollup_id, 'type', true )
+			)
+		);
 	}
 
 	/**
@@ -286,6 +296,19 @@ final class Field {
 	 * @param int $field_id Field post ID being deleted.
 	 */
 	private function delete_dependent_formulas( int $field_id ): void {
+		foreach ( $this->dependent_formula_ids( $field_id ) as $formula_id ) {
+			$this->detach_from_collections( $formula_id );
+			wp_delete_post( $formula_id, true );
+		}
+	}
+
+	/**
+	 * Finds formula fields whose stored dependencies include a field.
+	 *
+	 * @param int $field_id Dependency field post ID.
+	 * @return int[]
+	 */
+	private function dependent_formula_ids( int $field_id ): array {
 		$formula_ids = get_posts(
 			array(
 				'post_type'      => self::POST_TYPE,
@@ -303,18 +326,55 @@ final class Field {
 			)
 		);
 
-		foreach ( array_map( 'intval', $formula_ids ) as $formula_id ) {
-			if (
-				$formula_id === $field_id
-				|| self::POST_TYPE !== get_post_type( $formula_id )
-				|| 'formula' !== (string) get_post_meta( $formula_id, 'type', true )
-				|| ! in_array( $field_id, $this->formula_dependency_ids( $formula_id ), true )
-			) {
+		return array_values(
+			array_filter(
+				array_map( 'intval', $formula_ids ),
+				fn ( int $formula_id ): bool => $formula_id !== $field_id
+					&& self::POST_TYPE === get_post_type( $formula_id )
+					&& 'formula' === (string) get_post_meta( $formula_id, 'type', true )
+					&& in_array( $field_id, $this->formula_dependency_ids( $formula_id ), true )
+			)
+		);
+	}
+
+	/**
+	 * Returns every field deleted along with the requested field.
+	 *
+	 * Deleting a relation also deletes its reverse field. Deleting any field also
+	 * removes the rollups and formulas that depend on it. The REST guard needs
+	 * this list before deletion starts. `cleanup_after_delete()` follows those
+	 * links one field at a time.
+	 *
+	 * @param int $field_id Field post ID.
+	 * @return int[] Field IDs, including the requested one.
+	 */
+	public function deletion_cascade_ids( int $field_id ): array {
+		$queue = array( $field_id );
+		$seen  = array();
+
+		while ( ! empty( $queue ) ) {
+			$current_id = (int) array_pop( $queue );
+			if ( $current_id < 1 || isset( $seen[ $current_id ] ) ) {
 				continue;
 			}
-			$this->detach_from_collections( $formula_id );
-			wp_delete_post( $formula_id, true );
+			$field = get_post( $current_id );
+			if ( ! $field instanceof WP_Post || self::POST_TYPE !== $field->post_type ) {
+				continue;
+			}
+
+			$seen[ $current_id ] = true;
+			$reverse_id          = (int) get_post_meta( $current_id, 'relation_reverse_field_id', true );
+			if ( $reverse_id > 0 ) {
+				$queue[] = $reverse_id;
+			}
+			$queue = array_merge(
+				$queue,
+				$this->dependent_rollup_ids( $current_id ),
+				$this->dependent_formula_ids( $current_id )
+			);
 		}
+
+		return array_map( 'intval', array_keys( $seen ) );
 	}
 
 	/**

--- a/includes/Rest/DocumentsController.php
+++ b/includes/Rest/DocumentsController.php
@@ -349,7 +349,21 @@ final class DocumentsController {
 		// `untrashed_post` action fires synchronously inside `wp_untrash_post`,
 		// so a post-call query alone could not tell which descendants this
 		// restore brought back versus which were already out of trash.
-		$candidates = $this->cascade->descendants_for_root( $id );
+		$candidates           = $this->cascade->descendants_for_root( $id );
+		$restoring_active_ids = array_values(
+			array_filter(
+				array_merge( array( $id ), $candidates ),
+				static fn( int $post_id ): bool => Documents::STATUS_ARCHIVED
+					!== (string) get_post_meta( $post_id, '_wp_trash_meta_status', true )
+			)
+		);
+		$container_error      = $this->archive_cascade->container_error_for_documents(
+			$restoring_active_ids,
+			$restoring_active_ids
+		);
+		if ( $container_error instanceof WP_Error ) {
+			return $container_error;
+		}
 
 		$result = wp_untrash_post( $id );
 		if ( ! $result ) {

--- a/includes/Rest/FavoritesController.php
+++ b/includes/Rest/FavoritesController.php
@@ -88,9 +88,9 @@ final class FavoritesController {
 			);
 		}
 
-		$user_id          = get_current_user_id();
-		$existing_slots   = $this->stored_favorite_slots( $user_id );
-		$existing_hidden  = array_fill_keys(
+		$user_id         = get_current_user_id();
+		$existing_slots  = $this->stored_favorite_slots( $user_id );
+		$existing_hidden = array_fill_keys(
 			array_column(
 				array_filter(
 					$existing_slots,
@@ -100,10 +100,9 @@ final class FavoritesController {
 			),
 			true
 		);
-		$formatted        = array();
-		$requested        = array();
-		$requested_hidden = array();
-		$seen             = array();
+		$formatted       = array();
+		$requested       = array();
+		$seen            = array();
 
 		foreach ( $favorites as $favorite ) {
 			if ( ! is_array( $favorite ) ) {
@@ -125,8 +124,7 @@ final class FavoritesController {
 					if ( ! isset( $existing_hidden[ $id ] ) ) {
 						return $target;
 					}
-					$seen[ $id ]        = true;
-					$requested_hidden[] = $id;
+					$seen[ $id ] = true;
 					continue;
 				}
 				return $target;
@@ -137,11 +135,7 @@ final class FavoritesController {
 			$formatted[] = $target;
 		}
 
-		$stored = $this->merge_with_hidden_favorites(
-			$existing_slots,
-			$requested,
-			$requested_hidden
-		);
+		$stored = $this->merge_with_hidden_favorites( $existing_slots, $requested );
 		update_user_meta( $user_id, self::META_KEY, $stored );
 
 		return new WP_REST_Response(
@@ -158,14 +152,9 @@ final class FavoritesController {
 	 *
 	 * @param array<int, array{id: int, hidden: bool}> $slots Existing valid slots.
 	 * @param array<int, int>                          $requested Requested visible IDs.
-	 * @param array<int, int>                          $requested_hidden Requested hidden IDs.
 	 * @return array<int, int>
 	 */
-	private function merge_with_hidden_favorites(
-		array $slots,
-		array $requested,
-		array $requested_hidden
-	): array {
+	private function merge_with_hidden_favorites( array $slots, array $requested ): array {
 		$stored          = array();
 		$emitted         = array();
 		$requested_index = 0;
@@ -200,15 +189,6 @@ final class FavoritesController {
 			$stored[]       = $id;
 			$emitted[ $id ] = true;
 		}
-
-		foreach ( $requested_hidden as $id ) {
-			if ( isset( $emitted[ $id ] ) ) {
-				continue;
-			}
-			$stored[]       = $id;
-			$emitted[ $id ] = true;
-		}
-
 		return $stored;
 	}
 

--- a/includes/Rest/FieldsController.php
+++ b/includes/Rest/FieldsController.php
@@ -70,6 +70,8 @@ final class FieldsController {
 
 	public function register(): void {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		add_filter( 'rest_pre_insert_' . Field::POST_TYPE, array( $this, 'guard_core_field_write' ), 5, 2 );
+		add_filter( 'rest_dispatch_request', array( $this, 'guard_core_field_delete' ), 10, 4 );
 	}
 
 	public function register_routes(): void {
@@ -296,7 +298,11 @@ final class FieldsController {
 				array( 'status' => 404 )
 			);
 		}
-		return current_user_can( 'edit_post', $collection_id );
+		if ( ! current_user_can( 'edit_post', $collection_id ) ) {
+			return false;
+		}
+
+		return $this->archived_collection_error( $collection_id ) ?? true;
 	}
 
 	public function can_edit_field( WP_REST_Request $request ): bool|WP_Error {
@@ -309,7 +315,78 @@ final class FieldsController {
 				array( 'status' => 404 )
 			);
 		}
-		return current_user_can( 'edit_post', $field_id );
+		if ( ! current_user_can( 'edit_post', $field_id ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $request->get_method(), array( 'GET', 'HEAD' ), true ) ) {
+			$archive_error = $this->archived_collection_error_for_fields( array( $field_id ) );
+			if ( $archive_error instanceof WP_Error ) {
+				return $archive_error;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Blocks core REST updates to fields in archived collections.
+	 *
+	 * @param mixed           $prepared_post Prepared field post.
+	 * @param WP_REST_Request $request       Incoming core REST request.
+	 * @return mixed|WP_Error
+	 */
+	public function guard_core_field_write( $prepared_post, WP_REST_Request $request ) {
+		if ( is_wp_error( $prepared_post ) ) {
+			return $prepared_post;
+		}
+
+		$field_id = (int) $request->get_param( 'id' );
+		$field    = $field_id > 0 ? get_post( $field_id ) : null;
+		if ( ! $field instanceof WP_Post || Field::POST_TYPE !== $field->post_type ) {
+			return $prepared_post;
+		}
+
+		return $this->archived_collection_error_for_fields( array( $field_id ) ) ?? $prepared_post;
+	}
+
+	/**
+	 * Blocks core REST deletes that would change an archived collection's schema,
+	 * including reverse fields and dependent fields.
+	 *
+	 * @param mixed           $dispatch_result Result supplied by an earlier filter.
+	 * @param WP_REST_Request $request         Incoming REST request.
+	 * @param string          $route           Matched route pattern.
+	 * @param array           $handler         Matched route handler.
+	 * @return mixed|WP_Error
+	 */
+	public function guard_core_field_delete( $dispatch_result, WP_REST_Request $request, string $route, array $handler ) {
+		unset( $route );
+
+		$callback = $handler['callback'] ?? null;
+		if (
+			null !== $dispatch_result
+			|| 'DELETE' !== $request->get_method()
+			|| ! is_array( $callback )
+			|| ! isset( $callback[0], $callback[1] )
+			|| ! $callback[0] instanceof \WP_REST_Posts_Controller
+			|| 'delete_item' !== $callback[1]
+		) {
+			return $dispatch_result;
+		}
+
+		$field_id = (int) $request->get_param( 'id' );
+		$field    = get_post( $field_id );
+		if ( ! $field instanceof WP_Post || Field::POST_TYPE !== $field->post_type ) {
+			return $dispatch_result;
+		}
+
+		$affected_field_ids = rest_sanitize_boolean( $request->get_param( 'force' ) )
+			? ( new Field() )->deletion_cascade_ids( $field_id )
+			: array( $field_id );
+
+		return $this->archived_collection_error_for_fields( $affected_field_ids )
+			?? $dispatch_result;
 	}
 
 	public function create( WP_REST_Request $request ): WP_REST_Response|WP_Error {
@@ -745,7 +822,7 @@ final class FieldsController {
 		$field_id_str = (string) $field_id;
 
 		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- field→collection reverse lookup; bounded by a single matching row.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Looks up a field's collection and returns at most one row.
 		$collection_id = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s LIMIT 1",
@@ -776,6 +853,56 @@ final class FieldsController {
 
 	private static function is_wordbless_active(): bool {
 		return class_exists( '\WorDBless\PostMeta' );
+	}
+
+	/**
+	 * Returns an error when a request would change an archived collection's schema.
+	 *
+	 * @param int $collection_id Collection document ID.
+	 */
+	private function archived_collection_error( int $collection_id ): ?WP_Error {
+		if ( $collection_id < 1 ) {
+			return null;
+		}
+
+		$collection = get_post( $collection_id );
+		if ( ! $collection instanceof WP_Post || Document::POST_TYPE !== $collection->post_type ) {
+			return null;
+		}
+
+		$is_archived = Documents::STATUS_ARCHIVED === $collection->post_status;
+		if ( Documents::STATUS_TRASH === $collection->post_status ) {
+			$is_archived = Documents::STATUS_ARCHIVED
+				=== (string) get_post_meta( $collection_id, '_wp_trash_meta_status', true );
+		}
+		if ( ! $is_archived ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'cortext_collection_archived',
+			__( 'Restore this collection from Archive before changing its fields.', 'cortext' ),
+			array(
+				'status'        => 409,
+				'collection_id' => $collection_id,
+			)
+		);
+	}
+
+	/**
+	 * Checks each field's collection for Archive status.
+	 *
+	 * @param int[] $field_ids Field post IDs.
+	 */
+	private function archived_collection_error_for_fields( array $field_ids ): ?WP_Error {
+		foreach ( array_unique( array_map( 'intval', $field_ids ) ) as $field_id ) {
+			$error = $this->archived_collection_error( $this->collection_id_for_field( $field_id ) );
+			if ( $error instanceof WP_Error ) {
+				return $error;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -963,6 +1090,10 @@ final class FieldsController {
 				__( 'Relation target collection is required.', 'cortext' ),
 				array( 'status' => 400 )
 			);
+		}
+		$target_archive_error = $this->archived_collection_error( $target_collection_id );
+		if ( $target_archive_error instanceof WP_Error ) {
+			return $target_archive_error;
 		}
 
 		$source_collection = get_post( $collection_id );

--- a/tests/php/test-rest-documents-controller-mutations.php
+++ b/tests/php/test-rest-documents-controller-mutations.php
@@ -236,6 +236,301 @@ final class Test_Rest_Documents_Controller_Mutations extends BaseTestCase {
 		$this->assertSame( $before_revisions, $after_revisions );
 	}
 
+	public function test_core_rest_requires_trash_before_permanently_deleting_an_archived_document(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$post_id = $this->create_page();
+		$this->archive( $post_id );
+
+		$delete_request = new WP_REST_Request( 'DELETE', '/wp/v2/crtxt_documents/' . $post_id );
+		$delete_request->set_param( 'force', true );
+		$delete_response = rest_do_request( $delete_request );
+
+		$this->assertSame( 400, $delete_response->get_status() );
+		$this->assertSame( 'cortext_document_not_trashed', $delete_response->get_data()['code'] );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $post_id ) );
+		$this->assertSame( 'publish', get_post_meta( $post_id, ArchiveCascade::STATUS_META, true ) );
+
+		$trash_request  = new WP_REST_Request( 'DELETE', '/wp/v2/crtxt_documents/' . $post_id );
+		$trash_response = rest_do_request( $trash_request );
+
+		$this->assertSame( 200, $trash_response->get_status() );
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $post_id ) );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_meta( $post_id, '_wp_trash_meta_status', true ) );
+
+		$this->assertSame( 200, $this->permanent_delete( $post_id )->get_status() );
+		$this->assertNull( get_post( $post_id ) );
+	}
+
+	public function test_core_rest_rejects_creating_active_documents_under_archived_parents(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id = $this->create_page();
+		$this->archive( $parent_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/crtxt_documents' );
+		$request->set_param( 'title', 'Blocked child' );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'parent', $parent_id );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived_container', $response->get_data()['code'] );
+		$this->assertSame( $parent_id, $response->get_data()['data']['container_id'] );
+		$this->assertSame(
+			array(),
+			get_posts(
+				array(
+					'post_type'   => Document::POST_TYPE,
+					'post_status' => 'any',
+					'title'       => 'Blocked child',
+					'fields'      => 'ids',
+				)
+			)
+		);
+	}
+
+	public function test_core_rest_rejects_creating_active_rows_in_archived_collections(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$filler_term = wp_insert_term( 'Filler', TraitTaxonomy::TAXONOMY, array( 'slug' => 'filler' ) );
+		$this->assertIsArray( $filler_term );
+		$collection_id = $this->create_full_page_collection( 'archived-create-target' );
+		$this->assertNotSame( $collection_id, TraitTaxonomy::term_id_for_trait( $collection_id ) );
+		$this->archive( $collection_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/crtxt_documents' );
+		$request->set_param( 'title', 'Blocked row' );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'cortext_trait', $collection_id );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived_container', $response->get_data()['code'] );
+		$this->assertSame( $collection_id, $response->get_data()['data']['container_id'] );
+		$this->assertSame(
+			array(),
+			get_posts(
+				array(
+					'post_type'   => Document::POST_TYPE,
+					'post_status' => 'any',
+					'title'       => 'Blocked row',
+					'fields'      => 'ids',
+				)
+			)
+		);
+	}
+
+	public function test_core_rest_rejects_native_trait_terms_for_archived_collections(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$filler_term = wp_insert_term( 'Native filler', TraitTaxonomy::TAXONOMY, array( 'slug' => 'native-filler' ) );
+		$this->assertIsArray( $filler_term );
+		$collection_id = $this->create_full_page_collection( 'archived-native-trait-target' );
+		$term_id       = TraitTaxonomy::term_id_for_trait( $collection_id );
+		$this->assertNotSame( $collection_id, $term_id );
+		$this->archive( $collection_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/crtxt_documents' );
+		$request->set_param( 'title', 'Blocked native row' );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( TraitTaxonomy::TAXONOMY, array( $term_id ) );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived_container', $response->get_data()['code'] );
+		$this->assertSame( $collection_id, $response->get_data()['data']['container_id'] );
+	}
+
+	public function test_core_rest_lets_a_valid_trait_param_override_archived_native_terms(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$active_collection_id   = $this->create_full_page_collection( 'active-trait-winner' );
+		$archived_collection_id = $this->create_full_page_collection( 'archived-native-loser' );
+		$archived_term_id       = TraitTaxonomy::term_id_for_trait( $archived_collection_id );
+		$this->archive( $archived_collection_id );
+		// WordPress applies the native terms first. `assign_trait_from_request` then
+		// replaces them with the collection from `cortext_trait`.
+		add_action( 'rest_after_insert_' . Document::POST_TYPE, array( new Document(), 'assign_trait_from_request' ), 10, 3 );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/crtxt_documents' );
+		$request->set_param( 'title', 'Row despite stale native terms' );
+		$request->set_param( 'status', 'publish' );
+		$request->set_param( 'cortext_trait', $active_collection_id );
+		$request->set_param( TraitTaxonomy::TAXONOMY, array( $archived_term_id ) );
+
+		$response = rest_do_request( $request );
+		remove_all_actions( 'rest_after_insert_' . Document::POST_TYPE );
+
+		$this->assertSame( 201, $response->get_status() );
+		$row_id = (int) $response->get_data()['id'];
+		$this->assertSame(
+			array( TraitTaxonomy::term_id_for_trait( $active_collection_id ) ),
+			array_map( 'intval', wp_get_object_terms( $row_id, TraitTaxonomy::TAXONOMY, array( 'fields' => 'ids' ) ) )
+		);
+	}
+
+	public function test_core_rest_rejects_moving_active_documents_into_archived_containers(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id     = $this->create_page();
+		$collection_id = $this->create_full_page_collection( 'archived-update-target' );
+		$page_id       = $this->create_page( array( 'post_title' => 'Original page' ) );
+		$row_id        = $this->create_page( array( 'post_title' => 'Original row' ) );
+		$this->archive( $parent_id );
+		$this->archive( $collection_id );
+
+		$parent_request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $page_id );
+		$parent_request->set_param( 'parent', $parent_id );
+		$parent_request->set_param( 'title', 'Changed page' );
+		$parent_response = rest_do_request( $parent_request );
+
+		$trait_request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $row_id );
+		$trait_request->set_param( 'cortext_trait', $collection_id );
+		$trait_request->set_param( 'title', 'Changed row' );
+		$trait_response = rest_do_request( $trait_request );
+
+		$this->assertSame( 409, $parent_response->get_status() );
+		$this->assertSame( 409, $trait_response->get_status() );
+		$this->assertSame( 0, (int) get_post( $page_id )->post_parent );
+		$this->assertSame( 'Original page', get_post( $page_id )->post_title );
+		$this->assertSame( 'Original row', get_post( $row_id )->post_title );
+		$this->assertSame(
+			array(),
+			wp_get_object_terms( $row_id, TraitTaxonomy::TAXONOMY, array( 'fields' => 'ids' ) )
+		);
+	}
+
+	public function test_core_rest_rejects_writes_to_active_documents_still_in_archived_containers(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id     = $this->create_page();
+		$collection_id = $this->create_full_page_collection( 'archived-existing-container' );
+		$this->archive( $parent_id );
+		$this->archive( $collection_id );
+		$child_id  = $this->create_page(
+			array(
+				'post_content' => 'Existing content',
+				'post_parent'  => $parent_id,
+				'post_title'   => 'Existing child',
+			)
+		);
+		$row_id    = $this->create_row( $collection_id );
+		$row_title = get_post( $row_id )->post_title;
+
+		$child_request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $child_id );
+		$child_request->set_param( 'title', 'Changed child' );
+		$row_request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $row_id );
+		$row_request->set_param( 'title', 'Changed row' );
+		$autosave_request = new WP_REST_Request( 'POST', '/wp/v2/crtxt_documents/' . $child_id . '/autosaves' );
+		$autosave_request->set_param( 'content', 'Changed content' );
+
+		$this->assertSame( 409, rest_do_request( $child_request )->get_status() );
+		$this->assertSame( 409, rest_do_request( $row_request )->get_status() );
+		$this->assertSame( 409, rest_do_request( $autosave_request )->get_status() );
+		$this->assertSame( 'Existing child', get_post( $child_id )->post_title );
+		$this->assertSame( 'Existing content', get_post( $child_id )->post_content );
+		$this->assertSame( $row_title, get_post( $row_id )->post_title );
+	}
+
+	public function test_core_rest_allows_active_documents_to_leave_archived_containers_or_be_archived(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id     = $this->create_page();
+		$collection_id = $this->create_full_page_collection( 'archived-leave-target' );
+		$this->archive( $parent_id );
+		$this->archive( $collection_id );
+		$moved_id    = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$archived_id = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$row_id      = $this->create_row( $collection_id );
+
+		$move_request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $moved_id );
+		$move_request->set_param( 'parent', 0 );
+		$archive_request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $archived_id );
+		$archive_request->set_param( 'status', Documents::STATUS_ARCHIVED );
+		$leave_collection_request = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_documents/' . $row_id );
+		$leave_collection_request->set_param( TraitTaxonomy::TAXONOMY, array() );
+
+		$this->assertSame( 200, rest_do_request( $move_request )->get_status() );
+		$this->assertSame( 200, rest_do_request( $archive_request )->get_status() );
+		$this->assertSame( 200, rest_do_request( $leave_collection_request )->get_status() );
+		$this->assertSame( 0, (int) get_post( $moved_id )->post_parent );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $archived_id ) );
+		$this->assertSame(
+			array(),
+			wp_get_object_terms( $row_id, TraitTaxonomy::TAXONOMY, array( 'fields' => 'ids' ) )
+		);
+	}
+
+	public function test_cascaded_documents_cannot_be_unarchived_while_their_container_is_archived(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id = $this->create_page();
+		$child_id  = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$this->archive( $parent_id );
+
+		$response = $this->unarchive( $child_id );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived_container', $response->get_data()['code'] );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $child_id ) );
+		$this->assertSame( (string) $parent_id, (string) get_post_meta( $child_id, ArchiveCascade::PARENT_MARKER_META, true ) );
+	}
+
+	public function test_unarchive_rejects_descendants_that_belong_to_another_archived_container(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id     = $this->create_page();
+		$collection_id = $this->create_full_page_collection( 'overlapping-unarchive' );
+		$row_id        = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$term_id       = TraitTaxonomy::term_id_for_trait( $collection_id );
+		wp_set_object_terms( $row_id, array( $term_id ), TraitTaxonomy::TAXONOMY, false );
+		$this->archive( $parent_id );
+		$this->archive( $collection_id );
+
+		$response = $this->unarchive( $parent_id );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived_container', $response->get_data()['code'] );
+		$this->assertSame( $collection_id, $response->get_data()['data']['container_id'] );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $parent_id ) );
+		$this->assertSame( Documents::STATUS_ARCHIVED, get_post_status( $row_id ) );
+	}
+
+	public function test_trashed_document_cannot_be_restored_under_an_archived_parent(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id = $this->create_page();
+		$child_id  = $this->create_page( array( 'post_parent' => $parent_id ) );
+		wp_trash_post( $child_id );
+		$this->archive( $parent_id );
+
+		$response = $this->restore( $child_id );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived_container', $response->get_data()['code'] );
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $child_id ) );
+	}
+
+	public function test_restore_rejects_descendants_that_belong_to_another_archived_container(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+
+		$parent_id     = $this->create_page();
+		$collection_id = $this->create_full_page_collection( 'overlapping-restore' );
+		$row_id        = $this->create_page( array( 'post_parent' => $parent_id ) );
+		$term_id       = TraitTaxonomy::term_id_for_trait( $collection_id );
+		wp_set_object_terms( $row_id, array( $term_id ), TraitTaxonomy::TAXONOMY, false );
+		wp_trash_post( $parent_id );
+		$this->archive( $collection_id );
+
+		$response = $this->restore( $parent_id );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'cortext_document_archived_container', $response->get_data()['code'] );
+		$this->assertSame( $collection_id, $response->get_data()['data']['container_id'] );
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $parent_id ) );
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $row_id ) );
+	}
+
 	public function test_core_rest_archive_checks_every_page_in_the_cascade(): void {
 		$author_id = $this->create_user( 'contributor' );
 		$other_id  = $this->create_user( 'contributor' );

--- a/tests/php/test-rest-fields-controller.php
+++ b/tests/php/test-rest-fields-controller.php
@@ -21,12 +21,14 @@ use WP_REST_Server;
 
 final class Test_Rest_Fields_Controller extends BaseTestCase {
 
+	use InMemoryPostsQuery;
 	use InMemoryTermStore;
 
 	public function set_up(): void {
 		parent::set_up();
 
 		( new Document() )->register_post_type();
+		( new ArchiveCascade() )->register_status();
 		( new TraitTaxonomy() )->register_taxonomy();
 		$trait_taxonomy = new TraitTaxonomy();
 		add_action( 'added_post_meta', array( $trait_taxonomy, 'sync_term_on_meta_change' ), 10, 4 );
@@ -177,7 +179,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 					array(
 						'value' => 'doing',
 						'label' => 'Doing',
-						'color' => 'neon-magenta', // not in palette
+						'color' => 'neon-magenta', // Not in palette.
 					),
 				),
 			)
@@ -319,6 +321,289 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$this->assertSame( 403, $response->get_status() );
 	}
 
+	public function test_archived_collection_blocks_field_mutations_but_allows_reads(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$collection_id = $this->create_collection_with_slug( 'Archived schema', 'archived-schema' );
+
+		$text_response     = $this->create_field(
+			$collection_id,
+			array(
+				'title' => 'Notes',
+				'type'  => 'text',
+			)
+		);
+		$select_response   = $this->create_field(
+			$collection_id,
+			array(
+				'title'   => 'Status',
+				'type'    => 'select',
+				'options' => array(
+					array(
+						'value' => 'open',
+						'label' => 'Open',
+					),
+				),
+			)
+		);
+		$formula_response  = $this->create_field(
+			$collection_id,
+			array(
+				'title'      => 'Score',
+				'type'       => 'formula',
+				'expression' => '1',
+			)
+		);
+		$text_id           = (int) $text_response->get_data()['id'];
+		$select_id         = (int) $select_response->get_data()['id'];
+		$formula_id        = (int) $formula_response->get_data()['id'];
+		$stored_field_ids  = $this->stored_collection_field_ids( $collection_id );
+		$stored_options    = get_post_meta( $select_id, 'options', true );
+		$stored_expression = get_post_meta( $formula_id, 'expression', true );
+
+		wp_update_post(
+			array(
+				'ID'          => $collection_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$core_update = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_fields/' . $text_id );
+		$core_update->set_param( 'title', 'Changed notes' );
+		$core_trash  = new WP_REST_Request( 'DELETE', '/wp/v2/crtxt_fields/' . $text_id );
+		$core_delete = new WP_REST_Request( 'DELETE', '/wp/v2/crtxt_fields/' . $text_id );
+		$core_delete->set_param( 'force', true );
+
+		$responses = array(
+			$this->create_field(
+				$collection_id,
+				array(
+					'title' => 'Blocked field',
+					'type'  => 'text',
+				)
+			),
+			$this->duplicate_field( $collection_id, $text_id ),
+			$this->update_formula( $formula_id, array( 'expression' => '2' ) ),
+			$this->update_options(
+				$select_id,
+				array(
+					'options' => array(
+						array(
+							'value' => 'closed',
+							'label' => 'Closed',
+						),
+					),
+				)
+			),
+			$this->convert_field( $text_id, 'number' ),
+			rest_do_request( $core_update ),
+			rest_do_request( $core_trash ),
+			rest_do_request( $core_delete ),
+		);
+
+		foreach ( $responses as $response ) {
+			$this->assertSame( 409, $response->get_status() );
+			$this->assertSame( 'cortext_collection_archived', $response->get_data()['code'] );
+		}
+		$this->assertSame( $stored_field_ids, $this->stored_collection_field_ids( $collection_id ) );
+		$this->assertSame( 'Notes', get_post( $text_id )->post_title );
+		$this->assertSame( 'text', get_post_meta( $text_id, 'type', true ) );
+		$this->assertSame( $stored_options, get_post_meta( $select_id, 'options', true ) );
+		$this->assertSame( $stored_expression, get_post_meta( $formula_id, 'expression', true ) );
+
+		$usage_request = new WP_REST_Request(
+			'GET',
+			"/cortext/v1/fields/{$select_id}/options/open/usage"
+		);
+		$this->assertSame( 200, rest_do_request( $usage_request )->get_status() );
+		$usage_head = new WP_REST_Request(
+			'HEAD',
+			"/cortext/v1/fields/{$select_id}/options/open/usage"
+		);
+		$this->assertSame( 200, rest_do_request( $usage_head )->get_status() );
+		$core_read = new WP_REST_Request( 'GET', '/wp/v2/crtxt_fields/' . $text_id );
+		$this->assertSame( 200, rest_do_request( $core_read )->get_status() );
+
+		wp_trash_post( $collection_id );
+		$this->assertSame( Documents::STATUS_TRASH, get_post_status( $collection_id ) );
+		$this->assertSame(
+			Documents::STATUS_ARCHIVED,
+			get_post_meta( $collection_id, '_wp_trash_meta_status', true )
+		);
+		$trashed_core_update = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_fields/' . $text_id );
+		$trashed_core_update->set_param( 'title', 'Changed in Trash' );
+		foreach (
+			array(
+				rest_do_request( $trashed_core_update ),
+				$this->update_formula( $formula_id, array( 'expression' => '3' ) ),
+			) as $response
+		) {
+			$this->assertSame( 409, $response->get_status() );
+			$this->assertSame( 'cortext_collection_archived', $response->get_data()['code'] );
+		}
+		$this->assertSame( 'Notes', get_post( $text_id )->post_title );
+		$this->assertSame( $stored_expression, get_post_meta( $formula_id, 'expression', true ) );
+	}
+
+	public function test_relation_mutations_cannot_change_an_archived_target_schema(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$source_collection_id = $this->create_collection_with_slug( 'Active source', 'active-source' );
+		$target_collection_id = $this->create_collection_with_slug( 'Archived target', 'archived-target' );
+
+		$relation_response = $this->create_field(
+			$source_collection_id,
+			array(
+				'title'                 => 'Target',
+				'type'                  => 'relation',
+				'related_collection_id' => $target_collection_id,
+			)
+		);
+		$source_field_id   = (int) $relation_response->get_data()['id'];
+		$reverse_field_id  = (int) get_post_meta( $source_field_id, 'relation_reverse_field_id', true );
+		$source_fields     = $this->stored_collection_field_ids( $source_collection_id );
+		$target_fields     = $this->stored_collection_field_ids( $target_collection_id );
+
+		wp_update_post(
+			array(
+				'ID'          => $target_collection_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$create_response    = $this->create_field(
+			$source_collection_id,
+			array(
+				'title'                 => 'Another target',
+				'type'                  => 'relation',
+				'related_collection_id' => $target_collection_id,
+			)
+		);
+		$duplicate_response = $this->duplicate_field( $source_collection_id, $source_field_id );
+		$delete_request     = new WP_REST_Request( 'DELETE', '/wp/v2/crtxt_fields/' . $source_field_id );
+		$delete_request->set_param( 'force', true );
+		$delete_response = rest_do_request( $delete_request );
+
+		foreach ( array( $create_response, $duplicate_response, $delete_response ) as $response ) {
+			$this->assertSame( 409, $response->get_status() );
+			$this->assertSame( 'cortext_collection_archived', $response->get_data()['code'] );
+		}
+		$this->assertSame( $source_fields, $this->stored_collection_field_ids( $source_collection_id ) );
+		$this->assertSame( $target_fields, $this->stored_collection_field_ids( $target_collection_id ) );
+		$this->assertInstanceOf( \WP_Post::class, get_post( $source_field_id ) );
+		$this->assertInstanceOf( \WP_Post::class, get_post( $reverse_field_id ) );
+	}
+
+	public function test_core_delete_is_blocked_by_dependents_in_archived_collections(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$active_collection_id   = $this->create_collection_with_slug( 'Active fields', 'active-fields' );
+		$archived_collection_id = $this->create_collection_with_slug( 'Archived dependents', 'archived-dependents' );
+
+		$rollup_source_id  = (int) $this->create_field(
+			$active_collection_id,
+			array(
+				'title' => 'Rollup source',
+				'type'  => 'number',
+			)
+		)->get_data()['id'];
+		$formula_source_id = (int) $this->create_field(
+			$active_collection_id,
+			array(
+				'title' => 'Formula source',
+				'type'  => 'number',
+			)
+		)->get_data()['id'];
+		$stale_source_id   = (int) $this->create_field(
+			$active_collection_id,
+			array(
+				'title' => 'Stale source',
+				'type'  => 'number',
+			)
+		)->get_data()['id'];
+
+		$rollup_id  = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Dependent rollup',
+				'meta_input'  => array(
+					'type'                   => 'rollup',
+					'rollup_target_field_id' => (string) $rollup_source_id,
+				),
+			)
+		);
+		$formula_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Dependent formula',
+				'meta_input'  => array(
+					'type'                  => 'formula',
+					'formula_dep_field_ids' => wp_json_encode( array( $formula_source_id ) ),
+				),
+			)
+		);
+		$stale_id   = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Stale metadata',
+				'meta_input'  => array(
+					'type'                   => 'text',
+					'rollup_target_field_id' => (string) $stale_source_id,
+				),
+			)
+		);
+		foreach ( array( $rollup_id, $formula_id, $stale_id ) as $field_id ) {
+			add_post_meta( $archived_collection_id, 'cortext_fields', (string) $field_id );
+		}
+		wp_update_post(
+			array(
+				'ID'          => $archived_collection_id,
+				'post_status' => Documents::STATUS_ARCHIVED,
+			)
+		);
+
+		$this->install_in_memory_posts_query();
+		try {
+			$responses = array();
+			foreach ( array( $rollup_source_id, $formula_source_id, $stale_source_id ) as $source_id ) {
+				$request = new WP_REST_Request( 'DELETE', '/wp/v2/crtxt_fields/' . $source_id );
+				$request->set_param( 'force', true );
+				$responses[] = rest_do_request( $request );
+			}
+		} finally {
+			$this->uninstall_in_memory_posts_query();
+		}
+
+		$this->assertSame( 409, $responses[0]->get_status() );
+		$this->assertSame( 409, $responses[1]->get_status() );
+		$this->assertSame( 200, $responses[2]->get_status() );
+		$this->assertInstanceOf( \WP_Post::class, get_post( $rollup_source_id ) );
+		$this->assertInstanceOf( \WP_Post::class, get_post( $formula_source_id ) );
+		$this->assertNull( get_post( $stale_source_id ) );
+		foreach ( array( $rollup_id, $formula_id, $stale_id ) as $field_id ) {
+			$this->assertInstanceOf( \WP_Post::class, get_post( $field_id ) );
+		}
+	}
+
+	public function test_core_rest_updates_an_unattached_field(): void {
+		wp_set_current_user( $this->create_user( 'administrator' ) );
+		$field_id = (int) wp_insert_post(
+			array(
+				'post_type'   => Field::POST_TYPE,
+				'post_status' => 'private',
+				'post_title'  => 'Loose field',
+				'meta_input'  => array( 'type' => 'text' ),
+			)
+		);
+		$request  = new WP_REST_Request( 'PUT', '/wp/v2/crtxt_fields/' . $field_id );
+		$request->set_param( 'title', 'Updated loose field' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'Updated loose field', get_post( $field_id )->post_title );
+	}
+
 	public function test_create_rolls_back_field_when_attach_fails(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		$collection_id = $this->create_collection_with_slug( 'Attach Fails', 'attach' );
@@ -455,7 +740,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		$source_collection_id = $this->create_collection_with_slug( 'Projects', 'projects-roll' );
 		$target_collection_id = $this->create_collection_with_slug( 'Invoices', 'invoices-roll' );
 
-		$relation_id = (int) $this->create_field(
+		$relation_id   = (int) $this->create_field(
 			$source_collection_id,
 			array(
 				'title'                 => 'Invoices',
@@ -463,7 +748,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 				'related_collection_id' => $target_collection_id,
 			)
 		)->get_data()['id'];
-		$amount_id   = (int) $this->create_field(
+		$amount_id     = (int) $this->create_field(
 			$target_collection_id,
 			array(
 				'title' => 'Amount',
@@ -826,7 +1111,7 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		wp_set_current_user( $this->create_user( 'editor' ) );
 		$collection_id = $this->create_collection_with_slug( 'Items', 'form-rename' );
 
-		$price_id = (int) $this->create_field(
+		$price_id   = (int) $this->create_field(
 			$collection_id,
 			array(
 				'title' => 'Price',
@@ -1375,8 +1660,6 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 
 	public function test_update_options_migrates_and_counts_an_archived_row(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
-		( new ArchiveCascade() )->register_status();
-
 		$collection_id = $this->create_collection_with_slug( 'Archived options', 'archived-options' );
 		$field_id      = (int) $this->create_field(
 			$collection_id,
@@ -1664,8 +1947,6 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 
 	public function test_convert_collects_option_tokens_from_an_archived_row(): void {
 		wp_set_current_user( $this->create_user( 'editor' ) );
-		( new ArchiveCascade() )->register_status();
-
 		[ , $field_id, $row_ids ] = $this->fixture_text_field_with_rows(
 			'archived-token',
 			array( 'Waiting' )
@@ -2069,6 +2350,10 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 	}
 
 	/**
+	 * Creates a text field and rows with the supplied values.
+	 *
+	 * @param string   $slug   Collection slug.
+	 * @param string[] $values Row values.
 	 * @return array{0:int,1:int,2:int[]} Collection id, field id, row ids.
 	 */
 	private function fixture_text_field_with_rows( string $slug, array $values ): array {
@@ -2218,5 +2503,4 @@ final class Test_Rest_Fields_Controller extends BaseTestCase {
 		}
 		return $stored;
 	}
-
 }


### PR DESCRIPTION
## What

Follow-up to #425. Part of #423.

Archived documents now have to pass through Trash before permanent deletion. Active documents can no longer be created, moved, restored, or unarchived inside archived parents or collections. Field changes are also blocked when they would alter an archived collection's schema, including changes that cascade through relations, rollups, or formulas.

This also removes an unreachable Favorites merge path and notes that formula recomputes still include archived rows.

## Why

A few core REST and field dependency paths sat outside the read-only guards added in #425. They could leave active content inside Archive or change an archived collection's fields indirectly.

## How

The guards inspect every affected container or field before WordPress starts the write. They skip containers restored in the same operation, so restoring a complete archived tree still works.

## Testing Instructions

1. Archive a document. Send `DELETE /wp/v2/crtxt_documents/{id}?force=true` and confirm the request is rejected. Move the document to Trash, repeat the request, and confirm permanent deletion succeeds.
2. Archive a parent page and a collection. Try to create or move an active child or row into either one, then try to restore or unarchive an existing child while its container stays archived. Confirm each request is rejected.
3. Archive a collection and fetch one of its fields. Confirm reads still work, then try to update or delete the field and confirm the schema does not change.
4. Restore a complete archived page or collection cascade. Confirm the root and its descendants return together without a container error.
