### PR TITLE
Fix: keep mention icons when moving the caret

### DIFF
--- a/src/components/mention/icon.js
+++ b/src/components/mention/icon.js
@@ -26,6 +26,36 @@ const wpIconMaskCache = new Map();
 const mentionTargetIconCache = new Map();
 const mentionIconHydrators = new WeakMap();
 
+function updateAttribute( element, name, value ) {
+	if ( value ) {
+		if ( element.getAttribute( name ) === value ) {
+			return false;
+		}
+		element.setAttribute( name, value );
+		return true;
+	}
+	if ( element.hasAttribute( name ) ) {
+		element.removeAttribute( name );
+		return true;
+	}
+	return false;
+}
+
+function updateStyleProperty( element, property, value ) {
+	if ( value ) {
+		if ( element.style.getPropertyValue( property ) === value ) {
+			return false;
+		}
+		element.style.setProperty( property, value );
+		return true;
+	}
+	if ( element.style.getPropertyValue( property ) ) {
+		element.style.removeProperty( property );
+		return true;
+	}
+	return false;
+}
+
 function rangeIntersectsNode( range, node ) {
 	try {
 		return range.intersectsNode( node );
@@ -180,7 +210,11 @@ export function hydrateMentionWpIconMasks( root = document ) {
 			}
 			const mask = mentionWpIconMask( name );
 			if ( mask ) {
-				anchor.style.setProperty( '--cortext-mention-icon-mask', mask );
+				updateStyleProperty(
+					anchor,
+					'--cortext-mention-icon-mask',
+					mask
+				);
 			}
 		}
 	);
@@ -222,33 +256,46 @@ function fetchMentionTargetIcon( id ) {
 	return promise;
 }
 
-function applyMentionIcon( anchor, icon, imageUrl = '' ) {
+function mentionIconDomSnapshot( icon, imageUrl = '' ) {
 	const { attributes, style } = mentionIconSnapshotAttributes(
 		icon,
 		imageUrl
 	);
-
-	ICON_ATTRIBUTES.forEach( ( name ) => {
-		if ( attributes[ name ] ) {
-			anchor.setAttribute( name, attributes[ name ] );
-		} else {
-			anchor.removeAttribute( name );
-		}
-	} );
-	ICON_STYLE_PROPERTIES.forEach( ( property ) => {
-		anchor.style.removeProperty( property );
-	} );
-	Object.entries( style ).forEach( ( [ property, value ] ) => {
-		anchor.style.setProperty( property, value );
-	} );
-
-	const wpIconName = anchor.getAttribute( 'data-crtxt-icon-wp' );
+	const wpIconName = attributes[ 'data-crtxt-icon-wp' ];
 	if ( wpIconName ) {
 		const mask = mentionWpIconMask( wpIconName );
 		if ( mask ) {
-			anchor.style.setProperty( '--cortext-mention-icon-mask', mask );
+			style[ '--cortext-mention-icon-mask' ] = mask;
 		}
 	}
+	return { attributes, style };
+}
+
+function mentionIconDomSnapshotMatches( anchor, icon, imageUrl = '' ) {
+	const { attributes, style } = mentionIconDomSnapshot( icon, imageUrl );
+	return (
+		ICON_ATTRIBUTES.every(
+			( name ) =>
+				( anchor.getAttribute( name ) ?? '' ) ===
+				( attributes[ name ] ?? '' )
+		) &&
+		ICON_STYLE_PROPERTIES.every(
+			( property ) =>
+				anchor.style.getPropertyValue( property ) ===
+				( style[ property ] ?? '' )
+		)
+	);
+}
+
+function applyMentionIcon( anchor, icon, imageUrl = '' ) {
+	const { attributes, style } = mentionIconDomSnapshot( icon, imageUrl );
+
+	ICON_ATTRIBUTES.forEach( ( name ) => {
+		updateAttribute( anchor, name, attributes[ name ] ?? '' );
+	} );
+	ICON_STYLE_PROPERTIES.forEach( ( property ) => {
+		updateStyleProperty( anchor, property, style[ property ] ?? '' );
+	} );
 }
 
 export async function hydrateMentionIcons( root = document ) {
@@ -266,15 +313,18 @@ export async function hydrateMentionIcons( root = document ) {
 			if ( ! id ) {
 				return;
 			}
+
+			const { icon, imageUrl } = await fetchMentionTargetIcon( id );
 			if (
-				anchor.getAttribute( HYDRATED_FOR_ATTRIBUTE ) === String( id )
+				anchor.getAttribute( HYDRATED_FOR_ATTRIBUTE ) ===
+					String( id ) &&
+				mentionIconDomSnapshotMatches( anchor, icon, imageUrl )
 			) {
 				return;
 			}
 
-			const { icon, imageUrl } = await fetchMentionTargetIcon( id );
 			applyMentionIcon( anchor, icon, imageUrl );
-			anchor.setAttribute( HYDRATED_FOR_ATTRIBUTE, String( id ) );
+			updateAttribute( anchor, HYDRATED_FOR_ATTRIBUTE, String( id ) );
 		} )
 	);
 }
@@ -313,7 +363,19 @@ export function retainMentionIconHydrator( ownerDocument ) {
 		const MutationObserver = view?.MutationObserver;
 		const observer =
 			MutationObserver && ownerDocument.body
-				? new MutationObserver( scheduleHydrate )
+				? new MutationObserver( ( mutations ) => {
+						if (
+							mutations.some(
+								( mutation ) =>
+									mutation.type === 'childList' ||
+									mutation.target?.classList?.contains(
+										'cortext-mention'
+									)
+							)
+						) {
+							scheduleHydrate();
+						}
+				  } )
 				: null;
 
 		hydrate();
@@ -323,7 +385,7 @@ export function retainMentionIconHydrator( ownerDocument ) {
 		ownerDocument.addEventListener( 'keyup', updateSelection, true );
 		observer?.observe( ownerDocument.body, {
 			attributes: true,
-			attributeFilter: [ MENTION_ATTRIBUTE, 'data-crtxt-icon-wp' ],
+			attributeFilter: [ MENTION_ATTRIBUTE, ...ICON_ATTRIBUTES, 'style' ],
 			childList: true,
 			subtree: true,
 		} );

--- a/tests/js/components/mention.test.js
+++ b/tests/js/components/mention.test.js
@@ -250,6 +250,153 @@ describe( 'mention icons', () => {
 		anchor.remove();
 	} );
 
+	it( 'restores a wp icon after the editor resets its visual snapshot', async () => {
+		apiFetch.mockResolvedValue( {
+			id: 390,
+			meta: {
+				cortext_document_icon:
+					'{"type":"wp","name":"chartBar","color":"purple"}',
+			},
+		} );
+		const anchor = document.createElement( 'a' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-mention', '390' );
+		document.body.appendChild( anchor );
+
+		const release = retainMentionIconHydratorsForEditorDocument( document );
+
+		await waitFor( () => {
+			expect( anchor.getAttribute( 'data-crtxt-icon-wp' ) ).toBe(
+				'chartBar'
+			);
+		} );
+		expect( anchor.getAttribute( 'data-crtxt-icon-hydrated-for' ) ).toBe(
+			'390'
+		);
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		// Losing only the mask is enough for the generic document icon to show.
+		anchor.style.removeProperty( '--cortext-mention-icon-mask' );
+
+		await waitFor( () => {
+			expect(
+				anchor.style.getPropertyValue( '--cortext-mention-icon-mask' )
+			).toContain( 'data:image/svg+xml' );
+		} );
+
+		anchor.removeAttribute( 'data-crtxt-icon-wp' );
+		anchor.removeAttribute( 'data-crtxt-icon-color' );
+		anchor.style.removeProperty( '--cortext-mention-icon-color' );
+		anchor.style.removeProperty( '--cortext-mention-icon-mask' );
+
+		// Gutenberg can leave the hydration marker behind when it rebuilds the
+		// mention around a new caret position.
+		expect( anchor.getAttribute( 'data-crtxt-icon-hydrated-for' ) ).toBe(
+			'390'
+		);
+
+		await waitFor( () => {
+			expect( anchor.getAttribute( 'data-crtxt-icon-wp' ) ).toBe(
+				'chartBar'
+			);
+			expect( anchor.getAttribute( 'data-crtxt-icon-color' ) ).toBe(
+				'purple'
+			);
+			expect(
+				anchor.style.getPropertyValue( '--cortext-mention-icon-mask' )
+			).toContain( 'data:image/svg+xml' );
+		} );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		release();
+		anchor.remove();
+	} );
+
+	it( 'restores an emoji icon from the cached target snapshot', async () => {
+		apiFetch.mockResolvedValue( {
+			id: 391,
+			meta: {
+				cortext_document_icon: '{"type":"emoji","value":"📚"}',
+			},
+		} );
+		const anchor = document.createElement( 'a' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-mention', '391' );
+		document.body.appendChild( anchor );
+
+		await hydrateMentionIcons( document );
+		expect( anchor.getAttribute( 'data-crtxt-icon-emoji' ) ).toBe( '📚' );
+
+		anchor.removeAttribute( 'data-crtxt-icon-emoji' );
+		await hydrateMentionIcons( document );
+
+		expect( anchor.getAttribute( 'data-crtxt-icon-emoji' ) ).toBe( '📚' );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		anchor.remove();
+	} );
+
+	it( 'restores an image icon from the cached target snapshot', async () => {
+		apiFetch.mockImplementation( ( { path } ) => {
+			if ( path.startsWith( '/wp/v2/media/72' ) ) {
+				return Promise.resolve( {
+					id: 72,
+					media_details: {
+						sizes: {
+							thumbnail: {
+								source_url: '/media/books-thumbnail.jpg',
+							},
+						},
+					},
+				} );
+			}
+			return Promise.resolve( {
+				id: 392,
+				meta: {
+					cortext_document_icon: '{"type":"image","id":72}',
+				},
+			} );
+		} );
+		const anchor = document.createElement( 'a' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-mention', '392' );
+		document.body.appendChild( anchor );
+
+		await hydrateMentionIcons( document );
+		expect( anchor.getAttribute( 'data-crtxt-icon-image' ) ).toBe( 'true' );
+		expect(
+			anchor.style.getPropertyValue( '--cortext-mention-icon-image' )
+		).toContain( '/media/books-thumbnail.jpg' );
+
+		anchor.removeAttribute( 'data-crtxt-icon-image' );
+		anchor.style.removeProperty( '--cortext-mention-icon-image' );
+		await hydrateMentionIcons( document );
+
+		expect( anchor.getAttribute( 'data-crtxt-icon-image' ) ).toBe( 'true' );
+		expect(
+			anchor.style.getPropertyValue( '--cortext-mention-icon-image' )
+		).toContain( '/media/books-thumbnail.jpg' );
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		anchor.remove();
+	} );
+
+	it( 'keeps the generic fallback for targets without an icon', async () => {
+		apiFetch.mockResolvedValue( { id: 393 } );
+		const anchor = document.createElement( 'a' );
+		anchor.className = 'cortext-mention';
+		anchor.setAttribute( 'data-crtxt-mention', '393' );
+		document.body.appendChild( anchor );
+
+		await hydrateMentionIcons( document );
+		await hydrateMentionIcons( document );
+
+		expect( anchor ).not.toHaveAttribute( 'data-crtxt-icon-emoji' );
+		expect( anchor ).not.toHaveAttribute( 'data-crtxt-icon-image' );
+		expect( anchor ).not.toHaveAttribute( 'data-crtxt-icon-wp' );
+		expect( anchor.getAttribute( 'style' ) ).toBeNull();
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		anchor.remove();
+	} );
+
 	it( 'updates mentions inside the editor iframe from the mounted controller', async () => {
 		apiFetch.mockResolvedValue( {
 			id: 289,


### PR DESCRIPTION
## What

Fixes mentions switching to the generic document icon when the caret is placed beside them. WordPress, emoji, and image icons now stay visible while editing.

## Why

When Gutenberg rebuilds a mention around the caret, it can drop the icon but leave behind the marker that says it was already loaded. Cortext trusted that marker and did not restore the missing icon.

## Screenshots

| Before | After |
| --- | --- |
| <img width="290" height="76" alt="image" src="https://github.com/user-attachments/assets/085e1a91-2e09-41a0-8e32-8875746530af" /> | <img width="260" height="48" alt="image" src="https://github.com/user-attachments/assets/dea3d7d9-2ce0-4e22-9889-22758930c7fb" /> |

## Testing Instructions

1. Open a document with mentions that use WordPress, emoji, and image icons.
2. Place the caret directly before and after each mention, then type beside it.
3. Confirm that each mention keeps its original icon.