### PR TITLE
Desktop: Run the PHP server on a single worker by default

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -135,9 +135,9 @@ CORTEXT_RUNTIME=php-fpm npm --prefix apps/desktop start
 
 `php` is the default. It uses `apps/desktop/runtime/bin/php` first, then
 falls back to `php` on `PATH`. Set `CORTEXT_PHP_BIN` to force a specific
-binary. PHP's built-in server runs four worker children so request-heavy pages
-do not serialize; set `CORTEXT_PHP_CLI_SERVER_WORKERS` to change the count.
-Windows always uses a single worker.
+binary. Set `CORTEXT_PHP_CLI_SERVER_WORKERS=4` to run PHP's built-in server
+with worker children for request-heavy pages. Windows always uses a single
+worker.
 
 `franken` expects FrankenPHP at `apps/desktop/runtime/bin/frankenphp`, on
 `PATH`, or at `CORTEXT_FRANKENPHP_BIN`. Install the local binary with:

--- a/apps/desktop/lib/runtime.js
+++ b/apps/desktop/lib/runtime.js
@@ -17,10 +17,6 @@ const LEGACY_PORT = 9402;
 const RUNTIME_PORT_FIRST = 9403;
 const RUNTIME_PORT_LAST = 9498;
 const DEFAULT_READY_PATH = '/wp-includes/images/blank.gif';
-// The Library hydrates several DataViews at once and opening a row fans out into
-// more requests. A single-worker built-in server serializes that burst, so the
-// desktop runtime forks a small pool. Override with the env vars read below.
-const DEFAULT_PHP_CLI_SERVER_WORKERS = '4';
 const RUNTIME_AUTH_HEADER = 'X-Cortext-Desktop-Token';
 const RUNTIME_AUTH_ENV = 'CORTEXT_DESKTOP_AUTH_TOKEN';
 const WINDOWS_DIRECT_EXECUTABLE_EXTENSIONS = [ '.COM', '.EXE' ];
@@ -317,11 +313,12 @@ function phpCliWorkerConfig( env = process.env, platform = process.platform ) {
 		};
 	}
 
-	const workers = configured || DEFAULT_PHP_CLI_SERVER_WORKERS;
-
+	// Forking more than one worker hangs the packaged app: the shell paints and
+	// the canvas never arrives. The cause is still unknown, so the pool only
+	// runs when the env vars above ask for it.
 	return {
-		workers,
-		detached: Number.parseInt( workers, 10 ) > 1,
+		workers: configured,
+		detached: Number.parseInt( configured || '1', 10 ) > 1,
 		ignoredWorkers: null,
 	};
 }

--- a/apps/desktop/scripts/runtime.test.mjs
+++ b/apps/desktop/scripts/runtime.test.mjs
@@ -123,10 +123,10 @@ test( 'POSIX keeps the configured PHP worker count and uses a process group', ()
 	);
 } );
 
-test( 'POSIX forks a worker pool when nothing is configured', () => {
+test( 'POSIX runs a single worker when nothing is configured', () => {
 	assert.deepEqual( phpCliWorkerConfig( {}, 'darwin' ), {
-		workers: '4',
-		detached: true,
+		workers: null,
+		detached: false,
 		ignoredWorkers: null,
 	} );
 } );


### PR DESCRIPTION
## What

Reverts #410.

The desktop app's bundled PHP server goes back to a single worker. `CORTEXT_PHP_CLI_SERVER_WORKERS` still starts a pool if you want one.

## Why

Not to fix the packaged smoke test. That was the reason when this was opened, and it was wrong: the canvas hang is older than the worker pool and happens with a single worker too. #434 is where that gets chased.

The pool goes back to opt-in because it was never measured. It landed on a build eight days stale, and it quietly changes shutdown by moving PHP into its own process group. What four workers do to one SQLite file during first boot is untested too. A single worker is the setup that ran green for twelve builds straight.

It is worth bringing back, with a benchmark behind it, once CI is steady enough to measure anything.

## Testing Instructions

1. Start the desktop app and confirm the Library loads.
2. Check the running `php` processes: one, with no forked children.
3. Relaunch with `CORTEXT_PHP_CLI_SERVER_WORKERS=4` and confirm four children appear.