### PR TITLE
Desktop: Say what the renderer was waiting on when the canvas times out

### DIFF
--- a/apps/desktop/scripts/packaged-app-smoke.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.mjs
@@ -16,11 +16,18 @@ import { fileURLToPath } from 'node:url';
 
 const CORTEXT_URL_PATTERN = /\/wp-admin\/admin\.php\?page=cortext(?:&|$)/;
 const CORTEXT_ROOT_SELECTOR = '#cortext-root';
-const ACTIVE_CANVAS_SELECTOR =
-	'.cortext-workspace__pane[data-active="true"] .cortext-canvas';
+const PANE_SELECTOR = '.cortext-workspace__pane';
+const ACTIVE_PANE_SELECTOR = `${ PANE_SELECTOR }[data-active="true"]`;
+const CANVAS_SELECTOR = '.cortext-canvas';
+const ACTIVE_CANVAS_SELECTOR = `${ ACTIVE_PANE_SELECTOR } ${ CANVAS_SELECTOR }`;
 const START_TIMEOUT_MS = 120_000;
 const EXIT_TIMEOUT_MS = 30_000;
 const POLL_INTERVAL_MS = 250;
+const RUNTIME_PROBE_TIMEOUT_MS = 2_000;
+const REPORTED_URL_LENGTH = 140;
+const REPORTED_REQUESTS = 10;
+const REPORTED_MESSAGES = 20;
+const REPORTED_MARKUP_LENGTH = 600;
 
 function usage() {
 	return 'Usage: node apps/desktop/scripts/packaged-app-smoke.mjs --app <path-to-Cortext.app>';
@@ -304,6 +311,115 @@ async function firstRendererPage( browser ) {
 	throw new Error( 'Cortext did not open a renderer page.' );
 }
 
+function truncate( text, limit ) {
+	return text.length > limit ? `${ text.slice( 0, limit ) }...` : text;
+}
+
+// Watches the renderer so a timeout can name what it was waiting on. Playwright
+// only reports the selector it gave up on, which is the one thing we already
+// know.
+function recordRendererActivity( page ) {
+	const inFlight = new Map();
+	const settled = [];
+	const messages = [];
+
+	page.on( 'console', ( message ) =>
+		messages.push( `${ message.type() }: ${ message.text() }` )
+	);
+	page.on( 'pageerror', ( error ) =>
+		messages.push( `pageerror: ${ error.message }` )
+	);
+	page.on( 'request', ( pending ) => inFlight.set( pending, Date.now() ) );
+
+	const settle = ( pending, outcome ) => {
+		const startedAt = inFlight.get( pending );
+		inFlight.delete( pending );
+		settled.push( {
+			outcome,
+			url: pending.url(),
+			milliseconds: startedAt === undefined ? null : Date.now() - startedAt,
+		} );
+	};
+	page.on( 'requestfinished', ( pending ) => settle( pending, 'ok' ) );
+	page.on( 'requestfailed', ( pending ) =>
+		settle( pending, pending.failure()?.errorText || 'failed' )
+	);
+
+	return { inFlight, settled, messages };
+}
+
+// Answers the question the milestones cannot: whether the renderer is still
+// waiting on the runtime, gave up on a request, or rendered a pane that never
+// swapped in a canvas.
+async function describeStalledRenderer( page, activity ) {
+	const sections = [];
+
+	const stalled = [ ...activity.inFlight ].map(
+		( [ pending, startedAt ] ) =>
+			`  ${ Date.now() - startedAt }ms ${ pending.method() } ` +
+			truncate( pending.url(), REPORTED_URL_LENGTH )
+	);
+	sections.push(
+		stalled.length
+			? `Requests still in flight:\n${ stalled.join( '\n' ) }`
+			: 'No requests were still in flight.'
+	);
+
+	const slowest = activity.settled
+		.slice()
+		.sort( ( a, b ) => ( b.milliseconds ?? 0 ) - ( a.milliseconds ?? 0 ) )
+		.slice( 0, REPORTED_REQUESTS )
+		.map(
+			( entry ) =>
+				`  ${ entry.milliseconds }ms ${ entry.outcome } ` +
+				truncate( entry.url, REPORTED_URL_LENGTH )
+		);
+	if ( slowest.length ) {
+		sections.push( `Slowest completed requests:\n${ slowest.join( '\n' ) }` );
+	}
+
+	// An unauthenticated request is rejected by the runtime's router, so any
+	// status at all proves PHP is still serving and moves blame to the renderer.
+	const origin = new URL( page.url() ).origin;
+	try {
+		const { statusCode } = await request( origin, RUNTIME_PROBE_TIMEOUT_MS );
+		sections.push( `Runtime at ${ origin } answered HTTP ${ statusCode }.` );
+	} catch ( error ) {
+		sections.push( `Runtime at ${ origin } did not answer: ${ error.message }` );
+	}
+
+	const dom = await page.evaluate(
+		( selectors ) => ( {
+			panes: document.querySelectorAll( selectors.pane ).length,
+			activePanes: document.querySelectorAll( selectors.activePane ).length,
+			canvases: document.querySelectorAll( selectors.canvas ).length,
+			markup:
+				document.querySelector( selectors.activePane )?.innerHTML ?? null,
+		} ),
+		{
+			pane: PANE_SELECTOR,
+			activePane: ACTIVE_PANE_SELECTOR,
+			canvas: CANVAS_SELECTOR,
+		}
+	);
+	sections.push(
+		`Panes: ${ dom.panes } (${ dom.activePanes } active), ` +
+			`canvases: ${ dom.canvases }.\n` +
+			`Active pane markup: ${
+				dom.markup === null
+					? '(no active pane)'
+					: truncate( dom.markup, REPORTED_MARKUP_LENGTH )
+			}`
+	);
+
+	const messages = activity.messages.slice( -REPORTED_MESSAGES );
+	if ( messages.length ) {
+		sections.push( `Renderer console:\n  ${ messages.join( '\n  ' ) }` );
+	}
+
+	return sections.join( '\n\n' );
+}
+
 // Every milestone here shares the cold-start budget. The app is unpacking the
 // snapshot, installing WordPress and compiling PHP for the first time, and the
 // canvas is the last thing to land, so it needs at least as long as the URL it
@@ -318,6 +434,7 @@ export async function waitForCortextShell( page ) {
 	const milestones = [];
 	const reached = ( name ) =>
 		milestones.push( `${ name } ${ Date.now() - started }ms` );
+	const activity = recordRendererActivity( page );
 
 	try {
 		await page.waitForURL( CORTEXT_URL_PATTERN, {
@@ -340,11 +457,20 @@ export async function waitForCortextShell( page ) {
 	} catch ( error ) {
 		// A bare locator timeout cannot distinguish a slow agent from a wedged
 		// one. Report how far the boot got so the first failure is diagnosable.
-		appendErrorDetails(
-			error,
+		let details =
 			`Shell milestones: ${ milestones.join( ', ' ) || 'none reached' }\n` +
-				`Gave up after ${ Date.now() - started }ms.`
-		);
+			`Gave up after ${ Date.now() - started }ms.`;
+		try {
+			details = `${ details }\n\n${ await describeStalledRenderer(
+				page,
+				activity
+			) }`;
+		} catch ( reportError ) {
+			// The timeout is the finding. Losing the report is a shame; losing
+			// the failure it explains would be worse.
+			details = `${ details }\n\nCould not describe the renderer: ${ reportError.message }`;
+		}
+		appendErrorDetails( error, details );
 		throw error;
 	}
 

--- a/apps/desktop/scripts/packaged-app-smoke.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.mjs
@@ -365,6 +365,21 @@ async function describeStalledRenderer( page, activity ) {
 			: 'No requests were still in flight.'
 	);
 
+	// Kept separate from the slowest list because a request that fails usually
+	// fails fast, so ranking by duration hides exactly the ones worth seeing.
+	const failed = activity.settled
+		.filter( ( entry ) => entry.outcome !== 'ok' )
+		.map(
+			( entry ) =>
+				`  ${ entry.milliseconds }ms ${ entry.outcome } ` +
+				truncate( entry.url, REPORTED_URL_LENGTH )
+		);
+	sections.push(
+		failed.length
+			? `Failed requests:\n${ failed.join( '\n' ) }`
+			: 'No requests failed.'
+	);
+
 	const slowest = activity.settled
 		.slice()
 		.sort( ( a, b ) => ( b.milliseconds ?? 0 ) - ( a.milliseconds ?? 0 ) )
@@ -388,11 +403,19 @@ async function describeStalledRenderer( page, activity ) {
 		sections.push( `Runtime at ${ origin } did not answer: ${ error.message }` );
 	}
 
+	// Every pane stays mounted, active or not, so a canvas sitting in an
+	// inactive pane means the editor loaded and the workspace never switched to
+	// it. That is a different bug from a canvas that never mounted at all, and
+	// the active pane alone cannot tell the two apart.
 	const dom = await page.evaluate(
 		( selectors ) => ( {
-			panes: document.querySelectorAll( selectors.pane ).length,
-			activePanes: document.querySelectorAll( selectors.activePane ).length,
-			canvases: document.querySelectorAll( selectors.canvas ).length,
+			panes: [ ...document.querySelectorAll( selectors.pane ) ].map(
+				( pane ) => ( {
+					active: pane.dataset.active === 'true',
+					canvases: pane.querySelectorAll( selectors.canvas ).length,
+					content: pane.firstElementChild?.className || '(empty)',
+				} )
+			),
 			markup:
 				document.querySelector( selectors.activePane )?.innerHTML ?? null,
 		} ),
@@ -402,9 +425,13 @@ async function describeStalledRenderer( page, activity ) {
 			canvas: CANVAS_SELECTOR,
 		}
 	);
+	const panes = dom.panes.map(
+		( pane, index ) =>
+			`  ${ index } ${ pane.active ? 'active  ' : 'inactive' } ` +
+			`canvases=${ pane.canvases }  ${ truncate( pane.content, 80 ) }`
+	);
 	sections.push(
-		`Panes: ${ dom.panes } (${ dom.activePanes } active), ` +
-			`canvases: ${ dom.canvases }.\n` +
+		`Panes:\n${ panes.join( '\n' ) || '  (none)' }\n` +
 			`Active pane markup: ${
 				dom.markup === null
 					? '(no active pane)'

--- a/apps/desktop/scripts/packaged-app-smoke.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.mjs
@@ -26,7 +26,9 @@ const EXIT_TIMEOUT_MS = 30_000;
 const POLL_INTERVAL_MS = 250;
 const RUNTIME_PROBE_TIMEOUT_MS = 2_000;
 const REPORTED_URL_LENGTH = 140;
-const REPORTED_REQUESTS = 10;
+const REPORTED_REQUESTS = 80;
+const ASSET_PATTERN =
+	/\.(?:js|mjs|css|svg|png|jpe?g|gif|webp|woff2?|ttf|eot|map|ico)(?:\?|$)/;
 const REPORTED_MESSAGES = 20;
 const REPORTED_MARKUP_LENGTH = 600;
 
@@ -320,6 +322,7 @@ function truncate( text, limit ) {
 // only reports the selector it gave up on, which is the one thing we already
 // know.
 function recordRendererActivity( page ) {
+	const openedAt = Date.now();
 	const inFlight = new Map();
 	const settled = [];
 	const messages = [];
@@ -338,6 +341,7 @@ function recordRendererActivity( page ) {
 		settled.push( {
 			outcome,
 			url: pending.url(),
+			offset: startedAt === undefined ? null : startedAt - openedAt,
 			milliseconds: startedAt === undefined ? null : Date.now() - startedAt,
 		} );
 	};
@@ -346,7 +350,7 @@ function recordRendererActivity( page ) {
 		settle( pending, pending.failure()?.errorText || 'failed' )
 	);
 
-	return { inFlight, settled, messages };
+	return { openedAt, inFlight, settled, messages };
 }
 
 // Answers the question the milestones cannot: whether the renderer is still
@@ -381,17 +385,31 @@ async function describeStalledRenderer( page, activity ) {
 			: 'No requests failed.'
 	);
 
-	const slowest = activity.settled
+	// Chronological rather than ranked by duration: a boot that stalls does it at
+	// a particular point in the sequence, and the last request before the silence
+	// is the one worth reading. Scripts and styles are dropped because a few
+	// hundred of them bury the handful of REST calls that carry the boot.
+	const dataRequests = activity.settled.filter(
+		( entry ) => ! ASSET_PATTERN.test( entry.url )
+	);
+	const timeline = dataRequests
 		.slice()
-		.sort( ( a, b ) => ( b.milliseconds ?? 0 ) - ( a.milliseconds ?? 0 ) )
+		.sort( ( a, b ) => ( a.offset ?? 0 ) - ( b.offset ?? 0 ) )
 		.slice( 0, REPORTED_REQUESTS )
 		.map(
 			( entry ) =>
-				`  ${ entry.milliseconds }ms ${ entry.outcome } ` +
-				truncate( entry.url, REPORTED_URL_LENGTH )
+				`  +${ entry.offset }ms ${ entry.milliseconds }ms ` +
+				`${ entry.outcome } ${ truncate( entry.url, REPORTED_URL_LENGTH ) }`
 		);
-	if ( slowest.length ) {
-		sections.push( `Slowest completed requests:\n${ slowest.join( '\n' ) }` );
+	if ( timeline.length ) {
+		const assets = activity.settled.length - dataRequests.length;
+		const dropped = dataRequests.length - timeline.length;
+		sections.push(
+			`Requests (${ activity.settled.length } total, ` +
+				`${ assets } assets hidden` +
+				`${ dropped > 0 ? `, showing first ${ timeline.length }` : '' }):\n` +
+				timeline.join( '\n' )
+		);
 	}
 
 	// The address says which document the workspace was asked to open, which is

--- a/apps/desktop/scripts/packaged-app-smoke.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 
 const CORTEXT_URL_PATTERN = /\/wp-admin\/admin\.php\?page=cortext(?:&|$)/;
 const CORTEXT_ROOT_SELECTOR = '#cortext-root';
+const WORKSPACE_SELECTOR = '.cortext-workspace';
 const PANE_SELECTOR = '.cortext-workspace__pane';
 const ACTIVE_PANE_SELECTOR = `${ PANE_SELECTOR }[data-active="true"]`;
 const CANVAS_SELECTOR = '.cortext-canvas';
@@ -393,6 +394,10 @@ async function describeStalledRenderer( page, activity ) {
 		sections.push( `Slowest completed requests:\n${ slowest.join( '\n' ) }` );
 	}
 
+	// The address says which document the workspace was asked to open, which is
+	// the first thing to check when nothing painted.
+	sections.push( `Renderer URL: ${ truncate( page.url(), REPORTED_URL_LENGTH ) }` );
+
 	// An unauthenticated request is rejected by the runtime's router, so any
 	// status at all proves PHP is still serving and moves blame to the renderer.
 	const origin = new URL( page.url() ).origin;
@@ -409,6 +414,11 @@ async function describeStalledRenderer( page, activity ) {
 	// the active pane alone cannot tell the two apart.
 	const dom = await page.evaluate(
 		( selectors ) => ( {
+			// The workspace publishes the route it is on. A document target with
+			// no document pane below means the id never resolved.
+			targetKind:
+				document.querySelector( selectors.workspace )?.dataset
+					.targetKind ?? null,
 			panes: [ ...document.querySelectorAll( selectors.pane ) ].map(
 				( pane ) => ( {
 					active: pane.dataset.active === 'true',
@@ -420,11 +430,13 @@ async function describeStalledRenderer( page, activity ) {
 				document.querySelector( selectors.activePane )?.innerHTML ?? null,
 		} ),
 		{
+			workspace: WORKSPACE_SELECTOR,
 			pane: PANE_SELECTOR,
 			activePane: ACTIVE_PANE_SELECTOR,
 			canvas: CANVAS_SELECTOR,
 		}
 	);
+	sections.push( `Workspace target: ${ dom.targetKind ?? '(not rendered)' }` );
 	const panes = dom.panes.map(
 		( pane, index ) =>
 			`  ${ index } ${ pane.active ? 'active  ' : 'inactive' } ` +

--- a/apps/desktop/scripts/packaged-app-smoke.test.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.test.mjs
@@ -20,14 +20,28 @@ test( 'keeps packaged output in an already rendered error stack', () => {
 } );
 
 // Resolves the first `succeed` waits, then times out like Playwright would.
-function fakePage( succeed ) {
+// `dom` stands in for what the renderer painted by the time it gave up.
+function fakePage( succeed, dom = {} ) {
 	let calls = 0;
 	const step = async () => {
 		if ( calls++ >= succeed ) {
 			throw new Error( 'locator.waitFor: Timeout 120000ms exceeded.' );
 		}
 	};
-	return { waitForURL: step, locator: () => ( { waitFor: step } ) };
+	return {
+		waitForURL: step,
+		locator: () => ( { waitFor: step } ),
+		on: () => {},
+		// Port 1 refuses instantly, which is the runtime being unreachable.
+		url: () => 'http://127.0.0.1:1/wp-admin/admin.php?page=cortext',
+		evaluate: async () => ( {
+			panes: 1,
+			activePanes: 1,
+			canvases: 0,
+			markup: '<div class="cortext-loading"></div>',
+			...dom,
+		} ),
+	};
 }
 
 test( 'shell wait reports the milestones it reached before timing out', async () => {
@@ -50,6 +64,35 @@ test( 'shell wait says so when the boot never reached the first milestone', asyn
 
 test( 'shell wait resolves once the canvas is visible', async () => {
 	await waitForCortextShell( fakePage( 3 ) );
+} );
+
+test( 'shell wait reports what the renderer had painted and reached', async () => {
+	await assert.rejects( waitForCortextShell( fakePage( 2 ) ), ( error ) => {
+		assert.match( error.message, /No requests were still in flight\./ );
+		assert.match(
+			error.message,
+			/Runtime at http:\/\/127\.0\.0\.1:1 did not answer:/
+		);
+		assert.match( error.message, /Panes: 1 \(1 active\), canvases: 0\./ );
+		assert.match( error.message, /cortext-loading/ );
+		return true;
+	} );
+} );
+
+test( 'shell wait keeps the timeout when the report itself fails', async () => {
+	const page = fakePage( 2 );
+	page.evaluate = async () => {
+		throw new Error( 'Execution context was destroyed.' );
+	};
+
+	await assert.rejects( waitForCortextShell( page ), ( error ) => {
+		assert.match( error.message, /Timeout 120000ms exceeded/ );
+		assert.match(
+			error.message,
+			/Could not describe the renderer: Execution context was destroyed\./
+		);
+		return true;
+	} );
 } );
 
 async function listen( handler ) {

--- a/apps/desktop/scripts/packaged-app-smoke.test.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.test.mjs
@@ -35,6 +35,7 @@ function fakePage( succeed, dom = {} ) {
 		// Port 1 refuses instantly, which is the runtime being unreachable.
 		url: () => 'http://127.0.0.1:1/wp-admin/admin.php?page=cortext',
 		evaluate: async () => ( {
+			targetKind: 'document',
 			panes: [
 				{ active: true, canvases: 0, content: 'cortext-canvas__loading' },
 				{ active: false, canvases: 1, content: 'cortext-canvas' },
@@ -71,10 +72,12 @@ test( 'shell wait reports what the renderer had painted and reached', async () =
 	await assert.rejects( waitForCortextShell( fakePage( 2 ) ), ( error ) => {
 		assert.match( error.message, /No requests were still in flight\./ );
 		assert.match( error.message, /No requests failed\./ );
+		assert.match( error.message, /Renderer URL: http:\/\/127\.0\.0\.1:1\// );
 		assert.match(
 			error.message,
 			/Runtime at http:\/\/127\.0\.0\.1:1 did not answer:/
 		);
+		assert.match( error.message, /Workspace target: document/ );
 		assert.match( error.message, /cortext-loading/ );
 		return true;
 	} );

--- a/apps/desktop/scripts/packaged-app-smoke.test.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.test.mjs
@@ -35,9 +35,10 @@ function fakePage( succeed, dom = {} ) {
 		// Port 1 refuses instantly, which is the runtime being unreachable.
 		url: () => 'http://127.0.0.1:1/wp-admin/admin.php?page=cortext',
 		evaluate: async () => ( {
-			panes: 1,
-			activePanes: 1,
-			canvases: 0,
+			panes: [
+				{ active: true, canvases: 0, content: 'cortext-canvas__loading' },
+				{ active: false, canvases: 1, content: 'cortext-canvas' },
+			],
 			markup: '<div class="cortext-loading"></div>',
 			...dom,
 		} ),
@@ -69,12 +70,28 @@ test( 'shell wait resolves once the canvas is visible', async () => {
 test( 'shell wait reports what the renderer had painted and reached', async () => {
 	await assert.rejects( waitForCortextShell( fakePage( 2 ) ), ( error ) => {
 		assert.match( error.message, /No requests were still in flight\./ );
+		assert.match( error.message, /No requests failed\./ );
 		assert.match(
 			error.message,
 			/Runtime at http:\/\/127\.0\.0\.1:1 did not answer:/
 		);
-		assert.match( error.message, /Panes: 1 \(1 active\), canvases: 0\./ );
 		assert.match( error.message, /cortext-loading/ );
+		return true;
+	} );
+} );
+
+// The whole point of listing every pane: a canvas parked in an inactive one is
+// a workspace that never switched, not an editor that failed to load.
+test( 'shell wait shows a canvas sitting in an inactive pane', async () => {
+	await assert.rejects( waitForCortextShell( fakePage( 2 ) ), ( error ) => {
+		assert.match(
+			error.message,
+			/Panes:\n\s+0 active\s+canvases=0\s+cortext-canvas__loading/
+		);
+		assert.match(
+			error.message,
+			/\n\s+1 inactive\s+canvases=1\s+cortext-canvas/
+		);
 		return true;
 	} );
 } );


### PR DESCRIPTION
## What

When the packaged smoke test gives up waiting for the canvas, it now dumps what the renderer was actually doing: requests that never came back, the slowest ones that did, and the markup of the active pane. It also probes the runtime to see whether PHP is still answering, and prints the tail of the browser console. If the dump itself throws, the original timeout survives with a note explaining why.

## Why

The macOS smoke test fails about half the time, always in the same place: the shell paints and the canvas never shows up. All the log gives you is two timestamps, which is not enough to tell a stalled request from a runtime that died. The first time I ran this it caught four preflight requests to the local runtime hanging for 19 seconds while the runtime answered everything else fine.

## Testing Instructions

1. Build and package the desktop app, then run the packaged smoke test against it and confirm it still passes and prints the shell milestones.
2. Change `CANVAS_SELECTOR` in `packaged-app-smoke.mjs` to a class that does not exist and run it again. The failure should now list the in-flight requests, the runtime probe result, the pane markup, and the console tail.
3. Restore the selector.