### PR TITLE
Desktop Tooling: Cache the bundled PHP runtime between builds

### DIFF
--- a/.buildkite/commands/release-desktop.sh
+++ b/.buildkite/commands/release-desktop.sh
@@ -34,7 +34,18 @@ brew install cmake autoconf automake libtool bison re2c
 export PATH="$(brew --prefix bison)/bin:$PATH"
 
 echo "--- :php: build bundled arm64 PHP runtime"
+# Compiling PHP takes two and a half minutes and 33 GitHub API calls, one per
+# library it looks up. Unauthenticated those share a 60-an-hour cap with every
+# other mac agent, so busy afternoons fail on a 403 nobody caused.
+#
+# The binary depends on nothing but this installer, which pins both versions and
+# lists the extensions, so its hash is a safe key. A restored binary still gets
+# checked: install-runtime.mjs skips the build but verifies what it found. If
+# the agent has no cache bucket, both commands fail and PHP builds as usual.
+php_cache_key="cortext-php-$(uname -m)-$(hash_file apps/desktop/scripts/install-runtime.mjs)"
+restore_cache "$php_cache_key" || echo "Cache restore unavailable; building PHP."
 npm --prefix apps/desktop run runtime:php
+save_cache apps/desktop/runtime/bin/php "$php_cache_key" || echo "Cache save unavailable."
 
 echo "--- :card_index_dividers: build distribution snapshot"
 CORTEXT_DESKTOP_DISTRIBUTION=1 npm --prefix apps/desktop run snapshot


### PR DESCRIPTION
## What

The macOS release build reuses the PHP binary from a previous run instead of compiling it again. The key is the hash of the runtime installer, which pins the PHP and static-php-cli versions and lists the extensions, so changing any of those rebuilds.

## Why

Compiling PHP takes two and a half minutes and 33 calls to the GitHub API, one for every library it looks up. Unauthenticated those share a cap of 60 an hour with every other Automattic mac agent, so a busy afternoon fails the release on a 403 nobody caused. A cache hit makes no API calls.

## How

- Verifying a restored binary's version and extensions before it ships, rather than trusting whatever came out of the bucket
- Falling back to a full build on an agent with no cache bucket, so the release cannot fail on the cache itself

## Testing Instructions

1. With a PHP binary already at `apps/desktop/runtime/bin/php`, run the desktop runtime install and confirm it reports the binary exists and prints its version instead of compiling.
2. Build this branch twice. The second run should restore the binary and drop the PHP step from about two and a half minutes to seconds.