### PR TITLE
Desktop tooling: Stop the smoke test's cleanup from hiding why it failed

### DIFF
--- a/apps/desktop/scripts/packaged-app-smoke.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.mjs
@@ -159,6 +159,15 @@ function waitForProcessExit( child, timeoutMs, label ) {
 	} );
 }
 
+// ESRCH means the group is gone. EPERM means the kernel refuses to signal what
+// is left of it; we have seen that while an Electron helper outlived the app
+// and was exiting. The refusal is not understood, but neither case leaves
+// anything we can wait on or kill, and throwing fails a test that already
+// passed.
+function processGroupIsUnreachable( error ) {
+	return error.code === 'ESRCH' || error.code === 'EPERM';
+}
+
 function signalProcessGroup( child, signal ) {
 	if ( ! child?.pid ) {
 		return false;
@@ -167,14 +176,14 @@ function signalProcessGroup( child, signal ) {
 		process.kill( -child.pid, signal );
 		return true;
 	} catch ( error ) {
-		if ( error.code === 'ESRCH' ) {
+		if ( processGroupIsUnreachable( error ) ) {
 			return false;
 		}
 		throw error;
 	}
 }
 
-async function terminateProcessGroup( child ) {
+export async function terminateProcessGroup( child ) {
 	if ( ! child?.pid || ! signalProcessGroup( child, 'SIGTERM' ) ) {
 		return;
 	}
@@ -185,7 +194,7 @@ async function terminateProcessGroup( child ) {
 		try {
 			process.kill( -child.pid, 0 );
 		} catch ( error ) {
-			if ( error.code === 'ESRCH' ) {
+			if ( processGroupIsUnreachable( error ) ) {
 				return;
 			}
 			throw error;
@@ -201,7 +210,7 @@ async function assertProcessGroupIsClosed( child, label ) {
 		try {
 			process.kill( -child.pid, 0 );
 		} catch ( error ) {
-			if ( error.code === 'ESRCH' ) {
+			if ( processGroupIsUnreachable( error ) ) {
 				return;
 			}
 			throw error;
@@ -212,6 +221,22 @@ async function assertProcessGroupIsClosed( child, label ) {
 	throw new Error(
 		`${ label } left one or more processes running after shutdown.`
 	);
+}
+
+// Runs every step even when one throws, and hands back the first failure. A
+// throw inside a `finally` replaces whatever error was already on its way out,
+// so cleanup that raises on its own turns a canvas that never painted into a
+// teardown error nobody can act on.
+export async function runCleanupSteps( steps ) {
+	let firstError = null;
+	for ( const step of steps ) {
+		try {
+			await step();
+		} catch ( error ) {
+			firstError = firstError ?? error;
+		}
+	}
+	return firstError;
 }
 
 export function request( url, timeoutMs = 2_000 ) {
@@ -478,13 +503,22 @@ async function runSmoke( appPath ) {
 		if ( browser ) {
 			await browser.close().catch( () => {} );
 		}
-		await terminateProcessGroup( second?.child );
-		await terminateProcessGroup( first?.child );
-		rmSync( tempRoot, {
-			force: true,
-			maxRetries: 3,
-			recursive: true,
-		} );
+		const cleanupError = await runCleanupSteps( [
+			() => terminateProcessGroup( second?.child ),
+			() => terminateProcessGroup( first?.child ),
+			() =>
+				rmSync( tempRoot, {
+					force: true,
+					maxRetries: 3,
+					recursive: true,
+				} ),
+		] );
+		if ( completed && cleanupError ) {
+			throw cleanupError;
+		}
+		if ( cleanupError ) {
+			console.error( `Cleanup also failed: ${ cleanupError.message }` );
+		}
 		if ( ! completed ) {
 			console.error( 'Cleaned up after failed smoke test.' );
 		}

--- a/apps/desktop/scripts/packaged-app-smoke.test.mjs
+++ b/apps/desktop/scripts/packaged-app-smoke.test.mjs
@@ -6,8 +6,83 @@ import test from 'node:test';
 import {
 	appendErrorDetails,
 	request,
+	runCleanupSteps,
+	terminateProcessGroup,
 	waitForCortextShell,
 } from './packaged-app-smoke.mjs';
+
+test( 'cleanup finishes every step after one of them throws', async () => {
+	const ran = [];
+	const error = await runCleanupSteps( [
+		() => ran.push( 'stop second' ),
+		() => {
+			ran.push( 'stop first' );
+			throw new Error( 'kill EPERM' );
+		},
+		() => ran.push( 'remove temp dir' ),
+	] );
+
+	assert.deepEqual( ran, [ 'stop second', 'stop first', 'remove temp dir' ] );
+	assert.match( error.message, /kill EPERM/ );
+} );
+
+test( 'cleanup reports the first failure, not the last', async () => {
+	const error = await runCleanupSteps( [
+		() => {
+			throw new Error( 'first' );
+		},
+		() => {
+			throw new Error( 'second' );
+		},
+	] );
+
+	assert.match( error.message, /first/ );
+} );
+
+test( 'cleanup reports nothing when every step works', async () => {
+	assert.equal( await runCleanupSteps( [ () => {}, async () => {} ] ), null );
+} );
+
+function killError( code ) {
+	const error = new Error( `kill ${ code }` );
+	error.code = code;
+	return error;
+}
+
+// The signal lands, then the group stops answering with the given code.
+function killStub( t, code ) {
+	const signals = [];
+	t.mock.method( process, 'kill', ( pid, signal ) => {
+		signals.push( signal );
+		if ( signals.length === 1 ) {
+			return true;
+		}
+		throw killError( code );
+	} );
+	return signals;
+}
+
+test( 'teardown stops waiting when the process group is no longer ours', async ( t ) => {
+	const signals = killStub( t, 'EPERM' );
+
+	await terminateProcessGroup( { pid: 4242 } );
+
+	assert.deepEqual( signals, [ 'SIGTERM', 0 ] );
+} );
+
+test( 'teardown stops waiting once the process group is gone', async ( t ) => {
+	const signals = killStub( t, 'ESRCH' );
+
+	await terminateProcessGroup( { pid: 4242 } );
+
+	assert.deepEqual( signals, [ 'SIGTERM', 0 ] );
+} );
+
+test( 'teardown still reports an error it cannot explain', async ( t ) => {
+	killStub( t, 'EINVAL' );
+
+	await assert.rejects( terminateProcessGroup( { pid: 4242 } ), /EINVAL/ );
+} );
 
 test( 'keeps packaged output in an already rendered error stack', () => {
 	const error = new Error( 'Canvas did not load.' );


### PR DESCRIPTION
## What

When the packaged smoke test fails, the log now shows what actually went wrong. Its cleanup used to raise over the original error, so a canvas that never painted reached CI as `kill EPERM` with the milestones and diagnostics gone.

## Why

About half the macOS builds fail this smoke test, and a good share of those came back unreadable. The diagnostics #434 adds get destroyed the same way.

## How

- Ending the wait when the kernel says a process group is gone or no longer ours, instead of raising
- Running every cleanup step even when one fails, and reporting its own trouble only when the run had nothing more important to say

## Testing Instructions

1. Run the packaged smoke test against a build and confirm it still passes and prints the shell milestones.
2. Point the canvas selector at a class that does not exist and run it again. The failure should report the locator timeout and the milestones, and leave no `cortext-packaged-smoke-*` directory behind in the temp folder.