### PR TITLE
i18n: Prepare Cortext for WordPress.org translations

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -42,6 +42,7 @@
 
 # Source, tooling, tests, docs, and the desktop app (not part of the plugin)
 /src
+/languages
 /apps
 /scripts
 /tests

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ wordpress/
 # Build outputs
 build/
 dist/
+languages/
 playground/gallery/cortext.zip
 
 # macOS

--- a/includes/Formula/Compiler.php
+++ b/includes/Formula/Compiler.php
@@ -289,6 +289,7 @@ final class Compiler {
 		if ( 1 !== count( $args ) || 'literal' !== ( $args[0]['node'] ?? '' ) || 'text' !== ( $args[0]['type'] ?? '' ) ) {
 			throw new FormulaParseError(
 				'cortext_formula_invalid_prop',
+				/* translators: field() and prop() are canonical formula function names and must remain in English. */
 				__( 'Use a quoted field name, like field("Price"). prop("Price") works too.', 'cortext' )
 			);
 		}

--- a/includes/Formula/Functions.php
+++ b/includes/Formula/Functions.php
@@ -179,17 +179,26 @@ final class Functions {
 				throw new FormulaParseError(
 					'cortext_formula_type_mismatch',
 					sprintf(
-						/* translators: 1: function name, 2: argument number, 3: expected type. */
+						/* translators: 1: function name, 2: argument number, 3: localized expected value type. */
 						__( 'Value %2$d in %1$s() must be %3$s.', 'cortext' ),
 						$name,
 						$index + 1,
-						$type
+						self::display_type_label( $type )
 					)
 				);
 			}
 		}
 
 		return $return_type;
+	}
+
+	/**
+	 * Localizes an internal value type for display without changing formula data.
+	 */
+	private static function display_type_label( string $type ): string {
+		return 'text' === $type
+			? _x( 'text', 'formula value type', 'cortext' )
+			: $type;
 	}
 
 	/**
@@ -200,18 +209,21 @@ final class Functions {
 		if ( 3 !== count( $args ) ) {
 			throw new FormulaParseError(
 				'cortext_formula_invalid_arity',
+				/* translators: if() is a canonical formula function name and must remain in English. */
 				__( 'if() needs condition, then, and else values.', 'cortext' )
 			);
 		}
 		if ( ! self::type_matches( (string) $args[0]['type'], 'checkbox' ) ) {
 			throw new FormulaParseError(
 				'cortext_formula_type_mismatch',
+				/* translators: if() is a canonical formula function name and must remain in English. */
 				__( 'The if() condition must be true or false.', 'cortext' )
 			);
 		}
 		if ( $args[1]['type'] !== $args[2]['type'] ) {
 			throw new FormulaParseError(
 				'cortext_formula_mixed_if',
+				/* translators: if() and v0 are canonical formula identifiers and must remain unchanged. */
 				__( 'The then and else values in if() must use the same type in v0.', 'cortext' )
 			);
 		}
@@ -228,18 +240,21 @@ final class Functions {
 		if ( 3 !== count( $args ) ) {
 			throw new FormulaParseError(
 				'cortext_formula_invalid_arity',
+				/* translators: dateBetween() is a canonical formula function name and must remain in English. */
 				__( 'dateBetween() needs two dates and a unit.', 'cortext' )
 			);
 		}
 		if ( ! self::type_matches( (string) $args[0]['type'], 'date' ) || ! self::type_matches( (string) $args[1]['type'], 'date' ) ) {
 			throw new FormulaParseError(
 				'cortext_formula_type_mismatch',
+				/* translators: dateBetween() is a canonical formula function name and must remain in English. */
 				__( 'dateBetween() needs two dates.', 'cortext' )
 			);
 		}
 		if ( 'text' !== $args[2]['type'] ) {
 			throw new FormulaParseError(
 				'cortext_formula_type_mismatch',
+				/* translators: dateBetween() and "days" are canonical formula identifiers and must remain in English. */
 				__( 'The dateBetween() unit must be text, like "days".', 'cortext' )
 			);
 		}
@@ -253,12 +268,14 @@ final class Functions {
 		if ( 2 !== count( $args ) ) {
 			throw new FormulaParseError(
 				'cortext_formula_invalid_arity',
+				/* translators: formatDate() is a canonical formula function name and must remain in English. */
 				__( 'formatDate() needs a date and a format.', 'cortext' )
 			);
 		}
 		if ( ! self::type_matches( (string) $args[0]['type'], 'date' ) || 'text' !== $args[1]['type'] ) {
 			throw new FormulaParseError(
 				'cortext_formula_type_mismatch',
+				/* translators: formatDate() is a canonical formula function name and must remain in English. */
 				__( 'formatDate() needs a date and a text format.', 'cortext' )
 			);
 		}

--- a/includes/Frontend/Assets.php
+++ b/includes/Frontend/Assets.php
@@ -64,6 +64,8 @@ final class Assets {
 			true
 		);
 
+		wp_set_script_translations( 'cortext-frontend', 'cortext' );
+
 		wp_enqueue_style(
 			'cortext-frontend',
 			CORTEXT_URL . 'build/frontend.css',

--- a/includes/Rest/NotionController.php
+++ b/includes/Rest/NotionController.php
@@ -180,6 +180,7 @@ final class NotionController {
 		if ( '' === $data_source_id ) {
 			return new WP_Error(
 				'cortext_notion_missing_data_source',
+				/* translators: data_source_id is a Notion API property name and must remain unchanged. */
 				__( 'Missing data_source_id.', 'cortext' ),
 				array( 'status' => 400 )
 			);

--- a/includes/Rest/RowsController.php
+++ b/includes/Rest/RowsController.php
@@ -1178,6 +1178,7 @@ final class RowsController {
 		if ( ! is_array( $value ) ) {
 			return new WP_Error(
 				'rest_invalid_param',
+				/* translators: include is a REST parameter and must remain unchanged. */
 				__( 'Pass include as an array of row IDs.', 'cortext' ),
 				array( 'status' => 400 )
 			);
@@ -1210,7 +1211,7 @@ final class RowsController {
 		return new WP_Error(
 			'rest_invalid_param',
 			sprintf(
-				/* translators: %d: maximum number of rows allowed per page. */
+				/* translators: %d: maximum number of rows allowed per page. per_page is a REST parameter and must remain unchanged. */
 				__( 'per_page must be between 1 and %d.', 'cortext' ),
 				$max
 			),

--- a/includes/Rest/RowsFilterQuery.php
+++ b/includes/Rest/RowsFilterQuery.php
@@ -425,6 +425,7 @@ final class RowsFilterQuery {
 		if ( ! in_array( $relation, array( 'AND', 'OR' ), true ) ) {
 			return new WP_Error(
 				'cortext_invalid_filter_relation',
+				/* translators: AND and OR are canonical filter operators and must remain unchanged. */
 				__( 'Filter group relation must be AND or OR.', 'cortext' ),
 				array( 'status' => 400 )
 			);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"build": "wp-scripts build",
 		"build:zip": "./scripts/build-zip.sh",
 		"deploy:wporg": "./scripts/deploy-wporg.sh",
+		"i18n:pot": "wp i18n make-pot . languages/cortext.pot --slug=cortext --domain=cortext --include=cortext.php,includes,src",
 		"release:notes": "node scripts/release-notes.mjs",
 		"format": "wp-scripts format",
 		"format:check": "prettier --check '**/*.{js,jsx,json,ts,tsx,yml,yaml}' --config .prettierrc.js --ignore-path .prettierignore",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"build": "wp-scripts build",
 		"build:zip": "./scripts/build-zip.sh",
 		"deploy:wporg": "./scripts/deploy-wporg.sh",
-		"i18n:pot": "wp i18n make-pot . languages/cortext.pot --slug=cortext --domain=cortext --include=cortext.php,includes,src",
+		"i18n:pot": "wp i18n make-pot . languages/cortext.pot --slug=cortext --domain=cortext --include=cortext.php,includes,src --exclude=.context,apps,artifacts,build,dist,node_modules,vendor,wordpress",
 		"release:notes": "node scripts/release-notes.mjs",
 		"format": "wp-scripts format",
 		"format:check": "prettier --check '**/*.{js,jsx,json,ts,tsx,yml,yaml}' --config .prettierrc.js --ignore-path .prettierignore",

--- a/src/blocks/data-view/edit.js
+++ b/src/blocks/data-view/edit.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InspectorControls,
@@ -501,7 +501,10 @@ function CollectionInspectorControls( {
 					</>
 				) }
 			</PanelBody>
-			<PanelBody title={ __( 'View', 'cortext' ) } initialOpen={ false }>
+			<PanelBody
+				title={ _x( 'View', 'noun', 'cortext' ) }
+				initialOpen={ false }
+			>
 				{ isCollectionValid && (
 					<>
 						{ ! isOwner && (

--- a/src/components/ImportPane.js
+++ b/src/components/ImportPane.js
@@ -1,4 +1,4 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import {
@@ -255,7 +255,12 @@ function ImportBody( {
 			<Text variant="muted">
 				{ sprintf(
 					/* translators: %d: number of Notion collections found */
-					__( '%d collections', 'cortext' ),
+					_n(
+						'%d collection',
+						'%d collections',
+						collections.length,
+						'cortext'
+					),
 					collections.length
 				) }
 			</Text>
@@ -336,8 +341,10 @@ function CollectionCard( { collection, job, onImport } ) {
 				statusLine = processed
 					? sprintf(
 							/* translators: 1: documents processed so far, 2: seconds remaining before retry */
-							__(
+							_n(
+								'Imported %1$d document. Waiting for Notion: %2$d s…',
 								'Imported %1$d documents. Waiting for Notion: %2$d s…',
+								processed,
 								'cortext'
 							),
 							processed,
@@ -351,7 +358,12 @@ function CollectionCard( { collection, job, onImport } ) {
 			} else if ( processed ) {
 				statusLine = sprintf(
 					/* translators: %d: documents processed */
-					__( 'Importing %d documents…', 'cortext' ),
+					_n(
+						'Importing %d document…',
+						'Importing %d documents…',
+						processed,
+						'cortext'
+					),
 					processed
 				);
 			}
@@ -361,7 +373,12 @@ function CollectionCard( { collection, job, onImport } ) {
 			if ( processed ) {
 				statusLine = sprintf(
 					/* translators: %d: documents processed */
-					__( '%d documents imported.', 'cortext' ),
+					_n(
+						'%d document imported.',
+						'%d documents imported.',
+						processed,
+						'cortext'
+					),
 					processed
 				);
 			}

--- a/src/components/PublishedDocumentsPane.js
+++ b/src/components/PublishedDocumentsPane.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
 import {
@@ -188,7 +188,7 @@ export default function PublishedDocumentsPane() {
 							href={ item.link }
 							rel="noopener noreferrer"
 						>
-							{ __( 'View', 'cortext' ) }
+							{ _x( 'View', 'verb', 'cortext' ) }
 						</ExternalLink>
 					);
 				},

--- a/src/components/fields/FieldActionsMenu.js
+++ b/src/components/fields/FieldActionsMenu.js
@@ -1,4 +1,4 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	Icon,
@@ -487,19 +487,16 @@ export default function FieldActionsMenu( {
 					</p>
 					{ dependentRollups.length > 0 ? (
 						<p>
-							{ dependentRollups.length === 1
-								? __(
-										'This also deletes 1 rollup that uses it:',
-										'cortext'
-								  )
-								: sprintf(
-										/* translators: %d: number of dependent rollup fields */
-										__(
-											'This also deletes %d rollups that use it:',
-											'cortext'
-										),
-										dependentRollups.length
-								  ) }{ ' ' }
+							{ sprintf(
+								/* translators: %d: number of dependent rollup fields */
+								_n(
+									'This also deletes %d rollup that uses it:',
+									'This also deletes %d rollups that use it:',
+									dependentRollups.length,
+									'cortext'
+								),
+								dependentRollups.length
+							) }{ ' ' }
 							{ dependentRollups
 								.map( ( candidate ) => candidate.label )
 								.join( ', ' ) }
@@ -507,19 +504,16 @@ export default function FieldActionsMenu( {
 					) : null }
 					{ dependentFormulas.length > 0 ? (
 						<p>
-							{ dependentFormulas.length === 1
-								? __(
-										'This also deletes 1 formula that uses it:',
-										'cortext'
-								  )
-								: sprintf(
-										/* translators: %d: number of dependent formula fields */
-										__(
-											'This also deletes %d formulas that use it:',
-											'cortext'
-										),
-										dependentFormulas.length
-								  ) }{ ' ' }
+							{ sprintf(
+								/* translators: %d: number of dependent formula fields */
+								_n(
+									'This also deletes %d formula that uses it:',
+									'This also deletes %d formulas that use it:',
+									dependentFormulas.length,
+									'cortext'
+								),
+								dependentFormulas.length
+							) }{ ' ' }
 							{ dependentFormulas
 								.map( ( candidate ) => candidate.label )
 								.join( ', ' ) }

--- a/src/components/fields/FormulaConfig.js
+++ b/src/components/fields/FormulaConfig.js
@@ -6,12 +6,53 @@ import { seen as seenIcon, unseen as unseenIcon } from '@wordpress/icons';
 import './FormulaConfig.scss';
 
 import { useCollectionFieldsContext } from '../CollectionFieldsContext';
+import { fieldTypeLabel } from './fieldTypes';
 
+// Labels are localized for display, while reference names remain stable parts
+// of the formula DSL.
+const BUILT_IN_FIELD_DESCRIPTION = __( 'Built-in field', 'cortext' );
 const SYSTEM_FIELDS = [
-	{ label: 'Title', type: 'text' },
-	{ label: 'Created', type: 'datetime' },
-	{ label: 'Last edited', type: 'datetime' },
+	{
+		description: BUILT_IN_FIELD_DESCRIPTION,
+		label: __(
+			/* translators: Display label only. Formula references keep the canonical name "Title" in English. */
+			'Title',
+			'cortext'
+		),
+		referenceName: 'Title',
+		type: 'text',
+	},
+	{
+		description: BUILT_IN_FIELD_DESCRIPTION,
+		label: __(
+			/* translators: Display label only. Formula references keep the canonical name "Created" in English. */
+			'Created',
+			'cortext'
+		),
+		referenceName: 'Created',
+		type: 'datetime',
+	},
+	{
+		description: BUILT_IN_FIELD_DESCRIPTION,
+		label: __(
+			/* translators: Display label only. Formula references keep the canonical name "Last edited" in English. */
+			'Last edited',
+			'cortext'
+		),
+		referenceName: 'Last edited',
+		type: 'datetime',
+	},
 ];
+
+const FORMULA_TYPE_LABELS = {
+	alias: __( 'Alias', 'cortext' ),
+	field: __( 'Field', 'cortext' ),
+	'same type': __( 'Same type', 'cortext' ),
+};
+
+function typeLabel( type ) {
+	return FORMULA_TYPE_LABELS[ type ] ?? fieldTypeLabel( type ) ?? type;
+}
 
 const UNSUPPORTED_FIELD_REF_TYPES = new Set( [
 	'multiselect',
@@ -54,7 +95,11 @@ const FUNCTION_COMPLETIONS = [
 		insertText: 'prop("")',
 		caretOffset: 'prop("'.length,
 		type: 'alias',
-		description: __( 'Works the same as field().', 'cortext' ),
+		description: __(
+			/* translators: field() is a canonical formula function name and must remain in English. */
+			'Works the same as field().',
+			'cortext'
+		),
 	},
 	{
 		label: 'concat',
@@ -322,8 +367,11 @@ function escapePropName( name ) {
 }
 
 function uniqueProperties( fields, excludeRecordId ) {
-	const options = [ ...SYSTEM_FIELDS ];
-	const seen = new Set( options.map( ( option ) => option.label ) );
+	const options = SYSTEM_FIELDS.map( ( option ) => ( {
+		...option,
+		typeLabel: typeLabel( option.type ),
+	} ) );
+	const seen = new Set( options.map( ( option ) => option.referenceName ) );
 	fields.forEach( ( field ) => {
 		if (
 			field.recordId === excludeRecordId ||
@@ -336,9 +384,12 @@ function uniqueProperties( fields, excludeRecordId ) {
 			return;
 		}
 		seen.add( field.label );
+		const type = field.formulaResultType ?? field.cortextType ?? 'text';
 		options.push( {
 			label: field.label,
-			type: field.formulaResultType ?? field.cortextType ?? 'text',
+			referenceName: field.label,
+			type,
+			typeLabel: typeLabel( type ),
 		} );
 	} );
 	return options;
@@ -394,11 +445,14 @@ export default function FormulaConfig( {
 				.map( ( completion ) => ( {
 					...completion,
 					kind: 'function',
+					typeLabel: typeLabel( completion.type ),
 				} ) );
 		}
 		return properties
 			.filter( ( property ) =>
-				property.label.toLowerCase().includes( needle )
+				`${ property.label } ${ property.referenceName }`
+					.toLowerCase()
+					.includes( needle )
 			)
 			.slice( 0, 8 )
 			.map( ( property ) => ( {
@@ -424,7 +478,7 @@ export default function FormulaConfig( {
 			insertText = suggestion.insertText;
 			nextCaret = activeMatch.start + suggestion.caretOffset;
 		} else {
-			const escaped = escapePropName( suggestion.label );
+			const escaped = escapePropName( suggestion.referenceName );
 			const hasClosingSuffix = expression
 				.slice( activeMatch.end )
 				.startsWith( '")' );
@@ -600,7 +654,9 @@ export default function FormulaConfig( {
 					>
 						{ suggestions.map( ( suggestion, index ) => (
 							<button
-								key={ `${ suggestion.kind }-${ suggestion.label }` }
+								key={ `${ suggestion.kind }-${
+									suggestion.referenceName ?? suggestion.label
+								}` }
 								type="button"
 								className={
 									'cortext-formula-config__suggestion' +
@@ -626,7 +682,7 @@ export default function FormulaConfig( {
 										</small>
 									) : null }
 								</span>
-								<code>{ suggestion.type }</code>
+								<code>{ suggestion.typeLabel }</code>
 							</button>
 						) ) }
 					</div>
@@ -692,7 +748,13 @@ function FormulaReference() {
 		<div className="cortext-formula-reference">
 			<div className="cortext-formula-reference__header">
 				<strong>{ __( 'Formula language', 'cortext' ) }</strong>
-				<span>{ __( 'v0', 'cortext' ) }</span>
+				<span>
+					{ __(
+						/* translators: Technical version identifier for the formula language. */
+						'v0',
+						'cortext'
+					) }
+				</span>
 			</div>
 			<FormulaReferenceSection title={ __( 'Fields', 'cortext' ) }>
 				<FormulaReferenceRow
@@ -701,11 +763,16 @@ function FormulaReference() {
 				/>
 				<FormulaReferenceRow
 					code={ 'prop("Price")' }
-					text={ __( 'Works the same as field().', 'cortext' ) }
+					text={ __(
+						/* translators: field() is a canonical formula function name and must remain in English. */
+						'Works the same as field().',
+						'cortext'
+					) }
 				/>
 				<FormulaReferenceRow
 					code={ 'field("Title")' }
 					text={ __(
+						/* translators: Title, Created, and Last edited are canonical formula field names and must remain in English. */
 						'Built-in fields: Title, Created, Last edited.',
 						'cortext'
 					) }
@@ -750,6 +817,7 @@ function FormulaReference() {
 				<FormulaReferenceRow
 					code={ '=  ==  !=  >  <  >=  <=' }
 					text={ __(
+						/* translators: true and false are canonical formula literals and must remain in English. */
 						'Comparisons return true or false.',
 						'cortext'
 					) }
@@ -784,6 +852,7 @@ function FormulaReference() {
 				<FormulaReferenceRow
 					code={ 'if(condition, then, else)' }
 					text={ __(
+						/* translators: then, else, and v0 are labels in the canonical formula reference shown alongside this text. */
 						'The then and else values must use the same type in v0.',
 						'cortext'
 					) }
@@ -797,6 +866,7 @@ function FormulaReference() {
 				<FormulaReferenceRow
 					code={ 'dateBetween(a, b, "days")' }
 					text={ __(
+						/* translators: minutes, hours, days, weeks, months, and years are canonical formula unit values and must remain in English. */
 						'Difference between two dates. Units: minutes, hours, days, weeks, months, years.',
 						'cortext'
 					) }
@@ -804,6 +874,7 @@ function FormulaReference() {
 				<FormulaReferenceRow
 					code={ 'formatDate(d, "YYYY-MM-DD")' }
 					text={ __(
+						/* translators: The date-format tokens are canonical formula syntax and must remain unchanged. */
 						'Format a date as text. Tokens: YYYY, Y, MMMM, MMM, MM, DD, D, h, mm, A.',
 						'cortext'
 					) }

--- a/tests/js/components/PublishedDocumentsPane.test.js
+++ b/tests/js/components/PublishedDocumentsPane.test.js
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( value ) => value,
 	_n: ( single, plural, count ) => ( count === 1 ? single : plural ),
+	_x: ( value ) => value,
 	sprintf: ( value ) => value,
 } ) );
 

--- a/tests/js/components/fields/FormulaConfig.test.js
+++ b/tests/js/components/fields/FormulaConfig.test.js
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( value ) =>
+		( {
+			'Built-in field': 'Campo integrado',
+			Created: 'Creación',
+			'Date & time': 'Fecha y hora',
+			'Last edited': 'Última edición',
+			Text: 'Texto',
+			Title: 'Título',
+		} )[ value ] ?? value,
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const { createElement } = require( '@wordpress/element' );
+
+	return {
+		Button: ( {
+			children,
+			icon,
+			isBusy,
+			isPressed,
+			label,
+			onClick,
+			size,
+			variant,
+			...props
+		} ) =>
+			createElement(
+				'button',
+				{
+					...props,
+					type: 'button',
+					'aria-label': label,
+					'aria-pressed': isPressed,
+					onClick,
+				},
+				children ?? label
+			),
+		Notice: ( { children } ) => createElement( 'div', null, children ),
+	};
+} );
+
+jest.mock( '../../../../src/components/CollectionFieldsContext', () => ( {
+	useCollectionFieldsContext: jest.fn( () => ( { fields: [] } ) ),
+} ) );
+
+import FormulaConfig from '../../../../src/components/fields/FormulaConfig';
+import { useCollectionFieldsContext } from '../../../../src/components/CollectionFieldsContext';
+
+describe( 'FormulaConfig localized system field suggestions', () => {
+	beforeEach( () => {
+		useCollectionFieldsContext.mockReturnValue( { fields: [] } );
+	} );
+
+	it( 'shows a localized label but inserts the canonical reference name', () => {
+		const onSubmit = jest.fn();
+		const originalRequestAnimationFrame = window.requestAnimationFrame;
+		window.requestAnimationFrame = ( callback ) => callback();
+
+		try {
+			render(
+				<FormulaConfig onBack={ jest.fn() } onSubmit={ onSubmit } />
+			);
+
+			const editor = screen.getByLabelText( 'Formula' );
+			fireEvent.change( editor, {
+				target: { value: 'field("Tít', selectionStart: 10 },
+			} );
+
+			const titleSuggestion = screen.getByRole( 'option', {
+				name: /Título/,
+			} );
+			expect( titleSuggestion ).toHaveTextContent( 'Texto' );
+
+			fireEvent.mouseDown( titleSuggestion );
+
+			expect( editor ).toHaveValue( 'field("Title")' );
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'Create formula' } )
+			);
+			expect( onSubmit ).toHaveBeenCalledWith( 'field("Title")' );
+		} finally {
+			window.requestAnimationFrame = originalRequestAnimationFrame;
+		}
+	} );
+
+	it( 'distinguishes a localized built-in field from a custom field with the same label', () => {
+		useCollectionFieldsContext.mockReturnValue( {
+			fields: [
+				{
+					cortextType: 'text',
+					label: 'Título',
+					recordId: 42,
+				},
+			],
+		} );
+		const originalRequestAnimationFrame = window.requestAnimationFrame;
+		window.requestAnimationFrame = ( callback ) => callback();
+
+		try {
+			render(
+				<FormulaConfig onBack={ jest.fn() } onSubmit={ jest.fn() } />
+			);
+
+			const editor = screen.getByLabelText( 'Formula' );
+			fireEvent.change( editor, {
+				target: { value: 'field("Tít', selectionStart: 10 },
+			} );
+
+			const suggestions = screen.getAllByRole( 'option', {
+				name: /Título/,
+			} );
+			expect( suggestions ).toHaveLength( 2 );
+			const builtIn = suggestions.find( ( suggestion ) =>
+				suggestion.textContent.includes( 'Campo integrado' )
+			);
+			expect( builtIn ).toBeDefined();
+
+			fireEvent.mouseDown( builtIn );
+			expect( editor ).toHaveValue( 'field("Title")' );
+
+			fireEvent.change( editor, {
+				target: { value: 'field("Tít', selectionStart: 10 },
+			} );
+			const custom = screen
+				.getAllByRole( 'option', { name: /Título/ } )
+				.find(
+					( suggestion ) =>
+						! suggestion.textContent.includes( 'Campo integrado' )
+				);
+			expect( custom ).toBeDefined();
+			fireEvent.mouseDown( custom );
+			expect( editor ).toHaveValue( 'field("Título")' );
+		} finally {
+			window.requestAnimationFrame = originalRequestAnimationFrame;
+		}
+	} );
+} );

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -14,5 +14,6 @@ require_once $cortext_root . '/vendor/autoload.php';
 // Constants normally defined by cortext.php (main plugin file).
 define( 'CORTEXT_PATH', $cortext_root . '/' );
 define( 'CORTEXT_URL', 'http://example.org/wp-content/plugins/cortext/' );
+define( 'CORTEXT_VERSION', 'test' );
 
 \WorDBless\Load::load();

--- a/tests/php/test-formula-functions.php
+++ b/tests/php/test-formula-functions.php
@@ -188,6 +188,8 @@ final class Test_Formula_Functions extends BaseTestCase {
 	}
 
 	/**
+	 * Builds an expression that divides by zero.
+	 *
 	 * @return array<string,mixed>
 	 */
 	private function divide_by_zero_ast(): array {

--- a/tests/php/test-script-translations.php
+++ b/tests/php/test-script-translations.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for Cortext script translation registration.
+ *
+ * @package Cortext
+ */
+
+declare( strict_types=1 );
+
+namespace Cortext\Tests;
+
+use Cortext\Admin\Screen;
+use Cortext\Frontend\Assets;
+use WorDBless\BaseTestCase;
+
+final class Test_Script_Translations extends BaseTestCase {
+
+	private bool $created_build_directory = false;
+	private bool $created_shell_manifest  = false;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$build_directory = CORTEXT_PATH . 'build';
+		$manifest_path   = $build_directory . '/index.asset.php';
+
+		if ( ! is_dir( $build_directory ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- Creates an isolated test fixture.
+			mkdir( $build_directory );
+			$this->created_build_directory = true;
+		}
+
+		if ( ! file_exists( $manifest_path ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Creates an isolated test fixture.
+			file_put_contents(
+				$manifest_path,
+				"<?php\nreturn array( 'dependencies' => array(), 'version' => 'test' );\n"
+			);
+			$this->created_shell_manifest = true;
+		}
+	}
+
+	public function tear_down(): void {
+		if ( $this->created_shell_manifest ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removes the test fixture created above.
+			unlink( CORTEXT_PATH . 'build/index.asset.php' );
+		}
+
+		if ( $this->created_build_directory ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Removes the test fixture created above.
+			rmdir( CORTEXT_PATH . 'build' );
+		}
+
+		parent::tear_down();
+	}
+
+	public function test_admin_shell_uses_cortext_translations_without_a_custom_path(): void {
+		( new Screen() )->enqueue_assets( Screen::HOOK_SUFFIX );
+
+		$this->assertScriptUsesWordPressLanguagePacks( 'cortext-shell' );
+	}
+
+	public function test_frontend_runtime_uses_cortext_translations_without_a_custom_path(): void {
+		Assets::enqueue_frontend_runtime();
+
+		$this->assertScriptUsesWordPressLanguagePacks( 'cortext-frontend' );
+	}
+
+	private function assertScriptUsesWordPressLanguagePacks( string $handle ): void {
+		$scripts = wp_scripts();
+
+		$this->assertArrayHasKey( $handle, $scripts->registered );
+		$this->assertSame( 'cortext', $scripts->registered[ $handle ]->textdomain );
+		$this->assertSame( '', $scripts->registered[ $handle ]->translations_path );
+		$this->assertContains( 'wp-i18n', $scripts->registered[ $handle ]->deps );
+	}
+}


### PR DESCRIPTION
## What

Makes the user-facing strings in Cortext ready for translation on WordPress.org. Counts use proper plural forms and ambiguous labels carry context. Translator notes mark technical terms that must stay unchanged. Formula suggestions can be translated without changing the English identifiers saved in formulas.

## Why

Translations belong in GlotPress and reach sites through WordPress language packs. Keeping generated catalogs in the repository would duplicate that pipeline and make every new string depend on a committed Spanish update.

## How

The public frontend registers the `cortext` text domain with WordPress. A new `pnpm run i18n:pot` command creates an ignored POT on demand for translation tools.

WordPress.org has not published a Cortext language pack yet. Loading translations from lazy admin chunks will be checked separately once real pack files are available.

## Testing Instructions

Not applicable.