### PR TITLE
Fix: Keep sidebar document titles and icons in sync

### DIFF
--- a/src/components/DocumentIdentityControls.js
+++ b/src/components/DocumentIdentityControls.js
@@ -286,9 +286,10 @@ function PickerBody( {
 	const initialIconColor = currentWpIcon?.color ?? 'default';
 	const currentEmoji = decodeEmoji( currentIcon );
 
-	// editEntityRecord updates the local data store synchronously so
-	// every subscriber (icon block, sidebar tree) sees the new value
-	// immediately. The actual server save is debounced; without it,
+	// editEntityRecord updates core-data synchronously. The icon block reads it
+	// directly, and the lazy sidebar derives the active record's display fields
+	// from the same store, so both surfaces update immediately. The actual server
+	// save is debounced; without it,
 	// rapid picks (browsing emojis, switching colors) fire a save per
 	// click, and each server round-trip re-renders the whole post
 	// graph (including the trash sidebar's resolution state), which

--- a/src/components/sidebar/useSidebarTree.js
+++ b/src/components/sidebar/useSidebarTree.js
@@ -7,7 +7,6 @@ import {
 	useMemo,
 	useCallback,
 	useEffect,
-	useLayoutEffect,
 	useRef,
 } from '@wordpress/element';
 
@@ -338,34 +337,28 @@ export default function useSidebarTree( { selectedId, selectedCollectionId } ) {
 		expandedIdsRef.current = expandedIds;
 	}, [ expandedIds ] );
 
-	// Branch membership and pagination stay local; the active entity's title,
-	// icon, status, and slug come from core-data. Commit the overlay into the
-	// snapshots rather than deriving it: a derived overlay only covers the
-	// selected record, so the row would fall back to its stale snapshot the
-	// moment the user opens another document. Reconciling before paint also
-	// re-applies the value after a branch refetch serves the pre-save copy.
-	useLayoutEffect( () => {
-		if ( ! selectedTreeFields ) {
-			return;
-		}
-		setBranches( ( previous ) =>
+	// Branch membership and pagination stay local. Render-path consumers get
+	// the active entity's title, icon, status, and slug from core-data without
+	// mutating the server snapshots or refetching every loaded parent/page.
+	const displayBranches = useMemo(
+		() =>
 			overlaySidebarTreeRecord(
-				previous,
+				branches,
 				selectedRecordId,
 				selectedTreeFields
-			)
-		);
-	}, [ branches, selectedRecordId, selectedTreeFields ] );
+			),
+		[ branches, selectedRecordId, selectedTreeFields ]
+	);
 
 	const loadedRecords = useMemo( () => {
 		const byId = new Map();
-		branches.forEach( ( branch ) => {
+		displayBranches.forEach( ( branch ) => {
 			branch.records.forEach( ( record ) => {
 				byId.set( record.id, record );
 			} );
 		} );
 		return [ ...byId.values() ];
-	}, [ branches ] );
+	}, [ displayBranches ] );
 
 	const getBranch = useCallback(
 		( parentId ) => branchesRef.current.get( parentKey( parentId ) ),
@@ -726,10 +719,10 @@ export default function useSidebarTree( { selectedId, selectedCollectionId } ) {
 	}, [ refreshBranch, refreshLoadedBranches, revealRecordPath ] );
 
 	const tree = useMemo(
-		() => buildNodesForParent( ROOT_PARENT_ID, branches ),
-		[ branches ]
+		() => buildNodesForParent( ROOT_PARENT_ID, displayBranches ),
+		[ displayBranches ]
 	);
-	const rootBranch = branches.get( ROOT_PARENT_ID ) ?? EMPTY_BRANCH;
+	const rootBranch = displayBranches.get( ROOT_PARENT_ID ) ?? EMPTY_BRANCH;
 
 	return {
 		tree,

--- a/src/components/sidebar/useSidebarTree.js
+++ b/src/components/sidebar/useSidebarTree.js
@@ -1,13 +1,17 @@
 import apiFetch from '@wordpress/api-fetch';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import {
 	useState,
 	useMemo,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 } from '@wordpress/element';
 
+import { DOCUMENT_POST_TYPE } from '../../collections';
 import { SIDEBAR_TREE_CHANGED_EVENT } from '../../hooks/sidebarTreeInvalidation';
 
 export const ROOT_PARENT_ID = 0;
@@ -90,6 +94,82 @@ function mergeRecords( current, incoming ) {
 		out.push( record );
 	} );
 	return out;
+}
+
+function treeTitle( title ) {
+	if ( typeof title === 'string' ) {
+		return { raw: title, rendered: title };
+	}
+	if ( ! title || typeof title !== 'object' ) {
+		return undefined;
+	}
+	return {
+		raw: title.raw ?? title.rendered ?? '',
+		rendered: title.rendered ?? title.raw ?? '',
+	};
+}
+
+// Overlay the selected record's tree-consumed fields from core-data onto the
+// loaded REST snapshots. `title` is compared on `raw` alone: core-data holds
+// the raw string, while a snapshot's `rendered` came through `the_title`, so
+// comparing both would treat every texturized title as edited. `status` keeps
+// row actions current, and `slug` feeds canonical sidebar navigation.
+export function overlaySidebarTreeRecord( branches, recordId, fields ) {
+	if ( ! fields ) {
+		return branches;
+	}
+
+	const title = treeTitle( fields.title );
+	let nextBranches;
+	for ( const [ key, branch ] of branches ) {
+		const index = branch.records.findIndex(
+			( record ) => record.id === recordId
+		);
+		const record = branch.records[ index ];
+		if ( ! record ) {
+			continue;
+		}
+		const titleChanged =
+			title !== undefined && record.title?.raw !== title.raw;
+		const iconChanged =
+			typeof fields.icon === 'string' &&
+			record.meta?.cortext_document_icon !== fields.icon;
+		const statusChanged =
+			typeof fields.status === 'string' &&
+			record.status !== fields.status;
+		const slugChanged =
+			typeof fields.slug === 'string' && record.slug !== fields.slug;
+		if (
+			! titleChanged &&
+			! iconChanged &&
+			! statusChanged &&
+			! slugChanged
+		) {
+			continue;
+		}
+
+		const records = [ ...branch.records ];
+		const nextRecord = { ...record };
+		if ( titleChanged ) {
+			nextRecord.title = title;
+		}
+		if ( iconChanged ) {
+			nextRecord.meta = {
+				...( record.meta ?? {} ),
+				cortext_document_icon: fields.icon,
+			};
+		}
+		if ( statusChanged ) {
+			nextRecord.status = fields.status;
+		}
+		if ( slugChanged ) {
+			nextRecord.slug = fields.slug;
+		}
+		records[ index ] = nextRecord;
+		nextBranches ??= new Map( branches );
+		nextBranches.set( key, { ...branch, records } );
+	}
+	return nextBranches ?? branches;
 }
 
 function branchHasMore( branch ) {
@@ -224,6 +304,31 @@ export default function useSidebarTree( { selectedId, selectedCollectionId } ) {
 	const expandedIdsRef = useRef( expandedIds );
 	const loadingRef = useRef( new Map() );
 	const preferenceWriteRef = useRef( Promise.resolve() );
+	const selectedRecordId = normalizeId(
+		selectedId ?? selectedCollectionId ?? 0
+	);
+	const selectedTreeFields = useSelect(
+		( select ) => {
+			if ( selectedRecordId < 1 ) {
+				return null;
+			}
+			const record = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				DOCUMENT_POST_TYPE,
+				selectedRecordId
+			);
+			if ( ! record ) {
+				return null;
+			}
+			return {
+				title: record.title,
+				icon: record.meta?.cortext_document_icon,
+				status: record.status,
+				slug: record.slug,
+			};
+		},
+		[ selectedRecordId ]
+	);
 
 	useEffect( () => {
 		branchesRef.current = branches;
@@ -232,6 +337,25 @@ export default function useSidebarTree( { selectedId, selectedCollectionId } ) {
 	useEffect( () => {
 		expandedIdsRef.current = expandedIds;
 	}, [ expandedIds ] );
+
+	// Branch membership and pagination stay local; the active entity's title,
+	// icon, status, and slug come from core-data. Commit the overlay into the
+	// snapshots rather than deriving it: a derived overlay only covers the
+	// selected record, so the row would fall back to its stale snapshot the
+	// moment the user opens another document. Reconciling before paint also
+	// re-applies the value after a branch refetch serves the pre-save copy.
+	useLayoutEffect( () => {
+		if ( ! selectedTreeFields ) {
+			return;
+		}
+		setBranches( ( previous ) =>
+			overlaySidebarTreeRecord(
+				previous,
+				selectedRecordId,
+				selectedTreeFields
+			)
+		);
+	}, [ branches, selectedRecordId, selectedTreeFields ] );
 
 	const loadedRecords = useMemo( () => {
 		const byId = new Map();

--- a/tests/e2e/specs/sidebar-document-fields.spec.js
+++ b/tests/e2e/specs/sidebar-document-fields.spec.js
@@ -1,0 +1,185 @@
+/** E2E coverage for editor fields projected into the lazy sidebar tree. */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const INITIAL_EMOJI = '🏠';
+const UPDATED_EMOJI = '👍';
+
+function encodeEmoji( value ) {
+	return JSON.stringify( { type: 'emoji', value } );
+}
+
+async function deleteIfCreated( requestUtils, id ) {
+	if ( ! id ) {
+		return;
+	}
+	try {
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path: `/wp/v2/crtxt_documents/${ id }`,
+			params: { force: true },
+		} );
+	} catch {
+		// Best-effort cleanup; the record may already be gone.
+	}
+}
+
+async function waitForEditorPost( page, postId ) {
+	await page.waitForFunction(
+		( expectedPostId ) =>
+			window.wp?.data?.select( 'core/editor' )?.getCurrentPostId?.() ===
+			expectedPostId,
+		postId,
+		{ timeout: 15_000 }
+	);
+}
+
+function sidebarNodeByTitle( page, title ) {
+	return page
+		.locator( '[data-sidebar-section="pages"] .cortext-sidebar__node', {
+			has: page.getByRole( 'button', { name: title, exact: true } ),
+		} )
+		.first();
+}
+
+async function readSidebarIcon( node ) {
+	return node.locator( '.cortext-document-icon' ).evaluate( ( icon ) => {
+		return (
+			icon.querySelector( 'img.emoji' )?.alt ?? icon.textContent.trim()
+		);
+	} );
+}
+
+async function readSavedDocument( requestUtils, id ) {
+	return requestUtils.rest( {
+		method: 'GET',
+		path: `/wp/v2/crtxt_documents/${ id }`,
+		params: { context: 'edit' },
+	} );
+}
+
+test.describe( 'Sidebar document fields', () => {
+	test( 'updates the active title and icon without a reload', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		let document;
+		const suffix = Date.now().toString( 36 ).slice( -5 );
+		const initialTitle = `E2E Sidebar Fields ${ suffix }`;
+		const updatedTitle = `E2E Sidebar Updated ${ suffix }`;
+		const initialIcon = encodeEmoji( INITIAL_EMOJI );
+		const updatedIcon = encodeEmoji( UPDATED_EMOJI );
+
+		try {
+			document = await requestUtils.rest( {
+				method: 'POST',
+				path: '/wp/v2/crtxt_documents',
+				data: {
+					title: initialTitle,
+					status: 'private',
+					menu_order: -1000,
+					content:
+						'<!-- wp:paragraph --><p>Sidebar field test.</p><!-- /wp:paragraph -->',
+					meta: { cortext_document_icon: initialIcon },
+				},
+			} );
+
+			await admin.visitAdminPage(
+				'admin.php',
+				`page=cortext&p=/${ document.id }`
+			);
+			await waitForEditorPost( page, document.id );
+
+			let node = sidebarNodeByTitle( page, initialTitle );
+			await expect( node ).toBeVisible();
+			await expect
+				.poll( () => readSidebarIcon( node ) )
+				.toBe( INITIAL_EMOJI );
+
+			const editorCanvas = page.frameLocator(
+				'iframe[name="editor-canvas"]'
+			);
+			const titleEditor = editorCanvas
+				.locator(
+					'[data-type="core/post-title"][contenteditable="true"]'
+				)
+				.first();
+			await expect( titleEditor ).toBeVisible();
+			await titleEditor.fill( updatedTitle );
+			await titleEditor.blur();
+
+			node = sidebarNodeByTitle( page, updatedTitle );
+			await expect( node ).toBeVisible();
+			await expect
+				.poll(
+					async () => {
+						const saved = await readSavedDocument(
+							requestUtils,
+							document.id
+						);
+						return saved?.title?.raw ?? '';
+					},
+					{ timeout: 15_000 }
+				)
+				.toBe( updatedTitle );
+
+			const changeIcon = editorCanvas.getByRole( 'button', {
+				name: 'Change icon',
+			} );
+			await expect( changeIcon ).toBeVisible();
+			await changeIcon.evaluate( ( button ) => button.click() );
+
+			const picker = page.locator( '.cortext-document-identity-popover' );
+			await expect( picker ).toBeVisible();
+			const emoji = picker
+				.getByRole( 'button', { name: UPDATED_EMOJI, exact: true } )
+				.first();
+			await expect( emoji ).toBeVisible();
+			await emoji.evaluate( ( button ) => button.click() );
+
+			await expect
+				.poll( () => readSidebarIcon( node ) )
+				.toBe( UPDATED_EMOJI );
+			await expect
+				.poll(
+					async () => {
+						const saved = await readSavedDocument(
+							requestUtils,
+							document.id
+						);
+						return saved?.meta?.cortext_document_icon ?? '';
+					},
+					{ timeout: 15_000 }
+				)
+				.toBe( updatedIcon );
+
+			const remove = picker.locator(
+				'.cortext-document-identity-popover__remove'
+			);
+			if ( ! ( await remove.isVisible().catch( () => false ) ) ) {
+				await changeIcon.evaluate( ( button ) => button.click() );
+			}
+			await expect( remove ).toBeVisible();
+			await remove.evaluate( ( button ) => button.click() );
+
+			await expect(
+				node.locator( '.cortext-document-icon--fallback' )
+			).toBeVisible();
+			await expect
+				.poll(
+					async () => {
+						const saved = await readSavedDocument(
+							requestUtils,
+							document.id
+						);
+						return saved?.meta?.cortext_document_icon ?? '';
+					},
+					{ timeout: 15_000 }
+				)
+				.toBe( '' );
+		} finally {
+			await deleteIfCreated( requestUtils, document?.id );
+		}
+	} );
+} );

--- a/tests/js/components/sidebar/useSidebarTree.test.js
+++ b/tests/js/components/sidebar/useSidebarTree.test.js
@@ -500,6 +500,9 @@ describe( 'useSidebarTree', () => {
 				slug: 'new-title',
 			} )
 		);
+		expect( result.current.getBranch( ROOT_PARENT_ID ).records[ 0 ] ).toBe(
+			serverRecord
+		);
 
 		await act( async () => {
 			await result.current.refreshBranch( ROOT_PARENT_ID );
@@ -511,6 +514,9 @@ describe( 'useSidebarTree', () => {
 			status: 'publish',
 			slug: 'new-title',
 		} );
+		expect( result.current.getBranch( ROOT_PARENT_ID ).records[ 0 ] ).toBe(
+			serverRecord
+		);
 		expect( serverRecord ).toMatchObject( {
 			title: { raw: 'Old title', rendered: 'Old title' },
 			meta: { cortext_document_icon: 'old-icon' },
@@ -578,67 +584,5 @@ describe( 'useSidebarTree', () => {
 
 		await waitFor( () => expect( result.current.tree ).toHaveLength( 1 ) );
 		expect( result.current.tree[ 0 ].page ).toBe( serverRecord );
-	} );
-
-	it( 'keeps reconciled fields after the selection moves to another document', async () => {
-		const first = makeRecord( 1, 0, 'Old title' );
-		first.meta.cortext_document_icon = 'old-icon';
-		const second = makeRecord( 2, 0, 'Doc two' );
-		const registry = createSidebarRegistry( [ first, second ] );
-		mockTreeRequests( {
-			records: { 1: first, 2: second },
-			branches: {
-				'0:1': {
-					records: [ first, second ],
-					total: 2,
-					totalPages: 1,
-				},
-			},
-		} );
-
-		const { result, rerender } = renderHook(
-			( props ) => useSidebarTree( props ),
-			{
-				wrapper: registryWrapper( registry ),
-				initialProps: { selectedId: 1, selectedCollectionId: null },
-			}
-		);
-
-		await waitFor( () => expect( result.current.tree ).toHaveLength( 2 ) );
-
-		act( () => {
-			registry
-				.dispatch( coreStore )
-				.editEntityRecord( 'postType', 'crtxt_document', 1, {
-					title: 'New title',
-					meta: { cortext_document_icon: 'new-icon' },
-				} );
-		} );
-
-		await waitFor( () =>
-			expect( result.current.tree[ 0 ].page ).toMatchObject( {
-				title: { raw: 'New title', rendered: 'New title' },
-				meta: { cortext_document_icon: 'new-icon' },
-			} )
-		);
-
-		// The autosave lands: core-data holds the persisted values and clears
-		// the edits. The branch snapshot is still the pre-save copy, and no
-		// editor-save path invalidates it.
-		act( () => {
-			const saved = makeRecord( 1, 0, 'New title' );
-			saved.meta.cortext_document_icon = 'new-icon';
-			registry
-				.dispatch( coreStore )
-				.receiveEntityRecords( 'postType', 'crtxt_document', saved );
-		} );
-
-		rerender( { selectedId: 2, selectedCollectionId: null } );
-
-		await waitFor( () => expect( result.current.tree ).toHaveLength( 2 ) );
-		expect( result.current.tree[ 0 ].page ).toMatchObject( {
-			title: { raw: 'New title', rendered: 'New title' },
-			meta: { cortext_document_icon: 'new-icon' },
-		} );
 	} );
 } );

--- a/tests/js/components/sidebar/useSidebarTree.test.js
+++ b/tests/js/components/sidebar/useSidebarTree.test.js
@@ -1,8 +1,11 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
+import { store as coreStore } from '@wordpress/core-data';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
 
 import useSidebarTree, {
 	buildSidebarTreeBranchPath,
+	overlaySidebarTreeRecord,
 	ROOT_PARENT_ID,
 	SIDEBAR_TREE_PREFERENCES_PATH,
 } from '../../../../src/components/sidebar/useSidebarTree';
@@ -50,6 +53,43 @@ function parsedPath( path ) {
 	return new URL( path, 'https://example.test' );
 }
 
+function createSidebarRegistry( records = [] ) {
+	const registry = createRegistry();
+	registry.register( coreStore );
+	registry.dispatch( coreStore ).addEntities( [
+		{
+			kind: 'postType',
+			name: 'crtxt_document',
+			baseURL: '/wp/v2/crtxt_documents',
+			key: 'id',
+			rawAttributes: [ 'title', 'excerpt', 'content' ],
+			mergedEdits: { meta: true },
+			transientEdits: { blocks: true, selection: true },
+		},
+	] );
+	records.forEach( ( record ) => {
+		registry
+			.dispatch( coreStore )
+			.receiveEntityRecords( 'postType', 'crtxt_document', record );
+		registry
+			.dispatch( coreStore )
+			.finishResolution( 'getEntityRecord', [
+				'postType',
+				'crtxt_document',
+				record.id,
+			] );
+	} );
+	return registry;
+}
+
+function registryWrapper( registry ) {
+	return function Wrapper( { children } ) {
+		return (
+			<RegistryProvider value={ registry }>{ children }</RegistryProvider>
+		);
+	};
+}
+
 describe( 'buildSidebarTreeBranchPath', () => {
 	it( 'builds a request for one parent branch', () => {
 		const url = parsedPath( buildSidebarTreeBranchPath( 12, 3 ) );
@@ -68,6 +108,90 @@ describe( 'buildSidebarTreeBranchPath', () => {
 		expect( url.searchParams.get( '_fields' ) ).toContain(
 			'cortext_has_tree_children'
 		);
+	} );
+} );
+
+describe( 'overlaySidebarTreeRecord', () => {
+	it( 'overlays tree fields without mutating the REST snapshots', () => {
+		const rootRecord = makeRecord( 1 );
+		rootRecord.meta.other = 'preserved';
+		const duplicateRecord = { ...rootRecord, meta: { ...rootRecord.meta } };
+		const untouchedBranch = {
+			records: [ makeRecord( 2, 1 ) ],
+			page: 1,
+		};
+		const branches = new Map( [
+			[ 0, { records: [ rootRecord ], page: 1 } ],
+			[ 1, untouchedBranch ],
+			[ 2, { records: [ duplicateRecord ], page: 1 } ],
+		] );
+		const fields = {
+			title: 'New title',
+			icon: JSON.stringify( { type: 'emoji', value: '👍' } ),
+			status: 'publish',
+			slug: 'new-title',
+		};
+
+		const updated = overlaySidebarTreeRecord( branches, 1, fields );
+
+		expect( updated ).not.toBe( branches );
+		expect( updated.get( 0 ).records[ 0 ] ).toMatchObject( {
+			title: { raw: 'New title', rendered: 'New title' },
+			meta: {
+				cortext_document_icon: fields.icon,
+				other: 'preserved',
+			},
+			status: 'publish',
+			slug: 'new-title',
+		} );
+		expect( updated.get( 0 ).records[ 0 ].meta.other ).toBe( 'preserved' );
+		expect( updated.get( 2 ).records[ 0 ].meta.cortext_document_icon ).toBe(
+			fields.icon
+		);
+		expect( updated.get( 1 ) ).toBe( untouchedBranch );
+		expect( rootRecord ).toEqual(
+			expect.objectContaining( {
+				title: { raw: 'Page 1', rendered: 'Page 1' },
+				meta: {
+					cortext_document_icon: '',
+					other: 'preserved',
+				},
+				status: 'private',
+				slug: 'page-1',
+			} )
+		);
+	} );
+
+	it( 'preserves the map identity when every field is current', () => {
+		const record = makeRecord( 1 );
+		record.meta.cortext_document_icon = 'current';
+		const branches = new Map( [ [ 0, { records: [ record ], page: 1 } ] ] );
+
+		expect(
+			overlaySidebarTreeRecord( branches, 1, {
+				title: 'Page 1',
+				icon: 'current',
+				status: 'private',
+				slug: 'page-1',
+			} )
+		).toBe( branches );
+	} );
+
+	it( 'leaves a texturized title alone when only `rendered` differs', () => {
+		// WP runs `the_title` on `rendered`, so an unedited title with an
+		// ampersand never matches the raw string core-data holds.
+		const record = makeRecord( 1, 0, 'Tom & Jerry' );
+		record.title.rendered = 'Tom &#038; Jerry';
+		const branches = new Map( [ [ 0, { records: [ record ], page: 1 } ] ] );
+
+		expect(
+			overlaySidebarTreeRecord( branches, 1, {
+				title: 'Tom & Jerry',
+				icon: '',
+				status: 'private',
+				slug: 'page-1',
+			} )
+		).toBe( branches );
 	} );
 } );
 
@@ -329,5 +453,192 @@ describe( 'useSidebarTree', () => {
 				result.current.tree.map( ( node ) => node.page.id )
 			).toEqual( [ 1, 2 ] )
 		);
+	} );
+
+	it( 'derives selected tree fields from core-data across stale branch refetches', async () => {
+		const serverRecord = makeRecord( 1, 0, 'Old title' );
+		serverRecord.meta.cortext_document_icon = 'old-icon';
+		const registry = createSidebarRegistry( [ serverRecord ] );
+		mockTreeRequests( {
+			records: { 1: serverRecord },
+			branches: {
+				'0:1': {
+					records: [ serverRecord ],
+					total: 1,
+					totalPages: 1,
+				},
+			},
+		} );
+
+		const { result } = renderHook(
+			() =>
+				useSidebarTree( {
+					selectedId: 1,
+					selectedCollectionId: null,
+				} ),
+			{ wrapper: registryWrapper( registry ) }
+		);
+
+		await waitFor( () => expect( result.current.tree ).toHaveLength( 1 ) );
+
+		act( () => {
+			registry
+				.dispatch( coreStore )
+				.editEntityRecord( 'postType', 'crtxt_document', 1, {
+					title: 'New title',
+					meta: { cortext_document_icon: 'new-icon' },
+					status: 'publish',
+					slug: 'new-title',
+				} );
+		} );
+
+		await waitFor( () =>
+			expect( result.current.tree[ 0 ].page ).toMatchObject( {
+				title: { raw: 'New title', rendered: 'New title' },
+				meta: { cortext_document_icon: 'new-icon' },
+				status: 'publish',
+				slug: 'new-title',
+			} )
+		);
+
+		await act( async () => {
+			await result.current.refreshBranch( ROOT_PARENT_ID );
+		} );
+
+		expect( result.current.tree[ 0 ].page ).toMatchObject( {
+			title: { raw: 'New title', rendered: 'New title' },
+			meta: { cortext_document_icon: 'new-icon' },
+			status: 'publish',
+			slug: 'new-title',
+		} );
+		expect( serverRecord ).toMatchObject( {
+			title: { raw: 'Old title', rendered: 'Old title' },
+			meta: { cortext_document_icon: 'old-icon' },
+			status: 'private',
+			slug: 'page-1',
+		} );
+	} );
+
+	it( 'leaves an unedited record alone when its title is texturized', async () => {
+		const serverRecord = makeRecord( 1, 0, 'Tom & Jerry' );
+		serverRecord.title.rendered = 'Tom &#038; Jerry';
+		const registry = createSidebarRegistry( [ serverRecord ] );
+		mockTreeRequests( {
+			records: { 1: serverRecord },
+			branches: {
+				'0:1': {
+					records: [ serverRecord ],
+					total: 1,
+					totalPages: 1,
+				},
+			},
+		} );
+
+		const { result } = renderHook(
+			() =>
+				useSidebarTree( {
+					selectedId: 1,
+					selectedCollectionId: null,
+				} ),
+			{ wrapper: registryWrapper( registry ) }
+		);
+
+		await waitFor( () => expect( result.current.tree ).toHaveLength( 1 ) );
+		expect( result.current.tree[ 0 ].page ).toBe( serverRecord );
+	} );
+
+	it( 'leaves snapshots untouched when the selected id is absent from core-data', async () => {
+		const serverRecord = makeRecord( 1, 0, 'Server title' );
+		const registry = createSidebarRegistry();
+		registry
+			.dispatch( coreStore )
+			.finishResolution( 'getEntityRecord', [
+				'postType',
+				'crtxt_document',
+				99,
+			] );
+		mockTreeRequests( {
+			branches: {
+				'0:1': {
+					records: [ serverRecord ],
+					total: 1,
+					totalPages: 1,
+				},
+			},
+		} );
+
+		const { result } = renderHook(
+			() =>
+				useSidebarTree( {
+					selectedId: 99,
+					selectedCollectionId: null,
+				} ),
+			{ wrapper: registryWrapper( registry ) }
+		);
+
+		await waitFor( () => expect( result.current.tree ).toHaveLength( 1 ) );
+		expect( result.current.tree[ 0 ].page ).toBe( serverRecord );
+	} );
+
+	it( 'keeps reconciled fields after the selection moves to another document', async () => {
+		const first = makeRecord( 1, 0, 'Old title' );
+		first.meta.cortext_document_icon = 'old-icon';
+		const second = makeRecord( 2, 0, 'Doc two' );
+		const registry = createSidebarRegistry( [ first, second ] );
+		mockTreeRequests( {
+			records: { 1: first, 2: second },
+			branches: {
+				'0:1': {
+					records: [ first, second ],
+					total: 2,
+					totalPages: 1,
+				},
+			},
+		} );
+
+		const { result, rerender } = renderHook(
+			( props ) => useSidebarTree( props ),
+			{
+				wrapper: registryWrapper( registry ),
+				initialProps: { selectedId: 1, selectedCollectionId: null },
+			}
+		);
+
+		await waitFor( () => expect( result.current.tree ).toHaveLength( 2 ) );
+
+		act( () => {
+			registry
+				.dispatch( coreStore )
+				.editEntityRecord( 'postType', 'crtxt_document', 1, {
+					title: 'New title',
+					meta: { cortext_document_icon: 'new-icon' },
+				} );
+		} );
+
+		await waitFor( () =>
+			expect( result.current.tree[ 0 ].page ).toMatchObject( {
+				title: { raw: 'New title', rendered: 'New title' },
+				meta: { cortext_document_icon: 'new-icon' },
+			} )
+		);
+
+		// The autosave lands: core-data holds the persisted values and clears
+		// the edits. The branch snapshot is still the pre-save copy, and no
+		// editor-save path invalidates it.
+		act( () => {
+			const saved = makeRecord( 1, 0, 'New title' );
+			saved.meta.cortext_document_icon = 'new-icon';
+			registry
+				.dispatch( coreStore )
+				.receiveEntityRecords( 'postType', 'crtxt_document', saved );
+		} );
+
+		rerender( { selectedId: 2, selectedCollectionId: null } );
+
+		await waitFor( () => expect( result.current.tree ).toHaveLength( 2 ) );
+		expect( result.current.tree[ 0 ].page ).toMatchObject( {
+			title: { raw: 'New title', rendered: 'New title' },
+			meta: { cortext_document_icon: 'new-icon' },
+		} );
 	} );
 } );


### PR DESCRIPTION
## What

Updates the active document's title and icon in the sidebar as soon as they change in the editor, with no reload required.

## Why

The lazy sidebar stores separate REST snapshots, so editor changes could leave a row stale until its branch was fetched again.

## How

- Deriving current editor fields over loaded sidebar records without changing the REST snapshots.
- Comparing raw titles separately from WordPress-rendered titles so texturization does not look like an edit.

## Testing Instructions

1. Open a document with an icon.
2. Rename it from the canvas to `Tom & Jerry` and confirm the sidebar updates immediately.
3. Change its icon and confirm the sidebar updates without reloading.
4. Remove the icon and confirm the fallback icon appears without reloading.
